### PR TITLE
Allow ref version for doc generation

### DIFF
--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -44,6 +44,7 @@ Execution hints can be provided anywhere on the command line
 - skipdocs : skip generating documentation
 - non-interactive : make targets that run in interactive mode by default to run unassisted.
 - docs:<B> : the branch name B to use when generating documentation
+- ref:<B> : the reference version B to use when generating documentation
 - seed:<N> : provide a seed to run the tests with.
 - random:<K><:B> : sets random K to bool B if if B is omitted will default to true
   K can be: sourceserializer, typedkeys or oldconnection (only valid on windows)
@@ -95,6 +96,7 @@ Execution hints can be provided anywhere on the command line
         Seed: string;
         RandomArguments: string list;
         DocsBranch: string;
+        ReferenceBranch: string;
         RemainingArguments: string list;
         MultiTarget: MultiTarget;
         Target: string;
@@ -123,7 +125,8 @@ Execution hints can be provided anywhere on the command line
                x <> "non-interactive" && 
                not (x.StartsWith("seed:")) && 
                not (x.StartsWith("random:")) && 
-               not (x.StartsWith("docs:")))
+               not (x.StartsWith("docs:")) &&
+               not (x.StartsWith("ref:")))
         let target = 
             match (filteredArgs |> List.tryHead) with
             | Some t -> t.Replace("-one", "")
@@ -145,6 +148,10 @@ Execution hints can be provided anywhere on the command line
             DocsBranch = 
                 match args |> List.tryFind (fun x -> x.StartsWith("docs:")) with
                 | Some t -> t.Replace("docs:", "")
+                | _ -> ""
+            ReferenceBranch = 
+                match args |> List.tryFind (fun x -> x.StartsWith("ref:")) with
+                | Some t -> t.Replace("ref:", "")
                 | _ -> ""
             RemainingArguments = filteredArgs
             MultiTarget = 

--- a/build/scripts/Documentation.fs
+++ b/build/scripts/Documentation.fs
@@ -4,15 +4,27 @@ open System.IO
 
 open Projects
 open Commandline
+open Fake.Core
 
 module Documentation = 
 
     let Generate args = 
         let docGenerator = PrivateProject(DocGenerator)
         let path = Paths.ProjectOutputFolder docGenerator DotNetFramework.NetCoreApp2_1
-        let generator = sprintf "%s.dll" docGenerator.Name 
+        let generator = sprintf "%s.dll" docGenerator.Name
         
-        Tooling.DotNet.ExecIn path [generator; args.DocsBranch] |> ignore
+        let (|NotNullOrEmpty|_|) (candidate:string) =
+            if String.isNotNullOrEmpty candidate then Some candidate
+            else None
+        
+        let dotnetArgs =     
+            match (args.DocsBranch, args.ReferenceBranch) with
+            | (NotNullOrEmpty b, NotNullOrEmpty d) -> [ generator; "-b"; b; "-d"; d ];
+            | (NotNullOrEmpty b, _) -> [ generator; "-b"; b ];
+            | (_, NotNullOrEmpty d) -> [ generator; "-d"; d ];
+            | (_, _) -> [ generator ]
+        
+        Tooling.DotNet.ExecIn path dotnetArgs |> ignore
 
     // TODO: hook documentation validation into the process
     let Validate() = 

--- a/docs/aggregations/aggregation-meta-usage.asciidoc
+++ b/docs/aggregations/aggregation-meta-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/AggregationMetaUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/AggregationMetaUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
+++ b/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Parent/ParentAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Parent/ParentAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/ScriptedMetric/ScriptedMetricAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/reserved-aggregation-names.asciidoc
+++ b/docs/aggregations/reserved-aggregation-names.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/ReservedAggregationNames.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/ReservedAggregationNames.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/aggregations/writing-aggregations.asciidoc
+++ b/docs/aggregations/writing-aggregations.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Aggregations/WritingAggregations.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Aggregations/WritingAggregations.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/analysis/analysis-usage.asciidoc
+++ b/docs/analysis/analysis-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Analysis/AnalysisUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Analysis/AnalysisUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/certificates/working-with-certificates.asciidoc
+++ b/docs/client-concepts/certificates/working-with-certificates.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Certificates/WorkingWithCertificates.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -33,9 +33,11 @@ instance of `ConnectionSettings`. Since a <<lifetimes,single client and connecti
 life of the application>>, the lifetime of a single connection pool instance will also be bound to the lifetime
 of the application.
 
-There are four types of connection pool
+There are five types of connection pool
 
 * <<single-node-connection-pool,SingleNodeConnectionPool>>
+
+* <<cloud-connection-pool,CloudConnectionPool>>
 
 * <<static-connection-pool,StaticConnectionPool>>
 
@@ -57,45 +59,55 @@ your cluster through a single load balancer instance.
 ----
 var uri = new Uri("http://localhost:9201");
 var pool = new SingleNodeConnectionPool(uri);
-pool.Nodes.Should().HaveCount(1);
-var node = pool.Nodes.First();
-node.Uri.Port.Should().Be(9201);
+var client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
-This type of pool is hardwired to opt out of reseeding (thus, sniffing) as well as pinging 
-
-[source,csharp]
-----
-pool.SupportsReseeding.Should().BeFalse();
-pool.SupportsPinging.Should().BeFalse();
-----
+This type of pool is hardwired to opt out of reseeding (<<sniffing-behaviour, sniffing>>) as well as <<pinging-behaviour, pinging>> 
 
 When you use the low ceremony `ElasticClient` constructor that takes a single `Uri`,
 internally a `SingleNodeConnectionPool` is used
 
 [source,csharp]
 ----
-var client = new ElasticClient(uri);
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<SingleNodeConnectionPool>();
+client = new ElasticClient(uri);
 ----
 
