### PR TITLE
Write examples directly to asciidoc

### DIFF
--- a/examples/Docs/DeletePage/47b5ff897f26e9c943cee5c06034181d.asciidoc
+++ b/examples/Docs/DeletePage/47b5ff897f26e9c943cee5c06034181d.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/DeletePage.cs[tag=47b5ff897f26e9c943cee5c06034181d,indent=0]
+var deleteResponse = client.Delete<Tweet>(1, d => d
+    .Index("twitter")
+    .Routing("kimchy")
+);
 ----

--- a/examples/Docs/DeletePage/47b5ff897f26e9c943cee5c06034181d.asciidoc
+++ b/examples/Docs/DeletePage/47b5ff897f26e9c943cee5c06034181d.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line84 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/DeletePage.cs#L19-L30.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var deleteResponse = client.Delete<Tweet>(1, d => d

--- a/examples/Docs/DeletePage/c5e5873783246c7b1c01d8464fed72c4.asciidoc
+++ b/examples/Docs/DeletePage/c5e5873783246c7b1c01d8464fed72c4.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/DeletePage.cs[tag=c5e5873783246c7b1c01d8464fed72c4,indent=0]
+var deleteResponse = client.Delete<Tweet>(1, d => d.Index("twitter"));
 ----

--- a/examples/Docs/DeletePage/c5e5873783246c7b1c01d8464fed72c4.asciidoc
+++ b/examples/Docs/DeletePage/c5e5873783246c7b1c01d8464fed72c4.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line9 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/DeletePage.cs#L9-L17.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var deleteResponse = client.Delete<Tweet>(1, d => d.Index("twitter"));

--- a/examples/Docs/DeletePage/d90a84a24a407731dfc1929ac8327746.asciidoc
+++ b/examples/Docs/DeletePage/d90a84a24a407731dfc1929ac8327746.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/DeletePage.cs[tag=d90a84a24a407731dfc1929ac8327746,indent=0]
+var deleteResponse = client.Delete<Tweet>(1, d => d
+    .Index("twitter")
+    .Timeout("5m")
+);
 ----

--- a/examples/Docs/DeletePage/d90a84a24a407731dfc1929ac8327746.asciidoc
+++ b/examples/Docs/DeletePage/d90a84a24a407731dfc1929ac8327746.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line147 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/DeletePage.cs#L32-L43.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var deleteResponse = client.Delete<Tweet>(1, d => d

--- a/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
+++ b/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=0ba0b2db24852abccb7c0fc1098d566e,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    Counter = 1,
+    Tags = new[] { "white" }
+}, i => i
+.Index("twitter")
+.Id(2)
+.Routing("user1")
+);
 ----

--- a/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
+++ b/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line178 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L148-L168.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/GetPage/138ccd89f72aa7502dd9578403dcc589.asciidoc
+++ b/examples/Docs/GetPage/138ccd89f72aa7502dd9578403dcc589.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=138ccd89f72aa7502dd9578403dcc589,indent=0]
+var getResponse = client.Get<Tweet>(0, g => g
+    .Index("twitter")
+    .SourceEnabled(false)
+);
 ----

--- a/examples/Docs/GetPage/138ccd89f72aa7502dd9578403dcc589.asciidoc
+++ b/examples/Docs/GetPage/138ccd89f72aa7502dd9578403dcc589.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line72 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L30-L41.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(0, g => g

--- a/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
+++ b/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=1d65cb6d055c46a1bde809687d835b71,indent=0]
+var getResponse = client.Get<Tweet>(2, g => g
+    .Index("twitter")
+    .Routing("user1")
+);
 ----

--- a/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
+++ b/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line262 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L220-L231.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(2, g => g

--- a/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
+++ b/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line248 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L210-L218.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var sourceExistsResponse = client.SourceExists<Tweet>(1, s => s.Index("twitter"));

--- a/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
+++ b/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=2468ab381257d759d8a88af1141f6f9c,indent=0]
+var sourceExistsResponse = client.SourceExists<Tweet>(1, s => s.Index("twitter"));
 ----

--- a/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
+++ b/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line131 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L115-L131.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
+++ b/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=5eabcdbf61bfcb484dc694f25c2bba36,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    Counter = 1,
+    Tags = new[] { "red" }
+}, i => i.Index("twitter").Id(1));
 ----

--- a/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
+++ b/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line189 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L170-L184.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(2, g => g

--- a/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
+++ b/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=69a7be47f85138b10437113ab2f0d72d,indent=0]
+var getResponse = client.Get<Tweet>(2, g => g
+    .Index("twitter")
+    .Routing("user1")
+    .StoredFields(
+        f => f.Tags,
+        f => f.Counter)
+);
 ----

--- a/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
+++ b/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
@@ -1,4 +1,9 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=710c7871f20f176d51209b1574b0d61b,indent=0]
+var getResponse = client.Get<Tweet>(1, g => g
+    .Index("twitter")
+    .StoredFields(
+        f => f.Tags,
+        f => f.Counter)
+);
 ----

--- a/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
+++ b/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line144 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L133-L146.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(1, g => g

--- a/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
+++ b/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=745f9b8cdb8e91073f6e520e1d9f8c05,indent=0]
+var getResponse = client.Get<Tweet>(0, g => g
+    .Index("twitter")
+    .SourceIncludes("*.id,retweeted")
+);
 ----

--- a/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
+++ b/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line93 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L57-L75.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(0, g => g

--- a/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
+++ b/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line229 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L186-L194.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var sourceResponse = client.Source<Tweet>(1, s => s.Index("twitter"));

--- a/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
+++ b/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=89a8ac1509936acc272fc2d72907bc45,indent=0]
+var sourceResponse = client.Source<Tweet>(1, s => s.Index("twitter"));
 ----

--- a/examples/Docs/GetPage/8fdf2344c4fb3de6902ad7c5735270df.asciidoc
+++ b/examples/Docs/GetPage/8fdf2344c4fb3de6902ad7c5735270df.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line84 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L43-L55.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(0, g => g

--- a/examples/Docs/GetPage/8fdf2344c4fb3de6902ad7c5735270df.asciidoc
+++ b/examples/Docs/GetPage/8fdf2344c4fb3de6902ad7c5735270df.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=8fdf2344c4fb3de6902ad7c5735270df,indent=0]
+var getResponse = client.Get<Tweet>(0, g => g
+    .Index("twitter")
+    .SourceIncludes("*.id")
+    .SourceExcludes("entities")
+);
 ----

--- a/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
+++ b/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
@@ -1,4 +1,18 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=913770050ebbf3b9b549a899bc11060a,indent=0]
+var createIndexResponse = client.Indices.Create("twitter", c => c
+    .Map<Tweet>(m => m
+        .Properties(p => p
+            .Number(n => n
+                .Name(f => f.Counter)
+                .Type(NumberType.Integer)
+                .Store(false)
+            )
+            .Keyword(k => k
+                .Name(f => f.Tags)
+                .Store(true)
+            )
+        )
+    )
+);
 ----

--- a/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
+++ b/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line109 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L77-L113.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("twitter", c => c

--- a/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
+++ b/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=98234499cfec70487cec5d013e976a84,indent=0]
+var existsResponse = client.DocumentExists<Tweet>(0, g => g.Index("twitter"));
 ----

--- a/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
+++ b/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line46 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L20-L28.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var existsResponse = client.DocumentExists<Tweet>(0, g => g.Index("twitter"));

--- a/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
+++ b/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line238 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L196-L208.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var sourceFilteringResponse = client.Source<Tweet>(1, s => s

--- a/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
+++ b/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=d222c6a6ec7a3beca6c97011b0874512,indent=0]
+var sourceFilteringResponse = client.Source<Tweet>(1, s => s
+    .Index("twitter")
+    .SourceIncludes("*.id")
+    .SourceExcludes("entities")
+);
 ----

