### PR TITLE
Add ml to NodeRole enum

### DIFF
--- a/src/Nest/Cluster/NodesInfo/NodeRole.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeRole.cs
@@ -16,6 +16,9 @@ namespace Nest
 		Client,
 
 		[EnumMember(Value = "ingest")]
-		Ingest
+		Ingest,
+
+		[EnumMember(Value = "ml")]
+		MachineLearning
 	}
 }


### PR DESCRIPTION
This commit adds a MachineLearning role to the NodeRole enum. "ml" is now returned as
a node role value in node APIs in 8.0

Fixes #4040