### PR TITLE
Fix for #4057 - fallback parsing for `double` thread culture dependent.

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System;
+using System.Globalization;
 using System.Text;
 
 namespace Elasticsearch.Net.Utf8Json.Internal.DoubleConversion
@@ -636,7 +637,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal.DoubleConversion
                     input++;
                 }
                 var laststr = Encoding.UTF8.GetString(fallbackbuffer, 0, fallbackI);
-                return double.Parse(laststr);
+                return double.Parse(laststr, CultureInfo.InvariantCulture);
             }
 
             processed_characters_count = (current - input);

--- a/src/Tests/Tests.Reproduce/GithubIssue4057.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue4057.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.Serialization;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4057
+	{
+		[U]
+		[UseCulture("sv-SE")]
+		public void DoubleAffectedByPrecisionProblemDeserializesCorrectlyIndependentOfCurrentCulture()
+		{
+			var expected = 16.27749494276941D;
+
+			var tester = SerializationTester.Default;
+			var actual = tester.Deserializes<double>("16.27749494276941");
+
+			actual.Result.Should().NotBe(expected); // we are expecting precision problem;
+			Math.Round(actual.Result, 13).Should().Be(Math.Round(expected, 13));
+		}
+	}
+}


### PR DESCRIPTION
Fallback parsing for `double` numbers affected by rounding precision issues used culture dependent `double.Parse` method.

Closes #4057