### PR TITLE
Add wildcard and prefix interval rules

### DIFF
--- a/src/CodeGeneration/DocGenerator/StringExtensions.cs
+++ b/src/CodeGeneration/DocGenerator/StringExtensions.cs
@@ -38,6 +38,7 @@ namespace DocGenerator
 			{ "_ctxNumberofCommits", "\"_source.numberOfCommits > 0\"" },
 			{ "Project.First.Name", "\"Lesch Group\"" },
 			{ "Project.First.NumberOfCommits", "775" },
+			{ "IntervalsPrefix", "\"lorem\"" },
 			{ "LastNameSearch", "\"Stokes\"" },
 			{ "_first.Language", "\"painless\"" },
 			{ "_first.Init", "\"state.map = [:]\"" },

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
@@ -38,14 +38,12 @@ namespace Nest
 	public class IntervalsPrefix : IntervalsNoFilterBase, IIntervalsPrefix
 	{
 		/// <inheritdoc />
-		[DataMember(Name = "analyzer")]
 		public string Analyzer { get; set; }
 
 		/// <inheritdoc />
 		public string Prefix { get; set; }
 
 		/// <inheritdoc />
-		[DataMember(Name = "use_field")]
 		public Field UseField { get; set; }
 
 		internal override void WrapInContainer(IIntervalsContainer container) => container.Prefix = this;

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	/// <summary>
+	/// matches terms that start with a specified set of characters. This prefix can expand to match at most 128 terms.
+	/// If the prefix matches more than 128 terms, Elasticsearch returns an error.
+	/// You can use the index-prefixes option in the field mapping to avoid this limit.
+	/// <para />
+	/// Available in Elasticsearch 7.3.0+
+	/// </summary>
+	[ReadAs(typeof(IntervalsPrefix))]
+	public interface IIntervalsPrefix : IIntervalsNoFilter
+	{
+		/// <summary>
+		/// Analyzer used to normalize the prefix. Defaults to the top-level field's analyzer.
+		/// </summary>
+		[DataMember(Name = "analyzer")]
+		string Analyzer { get; set; }
+
+		/// <summary>
+		/// Beginning characters of terms you wish to find in the top-level field
+		/// </summary>
+		[DataMember(Name = "prefix")]
+		string Prefix { get; set; }
+
+		/// <summary>
+		/// If specified, then match intervals from this field rather than the top-level <field>.
+		/// The prefix is normalized using the search analyzer from this field, unless a separate analyzer is specified.
+		/// </summary>
+		[DataMember(Name = "use_field")]
+		Field UseField { get; set; }
+	}
+
+	/// <inheritdoc cref="IIntervalsPrefix" />
+	public class IntervalsPrefix : IntervalsNoFilterBase, IIntervalsPrefix
+	{
+		/// <inheritdoc />
+		[DataMember(Name = "analyzer")]
+		public string Analyzer { get; set; }
+
+		/// <inheritdoc />
+		public string Prefix { get; set; }
+
+		/// <inheritdoc />
+		[DataMember(Name = "use_field")]
+		public Field UseField { get; set; }
+
+		internal override void WrapInContainer(IIntervalsContainer container) => container.Prefix = this;
+	}
+
+	/// <inheritdoc cref="IIntervalsPrefix" />
+	public class IntervalsPrefixDescriptor : DescriptorBase<IntervalsPrefixDescriptor, IIntervalsPrefix>, IIntervalsPrefix
+	{
+		string IIntervalsPrefix.Analyzer { get; set; }
+		string IIntervalsPrefix.Prefix { get; set; }
+		Field IIntervalsPrefix.UseField { get; set; }
+
+		/// <inheritdoc cref="IIntervalsPrefix.Analyzer" />
+		public IntervalsPrefixDescriptor Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
+
+		/// <inheritdoc cref="IIntervalsPrefix.Prefix" />
+		public IntervalsPrefixDescriptor Prefix(string prefix) => Assign(prefix, (a, v) => a.Prefix = v);
+
+		/// <inheritdoc cref="IIntervalsPrefix.UseField" />
+		public IntervalsPrefixDescriptor UseField<T>(Expression<Func<T, object>> objectPath) => Assign(objectPath, (a, v) => a.UseField = v);
+
+		/// <inheritdoc cref="IIntervalsPrefix.UseField" />
+		public IntervalsPrefixDescriptor UseField(Field useField) => Assign(useField, (a, v) => a.UseField = v);
+	}
+}

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsPrefix.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace Nest
 {
 	/// <summary>
-	/// matches terms that start with a specified set of characters. This prefix can expand to match at most 128 terms.
+	/// Matches terms that start with a specified set of characters. This prefix can expand to match at most 128 terms.
 	/// If the prefix matches more than 128 terms, Elasticsearch returns an error.
 	/// You can use the index-prefixes option in the field mapping to avoid this limit.
 	/// <para />

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsQuery.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsQuery.cs
@@ -26,10 +26,16 @@ namespace Nest
 		/// <inheritdoc cref="IIntervalsMatch"/>
 		public IIntervalsMatch Match { get; set; }
 
+		/// <inheritdoc cref="IIntervalsPrefix"/>
+		public IIntervalsPrefix Prefix { get; set; }
+
+		/// <inheritdoc cref="IIntervalsWildcard"/>
+		public IIntervalsWildcard Wildcard { get; set; }
+
 		protected override bool Conditionless => IsConditionless(this);
 
 		internal static bool IsConditionless(IIntervalsQuery q) =>
-			q.Field.IsConditionless() || q.Match == null && q.AllOf == null && q.AnyOf == null;
+			q.Field.IsConditionless() || q.Match == null && q.AllOf == null && q.AnyOf == null && q.Prefix == null && q.Wildcard == null;
 
 		internal override void InternalWrapInContainer(IQueryContainer container) => container.Intervals = this;
 	}