--- a/examples/Docs/GetPage/fbcf5078a6a9e09790553804054c36b3.asciidoc
+++ b/examples/Docs/GetPage/fbcf5078a6a9e09790553804054c36b3.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/GetPage.cs[tag=fbcf5078a6a9e09790553804054c36b3,indent=0]
+var getResponse = client.Get<Tweet>(0, g => g.Index("twitter"));
 ----

--- a/examples/Docs/GetPage/fbcf5078a6a9e09790553804054c36b3.asciidoc
+++ b/examples/Docs/GetPage/fbcf5078a6a9e09790553804054c36b3.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line9 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/GetPage.cs#L10-L18.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Tweet>(0, g => g.Index("twitter"));

--- a/examples/Docs/IndexPage/048d8abd42d094bbdcf4452a58ccb35b.asciidoc
+++ b/examples/Docs/IndexPage/048d8abd42d094bbdcf4452a58ccb35b.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=048d8abd42d094bbdcf4452a58ccb35b,indent=0]
+var createResponse = client.Create(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+i => i
+    .Index("twitter")
+    .Id(1)
+);
 ----

--- a/examples/Docs/IndexPage/048d8abd42d094bbdcf4452a58ccb35b.asciidoc
+++ b/examples/Docs/IndexPage/048d8abd42d094bbdcf4452a58ccb35b.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line134 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L102-L124.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createResponse = client.Create(new Tweet

--- a/examples/Docs/IndexPage/1f336ecc62480c1d56351cc2f82d0d08.asciidoc
+++ b/examples/Docs/IndexPage/1f336ecc62480c1d56351cc2f82d0d08.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line357 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L198-L218.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/1f336ecc62480c1d56351cc2f82d0d08.asciidoc
+++ b/examples/Docs/IndexPage/1f336ecc62480c1d56351cc2f82d0d08.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=1f336ecc62480c1d56351cc2f82d0d08,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    Message = "elasticsearch now has versioning support, double cool!"
+},
+    i => i
+        .Index("twitter")
+        .Id(1)
+        .Version(2)
+        .VersionType(VersionType.External)
+);
 ----

--- a/examples/Docs/IndexPage/36818c6d9f434d387819c30bd9addb14.asciidoc
+++ b/examples/Docs/IndexPage/36818c6d9f434d387819c30bd9addb14.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=36818c6d9f434d387819c30bd9addb14,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+    i => i
+        .Index("twitter")
+);
 ----

--- a/examples/Docs/IndexPage/36818c6d9f434d387819c30bd9addb14.asciidoc
+++ b/examples/Docs/IndexPage/36818c6d9f434d387819c30bd9addb14.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line153 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L126-L147.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/625dc94df1f9affb49a082fd99d41620.asciidoc
+++ b/examples/Docs/IndexPage/625dc94df1f9affb49a082fd99d41620.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line204 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L149-L171.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/625dc94df1f9affb49a082fd99d41620.asciidoc
+++ b/examples/Docs/IndexPage/625dc94df1f9affb49a082fd99d41620.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=625dc94df1f9affb49a082fd99d41620,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+    i => i
+        .Index("twitter")
+        .Routing("kimchy")
+);
 ----

--- a/examples/Docs/IndexPage/804a97ff4d0613e6568e4efb19c52021.asciidoc
+++ b/examples/Docs/IndexPage/804a97ff4d0613e6568e4efb19c52021.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=804a97ff4d0613e6568e4efb19c52021,indent=0]
+var putSettingsResponse = client.Cluster.PutSettings(s => s
+    .Persistent(p => p
+        .Add("action.auto_create_index", "twitter,index10,-index1*,+ind*")
+    )
+);
+
+var putSettingsResponse2 = client.Cluster.PutSettings(s => s
+    .Persistent(p => p
+        .Add("action.auto_create_index", "false")
+    )
+);
+
+var putSettingsResponse3 = client.Cluster.PutSettings(s => s
+    .Persistent(p => p
+        .Add("action.auto_create_index", "true")
+    )
+);
 ----

--- a/examples/Docs/IndexPage/804a97ff4d0613e6568e4efb19c52021.asciidoc
+++ b/examples/Docs/IndexPage/804a97ff4d0613e6568e4efb19c52021.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line77 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L32-L75.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var putSettingsResponse = client.Cluster.PutSettings(s => s

--- a/examples/Docs/IndexPage/b918d6b798da673a33e49b94f61dcdc0.asciidoc
+++ b/examples/Docs/IndexPage/b918d6b798da673a33e49b94f61dcdc0.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line327 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L173-L196.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/b918d6b798da673a33e49b94f61dcdc0.asciidoc
+++ b/examples/Docs/IndexPage/b918d6b798da673a33e49b94f61dcdc0.asciidoc
@@ -1,4 +1,14 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=b918d6b798da673a33e49b94f61dcdc0,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+    i => i
+        .Index("twitter")
+        .Id(1)
+        .Timeout("5m")
+);
 ----

--- a/examples/Docs/IndexPage/bb143628fd04070683eeeadc9406d9cc.asciidoc
+++ b/examples/Docs/IndexPage/bb143628fd04070683eeeadc9406d9cc.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=bb143628fd04070683eeeadc9406d9cc,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+i => i.Index("twitter").Id(1));
 ----

--- a/examples/Docs/IndexPage/bb143628fd04070683eeeadc9406d9cc.asciidoc
+++ b/examples/Docs/IndexPage/bb143628fd04070683eeeadc9406d9cc.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line11 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L11-L30.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/d718b63cf1b6591a1d59a0cf4fd995eb.asciidoc
+++ b/examples/Docs/IndexPage/d718b63cf1b6591a1d59a0cf4fd995eb.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line121 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Docs/IndexPage.cs#L77-L100.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Tweet

--- a/examples/Docs/IndexPage/d718b63cf1b6591a1d59a0cf4fd995eb.asciidoc
+++ b/examples/Docs/IndexPage/d718b63cf1b6591a1d59a0cf4fd995eb.asciidoc
@@ -1,4 +1,14 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Docs/IndexPage.cs[tag=d718b63cf1b6591a1d59a0cf4fd995eb,indent=0]
+var indexResponse = client.Index(new Tweet
+{
+    User = "kimchy",
+    PostDate = new DateTime(2009, 11, 15, 14, 12, 12),
+    Message = "trying out Elasticsearch"
+},
+    i => i
+        .Index("twitter")
+        .Id(1)
+        .OpType(OpType.Create)
+    );
 ----

--- a/examples/Mapping/Dynamic/FieldMappingPage/4909bf2f9e86b4bdd6af1d0b13c0015d.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/4909bf2f9e86b4bdd6af1d0b13c0015d.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs[tag=4909bf2f9e86b4bdd6af1d0b13c0015d,indent=0]
+var indexResponse = client.Index<object>(
+    new { create_date = "2015/09/02" },
+    i => i.Index("my_index").Id(1));
+
+var getMappingResponse = client.Indices.GetMapping<object>(m => m
+    .Index("my_index")
+);
 ----

--- a/examples/Mapping/Dynamic/FieldMappingPage/4909bf2f9e86b4bdd6af1d0b13c0015d.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/4909bf2f9e86b4bdd6af1d0b13c0015d.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line50 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs#L8-L27.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index<object>(

--- a/examples/Mapping/Dynamic/FieldMappingPage/4eae628c9aaa259f80711c6e9cc6fd25.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/4eae628c9aaa259f80711c6e9cc6fd25.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line91 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs#L57-L83.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/FieldMappingPage/4eae628c9aaa259f80711c6e9cc6fd25.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/4eae628c9aaa259f80711c6e9cc6fd25.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs[tag=4eae628c9aaa259f80711c6e9cc6fd25,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .DynamicDateFormats(new[] { "MM/dd/yyyy" })
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new { create_date = "09/25/2015" },
+    i => i.Index("my_index").Id(1));
 ----