-However we urge that you always pass your connection settings explicitly
+However we encourage you to pass connection settings explicitly.
+
+[[cloud-connection-pool]]
+==== CloudConnectionPool
+
+A specialized subclass of `SingleNodeConnectionPool` that accepts a Cloud Id and credentials.
+When used the client will also pick Elastic Cloud optmized defaults for the connection settings.
+
+A Cloud Id for your cluster can be fetched from your Elastic Cloud cluster administration console.
+
+A Cloud Id should be in the form of `cluster_name:base_64_data` where `base_64_data` are the UUIDs for the services in this cloud instance e.g
+
+`host_name$elasticsearch_uuid$kibana_uuid$apm_uuid`
+
+Out of these, only `host_name` and `elasticsearch_uuid` are always available.
+
+A cloud connection pool can be created using credentials and a `cloudId`
 
 [source,csharp]
 ----
-client = new ElasticClient(new ConnectionSettings(uri));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<SingleNodeConnectionPool>();
+var credentials = new BasicAuthenticationCredentials("username", "password"); <1>
+var pool = new CloudConnectionPool(cloudId, credentials); <2>
+var client = new ElasticClient(new ConnectionSettings(pool));
 ----
+<1> a username and password that can access Elasticsearch service on Elastic Cloud
 
-or even better pass the connection pool explicitly
+<2> `cloudId` is a value that can be retrieved from the Elastic Cloud web console
+
+This type of pool, like its parent the `SingleNodeConnectionPool`, is hardwired to opt out of
+reseeding (<<sniffing-behaviour, sniffing>>) as well as <<pinging-behaviour, pinging>>.
+
+You can also directly create a cloud enabled connection using the `ElasticClient`'s constructor
 
 [source,csharp]
 ----
-client = new ElasticClient(new ConnectionSettings(pool));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<SingleNodeConnectionPool>();
+client = new ElasticClient(cloudId, credentials);
 ----
 
 [[static-connection-pool]]
@@ -104,17 +116,20 @@ client.ConnectionSettings.ConnectionPool
 The static connection pool is great if you have a known small sized cluster and do no want to enable
 sniffing to find out the cluster topology.
 
+Given a collection of `Uri` 
+
 [source,csharp]
 ----
 var uris = Enumerable.Range(9200, 5)
     .Select(port => new Uri($"http://localhost:{port}"));
 ----
 
-a connection pool can be seeded using an enumerable of `Uri` 
+a connection pool can be seeded with this collection 
 
 [source,csharp]
 ----
 var pool = new StaticConnectionPool(uris);
+var client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
 Or using an enumerable of `Node` 
@@ -123,32 +138,19 @@ Or using an enumerable of `Node`
 ----
 var nodes = uris.Select(u => new Node(u));
 pool = new StaticConnectionPool(nodes);
+client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
 This type of pool is hardwired to opt out of reseeding
-(and hence sniffing) but supports pinging when enabled
-
-[source,csharp]
-----
-pool.SupportsReseeding.Should().BeFalse();
-pool.SupportsPinging.Should().BeTrue();
-----
-
-To create a client using the static connection pool, pass
-the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-
-[source,csharp]
-----
-var client = new ElasticClient(new ConnectionSettings(pool));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<StaticConnectionPool>();
-----
+(<<sniffing-behaviour, sniffing>>) but supports <<pinging-behaviour, pinging>> when enabled.
 
 [[sniffing-connection-pool]]
 ==== SniffingConnectionPool
 
 A pool derived from `StaticConnectionPool`, a sniffing connection pool allows itself to be reseeded at run time.
 It comes with the very minor overhead of a `ReaderWriterLockSlim` to ensure thread safety.
+
+Given a collection of `Uri` 
 
 [source,csharp]
 ----
@@ -161,36 +163,21 @@ a connection pool can be seeded using an enumerable of `Uri`
 [source,csharp]
 ----
 var pool = new SniffingConnectionPool(uris);
+var client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
 Or using an enumerable of `Node`. A major benefit in using nodes is that you can include
-known node roles when seeding which
-NEST can use to favour sniffing on master eligible nodes first,
-and take master only nodes out of rotation for issuing client calls on.
+known node roles when seeding, which NEST can then use to favour particular API requests. For example,
+sniffing on master eligible nodes first, and take master only nodes out of rotation for issuing client calls on.
 
 [source,csharp]
 ----
 var nodes = uris.Select(u=>new Node(u));
 pool = new SniffingConnectionPool(nodes);
+client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
-This type of pool is hardwired to opt in to reseeding (and hence sniffing), and pinging 
-
-[source,csharp]
-----
-pool.SupportsReseeding.Should().BeTrue();
-pool.SupportsPinging.Should().BeTrue();
-----
-
-To create a client using the sniffing connection pool pass
-the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-
-[source,csharp]
-----
-var client = new ElasticClient(new ConnectionSettings(pool));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<SniffingConnectionPool>();
-----
+This type of pool is hardwired to opt in to reseeding (<<sniffing-behaviour, sniffing>>), and <<pinging-behaviour, pinging>> 
 
 [[sticky-connection-pool]]
 ==== StickyConnectionPool
@@ -198,6 +185,8 @@ client.ConnectionSettings.ConnectionPool
 A type of connection pool that returns the first live node to issue a request against, such that the node is _sticky_ between requests.
 It uses https://msdn.microsoft.com/en-us/library/system.threading.interlocked(v=vs.110).aspx[`System.Threading.Interlocked`]
 to keep an _indexer_ to the last live node in a thread safe manner.
+
+Given a collection of `Uri` 
 
 [source,csharp]
 ----
@@ -210,43 +199,28 @@ a connection pool can be seeded using an enumerable of `Uri`
 [source,csharp]
 ----
 var pool = new StickyConnectionPool(uris);
