### PR TITLE
fix #4029: Use enum item.Name instead of Enum.GetName to get enum value

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
@@ -166,7 +166,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			foreach (var item in type.GetFields().Where(fi => fi.FieldType == type))
 			{
 				var value = item.GetValue(null);
-				var name = Enum.GetName(type, value);
+				var name = item.Name;
 				var dataMember = item.GetCustomAttributes(typeof(DataMemberAttribute), true)
 					.OfType<DataMemberAttribute>()
 					.FirstOrDefault();


### PR DESCRIPTION
This is the propsed fix from the original repo of the code: https://github.com/neuecc/Utf8Json/pull/129

Resolves #4029 

I've tested this locally in a .NET Framework project and it works, compared to previously where it'd throw with an exception as mentioned in #4029.

I'm not sure if this should target 7.x or the master branch.