### PR TITLE
Ensure filters created are deleted

### DIFF
--- a/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetFilters/GetFiltersApiTests.cs
@@ -20,6 +20,12 @@ namespace Tests.XPack.MachineLearning.GetFilters
 				PutFilter(client, callUniqueValue.Value);
 		}
 
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				DeleteFilter(client, callUniqueValue.Value);
+		}
+
 		protected override bool ExpectIsValid => true;
 
 		protected override object ExpectJson => null;
@@ -69,6 +75,13 @@ namespace Tests.XPack.MachineLearning.GetFilters
 			foreach (var callUniqueValue in values)
 				for (var i = 0; i < 3; i++)
 					PutFilter(client, callUniqueValue.Value + "_" + (i + 1));
+		}
+
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				for (var i = 0; i < 3; i++)
+					DeleteFilter(client, callUniqueValue.Value + "_" + (i + 1));
 		}
 
 		protected override bool ExpectIsValid => true;

--- a/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/MachineLearningIntegrationTestBase.cs
@@ -50,6 +50,16 @@ namespace Tests.XPack.MachineLearning
 			return putFilterResponse;
 		}
 
+		protected DeleteFilterResponse DeleteFilter(IElasticClient client, string filterId)
+		{
+			var deleteFilterResponse = client.MachineLearning.DeleteFilter(filterId);
+
+			if (!deleteFilterResponse.IsValid)
+				throw new Exception($"Problem deleting filter {filterId} for integration test: {deleteFilterResponse.DebugInformation}");
+
+			return deleteFilterResponse;
+		}
+
 		protected PutCalendarResponse PutCalendar(IElasticClient client, string calendarId)
 		{
 			var putCalendarResponse = client.MachineLearning.PutCalendar(calendarId, f => f

--- a/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/PutFilter/PutFilterApiTests.cs
@@ -13,6 +13,12 @@ namespace Tests.XPack.MachineLearning.PutFilter
 	{
 		public PutFilterApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				DeleteFilter(client, callUniqueValue.Value);
+		}
+
 		protected override bool ExpectIsValid => true;
 
 		protected override object ExpectJson => new

--- a/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/UpdateFilter/UpdateFilterApiTests.cs
@@ -20,6 +20,12 @@ namespace Tests.XPack.MachineLearning.UpdateFilter
 				PutFilter(client, callUniqueValue.Value);
 		}
 
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+				DeleteFilter(client, callUniqueValue.Value);
+		}
+
 		protected override bool ExpectIsValid => true;
 
 		protected override object ExpectJson => new


### PR DESCRIPTION
This commit updates ML filter integration tests to ensure that filters created as part of a test are deleted.