### PR TITLE
Support for search_as_you_type field type and bool_prefix query type

### DIFF
--- a/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
+++ b/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
@@ -79,7 +79,7 @@ namespace Examples.Mapping.Types
 				.Index("my_index")
 				.Query(q => q
 					.MatchPhrasePrefix(pp => pp
-						.Field(doc => doc["my_field"])
+						.Field("my_field")
 						.Query("brown f"))));
 			// end::0ced86822f8c0a479af5e1fe28dfc2ec[]
 

--- a/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
+++ b/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
@@ -5,14 +5,18 @@ namespace Examples.Mapping.Types
 {
 	public class SearchAsYouTypePage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line18()
 		{
 			// tag::6f31f9cfe0dd741ccad4af62ba8f815e[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.Properties(p => p.SearchAsYouType(t => t.Name("my_field")))
+				)
+			);
 			// end::6f31f9cfe0dd741ccad4af62ba8f815e[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""properties"": {

--- a/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
+++ b/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Elastic.Xunit.XunitPlumbing;
 using Nest;
 
@@ -41,14 +42,20 @@ namespace Examples.Mapping.Types
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line89()
 		{
 			// tag::9bd25962f177e86dbc5a8030a420cc31[]
-			var response0 = new SearchResponse<object>();
+			var query = client.Search<object>(s => s
+				.Index("my_index")
+				.Query(q => q
+					.MultiMatch(mm => mm
+						.Query("brown f")
+						.Type(TextQueryType.BoolPrefix)
+						.Fields(f => f.Field("my_field").Field("my_field._2gram").Field("my_field._3gram")))));
 			// end::9bd25962f177e86dbc5a8030a420cc31[]
 
-			response0.MatchesExample(@"GET my_index/_search
+			query.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""multi_match"": {
@@ -64,14 +71,19 @@ namespace Examples.Mapping.Types
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U(Skip = "Is doc correct here?")]
 		public void Line151()
 		{
 			// tag::0ced86822f8c0a479af5e1fe28dfc2ec[]
-			var response0 = new SearchResponse<object>();
+			var query = client.Search<Dictionary<string, string>>(s => s
+				.Index("my_index")
+				.Query(q => q
+					.MatchPhrasePrefix(pp => pp
+						.Field(doc => doc["my_field"])
+						.Query("brown f"))));
 			// end::0ced86822f8c0a479af5e1fe28dfc2ec[]
 
-			response0.MatchesExample(@"GET my_index/_search
+			query.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""match_phrase_prefix"": {

--- a/src/Examples/Examples/Mapping/Types/TextPage.cs
+++ b/src/Examples/Examples/Mapping/Types/TextPage.cs
@@ -5,14 +5,18 @@ namespace Examples.Mapping.Types
 {
 	public class TextPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line22()
 		{
 			// tag::24ea1c6cdf10165228951e562b7ec0ef[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.Properties(p => p.Text(t => t.Name("full_name")))
+				)
+			);
 			// end::24ea1c6cdf10165228951e562b7ec0ef[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""properties"": {

--- a/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Nest
+{
+	public class SearchAsYouTypeAttribute : TextAttribute, ISearchAsYouTypeProperty
+	{
+		public SearchAsYouTypeAttribute() : base(FieldType.SearchAsYouType) { }
+
+		public int MaxShingleSize
+		{
+			get => Self.MaxShingleSize.GetValueOrDefault(3);
+			set => Self.MaxShingleSize = value;
+		}
+
+		int? ISearchAsYouTypeProperty.MaxShingleSize { get; set; }
+
+		private ISearchAsYouTypeProperty Self => this;
+	}
+}

--- a/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttribute.cs
@@ -8,7 +8,7 @@ namespace Nest
 
 		public int MaxShingleSize
 		{
-			get => Self.MaxShingleSize.GetValueOrDefault(3);
+			get => Self.MaxShingleSize.GetValueOrDefault();
 			set => Self.MaxShingleSize = value;
 		}
 

--- a/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
+++ b/src/Nest/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeProperty.cs
@@ -1,0 +1,39 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	[InterfaceDataContract]
+	public interface ISearchAsYouTypeProperty : ITextProperty
+	{
+		/// <summary>
+		/// The largest shingle size to index the input with and create subfields for.
+		/// </summary>
+		[DataMember(Name = "max_shingle_size")]
+		int? MaxShingleSize { get; set; }
+	}
+
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class SearchAsYouTypeProperty : TextProperty, ISearchAsYouTypeProperty
+	{
+		public SearchAsYouTypeProperty() : base(FieldType.SearchAsYouType) { }
+
+		/// <inheritdoc />
+		public int? MaxShingleSize { get; set; }
+	}
+
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class SearchAsYouTypePropertyDescriptor<T>
+		: TextPropertyDescriptorBase<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty, T>, ISearchAsYouTypeProperty
+		where T : class
+	{
+		public SearchAsYouTypePropertyDescriptor() : base(FieldType.SearchAsYouType) { }
+
+		int? ISearchAsYouTypeProperty.MaxShingleSize { get; set; }
+
+		/// <inheritdoc cref="ISearchAsYouTypeProperty.MaxShingleSize"/>
+		public SearchAsYouTypePropertyDescriptor<T> MaxShingleSize(int? maxShingleSize) => Assign(maxShingleSize, (a, v) => a.MaxShingleSize = v);
+	}
+}

--- a/src/Nest/Mapping/Types/Core/Text/TextAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/Text/TextAttribute.cs
@@ -1,8 +1,8 @@
 ﻿namespace Nest
 {
-	public class TextAttribute : ElasticsearchCorePropertyAttributeBase, ITextProperty
-	{
+	public class TextAttribute : ElasticsearchCorePropertyAttributeBase, ITextProperty {
 		public TextAttribute() : base(FieldType.Text) { }
+		protected TextAttribute(FieldType fieldType) : base(fieldType) { }
 
 		public string Analyzer
 		{

--- a/src/Nest/Mapping/Types/Core/Text/TextProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Text/TextProperty.cs
@@ -3,58 +3,57 @@ using System.Diagnostics;
 using System.Runtime.Serialization;
 using Elasticsearch.Net.Utf8Json;
 
-namespace Nest
-{
+namespace Nest {
 	[InterfaceDataContract]
-	public interface ITextProperty : ICoreProperty
-	{
-		[DataMember(Name ="analyzer")]
+	public interface ITextProperty : ICoreProperty {
+		[DataMember(Name = "analyzer")]
 		string Analyzer { get; set; }
 
-		[DataMember(Name ="boost")]
+		[DataMember(Name = "boost")]
 		double? Boost { get; set; }
 
-		[DataMember(Name ="eager_global_ordinals")]
+		[DataMember(Name = "eager_global_ordinals")]
 		bool? EagerGlobalOrdinals { get; set; }
 
-		[DataMember(Name ="fielddata")]
+		[DataMember(Name = "fielddata")]
 		bool? Fielddata { get; set; }
 
-		[DataMember(Name ="fielddata_frequency_filter")]
+		[DataMember(Name = "fielddata_frequency_filter")]
 		IFielddataFrequencyFilter FielddataFrequencyFilter { get; set; }
 
-		[DataMember(Name ="index")]
+		[DataMember(Name = "index")]
 		bool? Index { get; set; }
 
-		[DataMember(Name ="index_options")]
+		[DataMember(Name = "index_options")]
 		IndexOptions? IndexOptions { get; set; }
 
-		[DataMember(Name ="index_phrases")]
+		[DataMember(Name = "index_phrases")]
 		bool? IndexPhrases { get; set; }
 
-		[DataMember(Name ="index_prefixes")]
+		[DataMember(Name = "index_prefixes")]
 		ITextIndexPrefixes IndexPrefixes { get; set; }
 
-		[DataMember(Name ="norms")]
+		[DataMember(Name = "norms")]
 		bool? Norms { get; set; }
 
-		[DataMember(Name ="position_increment_gap")]
+		[DataMember(Name = "position_increment_gap")]
 		int? PositionIncrementGap { get; set; }
 
-		[DataMember(Name ="search_analyzer")]
+		[DataMember(Name = "search_analyzer")]
 		string SearchAnalyzer { get; set; }
 
-		[DataMember(Name ="search_quote_analyzer")]
+		[DataMember(Name = "search_quote_analyzer")]
 		string SearchQuoteAnalyzer { get; set; }
 
-		[DataMember(Name ="term_vector")]
+		[DataMember(Name = "term_vector")]
 		TermVectorOption? TermVector { get; set; }
 	}
 
 	[DebuggerDisplay("{DebugDisplay}")]
-	public class TextProperty : CorePropertyBase, ITextProperty
-	{
+	public class TextProperty : CorePropertyBase, ITextProperty {
 		public TextProperty() : base(FieldType.Text) { }
+
+		protected TextProperty(FieldType fieldType) : base(fieldType) { }
 
 		public string Analyzer { get; set; }
 
@@ -73,12 +72,14 @@ namespace Nest
 		public TermVectorOption? TermVector { get; set; }
 	}
 
-	[DebuggerDisplay("{DebugDisplay}")]
-	public class TextPropertyDescriptor<T>
-		: CorePropertyDescriptorBase<TextPropertyDescriptor<T>, ITextProperty, T>, ITextProperty
+	public abstract class TextPropertyDescriptorBase<TDescriptor, TInterface, T>
+		: CorePropertyDescriptorBase<TDescriptor, TInterface, T>, ITextProperty
+		where TDescriptor : TextPropertyDescriptorBase<TDescriptor, TInterface, T>, TInterface
+		where TInterface : class, ITextProperty
 		where T : class
-	{
-		public TextPropertyDescriptor() : base(FieldType.Text) { }
+	{ 
+
+		protected TextPropertyDescriptorBase(FieldType fieldType) : base(fieldType) { }
 
 		string ITextProperty.Analyzer { get; set; }
 		double? ITextProperty.Boost { get; set; }
@@ -95,36 +96,44 @@ namespace Nest
 		string ITextProperty.SearchQuoteAnalyzer { get; set; }
 		TermVectorOption? ITextProperty.TermVector { get; set; }
 
-		public TextPropertyDescriptor<T> Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
+		public TDescriptor Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
-		public TextPropertyDescriptor<T> EagerGlobalOrdinals(bool? eagerGlobalOrdinals = true) =>
+		public TDescriptor EagerGlobalOrdinals(bool? eagerGlobalOrdinals = true) =>
 			Assign(eagerGlobalOrdinals, (a, v) => a.EagerGlobalOrdinals = v);
 
-		public TextPropertyDescriptor<T> Fielddata(bool? fielddata = true) => Assign(fielddata, (a, v) => a.Fielddata = v);
+		public TDescriptor Fielddata(bool? fielddata = true) => Assign(fielddata, (a, v) => a.Fielddata = v);
 
-		public TextPropertyDescriptor<T> FielddataFrequencyFilter(Func<FielddataFrequencyFilterDescriptor, IFielddataFrequencyFilter> selector) =>
+		public TDescriptor FielddataFrequencyFilter(Func<FielddataFrequencyFilterDescriptor, IFielddataFrequencyFilter> selector) =>
 			Assign(selector, (a, v) => a.FielddataFrequencyFilter = v?.Invoke(new FielddataFrequencyFilterDescriptor()));
 
-		public TextPropertyDescriptor<T> IndexPrefixes(Func<TextIndexPrefixesDescriptor, ITextIndexPrefixes> selector) =>
+		public TDescriptor IndexPrefixes(Func<TextIndexPrefixesDescriptor, ITextIndexPrefixes> selector) =>
 			Assign(selector, (a, v) => a.IndexPrefixes = v?.Invoke(new TextIndexPrefixesDescriptor()));
 
-		public TextPropertyDescriptor<T> Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
+		public TDescriptor Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
 
-		public TextPropertyDescriptor<T> IndexPhrases(bool? indexPhrases = true) => Assign(indexPhrases, (a, v) => a.IndexPhrases = v);
+		public TDescriptor IndexPhrases(bool? indexPhrases = true) => Assign(indexPhrases, (a, v) => a.IndexPhrases = v);
 
-		public TextPropertyDescriptor<T> IndexOptions(IndexOptions? indexOptions) => Assign(indexOptions, (a, v) => a.IndexOptions = v);
+		public TDescriptor IndexOptions(IndexOptions? indexOptions) => Assign(indexOptions, (a, v) => a.IndexOptions = v);
 
-		public TextPropertyDescriptor<T> Norms(bool? enabled = true) => Assign(enabled, (a, v) => a.Norms = v);
+		public TDescriptor Norms(bool? enabled = true) => Assign(enabled, (a, v) => a.Norms = v);
 
-		public TextPropertyDescriptor<T> PositionIncrementGap(int? positionIncrementGap) =>
+		public TDescriptor PositionIncrementGap(int? positionIncrementGap) =>
 			Assign(positionIncrementGap, (a, v) => a.PositionIncrementGap = v);
 
-		public TextPropertyDescriptor<T> Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
+		public TDescriptor Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
 
-		public TextPropertyDescriptor<T> SearchAnalyzer(string searchAnalyzer) => Assign(searchAnalyzer, (a, v) => a.SearchAnalyzer = v);
+		public TDescriptor SearchAnalyzer(string searchAnalyzer) => Assign(searchAnalyzer, (a, v) => a.SearchAnalyzer = v);
 
-		public TextPropertyDescriptor<T> SearchQuoteAnalyzer(string searchQuoteAnalyzer) => Assign(searchQuoteAnalyzer, (a, v) => a.SearchQuoteAnalyzer = v);
+		public TDescriptor SearchQuoteAnalyzer(string searchQuoteAnalyzer) => Assign(searchQuoteAnalyzer, (a, v) => a.SearchQuoteAnalyzer = v);
 
-		public TextPropertyDescriptor<T> TermVector(TermVectorOption? termVector) => Assign(termVector, (a, v) => a.TermVector = v);
+		public TDescriptor TermVector(TermVectorOption? termVector) => Assign(termVector, (a, v) => a.TermVector = v);
+	}
+
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class TextPropertyDescriptor<T>
+		: TextPropertyDescriptorBase<TextPropertyDescriptor<T>, ITextProperty, T>, ITextProperty
+		where T : class
+	{
+		public TextPropertyDescriptor() : base(FieldType.Text) { }
 	}
 }

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -40,6 +40,12 @@ namespace Nest
 		[EnumMember(Value = "text")]
 		Text,
 
+		/// <summary>
+		/// A text-like field that is optimized to provide out-of-the-box support for queries that serve an as-you-type completion use case.
+		/// </summary>
+		[EnumMember(Value = "search_as_you_type")]
+		SearchAsYouType,
+
 		[EnumMember(Value = "date")]
 		Date,
 

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -154,6 +154,8 @@ namespace Nest
 
 		public PropertiesDescriptor<T> Text(Func<TextPropertyDescriptor<T>, ITextProperty> selector) => SetProperty(selector);
 
+		public PropertiesDescriptor<T> SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector) => SetProperty(selector);
+
 		public PropertiesDescriptor<T> TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector) => SetProperty(selector);
 
 		public PropertiesDescriptor<T> FieldAlias(Func<FieldAliasPropertyDescriptor<T>, IFieldAliasProperty> selector) => SetProperty(selector);

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -56,6 +56,7 @@ namespace Nest
 			{
 				case FieldType.Text: return Deserialize<TextProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Keyword: return Deserialize<KeywordProperty>(ref segmentReader, formatterResolver);
+				case FieldType.SearchAsYouType: return Deserialize<SearchAsYouTypeProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Float:
 				case FieldType.Double:
 				case FieldType.Byte:
@@ -113,6 +114,9 @@ namespace Nest
 					break;
 				case "keyword":
 					Serialize<IKeywordProperty>(ref writer, value, formatterResolver);
+					break;
+				case "search_as_you_type":
+					Serialize<ISearchAsYouTypeProperty>(ref writer, value, formatterResolver);
 					break;
 				case "float":
 				case "double":

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -66,6 +66,13 @@ namespace Nest
 							Accept(t.Fields);
 						});
 						break;
+					case FieldType.SearchAsYouType:
+						Visit<ISearchAsYouTypeProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+							Accept(t.Fields);
+						});
+						break;
 					case FieldType.HalfFloat:
 					case FieldType.ScaledFloat:
 					case FieldType.Float:

--- a/src/Nest/QueryDsl/FullText/MultiMatch/TextQueryType.cs
+++ b/src/Nest/QueryDsl/FullText/MultiMatch/TextQueryType.cs
@@ -20,6 +20,9 @@ namespace Nest
 		Phrase,
 
 		[EnumMember(Value = "phrase_prefix")]
-		PhrasePrefix
+		PhrasePrefix,
+
+		[EnumMember(Value = "bool_prefix")]
+		BoolPrefix
 	}
 }

--- a/src/Nest/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
+++ b/src/Nest/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
@@ -57,6 +57,7 @@ namespace Nest
 		public FieldCapabilities Percolator => BackingDictionary.TryGetValue("percolator", out var f) ? f : null;
 		public FieldCapabilities Routing => BackingDictionary.TryGetValue("_routing", out var f) ? f : null;
 		public FieldCapabilities ScaledFloat => BackingDictionary.TryGetValue("scaled_float", out var f) ? f : null;
+		public FieldCapabilities SearchAsYouType => BackingDictionary.TryGetValue("search_as_you_type", out var f) ? f : null;
 		public FieldCapabilities Short => BackingDictionary.TryGetValue("short", out var f) ? f : null;
 		public FieldCapabilities Source => BackingDictionary.TryGetValue("_source", out var f) ? f : null;
 		public FieldCapabilities Text => BackingDictionary.TryGetValue("text", out var f) ? f : null;

--- a/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttributeTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeAttributeTests.cs
@@ -1,0 +1,67 @@
+﻿using Nest;
+
+namespace Tests.Mapping.Types.Core.SearchAsYouType
+{
+	public class SearchAsYouTypeTest
+	{
+		[SearchAsYouType(
+			MaxShingleSize = 4,
+			Analyzer = "myanalyzer",
+			Boost = 1.2,
+			EagerGlobalOrdinals = true,
+			Fielddata = true,
+			Index = true,
+			IndexOptions = IndexOptions.Offsets,
+			PositionIncrementGap = 5,
+			SearchAnalyzer = "mysearchanalyzer",
+			SearchQuoteAnalyzer = "mysearchquoteanalyzer",
+			Similarity = "classic",
+			Store = true,
+			Norms = false,
+			TermVector = TermVectorOption.WithPositionsOffsets)]
+		public string Full { get; set; }
+
+		[SearchAsYouType(MaxShingleSize = 1)]
+		public string MaxShingleSize { get; set; }
+
+		[SearchAsYouType]
+		public string Minimal { get; set; }
+	}
+
+	public class SearchAsYouTypeAttributeTests : AttributeTestsBase<SearchAsYouTypeTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				full = new
+				{
+					type = "search_as_you_type",
+					max_shingle_size = 4,
+					analyzer = "myanalyzer",
+					boost = 1.2,
+					eager_global_ordinals = true,
+					fielddata = true,
+					index = true,
+					index_options = "offsets",
+					position_increment_gap = 5,
+					search_analyzer = "mysearchanalyzer",
+					search_quote_analyzer = "mysearchquoteanalyzer",
+					similarity = "classic",
+					store = true,
+					norms = false,
+					term_vector = "with_positions_offsets"
+				},
+				maxShingleSize = new
+				{
+					type = "search_as_you_type",
+					max_shingle_size = 1
+				},
+				minimal = new
+				{
+					type = "search_as_you_type"
+				}
+			}
+		};
+	}
+}

--- a/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypePropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypePropertyTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Core.SearchAsYouType
+{
+	public class SearchAsYouTypePropertyTests : PropertyTestsBase
+	{
+		public SearchAsYouTypePropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				name = new
+				{
+					max_shingle_size = 4,
+					type = "search_as_you_type",
+					analyzer = "standard",
+					boost = 1.2,
+					copy_to = new[] { "other_field" },
+					eager_global_ordinals = true,
+					fielddata = true,
+					fielddata_frequency_filter = new
+					{
+						min = 1.0,
+						max = 100.00,
+						min_segment_size = 2
+					},
+					fields = new
+					{
+						raw = new
+						{
+							type = "keyword",
+							ignore_above = 100
+						}
+					},
+					index = true,
+					index_options = "offsets",
+					position_increment_gap = 5,
+					search_analyzer = "standard",
+					search_quote_analyzer = "standard",
+					similarity = "BM25",
+					store = true,
+					norms = false,
+					term_vector = "with_positions_offsets"
+				}
+			}
+		};
+
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.SearchAsYouType(s => s
+				.MaxShingleSize(4)
+				.Name(p => p.Name)
+				.Analyzer("standard")
+				.Boost(1.2)
+				.CopyTo(c => c
+					.Field("other_field")
+				)
+				.EagerGlobalOrdinals()
+				.Fielddata()
+				.FielddataFrequencyFilter(ff => ff
+					.Min(1)
+					.Max(100)
+					.MinSegmentSize(2)
+				)
+				.Fields(fd => fd
+					.Keyword(k => k
+						.Name("raw")
+						.IgnoreAbove(100)
+					)
+				)
+				.Index()
+				.IndexOptions(IndexOptions.Offsets)
+				.PositionIncrementGap(5)
+				.SearchAnalyzer("standard")
+				.SearchQuoteAnalyzer("standard")
+				.Similarity("BM25")
+				.Store()
+				.Norms(false)
+				.TermVector(TermVectorOption.WithPositionsOffsets)
+			);
+
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"name", new SearchAsYouTypeProperty
+				{
+					MaxShingleSize = 4,
+					Analyzer = "standard",
+					Boost = 1.2,
+					CopyTo = "other_field",
+					EagerGlobalOrdinals = true,
+					Fielddata = true,
+					FielddataFrequencyFilter = new FielddataFrequencyFilter
+					{
+						Min = 1,
+						Max = 100,
+						MinSegmentSize = 2
+					},
+					Fields = new Properties
+					{
+						{
+							"raw", new KeywordProperty
+							{
+								IgnoreAbove = 100
+							}
+						}
+					},
+					Index = true,
+					IndexOptions = IndexOptions.Offsets,
+					PositionIncrementGap = 5,
+					SearchAnalyzer = "standard",
+					SearchQuoteAnalyzer = "standard",
+					Similarity = "BM25",
+					Store = true,
+					Norms = false,
+					TermVector = TermVectorOption.WithPositionsOffsets
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
The search_as_you_type field type was introduced in ElasticSearch 7.2. We missed this functionality in NEST so we went ahead and implemented it.

Also added the bool_prefix query type that we needed to implement our search completions.

Reported in issue #4033