@@ -45,10 +51,20 @@ namespace Nest
 		IIntervalsAllOf IIntervalsContainer.AllOf { get; set; }
 		IIntervalsAnyOf IIntervalsContainer.AnyOf { get; set; }
 		IIntervalsMatch IIntervalsContainer.Match { get; set; }
+		IIntervalsPrefix IIntervalsContainer.Prefix { get; set; }
+		IIntervalsWildcard IIntervalsContainer.Wildcard { get; set; }
 
 		/// <inheritdoc cref="IntervalsQuery.Match" />
 		public IntervalsQueryDescriptor<T> Match(Func<IntervalsMatchDescriptor, IIntervalsMatch> selector) =>
 			Assign(selector, (a, v) => a.Match = v?.Invoke(new IntervalsMatchDescriptor()));
+
+		/// <inheritdoc cref="IntervalsQuery.Prefix" />
+		public IntervalsQueryDescriptor<T> Prefix(Func<IntervalsPrefixDescriptor, IIntervalsPrefix> selector) =>
+			Assign(selector, (a, v) => a.Prefix = v?.Invoke(new IntervalsPrefixDescriptor()));
+
+		/// <inheritdoc cref="IntervalsQuery.Wildcard" />
+		public IntervalsQueryDescriptor<T> Wildcard(Func<IntervalsWildcardDescriptor, IIntervalsWildcard> selector) =>
+			Assign(selector, (a, v) => a.Wildcard = v?.Invoke(new IntervalsWildcardDescriptor()));
 
 		/// <inheritdoc cref="IntervalsQuery.AnyOf" />
 		public IntervalsQueryDescriptor<T> AnyOf(Func<IntervalsAnyOfDescriptor, IIntervalsAnyOf> selector) =>
@@ -75,6 +91,14 @@ namespace Nest
 		/// <inheritdoc cref="IIntervalsMatch" />
 		[DataMember(Name = "match")]
 		IIntervalsMatch Match { get; set; }
+
+		/// <inheritdoc cref="IIntervalsPrefix" />
+		[DataMember(Name = "prefix")]
+		IIntervalsPrefix Prefix { get; set; }
+
+		/// <inheritdoc cref="IIntervalsWildcard" />
+		[DataMember(Name = "wildcard")]
+		IIntervalsWildcard Wildcard { get; set; }
 	}
 
 	/// <inheritdoc cref="IIntervalsContainer" />
@@ -88,11 +112,23 @@ namespace Nest
 			intervals.WrapInContainer(this);
 		}
 
+		public IntervalsContainer(IntervalsNoFilterBase intervals)
+		{
+			intervals.ThrowIfNull(nameof(intervals));
+			intervals.WrapInContainer(this);
+		}
+
 		IIntervalsAllOf IIntervalsContainer.AllOf { get; set; }
 		IIntervalsAnyOf IIntervalsContainer.AnyOf { get; set; }
 		IIntervalsMatch IIntervalsContainer.Match { get; set; }