+var client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
-Or using an enumerable of `Node`.
-A major benefit here is you can include known node roles when seeding and
-NEST can use this information to favour sniffing on master eligible nodes first
-and take master only nodes out of rotation for issuing client calls on.
+Or using an enumerable of `Node`, similar to `SniffingConnectionPool`
 
 [source,csharp]
 ----
 var nodes = uris.Select(u=>new Node(u));
 pool = new StickyConnectionPool(nodes);
+client = new ElasticClient(new ConnectionSettings(pool));
 ----
 
-This type of pool is hardwired to opt out of reseeding (and hence sniffing), but does support sniffing
-
-[source,csharp]
-----
-pool.SupportsReseeding.Should().BeFalse();
-pool.SupportsPinging.Should().BeTrue();
-----
-
-To create a client using the sticky connection pool pass
-the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-
-[source,csharp]
-----
-var client = new ElasticClient(new ConnectionSettings(pool));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<StickyConnectionPool>();
-----
+This type of pool is hardwired to opt out of reseeding (<<sniffing-behaviour, sniffing>>), but does support <<pinging-behaviour, pinging>>. 
 
 [[sticky-sniffing-connection-pool]]
 ==== Sticky Sniffing Connection Pool
 
 A type of connection pool that returns the first live node to issue a request against, such that the node is _sticky_ between requests.
-This implementation supports sniffing and sorting so that each instance of your application can favor a node in the same rack based
-on node attributes for instance.
+This implementation supports sniffing and sorting so that each instance of your application can favour a node. For example,
+a node in the same rack, based on node attributes.
+
+Given a collection of `Uri` 
 
 [source,csharp]
 ----
@@ -254,28 +228,25 @@ var uris = Enumerable.Range(9200, 5)
     .Select(port => new Uri($"http://localhost:{port}"));
 ----
 
-a sniffing sorted sticky pool takes a second parameter `Func` takes a Node and returns a weight.
-Nodes will be sorted descending by weight. In the following example we score nodes that are client nodes
-AND in rack_id `rack_one` the highest
+a sniffing sorted sticky pool takes a second parameter, a delegate of `Func<Node, float>`, that takes a Node and returns a weight.
+Nodes will be sorted in descending order by weight. In the following example, nodes are scored so that client nodes
+in rack_id `rack_one` score the highest
 
 [source,csharp]
 ----
-var pool = new StickySniffingConnectionPool(uris, n =>
-    (n.ClientNode ? 10 : 0)
-    + (n.Settings.TryGetValue("node.attr.rack_id", out var rackId)
-            && rackId.ToString() == "rack_one" ? 10 : 0));
+var pool = new StickySniffingConnectionPool(uris, node =>
+{
+    var weight = 0f;
 
-pool.SupportsReseeding.Should().BeTrue();
-pool.SupportsPinging.Should().BeTrue();
-----
+    if (node.ClientNode)
+        weight += 10;
 
-To create a client using the sticky sniffing connection pool pass
-the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
+    if (node.Settings.TryGetValue("node.attr.rack_id", out var rackId) && rackId.ToString() == "rack_one")
+        weight += 10;
 
-[source,csharp]
-----
+    return weight;
+});
+
 var client = new ElasticClient(new ConnectionSettings(pool));
-client.ConnectionSettings.ConnectionPool
-    .Should().BeOfType<StickySniffingConnectionPool>();
 ----
 

--- a/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/DateTimeProviders.Doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/DateTimeProviders.Doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/KeepingTrackOfNodes.Doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/KeepingTrackOfNodes.Doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/RequestPipelines.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/Transports.Doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnexpectedExceptions.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnrecoverableExceptions.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Exceptions/UnrecoverableExceptions.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
+++ b/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Failover/FallingOver.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Failover/FallingOver.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
+++ b/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/MaxRetries/RespectsMaxRetry.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/MaxRetries/RespectsMaxRetry.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/FirstUsage.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/FirstUsage.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/Revival.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Pinging/Revival.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RequestTimeoutsOverrides.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsAllowedStatusCode.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsAllowedStatusCode.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsForceNode.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsForceNode.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsMaxRetryOverrides.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/RespectsMaxRetryOverrides.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/RoundRobin.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/RoundRobin.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/SkipDeadNodes.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/RoundRobin/SkipDeadNodes.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/AddressParsing.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnConnectionFailure.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnConnectionFailure.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStartup.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStartup.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/RoleDetection.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/SkipDeadNodes.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/SkipDeadNodes.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/StickySniffingConnectionPool.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/Sticky.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sticky/Sticky.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/connection/modifying-default-connection.asciidoc
+++ b/docs/client-concepts/connection/modifying-default-connection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Connection/ModifyingDefaultConnection.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Analysis/TestingAnalyzers.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Analysis/TestingAnalyzers.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Analysis/WritingAnalyzers.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Analysis/WritingAnalyzers.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
+++ b/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/CovariantHits/CovariantSearchResults.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/getting-started.asciidoc
+++ b/docs/client-concepts/high-level/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
+++ b/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/IndexingDocuments.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/IndexingDocuments.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
+++ b/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/IngestNodes.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/IngestNodes.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/indexing/pipelines.asciidoc
+++ b/docs/client-concepts/high-level/indexing/pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/Pipelines.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Indexing/Pipelines.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/document-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/document-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/DocumentPaths.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/DocumentPaths.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/FieldInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/ids-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/ids-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IdsInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IndexNameInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/indices-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/indices-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/IndicesPaths.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/property-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/property-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/PropertyInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/PropertyInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/routing-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/routing-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/RoutingInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Inference/TypesAndRelationsInference.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AttributeMapping.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AttributeMapping.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/auto-map.asciidoc
+++ b/docs/client-concepts/high-level/mapping/auto-map.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/AutoMap.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/FluentMapping.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/FluentMapping.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
+++ b/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/IgnoringProperties.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
+++ b/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/MultiFields.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/MultiFields.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/VisitorPatternMapping.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/VisitorPatternMapping.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
+++ b/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/CustomSerialization.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/low-level/getting-started.asciidoc
+++ b/docs/client-concepts/low-level/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/LowLevel/GettingStarted.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/low-level/lifetimes.asciidoc
+++ b/docs/client-concepts/low-level/lifetimes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/low-level/post-data.asciidoc
+++ b/docs/client-concepts/low-level/post-data.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/troubleshooting/audit-trail.asciidoc
+++ b/docs/client-concepts/troubleshooting/audit-trail.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/AuditTrail.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
@@ -82,6 +82,6 @@ some understanding of how long it took
 [source,csharp]
 ----
 response.ApiCall.AuditTrail
