### PR TITLE
Add minimum_interval to AutoDateHistogram aggregation

### DIFF
--- a/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregation.cs
@@ -33,6 +33,13 @@ namespace Nest
 
 		[DataMember(Name = "time_zone")]
 		string TimeZone { get; set; }
+
+		/// <summary>
+		/// Specify the minimum rounding interval that should be used. This can make the collection process
+		/// more efficient, as the aggregation will not attempt to round at any interval lower than this.
+		/// </summary>
+		[DataMember(Name = "minimum_interval")]
+		MinimumInterval? MinimumInterval { get; set; }
 	}
 
 	public class AutoDateHistogramAggregation : BucketAggregationBase, IAutoDateHistogramAggregation
@@ -63,6 +70,8 @@ namespace Nest
 		public IDictionary<string, object> Params { get; set; }
 		public IScript Script { get; set; }
 		public string TimeZone { get; set; }
+
+		public MinimumInterval? MinimumInterval { get; set; }
 
 		internal override void WrapInContainer(AggregationContainer c) => c.AutoDateHistogram = this;
 	}
@@ -99,6 +108,8 @@ namespace Nest
 
 		string IAutoDateHistogramAggregation.TimeZone { get; set; }
 
+		MinimumInterval? IAutoDateHistogramAggregation.MinimumInterval { get; set; }
+
 		public AutoDateHistogramAggregationDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
 
 		public AutoDateHistogramAggregationDescriptor<T> Field<TValue>(Expression<Func<T, TValue>> field) => Assign(field, (a, v) => a.Field = v);
@@ -117,5 +128,8 @@ namespace Nest
 		public AutoDateHistogramAggregationDescriptor<T> Offset(string offset) => Assign(offset, (a, v) => a.Offset = v);
 
 		public AutoDateHistogramAggregationDescriptor<T> Missing(DateTime? missing) => Assign(missing, (a, v) => a.Missing = v);
+
+		/// <inheritdoc cref="IAutoDateHistogramAggregation.MinimumInterval"/>
+		public AutoDateHistogramAggregationDescriptor<T> MinimumInterval(MinimumInterval? minimumInterval) => Assign(minimumInterval, (a, v) => a.MinimumInterval = v);
 	}
 }

--- a/src/Nest/Aggregations/Bucket/AutoDateHistogram/MinimumInterval.cs
+++ b/src/Nest/Aggregations/Bucket/AutoDateHistogram/MinimumInterval.cs
@@ -1,0 +1,27 @@
+using System.Runtime.Serialization;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	[StringEnum]
+	public enum MinimumInterval
+	{
+		[EnumMember(Value = "second")]
+		Second,
+
+		[EnumMember(Value = "minute")]
+		Minute,
+
+		[EnumMember(Value = "hour")]
+		Hour,
+
+		[EnumMember(Value = "day")]
+		Day,
+
+		[EnumMember(Value = "month")]
+		Month,
+
+		[EnumMember(Value = "year")]
+		Year
+	}
+}

--- a/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
@@ -36,7 +36,8 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 					field = "startedOn",
 					buckets = 10,
 					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", //<1> Note the inclusion of `date_optional_time` to `format`
-					missing = FixedDate
+					missing = FixedDate,
+					minimum_interval = "day"
 				},
 				aggs = new
 				{
@@ -64,6 +65,7 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 				.Buckets(10)
 				.Format("yyyy-MM-dd'T'HH:mm:ss")
 				.Missing(FixedDate)
+				.MinimumInterval(MinimumInterval.Day)
 				.Aggregations(childAggs => childAggs
 					.Nested("project_tags", n => n
 						.Path(p => p.Tags)
@@ -81,6 +83,7 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 				Buckets = 10,
 				Format = "yyyy-MM-dd'T'HH:mm:ss",
 				Missing = FixedDate,
+				MinimumInterval = MinimumInterval.Day,
 				Aggregations = new NestedAggregation("project_tags")
 				{
 					Path = Field<Project>(p => p.Tags),


### PR DESCRIPTION
Relates: #4001

This commit adds the minimum_interval property to auto date histogram aggregation. A new enum needs to be introduced for this as DateInterval contains values that are invalid for the minimum_interval.