+		IIntervalsPrefix IIntervalsContainer.Prefix { get; set; }
+		IIntervalsWildcard IIntervalsContainer.Wildcard { get; set; }
 
 		public static implicit operator IntervalsContainer(IntervalsBase intervals) => intervals == null
+			? null
+			: new IntervalsContainer(intervals);
+
+		public static implicit operator IntervalsContainer(IntervalsNoFilterBase intervals) => intervals == null
 			? null
 			: new IntervalsContainer(intervals);
 	}
@@ -109,6 +145,14 @@ namespace Nest
 		public IntervalsDescriptor Match(Func<IntervalsMatchDescriptor, IIntervalsMatch> selector) =>
 			Assign(selector, (a, v) => a.Match = v?.Invoke(new IntervalsMatchDescriptor()));
 
+		/// <inheritdoc cref="IntervalsPrefixDescriptor" />
+		public IntervalsDescriptor Prefix(Func<IntervalsPrefixDescriptor, IIntervalsPrefix> selector) =>
+			Assign(selector, (a, v) => a.Prefix = v?.Invoke(new IntervalsPrefixDescriptor()));
+
+		/// <inheritdoc cref="IntervalsWildcardDescriptor" />
+		public IntervalsDescriptor Wildcard(Func<IntervalsWildcardDescriptor, IIntervalsWildcard> selector) =>
+			Assign(selector, (a, v) => a.Wildcard = v?.Invoke(new IntervalsWildcardDescriptor()));
+
 		/// <inheritdoc cref="IntervalsAnyOfDescriptor" />
 		public IntervalsDescriptor AnyOf(Func<IntervalsAnyOfDescriptor, IIntervalsAnyOf> selector) =>
 			Assign(selector, (a, v) => a.AnyOf = v?.Invoke(new IntervalsAnyOfDescriptor()));
@@ -118,8 +162,9 @@ namespace Nest
 			Assign(selector, (a, v) => a.AllOf = v?.Invoke(new IntervalsAllOfDescriptor()));
 	}
 
+	// TODO: Rename this to IIntervalsWithFilter and IIntervalsNoFilter to IIntervals in 8.0
 	/// <summary>
-	/// An <see cref="IIntervalsQuery" /> rule
+	/// An <see cref="IIntervalsQuery" /> rule with an optional filter
 	/// </summary>
 	public interface IIntervals
 	{
@@ -131,6 +176,13 @@ namespace Nest
 	}
 
 	/// <summary>
+	/// An <see cref="IIntervalsQuery" /> rule
+	/// </summary>
+	public interface IIntervalsNoFilter
+	{
+	}
+
+	/// <summary>
 	/// Base type for an <see cref="IIntervals" /> implementation
 	/// </summary>
 	public abstract class IntervalsBase : IIntervals
@@ -138,6 +190,14 @@ namespace Nest
 		/// <inheritdoc />
 		public IIntervalsFilter Filter { get; set; }
 
+		internal abstract void WrapInContainer(IIntervalsContainer container);
+	}
+
+	/// <summary>
+	/// Base type for an <see cref="IIntervalsNoFilter" /> implementation
+	/// </summary>
+	public abstract class IntervalsNoFilterBase : IIntervalsNoFilter
+	{
 		internal abstract void WrapInContainer(IIntervalsContainer container);
 	}
 
@@ -165,6 +225,14 @@ namespace Nest
 		/// <inheritdoc cref="IIntervalsMatch" />
 		public IntervalsListDescriptor Match(Func<IntervalsMatchDescriptor, IIntervalsMatch> selector) =>
 			Assign(selector, (a, v) => a.AddIfNotNull(new IntervalsDescriptor().Match(v)));
+
+		/// <inheritdoc cref="IIntervalsPrefix" />
+		public IntervalsListDescriptor Prefix(Func<IntervalsPrefixDescriptor, IIntervalsPrefix> selector) =>
+			Assign(selector, (a, v) => a.AddIfNotNull(new IntervalsDescriptor().Prefix(v)));
+
+		/// <inheritdoc cref="IIntervalsWildcard" />
+		public IntervalsListDescriptor Wildcard(Func<IntervalsWildcardDescriptor, IIntervalsWildcard> selector) =>
+			Assign(selector, (a, v) => a.AddIfNotNull(new IntervalsDescriptor().Wildcard(v)));
 
 		/// <inheritdoc cref="IIntervalsAnyOf" />
 		public IntervalsListDescriptor AnyOf(Func<IntervalsAnyOfDescriptor, IIntervalsAnyOf> selector) =>

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
@@ -29,7 +29,7 @@ namespace Nest
 		string Pattern { get; set; }
 
 		/// <summary>