--- a/examples/Mapping/Dynamic/FieldMappingPage/95fa846e5d0a75210f9ad1fa1acfa8f3.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/95fa846e5d0a75210f9ad1fa1acfa8f3.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs[tag=95fa846e5d0a75210f9ad1fa1acfa8f3,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .DateDetection(false)
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new { create_date = "2015/09/02" },
+    i => i.Index("my_index").Id(1));
 ----

--- a/examples/Mapping/Dynamic/FieldMappingPage/95fa846e5d0a75210f9ad1fa1acfa8f3.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/95fa846e5d0a75210f9ad1fa1acfa8f3.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line68 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs#L29-L55.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/FieldMappingPage/fa3cd4ffaec8273656a328ae29f32c65.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/fa3cd4ffaec8273656a328ae29f32c65.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs[tag=fa3cd4ffaec8273656a328ae29f32c65,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .NumericDetection(true)
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new { my_float = "1.0", my_integer = "1" },
+    i => i.Index("my_index").Id(1));
 ----

--- a/examples/Mapping/Dynamic/FieldMappingPage/fa3cd4ffaec8273656a328ae29f32c65.asciidoc
+++ b/examples/Mapping/Dynamic/FieldMappingPage/fa3cd4ffaec8273656a328ae29f32c65.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line117 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/FieldMappingPage.cs#L85-L112.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
@@ -1,4 +1,31 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs[tag=0b91c082258ce623cc716b679aace653,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .DynamicTemplates(dt => dt
+            .DynamicTemplate("full_name", d => d
+                .PathMatch("name.*")
+                .PathUnmatch("*.middle")
+                .Mapping(mm => mm
+                    .Text(n => n
+                        .CopyTo(ct => ct.Field("full_name"))
+                    )
+                )
+            )
+        )
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new
+    {
+        name = new
+        {
+            first = "John",
+            middle = "Winston",
+            last = "Lennon"
+        }
+    },
+    i => i.Index("my_index").Id(1)
+);
 ----

--- a/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line179 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L136-L203.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/TemplatesPage/4f54b88e05c7a62901062e9e0ed13e5a.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/4f54b88e05c7a62901062e9e0ed13e5a.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line125 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L84-L134.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/TemplatesPage/4f54b88e05c7a62901062e9e0ed13e5a.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/4f54b88e05c7a62901062e9e0ed13e5a.asciidoc
@@ -1,4 +1,24 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs[tag=4f54b88e05c7a62901062e9e0ed13e5a,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .DynamicTemplates(dt => dt
+            .DynamicTemplate("longs_as_strings", d => d
+                .MatchMappingType("string")
+                .Match("long_*")
+                .Unmatch("*_text")
+                .Mapping(mm => mm
+                    .Number(n => n
+                        .Type(NumberType.Long)
+                    )
+                )
+            )
+        )
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new { long_num = "5", long_text = "foo" },
+    i => i.Index("my_index").Id(1)
+);
 ----

--- a/examples/Mapping/Dynamic/TemplatesPage/bb33e638fdeded7d721d9bbac2305fda.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/bb33e638fdeded7d721d9bbac2305fda.asciidoc
@@ -1,4 +1,35 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs[tag=bb33e638fdeded7d721d9bbac2305fda,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .DynamicTemplates(dt => dt
+            .DynamicTemplate("integers", d => d
+                .MatchMappingType("long")
+                .Mapping(mm => mm
+                    .Number(n => n
+                        .Type(NumberType.Integer)
+                    )
+                )
+            )
+            .DynamicTemplate("strings", d => d
+                .MatchMappingType("string")
+                .Mapping(mm => mm
+                    .Text(t => t
+                        .Fields(f => f
+                            .Keyword(k => k
+                                .Name("raw")
+                                .IgnoreAbove(256)
+                            )
+                        )
+                    )
+                )
+            )
+        )
+    )
+);
+
+var indexResponse = client.Index<object>(
+    new { my_integer = 5, my_string = "Some string" },
+    i => i.Index("my_index").Id(1)
+    );
 ----

--- a/examples/Mapping/Dynamic/TemplatesPage/bb33e638fdeded7d721d9bbac2305fda.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/bb33e638fdeded7d721d9bbac2305fda.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line71 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L9-L82.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
@@ -1,4 +1,16 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs[tag=be51ed37c8425d281a8153abe56b04cb,indent=0]
+var indexResponse = client.Index<object>(new
+{
+    name = new
+    {
+        first = "Paul",
+        last = "McCartney",
+        title = new
+        {
+            value = "Sir",
+            category = "order of chivalry"
+        }
+    }
+}, i => i.Index("my_index").Id(2));
 ----

--- a/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line215 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L205-L235.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index<object>(new

--- a/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line222 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L151-L177.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
@@ -1,4 +1,14 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=28aad2c5942bfb221c2bf1bbdc01658e,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("city.*")
+            )
+            .Query("this AND that OR thus")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line275 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L203-L230.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
@@ -1,4 +1,15 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=58b5003c0a53a39bf509aa3797aad471,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("content")
+                .Field("name.*^5")
+            )
+            .Query("this AND that OR thus")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line329 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L260-L290.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
@@ -1,4 +1,15 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=60ee33f3acfdd0fe6f288ac77312c780,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("title")
+            )
+            .Query("this that thus")
+            .MinimumShouldMatch(2)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
@@ -1,4 +1,17 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=6f21a878fee3b43c5332b81aaddbeac7,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("title")
+                .Field("content")
+            )
+            .Query("this OR that OR thus")
+            .Type(TextQueryType.CrossFields)
+            .MinimumShouldMatch(2)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line411 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L360-L394.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/81f09836772b03f6e7e8e7986409d67e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/81f09836772b03f6e7e8e7986409d67e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line11 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L9-L33.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/81f09836772b03f6e7e8e7986409d67e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/81f09836772b03f6e7e8e7986409d67e.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=81f09836772b03f6e7e8e7986409d67e,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .DefaultField("content")
+            .Query("this AND that OR thus")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
@@ -1,4 +1,16 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=a2a25aad1fea9a541b52ac613c78fb64,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("content")
+                .Field("name^5")
+            )
+            .Query("this AND that OR thus")
+            .TieBreaker(0)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line202 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L114-L149.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line356 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L292-L324.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
@@ -1,4 +1,16 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=be1bd47393646ac6bbee177d1cdb7738,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("title")
+                .Field("content")
+            )
+            .Query("this that thus")
+            .MinimumShouldMatch(2)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=db6cba451ba562abe953d09ad80cc15c,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Query("city.\\*:(this AND that OR thus)")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line240 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L179-L201.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/e17e8852ec3f31781e1364f4dffeb6d0.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/e17e8852ec3f31781e1364f4dffeb6d0.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=e17e8852ec3f31781e1364f4dffeb6d0,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Query("(content:this OR name:this) AND (content:that OR name:that)")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/e17e8852ec3f31781e1364f4dffeb6d0.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/e17e8852ec3f31781e1364f4dffeb6d0.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line185 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L90-L112.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/f2d68493abd3ca430bd03a7f7f8d18f9.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/f2d68493abd3ca430bd03a7f7f8d18f9.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line168 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L61-L88.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/f2d68493abd3ca430bd03a7f7f8d18f9.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/f2d68493abd3ca430bd03a7f7f8d18f9.asciidoc
@@ -1,4 +1,15 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=f2d68493abd3ca430bd03a7f7f8d18f9,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("content")
+                .Field("name")
+            )
+            .Query("this AND that")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=f32f0c19b42de3b87dd764fe4ca17e7c,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .DefaultField("title")
+            .Query("ny city")
+            .AutoGenerateSynonymsPhraseQuery(false)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line300 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L232-L258.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line381 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L326-L358.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
@@ -1,4 +1,16 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=fdd38f0d248385a444c777e7acd97846,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .Fields(f => f
+                .Field("title")
+                .Field("content")
+            )
+            .Query("this OR that OR thus")
+            .MinimumShouldMatch(2)
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/fe1dd67108b04e07d0832b539d4e0d99.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/fe1dd67108b04e07d0832b539d4e0d99.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs[tag=fe1dd67108b04e07d0832b539d4e0d99,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q
+        .QueryString(qs => qs
+            .DefaultField("content")
+            .Query("(new york city) OR (big apple)")
+        )
+    )
+);
 ----