-    .Should().OnlyContain(a => a.Ended - a.Started > TimeSpan.Zero);
+    .Should().OnlyContain(a => a.Ended - a.Started >= TimeSpan.Zero);
 ----
 

--- a/docs/client-concepts/troubleshooting/debug-information.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-information.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
+++ b/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/DeprecationLogging.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/DeprecationLogging.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
+++ b/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/DiagnosticSource.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/DiagnosticSource.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/LoggingWithFiddler.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/LoggingWithFiddler.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/ClientConcepts/Troubleshooting/LoggingWithOnRequestCompleted.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/ClientConcepts/Troubleshooting/LoggingWithOnRequestCompleted.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/descriptors.asciidoc
+++ b/docs/code-standards/descriptors.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Descriptors.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Descriptors.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/elastic-client.asciidoc
+++ b/docs/code-standards/elastic-client.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/ElasticClient.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/ElasticClient.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/naming-conventions.asciidoc
+++ b/docs/code-standards/naming-conventions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/NamingConventions.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/NamingConventions.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/queries.asciidoc
+++ b/docs/code-standards/queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Queries.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Queries.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/requests.asciidoc
+++ b/docs/code-standards/requests.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Requests.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Requests.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/responses.asciidoc
+++ b/docs/code-standards/responses.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Responses.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Responses.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/serialization/converters.asciidoc
+++ b/docs/code-standards/serialization/converters.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Serialization/Converters.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Serialization/Converters.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/code-standards/serialization/properties.asciidoc
+++ b/docs/code-standards/serialization/properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CodeStandards/Serialization/Properties.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CodeStandards/Serialization/Properties.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CommonOptions/DateMath/DateMathExpressions.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/common-options/distance-unit/distance-units.asciidoc
+++ b/docs/common-options/distance-unit/distance-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CommonOptions/DistanceUnit/DistanceUnits.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CommonOptions/DistanceUnit/DistanceUnits.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/common-options/union/union.asciidoc
+++ b/docs/common-options/union/union.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/CommonOptions/Union/Union.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/CommonOptions/Union/Union.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/mapping/local-metadata/local-metadata-usage.asciidoc
+++ b/docs/mapping/local-metadata/local-metadata-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Mapping/LocalMetadata/LocalMetadataUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Mapping/LocalMetadata/LocalMetadataUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/mapping/scalar/scalar-usage.asciidoc
+++ b/docs/mapping/scalar/scalar-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Mapping/Scalar/ScalarUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Mapping/Scalar/ScalarUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
+++ b/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/BoolDsl/BoolDsl.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/Bool/BoolDslComplexQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/Bool/BoolQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
+++ b/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/Boosting/BoostingQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/Boosting/BoostingQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/ConstantScore/ConstantScoreQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/ConstantScore/ConstantScoreQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
+++ b/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/Dismax/DismaxQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
+++ b/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/CommonTerms/CommonTermsUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/CommonTerms/CommonTermsUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
+++ b/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/Intervals/IntervalsUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/Intervals/IntervalsUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/MatchPhrasePrefix/MatchPhrasePrefixUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/MatchPhrase/MatchPhraseUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/MatchPhrase/MatchPhraseUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/match/match-usage.asciidoc
+++ b/docs/query-dsl/full-text/match/match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/Match/MatchUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
+++ b/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/MultiMatch/MultiMatchUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/QueryString/QueryStringUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/FullText/SimpleQueryString/SimpleQueryStringUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
+++ b/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Geo/BoundingBox/GeoBoundingBoxQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
+++ b/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Geo/Distance/GeoDistanceQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
+++ b/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Geo/Polygon/GeoPolygonQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/geo/shape/geo-shape-query-usage.asciidoc
+++ b/docs/query-dsl/geo/shape/geo-shape-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Geo/Shape/GeoShapeQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Joining/HasChild/HasChildQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Joining/HasChild/HasChildQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Joining/HasParent/HasParentQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Joining/HasParent/HasParentQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
+++ b/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Joining/Nested/NestedQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Joining/Nested/NestedQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
+++ b/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Joining/ParentId/ParentIdQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Joining/ParentId/ParentIdQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/match-none-query-usage.asciidoc
+++ b/docs/query-dsl/match-none-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/MatchNoneQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/MatchNoneQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/NestSpecific/Raw/RawCombineUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/NestSpecific/Raw/RawCombineUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/NestSpecific/Raw/RawQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/NestSpecific/Raw/RawQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
+++ b/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Containing/SpanContainingQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Containing/SpanContainingQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
+++ b/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/FieldMasking/SpanFieldMaskingUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/FieldMasking/SpanFieldMaskingUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/first/span-first-query-usage.asciidoc
+++ b/docs/query-dsl/span/first/span-first-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/First/SpanFirstQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/First/SpanFirstQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/MultiTerm/SpanMultiTermQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/MultiTerm/SpanMultiTermQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/near/span-near-query-usage.asciidoc
+++ b/docs/query-dsl/span/near/span-near-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Near/SpanNearQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Near/SpanNearQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/not/span-not-query-usage.asciidoc
+++ b/docs/query-dsl/span/not/span-not-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Not/SpanNotQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Not/SpanNotQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/or/span-or-query-usage.asciidoc
+++ b/docs/query-dsl/span/or/span-or-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Or/SpanOrQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Or/SpanOrQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/term/span-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/term/span-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Term/SpanTermQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Term/SpanTermQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/span/within/span-within-query-usage.asciidoc
+++ b/docs/query-dsl/span/within/span-within-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Span/Within/SpanWithinQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Span/Within/SpanWithinQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisFullDocumentQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/MoreLikeThis/MoreLikeThisQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/Percolate/PercolateQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/ScriptScore/ScriptScoreQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/specialized/script/script-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script/script-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Specialized/Script/ScriptQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Specialized/Script/ScriptQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Exists/ExistsQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Exists/ExistsQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyDateQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyNumericQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Fuzzy/FuzzyQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Ids/IdsQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Ids/IdsQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Prefix/PrefixQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Range/DateRangeQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Range/LongRangeQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Range/NumericRangeQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Range/NumericRangeQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Range/TermRangeQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Range/TermRangeQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Regexp/RegexpQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Regexp/RegexpQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/term/term-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/term/term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Term/TermQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Term/TermQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/TermsSet/TermsSetQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/TermsSet/TermsSetQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsListQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsLookupQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsLookupQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Terms/TermsQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
+++ b/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/QueryDsl/Verbatim/VerbatimAndStrictQueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/explain-usage.asciidoc
+++ b/docs/search/request/explain-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/ExplainUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/ExplainUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/fields-usage.asciidoc
+++ b/docs/search/request/fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/FieldsUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/FieldsUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/from-and-size-usage.asciidoc
+++ b/docs/search/request/from-and-size-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/FromAndSizeUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/FromAndSizeUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/highlighting-usage.asciidoc
+++ b/docs/search/request/highlighting-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/HighlightingUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/HighlightingUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/indices-boost-usage.asciidoc
+++ b/docs/search/request/indices-boost-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/IndicesBoostUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/IndicesBoostUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/inner-hits-usage.asciidoc
+++ b/docs/search/request/inner-hits-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/InnerHitsUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/InnerHitsUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/min-score-usage.asciidoc
+++ b/docs/search/request/min-score-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/MinScoreUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/MinScoreUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/post-filter-usage.asciidoc
+++ b/docs/search/request/post-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/PostFilterUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/PostFilterUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/profile-usage.asciidoc
+++ b/docs/search/request/profile-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/ProfileUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/ProfileUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/query-usage.asciidoc
+++ b/docs/search/request/query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/QueryUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/QueryUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/script-fields-usage.asciidoc
+++ b/docs/search/request/script-fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/ScriptFieldsUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/ScriptFieldsUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/search-after-usage.asciidoc
+++ b/docs/search/request/search-after-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/SearchAfterUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/SearchAfterUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/sliced-scroll-search-usage.asciidoc
+++ b/docs/search/request/sliced-scroll-search-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/SlicedScrollSearchUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/SlicedScrollSearchUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/sort-usage.asciidoc
+++ b/docs/search/request/sort-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/SortUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/SortUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/source-filtering-usage.asciidoc
+++ b/docs/search/request/source-filtering-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/SourceFilteringUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/SourceFilteringUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/request/suggest-usage.asciidoc
+++ b/docs/search/request/suggest-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/SuggestUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Request/SuggestUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/returned-fields.asciidoc
+++ b/docs/search/returned-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/ReturnedFields.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/ReturnedFields.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/search/collapsing/field-collapse-usage.asciidoc
+++ b/docs/search/search/collapsing/field-collapse-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Search/Collapsing/FieldCollapseUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Search/Collapsing/FieldCollapseUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/search/rescoring/rescore-usage.asciidoc
+++ b/docs/search/search/rescoring/rescore-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Search/Rescoring/RescoreUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/Search/Rescoring/RescoreUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/search/writing-queries.asciidoc
+++ b/docs/search/writing-queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/WritingQueries.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/Search/WritingQueries.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
+++ b/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUsageTests.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUsageTests.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
+++ b/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.1
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
 
 :github: https://github.com/elastic/elasticsearch-net
 