-		/// If specified, then match intervals from this field rather than the top-level <field>.
+		/// If specified, then match intervals from this field rather than the top-level field.
 		/// The prefix is normalized using the search analyzer from this field, unless a separate analyzer is specified.
 		/// </summary>
 		[DataMember(Name = "use_field")]

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
@@ -5,7 +5,7 @@ using System.Runtime.Serialization;
 namespace Nest
 {
 	/// <summary>
-	/// matches terms using a wildcard pattern. This pattern can expand to match at most 128 terms.
+	/// Matches terms using a wildcard pattern. This pattern can expand to match at most 128 terms.
 	/// If the pattern matches more than 128 terms, Elasticsearch returns an error.
 	/// <para />
 	/// Available in Elasticsearch 7.3.0+

--- a/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
+++ b/src/Nest/QueryDsl/FullText/Intervals/IntervalsWildcard.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq.Expressions;
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	/// <summary>
+	/// matches terms using a wildcard pattern. This pattern can expand to match at most 128 terms.
+	/// If the pattern matches more than 128 terms, Elasticsearch returns an error.
+	/// <para />
+	/// Available in Elasticsearch 7.3.0+
+	/// </summary>
+	[ReadAs(typeof(IntervalsWildcard))]
+	public interface IIntervalsWildcard : IIntervalsNoFilter
+	{
+		/// <summary>
+		/// Analyzer used to normalize the prefix. Defaults to the top-level field's analyzer.
+		/// </summary>
+		[DataMember(Name = "analyzer")]
+		string Analyzer { get; set; }
+
+		/// <summary>
+		/// Wildcard pattern used to find matching terms. Supports two wildcard operators:
+		/// <para />?, which matches any single character
+		/// <para />*, which can match zero or more characters, including an empty one
+		/// <para />Warning: Avoid beginning patterns with * or ?. This can increase the iterations needed to find matching terms and slow search performance.
+		/// </summary>
+		[DataMember(Name = "pattern")]
+		string Pattern { get; set; }
+
+		/// <summary>
+		/// If specified, then match intervals from this field rather than the top-level <field>.
+		/// The prefix is normalized using the search analyzer from this field, unless a separate analyzer is specified.
+		/// </summary>
+		[DataMember(Name = "use_field")]
+		Field UseField { get; set; }
+	}
+
+	/// <inheritdoc cref="IIntervalsWildcard" />
+	public class IntervalsWildcard : IntervalsNoFilterBase, IIntervalsWildcard
+	{
+		/// <inheritdoc />
+		public string Analyzer { get; set; }
+
+		/// <inheritdoc />
+		public string Pattern { get; set; }
+
+		/// <inheritdoc />
+		public Field UseField { get; set; }
+
+		internal override void WrapInContainer(IIntervalsContainer container) => container.Wildcard = this;
+	}
+
+	/// <inheritdoc cref="IIntervalsWildcard" />
+	public class IntervalsWildcardDescriptor : DescriptorBase<IntervalsWildcardDescriptor, IIntervalsWildcard>, IIntervalsWildcard
+	{
+		string IIntervalsWildcard.Analyzer { get; set; }
+		string IIntervalsWildcard.Pattern { get; set; }
+		Field IIntervalsWildcard.UseField { get; set; }
+
+		/// <inheritdoc cref="IIntervalsWildcard.Analyzer" />
+		public IntervalsWildcardDescriptor Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
+
+		/// <inheritdoc cref="IIntervalsWildcard.Pattern" />
+		public IntervalsWildcardDescriptor Pattern(string pattern) => Assign(pattern, (a, v) => a.Pattern = v);
+
+		/// <inheritdoc cref="IIntervalsWildcard.UseField" />
+		public IntervalsWildcardDescriptor UseField<T>(Expression<Func<T, object>> objectPath) => Assign(objectPath, (a, v) => a.UseField = v);
+
+		/// <inheritdoc cref="IIntervalsWildcard.UseField" />
+		public IntervalsWildcardDescriptor UseField(Field useField) => Assign(useField, (a, v) => a.UseField = v);
+	}
+}


### PR DESCRIPTION
Relates: #4001

This commit adds wildcard and prefix rules support to the Intervals query.
Neither wildcard or prefix rules support filters, so a new IIntervalsNoFilter interface
is introduced for these rules. Added TODO to consolidate rules in 8.0