--- a/examples/QueryDsl/QueryStringQueryPage/fe1dd67108b04e07d0832b539d4e0d99.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/fe1dd67108b04e07d0832b539d4e0d99.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line28 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L35-L59.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/Root/AnalysisPage/7ffee3c2a5581994fc0ea59dd106d39f.asciidoc
+++ b/examples/Root/AnalysisPage/7ffee3c2a5581994fc0ea59dd106d39f.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line42 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/AnalysisPage.cs#L8-L35.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Root/AnalysisPage/7ffee3c2a5581994fc0ea59dd106d39f.asciidoc
+++ b/examples/Root/AnalysisPage/7ffee3c2a5581994fc0ea59dd106d39f.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/AnalysisPage.cs[tag=7ffee3c2a5581994fc0ea59dd106d39f,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .Properties(p => p
+            .Text(t => t
+                .Name("title")
+                .Analyzer("standard")
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/0caf6b6b092ecbcf6f996053678a2384.asciidoc
+++ b/examples/Root/GettingStartedPage/0caf6b6b092ecbcf6f996053678a2384.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line284 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L43-L57.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("customer", c => c

--- a/examples/Root/GettingStartedPage/0caf6b6b092ecbcf6f996053678a2384.asciidoc
+++ b/examples/Root/GettingStartedPage/0caf6b6b092ecbcf6f996053678a2384.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=0caf6b6b092ecbcf6f996053678a2384,indent=0]
+var createIndexResponse = client.Indices.Create("customer", c => c
+    .Pretty()
+);
+
+var catResponse = client.Cat.Indices(h => h.Verbose());
 ----

--- a/examples/Root/GettingStartedPage/171d3a3af2d0f46cae5896c5bd3da4b5.asciidoc
+++ b/examples/Root/GettingStartedPage/171d3a3af2d0f46cae5896c5bd3da4b5.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line944 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L636-L678.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/171d3a3af2d0f46cae5896c5bd3da4b5.asciidoc
+++ b/examples/Root/GettingStartedPage/171d3a3af2d0f46cae5896c5bd3da4b5.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=171d3a3af2d0f46cae5896c5bd3da4b5,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Bool(b => b
+            .Should(sh => sh
+                    .Match(m => m
+                        .Field(f => f.Address)
+                        .Query("mill")
+                    ), sh => sh
+                    .Match(m => m
+                        .Field(f => f.Address)
+                        .Query("lane")
+                    )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/193864342d9f0a36ec84a91ca325f5ec.asciidoc
+++ b/examples/Root/GettingStartedPage/193864342d9f0a36ec84a91ca325f5ec.asciidoc
@@ -1,4 +1,9 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=193864342d9f0a36ec84a91ca325f5ec,indent=0]
+var bulkResponse = client.Bulk(b => b
+    .Index("customer")
+    .Update<Customer>(i => i.Doc(new Customer { Name = "John Doe becomes Jane Doe" }).Id("1"))
+    .Delete<Customer>(i => i.Id("2"))
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/193864342d9f0a36ec84a91ca325f5ec.asciidoc
+++ b/examples/Root/GettingStartedPage/193864342d9f0a36ec84a91ca325f5ec.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line562 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L292-L308.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var bulkResponse = client.Bulk(b => b

--- a/examples/Root/GettingStartedPage/1c0f3b0bc4b7e53b53755fd3bda5b8cf.asciidoc
+++ b/examples/Root/GettingStartedPage/1c0f3b0bc4b7e53b53755fd3bda5b8cf.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line470 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L174-L191.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Customer

--- a/examples/Root/GettingStartedPage/1c0f3b0bc4b7e53b53755fd3bda5b8cf.asciidoc
+++ b/examples/Root/GettingStartedPage/1c0f3b0bc4b7e53b53755fd3bda5b8cf.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=1c0f3b0bc4b7e53b53755fd3bda5b8cf,indent=0]
+var indexResponse = client.Index(new Customer
+{
+    Name = "Jane Doe"
+}, i => i
+.Index("customer")
+.Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/21fe98843fe0b5473f515d21803db409.asciidoc
+++ b/examples/Root/GettingStartedPage/21fe98843fe0b5473f515d21803db409.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line311 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L59-L77.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Customer

--- a/examples/Root/GettingStartedPage/21fe98843fe0b5473f515d21803db409.asciidoc
+++ b/examples/Root/GettingStartedPage/21fe98843fe0b5473f515d21803db409.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=21fe98843fe0b5473f515d21803db409,indent=0]
+var indexResponse = client.Index(new Customer
+{
+    Name = "John Doe"
+}, c => c
+.Index("customer")
+.Id(1)
+.Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
+++ b/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line909 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L564-L590.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
+++ b/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=231aa0bb39c35fe199d28fe0e4a62b2e,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .MatchPhrase(m => m
+            .Field(f => f.Address)
+            .Query("mill lane")
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
+++ b/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=251ea12c1248385ab409906ac64d9ee9,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Bool(b => b
+            .Must(mu => mu
+                .MatchAll()
+            )
+            .Filter(f => f
+                .Range(r => r
+                    .Field(ff => ff.Balance)
+                    .GreaterThanOrEquals(20000)
+                    .LessThanOrEquals(30000)
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
+++ b/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line1018 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L772-L824.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/2de2349b7010652ca6104fb60f531a80.asciidoc
+++ b/examples/Root/GettingStartedPage/2de2349b7010652ca6104fb60f531a80.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=2de2349b7010652ca6104fb60f531a80,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Bool(b => b
+            .Must(mu => mu
+                .Match(m => m
+                    .Field(f => f.Address)
+                    .Query("mill")
+                ), mu => mu
+                .Match(m => m
+                    .Field(f => f.Address)
+                    .Query("lane")
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/2de2349b7010652ca6104fb60f531a80.asciidoc
+++ b/examples/Root/GettingStartedPage/2de2349b7010652ca6104fb60f531a80.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line923 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L592-L634.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/2e6bfd38c9bcb728227f0d4dd11c09a2.asciidoc
+++ b/examples/Root/GettingStartedPage/2e6bfd38c9bcb728227f0d4dd11c09a2.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line873 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L480-L506.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/2e6bfd38c9bcb728227f0d4dd11c09a2.asciidoc
+++ b/examples/Root/GettingStartedPage/2e6bfd38c9bcb728227f0d4dd11c09a2.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=2e6bfd38c9bcb728227f0d4dd11c09a2,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Match(m => m
+            .Field(f => f.AccountNumber)
+            .Query("20")
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/345ea7e9cb5af9e052ce0cf6f1f52c23.asciidoc
+++ b/examples/Root/GettingStartedPage/345ea7e9cb5af9e052ce0cf6f1f52c23.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=345ea7e9cb5af9e052ce0cf6f1f52c23,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+);
 ----

--- a/examples/Root/GettingStartedPage/345ea7e9cb5af9e052ce0cf6f1f52c23.asciidoc
+++ b/examples/Root/GettingStartedPage/345ea7e9cb5af9e052ce0cf6f1f52c23.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line789 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L367-L381.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/37a3b66b555aed55618254f50d572cd6.asciidoc
+++ b/examples/Root/GettingStartedPage/37a3b66b555aed55618254f50d572cd6.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=37a3b66b555aed55618254f50d572cd6,indent=0]
+var getResponse = client.Get<Customer>(1, g => g
+    .Index("customer")
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/37a3b66b555aed55618254f50d572cd6.asciidoc
+++ b/examples/Root/GettingStartedPage/37a3b66b555aed55618254f50d572cd6.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line347 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L79-L90.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var getResponse = client.Get<Customer>(1, g => g

--- a/examples/Root/GettingStartedPage/37c778346eb67042df5e8edf2485e40a.asciidoc
+++ b/examples/Root/GettingStartedPage/37c778346eb67042df5e8edf2485e40a.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line454 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L154-L172.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Customer

--- a/examples/Root/GettingStartedPage/37c778346eb67042df5e8edf2485e40a.asciidoc
+++ b/examples/Root/GettingStartedPage/37c778346eb67042df5e8edf2485e40a.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=37c778346eb67042df5e8edf2485e40a,indent=0]
+var indexResponse = client.Index(new Customer
+{
+    Name = "Jane Doe"
+}, i => i
+.Index("customer")
+.Id(2)
+.Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/38dfa309717488362d0f784e17ebd1b5.asciidoc
+++ b/examples/Root/GettingStartedPage/38dfa309717488362d0f784e17ebd1b5.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line513 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L234-L258.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var updateResponse = client.Update<Customer>(1, u => u

--- a/examples/Root/GettingStartedPage/38dfa309717488362d0f784e17ebd1b5.asciidoc
+++ b/examples/Root/GettingStartedPage/38dfa309717488362d0f784e17ebd1b5.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=38dfa309717488362d0f784e17ebd1b5,indent=0]
+var updateResponse = client.Update<Customer>(1, u => u
+    .Script(s => s
+        .Source("ctx._source.age += 5")
+    )
+    .Index("customer")
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/3c31f9eb032861bff64abd8b14758991.asciidoc
+++ b/examples/Root/GettingStartedPage/3c31f9eb032861bff64abd8b14758991.asciidoc
@@ -1,4 +1,9 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=3c31f9eb032861bff64abd8b14758991,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+    .From(10)
+    .Size(10)
+);
 ----

--- a/examples/Root/GettingStartedPage/3c31f9eb032861bff64abd8b14758991.asciidoc
+++ b/examples/Root/GettingStartedPage/3c31f9eb032861bff64abd8b14758991.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line820 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L401-L419.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/3d7527bb7ac3b0e1f97b22bdfeb99070.asciidoc
+++ b/examples/Root/GettingStartedPage/3d7527bb7ac3b0e1f97b22bdfeb99070.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line805 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L383-L399.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/3d7527bb7ac3b0e1f97b22bdfeb99070.asciidoc
+++ b/examples/Root/GettingStartedPage/3d7527bb7ac3b0e1f97b22bdfeb99070.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=3d7527bb7ac3b0e1f97b22bdfeb99070,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+    .Size(1)
+);
 ----

--- a/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
+++ b/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
@@ -1,4 +1,22 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=47bb632c6091ad0cd94bc660bdd309a5,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Bool(b => b
+            .Must(mu => mu
+                .Match(m => m
+                    .Field(f => f.Age)
+                    .Query("40")
+                )
+            )
+            .MustNot(mn => mn
+                .Match(m => m
+                    .Field(ff => ff.State)
+                    .Query("ID")
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
+++ b/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line988 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L724-L770.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
+++ b/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=506844befdc5691d835771bcbb1c1a60,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+    .Sort(so => so.Ascending(f => f.AccountNumber))
+);
 ----

--- a/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
+++ b/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line720 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L339-L365.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/5d38d4da86157b897e4876674bd169ef.asciidoc
+++ b/examples/Root/GettingStartedPage/5d38d4da86157b897e4876674bd169ef.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=5d38d4da86157b897e4876674bd169ef,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Bool(b => b
+            .MustNot(mn => mn
+                    .Match(m => m
+                        .Field(f => f.Address)
+                        .Query("mill")
+                    ), mn => mn
+                    .Match(m => m
+                        .Field(f => f.Address)
+                        .Query("lane")
+                    )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/5d38d4da86157b897e4876674bd169ef.asciidoc
+++ b/examples/Root/GettingStartedPage/5d38d4da86157b897e4876674bd169ef.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line965 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L680-L722.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
+++ b/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
@@ -1,4 +1,20 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=645796e8047967ca4a7635a22a876f4c,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Size(0)
+    .Aggregations(a => a
+        .Terms("group_by_state", ra => ra
+            .Field(f => f.State.Suffix("keyword"))
+            .Order(o => o
+                .Descending("average_balance")
+            )
+            .Aggregations(aa => aa
+                .Average("average_balance", av => av
+                    .Field(f => f.Balance)
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
+++ b/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line1172 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L894-L946.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/6a8d7b34f2b42d5992aaa1ff147062d9.asciidoc
+++ b/examples/Root/GettingStartedPage/6a8d7b34f2b42d5992aaa1ff147062d9.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line489 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L193-L211.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var updateResponse = client.Update<Customer>(1, u => u

--- a/examples/Root/GettingStartedPage/6a8d7b34f2b42d5992aaa1ff147062d9.asciidoc
+++ b/examples/Root/GettingStartedPage/6a8d7b34f2b42d5992aaa1ff147062d9.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=6a8d7b34f2b42d5992aaa1ff147062d9,indent=0]
+var updateResponse = client.Update<Customer>(1, u => u
+    .Doc(new Customer
+    {
+        Name = "Jane Doe"
+    })
+    .Index("customer")
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/731621af937d66170347b9cc6b4a3c48.asciidoc
+++ b/examples/Root/GettingStartedPage/731621af937d66170347b9cc6b4a3c48.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=731621af937d66170347b9cc6b4a3c48,indent=0]
+var updateResponse = client.Update<Customer>(1, u => u
+    .Doc(new Customer
+    {
+        Name = "Jane Doe",
+        Age = 20
+    })
+    .Index("customer")
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/731621af937d66170347b9cc6b4a3c48.asciidoc
+++ b/examples/Root/GettingStartedPage/731621af937d66170347b9cc6b4a3c48.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line501 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L213-L232.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var updateResponse = client.Update<Customer>(1, u => u

--- a/examples/Root/GettingStartedPage/75bda7da7fefff2c16f0423a9aa41c6e.asciidoc
+++ b/examples/Root/GettingStartedPage/75bda7da7fefff2c16f0423a9aa41c6e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line442 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L134-L152.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var indexResponse = client.Index(new Customer

--- a/examples/Root/GettingStartedPage/75bda7da7fefff2c16f0423a9aa41c6e.asciidoc
+++ b/examples/Root/GettingStartedPage/75bda7da7fefff2c16f0423a9aa41c6e.asciidoc
@@ -1,4 +1,11 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=75bda7da7fefff2c16f0423a9aa41c6e,indent=0]
+var indexResponse = client.Index(new Customer
+{
+    Name = "Jane Doe"
+}, i => i
+.Index("customer")
+.Id(1)
+.Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/7d32a32357b5ea8819b72608fcc6fd07.asciidoc
+++ b/examples/Root/GettingStartedPage/7d32a32357b5ea8819b72608fcc6fd07.asciidoc
@@ -1,4 +1,9 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=7d32a32357b5ea8819b72608fcc6fd07,indent=0]
+var bulkResponse = client.Bulk(b => b
+    .Index("customer")
+    .Index<Customer>(i => i.Document(new Customer { Name = "John Doe" }).Id("1"))
+    .Index<Customer>(i => i.Document(new Customer { Name = "Jane Doe" }).Id("2"))
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/7d32a32357b5ea8819b72608fcc6fd07.asciidoc
+++ b/examples/Root/GettingStartedPage/7d32a32357b5ea8819b72608fcc6fd07.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line550 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L273-L290.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var bulkResponse = client.Bulk(b => b

--- a/examples/Root/GettingStartedPage/92e3c75133dc4fdb2cc65f149001b40b.asciidoc
+++ b/examples/Root/GettingStartedPage/92e3c75133dc4fdb2cc65f149001b40b.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line378 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L92-L104.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var deleteResponse = client.Indices.Delete("customer", d => d.Pretty());

--- a/examples/Root/GettingStartedPage/92e3c75133dc4fdb2cc65f149001b40b.asciidoc
+++ b/examples/Root/GettingStartedPage/92e3c75133dc4fdb2cc65f149001b40b.asciidoc
@@ -1,4 +1,6 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=92e3c75133dc4fdb2cc65f149001b40b,indent=0]
+var deleteResponse = client.Indices.Delete("customer", d => d.Pretty());
+
+var catResponse = client.Cat.Indices(h => h.Verbose());
 ----

--- a/examples/Root/GettingStartedPage/9c5ef83db886840355ff662b6e9ae8ab.asciidoc
+++ b/examples/Root/GettingStartedPage/9c5ef83db886840355ff662b6e9ae8ab.asciidoc
@@ -1,4 +1,7 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=9c5ef83db886840355ff662b6e9ae8ab,indent=0]
+var deleteResponse = client.Delete<Customer>(2, d => d
+    .Index("customer")
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/9c5ef83db886840355ff662b6e9ae8ab.asciidoc
+++ b/examples/Root/GettingStartedPage/9c5ef83db886840355ff662b6e9ae8ab.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line532 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L260-L271.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var deleteResponse = client.Delete<Customer>(2, d => d

--- a/examples/Root/GettingStartedPage/b8459547da50aebddbcdd1aaaac02b5f.asciidoc
+++ b/examples/Root/GettingStartedPage/b8459547da50aebddbcdd1aaaac02b5f.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=b8459547da50aebddbcdd1aaaac02b5f,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+    .Source(sf => sf
+        .Includes(ff => ff
+            .Field(f => f.AccountNumber)
+            .Field(f => f.Balance)
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/b8459547da50aebddbcdd1aaaac02b5f.asciidoc
+++ b/examples/Root/GettingStartedPage/b8459547da50aebddbcdd1aaaac02b5f.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line854 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L449-L478.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/b8eab60f6441edf314306d8194c7cd56.asciidoc
+++ b/examples/Root/GettingStartedPage/b8eab60f6441edf314306d8194c7cd56.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=b8eab60f6441edf314306d8194c7cd56,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Match(m => m
+            .Field(f => f.Address)
+            .Query("mill")
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/b8eab60f6441edf314306d8194c7cd56.asciidoc
+++ b/examples/Root/GettingStartedPage/b8eab60f6441edf314306d8194c7cd56.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line885 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L508-L534.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/c181969ef91c3b4a2513c1885be98e26.asciidoc
+++ b/examples/Root/GettingStartedPage/c181969ef91c3b4a2513c1885be98e26.asciidoc
@@ -1,4 +1,9 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=c181969ef91c3b4a2513c1885be98e26,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q.QueryString(qs => qs.Query("*")))
+    .Sort(so => so.Ascending(f => f.AccountNumber))
+    .Pretty()
+);
 ----

--- a/examples/Root/GettingStartedPage/c181969ef91c3b4a2513c1885be98e26.asciidoc
+++ b/examples/Root/GettingStartedPage/c181969ef91c3b4a2513c1885be98e26.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line647 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L310-L337.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/c3fa04519df668d6c27727a12ab09648.asciidoc
+++ b/examples/Root/GettingStartedPage/c3fa04519df668d6c27727a12ab09648.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=c3fa04519df668d6c27727a12ab09648,indent=0]
+var catResponse = client.Cat.Indices(h => h.Verbose());
 ----

--- a/examples/Root/GettingStartedPage/c3fa04519df668d6c27727a12ab09648.asciidoc
+++ b/examples/Root/GettingStartedPage/c3fa04519df668d6c27727a12ab09648.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line263 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L33-L41.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var catResponse = client.Cat.Indices(h => h.Verbose());

--- a/examples/Root/GettingStartedPage/c84b5f9c6528f84a08c5318b3385d55c.asciidoc
+++ b/examples/Root/GettingStartedPage/c84b5f9c6528f84a08c5318b3385d55c.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line1201 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L948-L1028.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/c84b5f9c6528f84a08c5318b3385d55c.asciidoc
+++ b/examples/Root/GettingStartedPage/c84b5f9c6528f84a08c5318b3385d55c.asciidoc
@@ -1,4 +1,27 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=c84b5f9c6528f84a08c5318b3385d55c,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Size(0)
+    .Aggregations(a => a
+        .Range("group_by_age", ra => ra
+            .Field(f => f.Age)
+            .Ranges(
+                r => r.From(20).To(30),
+                r => r.From(30).To(40),
+                r => r.From(40).To(50)
+            )
+            .Aggregations(aa => aa
+                .Terms("group_by_gender", t => t
+                    .Field(f => f.Gender.Suffix("keyword"))
+                    .Aggregations(aaa => aaa
+                        .Average("average_balance", av => av
+                            .Field(f => f.Balance)
+                        )
+                    )
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
+++ b/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=cd247f267968aa0927bfdad56852f8f5,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Query(q => q
+        .Match(m => m
+            .Field(f => f.Address)
+            .Query("mill lane")
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
+++ b/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line897 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L536-L562.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
+++ b/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
@@ -1,4 +1,17 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=cfbaea6f0df045c5d940bbb6a9c69cd8,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Size(0)
+    .Aggregations(a => a
+        .Terms("group_by_state", ra => ra
+            .Field(f => f.State.Suffix("keyword"))
+            .Aggregations(aa => aa
+                .Average("average_balance", av => av
+                    .Field(f => f.Balance)
+                )
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
+++ b/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line1144 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L854-L892.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/db20adb70a8e8d0709d15ba0daf18d23.asciidoc
+++ b/examples/Root/GettingStartedPage/db20adb70a8e8d0709d15ba0daf18d23.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=db20adb70a8e8d0709d15ba0daf18d23,indent=0]
+var catResponse = client.Cat.Nodes(h => h.Verbose());
 ----

--- a/examples/Root/GettingStartedPage/db20adb70a8e8d0709d15ba0daf18d23.asciidoc
+++ b/examples/Root/GettingStartedPage/db20adb70a8e8d0709d15ba0daf18d23.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line240 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L23-L31.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var catResponse = client.Cat.Nodes(h => h.Verbose());

--- a/examples/Root/GettingStartedPage/e8035a7476601ad4b136edb250f92d53.asciidoc
+++ b/examples/Root/GettingStartedPage/e8035a7476601ad4b136edb250f92d53.asciidoc
@@ -1,4 +1,10 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=e8035a7476601ad4b136edb250f92d53,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .MatchAll()
+    .Sort(so => so
+        .Field(f => f.Balance, SortOrder.Descending)
+    )
+);
 ----

--- a/examples/Root/GettingStartedPage/e8035a7476601ad4b136edb250f92d53.asciidoc
+++ b/examples/Root/GettingStartedPage/e8035a7476601ad4b136edb250f92d53.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line836 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L421-L447.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
+++ b/examples/Root/GettingStartedPage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=f8cc4b331a19ff4df8e4a490f906ee69,indent=0]
+var catResponse = client.Cat.Health(h => h.Verbose());
 ----

--- a/examples/Root/GettingStartedPage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
+++ b/examples/Root/GettingStartedPage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line209 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L13-L21.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var catResponse = client.Cat.Health(h => h.Verbose());

--- a/examples/Root/GettingStartedPage/fa5f618ced25ed2e67a1439bb77ba340.asciidoc
+++ b/examples/Root/GettingStartedPage/fa5f618ced25ed2e67a1439bb77ba340.asciidoc
@@ -1,4 +1,13 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=fa5f618ced25ed2e67a1439bb77ba340,indent=0]
+var createIndexResponse = client.Indices.Create("customer");
+
+var indexResponse = client.Index(new Customer { Name = "John Doe" }, i => i
+    .Index("customer")
+    .Id(1)
+);
+
+var getResponse = client.Get<Customer>(1, g => g.Index("customer"));
+
+var deleteIndexResponse = client.Indices.Delete("customer");
 ----

--- a/examples/Root/GettingStartedPage/fa5f618ced25ed2e67a1439bb77ba340.asciidoc
+++ b/examples/Root/GettingStartedPage/fa5f618ced25ed2e67a1439bb77ba340.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line398 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L106-L132.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("customer");

--- a/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
+++ b/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line1051 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/GettingStartedPage.cs#L826-L852.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Account>(s => s

--- a/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
+++ b/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
@@ -1,4 +1,12 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/GettingStartedPage.cs[tag=feefeb68144002fd1fff57b77b95b85e,indent=0]
+var searchResponse = client.Search<Account>(s => s
+    .Index("bank")
+    .Size(0)
+    .Aggregations(a => a
+        .Terms("group_by_state", ra => ra
+            .Field(f => f.State.Suffix("keyword"))
+        )
+    )
+);
 ----

--- a/examples/Root/MappingPage/b311b42b7dcc69821df1f77bfaf2d50d.asciidoc
+++ b/examples/Root/MappingPage/b311b42b7dcc69821df1f77bfaf2d50d.asciidoc
@@ -1,4 +1,16 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/MappingPage.cs[tag=b311b42b7dcc69821df1f77bfaf2d50d,indent=0]
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map(m => m
+        .Properties(p => p
+            .Text(t => t.Name("title"))
+            .Text(t => t.Name("name"))
+            .Number(n => n.Name("age").Type(NumberType.Integer))
+            .Date(d => d
+                .Name("created")
+                .Format("strict_date_optional_time||epoch_millis")
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/MappingPage/b311b42b7dcc69821df1f77bfaf2d50d.asciidoc
+++ b/examples/Root/MappingPage/b311b42b7dcc69821df1f77bfaf2d50d.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line141 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/MappingPage.cs#L8-L41.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var createIndexResponse = client.Indices.Create("my_index", c => c

--- a/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
+++ b/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line74 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/SearchPage.cs#L83-L100.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var putSettingsResponse = client.Cluster.PutSettings(c => c

--- a/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
+++ b/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/SearchPage.cs[tag=014b788c879e4aaa1020672e45e25473,indent=0]
+var putSettingsResponse = client.Cluster.PutSettings(c => c
+    .Transient(t => t
+        .Add("cluster.routing.use_adaptive_replica_selection", false)
+    )
+);
 ----

--- a/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
+++ b/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
@@ -1,4 +1,8 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/SearchPage.cs[tag=189a921df2f5b1fe580937210ce9c1c2,indent=0]
+var searchResponse = client.Search<object>(s => s
+    .Index("")
+    .Query(q => q.MatchAll())
+    .Stats("group1", "group2")
+);
 ----

--- a/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
+++ b/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line99 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/SearchPage.cs#L102-L129.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<object>(s => s

--- a/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
+++ b/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
@@ -1,4 +1,19 @@
 [source, csharp]
 ----
-include::../../../src/Examples/Examples/Root/SearchPage.cs[tag=8acc1d67b152e7027e0f0e1a8b4b2431,indent=0]
+var searchResponse = client.Search<Tweet>(s => s
+    .Index("twitter")
+    .Routing("kimchy")
+    .Query(q => q
+        .Bool(b => b
+            .Must(mu => mu
+                .QueryString(qs => qs
+                    .Query("some query string here")
+                )
+            )
+            .Filter(f => f
+                .Term(t => t.User, "kimchy")
+            )
+        )
+    )
+);
 ----

--- a/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
+++ b/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line33 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Root/SearchPage.cs#L32-L81.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var searchResponse = client.Search<Tweet>(s => s

--- a/examples/Setup/Install/CheckRunningPage/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
+++ b/examples/Setup/Install/CheckRunningPage/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
@@ -1,3 +1,10 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line7 in https://github.com/elastic/elasticsearch-net/tree/docs/example-callouts/src/Examples/Examples/Setup/Install/CheckRunningPage.cs#L8-L16.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
 [source, csharp]
 ----
 var nodeInfoResponse = client.RootNodeInfo();

--- a/examples/Setup/Install/CheckRunningPage/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
+++ b/examples/Setup/Install/CheckRunningPage/3d1ff6097e2359f927c88c2ccdb36252.asciidoc
@@ -1,4 +1,4 @@
 [source, csharp]
 ----
-include::../../../../src/Examples/Examples/Setup/Install/CheckRunningPage.cs[tag=3d1ff6097e2359f927c88c2ccdb36252,indent=0]
+var nodeInfoResponse = client.RootNodeInfo();
 ----

--- a/src/Examples/ExamplesGenerator/AsciiDocGenerator.cs
+++ b/src/Examples/ExamplesGenerator/AsciiDocGenerator.cs
@@ -1,13 +1,31 @@
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Formatting;
+using Microsoft.CodeAnalysis.Formatting;
 using static ExamplesGenerator.ExampleLocation;
+using static Microsoft.CodeAnalysis.Formatting.FormattingOptions;
+using static Microsoft.CodeAnalysis.LanguageNames;
 
 namespace ExamplesGenerator
 {
 	internal static class AsciiDocGenerator
 	{
+		private static readonly AdhocWorkspace Workspace;
+
+		static AsciiDocGenerator()
+		{
+			Workspace = new AdhocWorkspace();
+			Workspace.Options = Workspace.Options
+				.WithChangedOption(NewLine, CSharp, "\n")
+				.WithChangedOption(IndentationSize, CSharp, 4)
+				.WithChangedOption(SmartIndent, CSharp, IndentStyle.Smart)
+				.WithChangedOption(UseTabs, CSharp, false)
+				.WithChangedOption(CSharpFormattingOptions.IndentBlock, false)
+				.WithChangedOption(TabSize, CSharp, 4);
+		}
+
 		public static void GenerateExampleAsciiDoc(IEnumerable<ImplementedExample> examples)
 		{
 			foreach (var file in ExamplesAsciiDocDir.EnumerateFiles())
@@ -17,25 +35,30 @@ namespace ExamplesGenerator
 
 			foreach (var example in examples)
 			{
-				var cSharpFile = new FileInfo(example.Path);
 				var relativeExampleDirectory = example.Path
-					.Replace(ExamplesCSharpProject.FullName, string.Empty)
 					.Replace(".cs", string.Empty)
+					.Replace(ExamplesCSharpProject.FullName, string.Empty)
 					.TrimStart(Path.DirectorySeparatorChar);
 
 				var exampleFile = new FileInfo(Path.Combine(ExamplesAsciiDocDir.FullName, relativeExampleDirectory, example.Hash + ".asciidoc"));
 
-				var cSharpFileUri = new Uri(cSharpFile.FullName);
-				var includeRelativePath = new Uri(exampleFile.FullName).MakeRelativeUri(cSharpFileUri);
-
 				if (!exampleFile.Directory.Exists)
 					exampleFile.Directory.Create();
+
+				var source = Formatter.Format(example.Body, Workspace)
+					.ToFullString()
+					.RemoveOpeningBraceAndNewLines()
+					.RemoveClosingBraceAndNewLines()
+					.ExtractCallouts(out var callouts);
 
 				var builder = new StringBuilder()
 					.AppendLine("[source, csharp]")
 					.AppendLine("----")
-					.AppendLine($"include::{includeRelativePath}[tag={example.Hash},indent=0]")
+					.AppendLine(source)
 					.AppendLine("----");
+
+				foreach (var callout in callouts)
+					builder.AppendLine(callout);
 
 				File.WriteAllText(Path.Combine(exampleFile.FullName), builder.ToString());
 			}

--- a/src/Examples/ExamplesGenerator/CSharpParser.cs
+++ b/src/Examples/ExamplesGenerator/CSharpParser.cs
@@ -2,11 +2,13 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
+using System.Runtime.CompilerServices;
+using System.Runtime.Serialization;
 using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
+using static Microsoft.CodeAnalysis.CSharp.SyntaxFactory;
 
 namespace ExamplesGenerator
 {
@@ -15,6 +17,14 @@ namespace ExamplesGenerator
 	/// </summary>
 	internal static class CSharpParser
 	{
+		private static readonly Regex StartTag = new Regex(@"// tag::(?<hash>.*?)\[\]");
+		private static readonly Regex EndTag = new Regex(@"// end::(?<hash>.*?)\[\]");
+
+		private static Func<SyntaxTrivia, bool> SingleLineTriviaMatches(Regex regex)
+		{
+			return t => t.IsKind(SyntaxKind.SingleLineCommentTrivia) && regex.IsMatch(t.ToFullString());
+		}
+
 		public static IEnumerable<ImplementedExample> ParseImplementedExamples()
 		{
 			foreach (var path in Directory.EnumerateFiles(ExampleLocation.ExamplesCSharpProject.FullName, "*Page.cs", SearchOption.AllDirectories))
@@ -37,17 +47,37 @@ namespace ExamplesGenerator
 					if (uAttribute.ArgumentList == null)
 					{
 						// opening tag comment is leading trivia on the first statement
-						var openTagComment = methodDeclaration.Body.Statements.First().GetLeadingTrivia()
-							.Single(t => t.IsKind(SyntaxKind.SingleLineCommentTrivia) && Tag.IsMatch(t.ToFullString()));
+						var openTagComment = methodDeclaration.Body.Statements.First()
+							.GetLeadingTrivia().Single(SingleLineTriviaMatches(StartTag));
 
-						var hash = Tag.Match(openTagComment.ToFullString()).Groups["hash"].Value;
+						var hash = StartTag.Match(openTagComment.ToFullString()).Groups["hash"].Value;
 
-						yield return new ImplementedExample(path, hash);
+						var statements = new List<StatementSyntax>();
+
+						for (int i = 0; i < methodDeclaration.Body.Statements.Count; i++)
+						{
+							var statement = methodDeclaration.Body.Statements[i];
+
+							// end tag can be reported as leading trivia on the first match example assertion, which denotes the end of
+							// statements we're interested in
+							if (statement.GetLeadingTrivia().Any(SingleLineTriviaMatches(EndTag)))
+								break;
+
+							statements.Add(i == 0 ? statement.ReplaceTrivia(openTagComment, default(SyntaxTrivia)) : statement);
+
+							if (statement.GetTrailingTrivia().Any(SingleLineTriviaMatches(EndTag)))
+							{
+								statements.Add(statement.WithoutTrailingTrivia());
+								break;
+							}
+						}
+
+						var body = Block(statements);
+
+						yield return new ImplementedExample(path, hash, body);
 					}
 				}
 			}
 		}
-
-		private static Regex Tag = new Regex(@"// tag::(?<hash>.*?)\[\]");
 	}
 }

--- a/src/Examples/ExamplesGenerator/CSharpParser.cs
+++ b/src/Examples/ExamplesGenerator/CSharpParser.cs
@@ -72,9 +72,14 @@ namespace ExamplesGenerator
 							}
 						}
 
+						// create a new block with collected statements. We need a SyntaxNode to work with
 						var body = Block(statements);
 
-						yield return new ImplementedExample(path, hash, body);
+						var method = methodDeclaration.Identifier.Text;
+						var startLineNumber = methodDeclaration.SyntaxTree.GetLineSpan(methodDeclaration.Span).StartLinePosition.Line + 1;
+						var endLineNumber = methodDeclaration.SyntaxTree.GetLineSpan(methodDeclaration.Span).EndLinePosition.Line + 1;
+
+						yield return new ImplementedExample(method, startLineNumber, endLineNumber, path, hash, body);
 					}
 				}
 			}

--- a/src/Examples/ExamplesGenerator/ImplementedExample.cs
+++ b/src/Examples/ExamplesGenerator/ImplementedExample.cs
@@ -8,12 +8,20 @@ namespace ExamplesGenerator
 	/// </summary>
 	internal class ImplementedExample
 	{
-		public ImplementedExample(string path, string hash, BlockSyntax body)
+		public ImplementedExample(string method, int startLineNumber, int endLineNumber, string path, string hash, BlockSyntax body)
 		{
+			Method = method;
+			StartLineNumber = startLineNumber;
+			EndLineNumber = endLineNumber;
 			Path = path;
 			Hash = hash;
 			Body = body;
 		}
+
+		/// <summary>
+		/// The end line number in the C# file
+		/// </summary>
+		public int EndLineNumber { get; set; }
 
 		/// <summary>
 		/// The collection of statements that make up this example
@@ -29,5 +37,15 @@ namespace ExamplesGenerator
 		/// The path to the source C# file
 		/// </summary>
 		public string Path { get; }
+
+		/// <summary>
+		/// The method name in the C# file
+		/// </summary>
+		public string Method { get; }
+
+		/// <summary>
+		/// The start line number in the C# file
+		/// </summary>
+		public int StartLineNumber { get; }
 	}
 }

--- a/src/Examples/ExamplesGenerator/ImplementedExample.cs
+++ b/src/Examples/ExamplesGenerator/ImplementedExample.cs
@@ -1,3 +1,6 @@
+using System.Collections.Generic;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
 namespace ExamplesGenerator
 {
 	/// <summary>
@@ -5,11 +8,17 @@ namespace ExamplesGenerator
 	/// </summary>
 	internal class ImplementedExample
 	{
-		public ImplementedExample(string path, string hash)
+		public ImplementedExample(string path, string hash, BlockSyntax body)
 		{
 			Path = path;
 			Hash = hash;
+			Body = body;
 		}
+
+		/// <summary>
+		/// The collection of statements that make up this example
+		/// </summary>
+		public BlockSyntax Body { get; }
 
 		/// <summary>
 		/// The example hash

--- a/src/Examples/ExamplesGenerator/StringExtensions.cs
+++ b/src/Examples/ExamplesGenerator/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace ExamplesGenerator {
@@ -9,6 +11,10 @@ namespace ExamplesGenerator {
 
 		private static readonly Regex LowercasePascal = new Regex(@"\b([a-z])");
 
+		private static readonly Regex Callout = new Regex(@"//[ \t]*(?<callout>\<\d+\>)[ \t]*(?<text>\S.*)");
+
+		private static readonly Regex CalloutReplacer = new Regex(@"//[ \t]*\<(\d+)\>.*");
+
 		public static string EscapeDoubleQuotes(this string input) => DoubleQuotes.Replace(input, "\"\"");
 
 		public static string Indent(this string input, string indent) => NewLine.Replace(input, "\n" + indent);
@@ -18,5 +24,28 @@ namespace ExamplesGenerator {
 					.Replace("-", " ")
 					.Replace("_", " "), m => m.Captures[0].Value.ToUpper())
 				.Replace(" ", string.Empty);
+
+		public static string RemoveOpeningBraceAndNewLines(this string input) =>
+			input.TrimStart('{').TrimStart();
+
+		public static string RemoveClosingBraceAndNewLines(this string input) =>
+			input.TrimEnd('}').TrimEnd();
+
+		public static string ExtractCallouts(this string input, out List<string> callouts)
+		{
+			var matches = Callout.Matches(input);
+			callouts = new List<string>();
+
+			if (matches.Count == 0)
+				return input;
+
+			foreach (Match match in matches)
+				callouts.Add($"{match.Groups["callout"].Value} {match.Groups["text"].Value}");
+
+			if (callouts.Any())
+				input = CalloutReplacer.Replace(input, "//<$1>");
+
+			return input;
+		}
 	}
 }


### PR DESCRIPTION
This commit replaces the AsciiDoc include in generated examples with the C# source code.
Doing so also allows any examples to include callouts, similar to doc generation e.g.

```c#
var deleteResponse = client.Delete<Tweet>(1, d => d
    .Index("twitter")
    .Routing("kimchy") // <1> Use a routing parameter
);
```

will emit

```asciidoc
[source,csharp]
----
var deleteResponse = client.Delete<Tweet>(1, d => d
    .Index("twitter")
    .Routing("kimchy") //<1>
);
----
<1>  Use a routing parameter
```