@@ -7,7 +7,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/XPack/Security/RoleMapping/RoleMappingRules.doc.cs. 
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/docs/reference-version/src/Tests/Tests/XPack/Security/RoleMapping/RoleMappingRules.doc.cs. 
 If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.7.179" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />

--- a/src/CodeGeneration/DocGenerator/Program.cs
+++ b/src/CodeGeneration/DocGenerator/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using CommandLine;
 
 namespace DocGenerator
 {
@@ -38,7 +39,7 @@ namespace DocGenerator
 										 .Last().Value
 										 .Split(".")
 										 .Take(2));
-			Console.WriteLine("Using global.json version: " + globalJsonVersion);
+
 			DocVersion = globalJsonVersion;
 
 			var process = new Process
@@ -88,22 +89,41 @@ namespace DocGenerator
 
 		private static int Main(string[] args)
 		{
-			try
-			{
-				if (args.Length > 0)
-					BranchName = args[0];
+			return Parser.Default.ParseArguments<DocGeneratorOptions>(args)
+				.MapResult(
+					opts =>
+					{
+						try
+						{
+							if (!string.IsNullOrEmpty(opts.BranchName))
+								BranchName = opts.BranchName;
 
-				Console.WriteLine($"Using branch name {BranchName} in documentation");
+							if (!string.IsNullOrEmpty(opts.DocVersion))
+								DocVersion = opts.DocVersion;
 
-				LitUp.GoAsync(args).Wait();
-				return 0;
-			}
-			catch (AggregateException ae)
-			{
-				var ex = ae.InnerException ?? ae;
-				Console.WriteLine(ex.Message);
-				return 1;
-			}
+							Console.WriteLine($"Using branch name {BranchName} in documentation");
+							Console.WriteLine($"Using doc reference version {DocVersion} in documentation");
+
+							LitUp.GoAsync(args).Wait();
+							return 0;
+						}
+						catch (AggregateException ae)
+						{
+							var ex = ae.InnerException ?? ae;
+							Console.WriteLine(ex.Message);
+							return 1;
+						}
+					},
+					errs => 1);
 		}
+	}
+
+	public class DocGeneratorOptions
+	{
+		[Option('b', "branch", Required = false, HelpText = "The version that appears in generated from source link")]
+		public string BranchName { get; set; }
+
+		[Option('d', "docs", Required = false, HelpText = "The version that links to the Elasticsearch reference documentation")]
+		public string DocVersion { get; set; }
 	}
 }

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -55,39 +55,38 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		{
 			var uri = new Uri("http://localhost:9201");
 			var pool = new SingleNodeConnectionPool(uri);
-			pool.Nodes.Should().HaveCount(1);
-			var node = pool.Nodes.First();
-			node.Uri.Port.Should().Be(9201);
+			var client = new ElasticClient(new ConnectionSettings(pool));
 
-			/** This type of pool is hardwired to opt out of reseeding (thus, sniffing) as well as pinging */
-			pool.SupportsReseeding.Should().BeFalse();
-			pool.SupportsPinging.Should().BeFalse();
+			/** This type of pool is hardwired to opt out of reseeding (<<sniffing-behaviour, sniffing>>) as well as <<pinging-behaviour, pinging>> */
+			// hide
+			{
+				pool.Nodes.Should().HaveCount(1);
+				var node = pool.Nodes.First();
+				node.Uri.Port.Should().Be(9201);
+				pool.SupportsReseeding.Should().BeFalse();
+				pool.SupportsPinging.Should().BeFalse();
+				client.ConnectionSettings.ConnectionPool
+					.Should()
+					.BeOfType<SingleNodeConnectionPool>();
+			}
 
 			/** When you use the low ceremony `ElasticClient` constructor that takes a single `Uri`,
 			* internally a `SingleNodeConnectionPool` is used
 			*/
-			var client = new ElasticClient(uri);
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<SingleNodeConnectionPool>();
+			client = new ElasticClient(uri);
 
-			/** However we urge that you always pass your connection settings explicitly
-			 */
-			client = new ElasticClient(new ConnectionSettings(uri));
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<SingleNodeConnectionPool>();
-
-			/** or even better pass the connection pool explicitly
-			 */
-			client = new ElasticClient(new ConnectionSettings(pool));
+			/** However we encourage you to pass connection settings explicitly.
+			*/
+			// hide
 			client.ConnectionSettings.ConnectionPool
 				.Should().BeOfType<SingleNodeConnectionPool>();
 		}
-		
+
 		/**
 		* [[cloud-connection-pool]]
 		* ==== CloudConnectionPool
 		*
-		* A specialized subclass of `SingleNodeConnectionPool that accepts a Cloud Id and credentials.
+		* A specialized subclass of `SingleNodeConnectionPool` that accepts a Cloud Id and credentials.
 		* When used the client will also pick Elastic Cloud optmized defaults for the connection settings.
 		 *
 		 * A Cloud Id for your cluster can be fetched from your Elastic Cloud cluster administration console.
@@ -97,72 +96,89 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		 * `host_name$elasticsearch_uuid$kibana_uuid$apm_uuid`
 		 *
 		 * Out of these, only `host_name` and `elasticsearch_uuid` are always available.
-		 * 
+		 *
 		*/
 		[U] public void CloudConnectionPool()
 		{
+			// hide
 			string ToBase64(string s) => Convert.ToBase64String(Encoding.UTF8.GetBytes(s));
-			/* Here we obviously use a ficticuous Cloud Id so lets create a fake one. */
-
+			// hide
 			var hostName = "cloud-endpoint.example";
+			// hide
 			var elasticsearchUuid = "3dadf823f05388497ea684236d918a1a";
+			// hide
 			var services = $"{hostName}${elasticsearchUuid}$3f26e1609cf54a0f80137a80de560da4";
+			// hide
 			var cloudId = $"my_cluster:{ToBase64(services)}";
 
-			/*
-			 * In a real scenario you would be able to copy paste `cloudId`
-			 *
-			 * A cloud connection pool always needs credentials as well here opt for basic auth 
-			 */
-			var credentials = new BasicAuthenticationCredentials("username", "password");
-			var pool = new CloudConnectionPool(cloudId, credentials);
-			pool.UsingSsl.Should().BeTrue();
-			pool.Nodes.Should().HaveCount(1);
-			var node = pool.Nodes.First();
-			node.Uri.Port.Should().Be(443);
-			node.Uri.Host.Should().Be($"{elasticsearchUuid}.{hostName}");
-			node.Uri.Scheme.Should().Be("https");
-
-			/** This type of pool like its parent the `SingleNodeConnectionPool` is hardwired to opt out of
-			 * reseeding (thus, sniffing) as well as pinging
-			 */
-			pool.SupportsReseeding.Should().BeFalse();
-			pool.SupportsPinging.Should().BeFalse();
-
 			/**
-			 * You can also directly create a cloud enabled connection using the clients constructor
-			*/
-			var client = new ElasticClient(cloudId, credentials);
-			client.ConnectionSettings.ConnectionPool
-				.Should()
-				.BeOfType<CloudConnectionPool>();
-
-			/** However we urge that you always pass your connection settings explicitly
+			 * A cloud connection pool can be created using credentials and a `cloudId`
 			 */
-			client = new ElasticClient(new ConnectionSettings(pool));
-			client.ConnectionSettings.ConnectionPool.Should().BeOfType<CloudConnectionPool>();
+			var credentials = new BasicAuthenticationCredentials("username", "password"); // <1> a username and password that can access Elasticsearch service on Elastic Cloud
+			var pool = new CloudConnectionPool(cloudId, credentials); // <2> `cloudId` is a value that can be retrieved from the Elastic Cloud web console
+			var client = new ElasticClient(new ConnectionSettings(pool));
 
-			client.ConnectionSettings.EnableHttpCompression.Should().BeTrue();
-			client.ConnectionSettings.BasicAuthenticationCredentials.Should().NotBeNull();
-			client.ConnectionSettings.BasicAuthenticationCredentials.Username.Should().Be("username");
-
-			//hide
-			var badCloudIds = new[]
+			// hide
 			{
-				"", 
-				"my_cluster", 
-				"my_cluster:", 
-				$"my_cluster:{ToBase64("hostname")}", 
-				$"my_cluster:{ToBase64("hostname$")}"
-			};
-			foreach (var id in badCloudIds)
-			{
-				Action create = () => new ElasticClient(id, credentials);
-
-				create.Should().Throw<ArgumentException>()
-					.And.Message.Should().Contain("should be a string in the form of cluster_name:base_64_data");
+				pool.UsingSsl.Should().BeTrue();
+				pool.Nodes.Should().HaveCount(1);
+				var node = pool.Nodes.First();
+				node.Uri.Port.Should().Be(443);
+				node.Uri.Host.Should().Be($"{elasticsearchUuid}.{hostName}");
+				node.Uri.Scheme.Should().Be("https");
 			}
 
+			/** This type of pool, like its parent the `SingleNodeConnectionPool`, is hardwired to opt out of
+			 * reseeding (<<sniffing-behaviour, sniffing>>) as well as <<pinging-behaviour, pinging>>.
+			 */
+			// hide
+			{
+				pool.SupportsReseeding.Should().BeFalse();
+				pool.SupportsPinging.Should().BeFalse();
+			}
+
+			/**
+			 * You can also directly create a cloud enabled connection using the `ElasticClient`'s constructor
+			*/
+			client = new ElasticClient(cloudId, credentials);
+
+			// hide
+			{
+				client.ConnectionSettings.ConnectionPool
+					.Should()
+					.BeOfType<CloudConnectionPool>();
+			}
+
+			// hide
+			{
+				client = new ElasticClient(new ConnectionSettings(pool));
+				client.ConnectionSettings.ConnectionPool.Should().BeOfType<CloudConnectionPool>();
+				client.ConnectionSettings.EnableHttpCompression.Should().BeTrue();
+				client.ConnectionSettings.BasicAuthenticationCredentials.Should().NotBeNull();
+				client.ConnectionSettings.BasicAuthenticationCredentials.Username.Should().Be("username");
+			}
+
+			//hide
+			{
+				var badCloudIds = new[]
+				{
+					"",
+					"my_cluster",
+					"my_cluster:",
+					$"my_cluster:{ToBase64("hostname")}",
+					$"my_cluster:{ToBase64("hostname$")}"
+				};
+
+				foreach (var id in badCloudIds)
+				{
+					Action create = () => new ElasticClient(id, credentials);
+
+					create.Should()
+						.Throw<ArgumentException>()
+						.And.Message.Should()
+						.Contain("should be a string in the form of cluster_name:base_64_data");
+				}
+			}
 		}
 
 		/**[[static-connection-pool]]
@@ -173,28 +189,29 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		*/
 		[U] public void Static()
 		{
+			/** Given a collection of `Uri` */
 			var uris = Enumerable.Range(9200, 5)
 				.Select(port => new Uri($"http://localhost:{port}"));
 
-			/** a connection pool can be seeded using an enumerable of `Uri` */
+			/** a connection pool can be seeded with this collection */
 			var pool = new StaticConnectionPool(uris);
+			var client = new ElasticClient(new ConnectionSettings(pool));
 
 			/** Or using an enumerable of `Node` */
 			var nodes = uris.Select(u => new Node(u));
 			pool = new StaticConnectionPool(nodes);
+			client = new ElasticClient(new ConnectionSettings(pool));
 
 			/** This type of pool is hardwired to opt out of reseeding
-			 * (and hence sniffing) but supports pinging when enabled
+			 * (<<sniffing-behaviour, sniffing>>) but supports <<pinging-behaviour, pinging>> when enabled.
 			 */
-			pool.SupportsReseeding.Should().BeFalse();
-			pool.SupportsPinging.Should().BeTrue();
-
-			/** To create a client using the static connection pool, pass
-			* the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-			*/
-			var client = new ElasticClient(new ConnectionSettings(pool));
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<StaticConnectionPool>();
+			//hide
+			{
+				pool.SupportsReseeding.Should().BeFalse();
+				pool.SupportsPinging.Should().BeTrue();
+				client.ConnectionSettings.ConnectionPool
+					.Should().BeOfType<StaticConnectionPool>();
+			}
 		}
 
 		/**[[sniffing-connection-pool]]
@@ -205,30 +222,31 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		*/
 		[U] public void Sniffing()
 		{
+			/** Given a collection of `Uri` */
 			var uris = Enumerable.Range(9200, 5)
 				.Select(port => new Uri($"http://localhost:{port}"));
 
 			/** a connection pool can be seeded using an enumerable of `Uri` */
 			var pool = new SniffingConnectionPool(uris);
+			var client = new ElasticClient(new ConnectionSettings(pool));
 
 			/** Or using an enumerable of `Node`. A major benefit in using nodes is that you can include
-			* known node roles when seeding which
-			* NEST can use to favour sniffing on master eligible nodes first,
-			* and take master only nodes out of rotation for issuing client calls on.
+			* known node roles when seeding, which NEST can then use to favour particular API requests. For example,
+			* sniffing on master eligible nodes first, and take master only nodes out of rotation for issuing client calls on.
 			*/
 			var nodes = uris.Select(u=>new Node(u));
 			pool = new SniffingConnectionPool(nodes);
+			client = new ElasticClient(new ConnectionSettings(pool));
 
-			/** This type of pool is hardwired to opt in to reseeding (and hence sniffing), and pinging */
-			pool.SupportsReseeding.Should().BeTrue();
-			pool.SupportsPinging.Should().BeTrue();
-
-			/** To create a client using the sniffing connection pool pass
-			* the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-			*/
-			var client = new ElasticClient(new ConnectionSettings(pool));
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<SniffingConnectionPool>();
+			/** This type of pool is hardwired to opt in to reseeding (<<sniffing-behaviour, sniffing>>), and <<pinging-behaviour, pinging>> */
+			//hide
+			{
+				pool.SupportsReseeding.Should().BeTrue();
+				pool.SupportsPinging.Should().BeTrue();
+				client.ConnectionSettings.ConnectionPool
+					.Should()
+					.BeOfType<SniffingConnectionPool>();
+			}
 		}
 
 		/**[[sticky-connection-pool]]
@@ -240,63 +258,71 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		*/
 		[U] public void Sticky()
 		{
+			/** Given a collection of `Uri` */
 			var uris = Enumerable.Range(9200, 5)
 				.Select(port => new Uri($"http://localhost:{port}"));
 
 			/** a connection pool can be seeded using an enumerable of `Uri` */
 			var pool = new StickyConnectionPool(uris);
+			var client = new ElasticClient(new ConnectionSettings(pool));
 
-			/** Or using an enumerable of `Node`.
-			* A major benefit here is you can include known node roles when seeding and
-			* NEST can use this information to favour sniffing on master eligible nodes first
-			* and take master only nodes out of rotation for issuing client calls on.
+			/** Or using an enumerable of `Node`, similar to `SniffingConnectionPool`
 			*/
 			var nodes = uris.Select(u=>new Node(u));
 			pool = new StickyConnectionPool(nodes);
+			client = new ElasticClient(new ConnectionSettings(pool));
 
-			/** This type of pool is hardwired to opt out of reseeding (and hence sniffing), but does support sniffing*/
-			pool.SupportsReseeding.Should().BeFalse();
-			pool.SupportsPinging.Should().BeTrue();
-
-			/** To create a client using the sticky connection pool pass
-			* the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-			*/
-			var client = new ElasticClient(new ConnectionSettings(pool));
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<StickyConnectionPool>();
+			/** This type of pool is hardwired to opt out of reseeding (<<sniffing-behaviour, sniffing>>), but does support <<pinging-behaviour, pinging>>. */
+			// hide
+			{
+				pool.SupportsReseeding.Should().BeFalse();
+				pool.SupportsPinging.Should().BeTrue();
+				client.ConnectionSettings.ConnectionPool
+					.Should()
+					.BeOfType<StickyConnectionPool>();
+			}
 		}
 
 		/**[[sticky-sniffing-connection-pool]]
 		* ==== Sticky Sniffing Connection Pool
 		*
 		* A type of connection pool that returns the first live node to issue a request against, such that the node is _sticky_ between requests.
-		* This implementation supports sniffing and sorting so that each instance of your application can favor a node in the same rack based
-		* on node attributes for instance.
+		* This implementation supports sniffing and sorting so that each instance of your application can favour a node. For example,
+		* a node in the same rack, based on node attributes.
 		*/
 		[U] public void SniffingSortedSticky()
 		{
+			/** Given a collection of `Uri` */
 			var uris = Enumerable.Range(9200, 5)
 				.Select(port => new Uri($"http://localhost:{port}"));
 
-			/** a sniffing sorted sticky pool takes a second parameter `Func` takes a Node and returns a weight.
-			* Nodes will be sorted descending by weight. In the following example we score nodes that are client nodes
-			* AND in rack_id `rack_one` the highest
+			/** a sniffing sorted sticky pool takes a second parameter, a delegate of `Func<Node, float>`, that takes a Node and returns a weight.
+			* Nodes will be sorted in descending order by weight. In the following example, nodes are scored so that client nodes
+			* in rack_id `rack_one` score the highest
 			*/
+			var pool = new StickySniffingConnectionPool(uris, node =>
+			{
+				var weight = 0f;
 
-			var pool = new StickySniffingConnectionPool(uris, n =>
-				(n.ClientNode ? 10 : 0)
-				+ (n.Settings.TryGetValue("node.attr.rack_id", out var rackId)
-						&& rackId.ToString() == "rack_one" ? 10 : 0));
+				if (node.ClientNode)
+					weight += 10;
 
-			pool.SupportsReseeding.Should().BeTrue();
-			pool.SupportsPinging.Should().BeTrue();
+				if (node.Settings.TryGetValue("node.attr.rack_id", out var rackId) && rackId.ToString() == "rack_one")
+					weight += 10;
 
-			/** To create a client using the sticky sniffing connection pool pass
-			* the connection pool to the `ConnectionSettings` you pass to `ElasticClient`
-			*/
+				return weight;
+			});
+
 			var client = new ElasticClient(new ConnectionSettings(pool));
-			client.ConnectionSettings.ConnectionPool
-				.Should().BeOfType<StickySniffingConnectionPool>();
+
+			// hide
+			{
+				pool.SupportsReseeding.Should().BeTrue();
+				pool.SupportsPinging.Should().BeTrue();
+				client.ConnectionSettings.ConnectionPool
+					.Should()
+					.BeOfType<StickySniffingConnectionPool>();
+			}
 		}
 	}
 }


### PR DESCRIPTION
This PR allows a reference version to be passed when generating documentation. The reference version is the version used in the link to the Elasticsearch reference documentation.

- Improve connection pooling docs
    Improve the connection pooling docs by hiding test assertions from being output in documentation, and linking to sniffing and pinging behaviour docs.
- Regen docs for master