### PR TITLE
Add voting_only to ClusterNodeStats and XPackInfo

### DIFF
--- a/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
+++ b/src/Nest/Cluster/ClusterStats/ClusterNodesStats.cs
@@ -6,217 +6,220 @@ namespace Nest
 	[DataContract]
 	public class ClusterNodesStats
 	{
-		[DataMember(Name ="count")]
+		[DataMember(Name = "count")]
 		public ClusterNodeCount Count { get; internal set; }
 
-		[DataMember(Name ="discovery_types")]
+		[DataMember(Name = "discovery_types")]
 		public IReadOnlyDictionary<string, int> DiscoveryTypes { get; internal set; }
 
-		[DataMember(Name ="packaging_types")]
-		public IReadOnlyCollection<NodePackagingType> PackagingTypes { get; internal set; }
-
-		[DataMember(Name ="fs")]
+		[DataMember(Name = "fs")]
 		public ClusterFileSystem FileSystem { get; internal set; }
 
-		[DataMember(Name ="jvm")]
+		[DataMember(Name = "jvm")]
 		public ClusterJvm Jvm { get; internal set; }
 
-		[DataMember(Name ="network_types")]
+		[DataMember(Name = "network_types")]
 		public ClusterNetworkTypes NetworkTypes { get; internal set; }
 
-		[DataMember(Name ="os")]
+		[DataMember(Name = "os")]
 		public ClusterOperatingSystemStats OperatingSystem { get; internal set; }
 
-		[DataMember(Name ="plugins")]
+		[DataMember(Name = "packaging_types")]
+		public IReadOnlyCollection<NodePackagingType> PackagingTypes { get; internal set; }
+
+		[DataMember(Name = "plugins")]
 		public IReadOnlyCollection<PluginStats> Plugins { get; internal set; }
 
-		[DataMember(Name ="process")]
+		[DataMember(Name = "process")]
 		public ClusterProcess Process { get; internal set; }
 
-		[DataMember(Name ="versions")]
+		[DataMember(Name = "versions")]
 		public IReadOnlyCollection<string> Versions { get; internal set; }
 	}
 
 	public class NodePackagingType
 	{
-		[DataMember(Name ="flavor")]
+		[DataMember(Name = "count")]
+		public int Count { get; internal set; }
+
+		[DataMember(Name = "flavor")]
 		public string Flavor { get; internal set; }
 
-		[DataMember(Name ="type")]
+		[DataMember(Name = "type")]
 		public string Type { get; internal set; }
-
-		[DataMember(Name ="count")]
-		public int Count { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterNetworkTypes
 	{
-		[DataMember(Name ="http_types")]
+		[DataMember(Name = "http_types")]
 		public IReadOnlyDictionary<string, int> HttpTypes { get; internal set; }
 
-		[DataMember(Name ="transport_types")]
+		[DataMember(Name = "transport_types")]
 		public IReadOnlyDictionary<string, int> TransportTypes { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterFileSystem
 	{
-		[DataMember(Name ="available_in_bytes")]
+		[DataMember(Name = "available_in_bytes")]
 		public long AvailableInBytes { get; internal set; }
 
-		[DataMember(Name ="free_in_bytes")]
+		[DataMember(Name = "free_in_bytes")]
 		public long FreeInBytes { get; internal set; }
 
-		[DataMember(Name ="total_in_bytes")]
+		[DataMember(Name = "total_in_bytes")]
 		public long TotalInBytes { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterJvm
 	{
-		[DataMember(Name ="max_uptime_in_millis")]
+		[DataMember(Name = "max_uptime_in_millis")]
 		public long MaxUptimeInMilliseconds { get; internal set; }
 
-		[DataMember(Name ="mem")]
+		[DataMember(Name = "mem")]
 		public ClusterJvmMemory Memory { get; internal set; }
 
-		[DataMember(Name ="threads")]
+		[DataMember(Name = "threads")]
 		public long Threads { get; internal set; }
 
-		[DataMember(Name ="versions")]
+		[DataMember(Name = "versions")]
 		public IReadOnlyCollection<ClusterJvmVersion> Versions { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterJvmVersion
 	{
-		[DataMember(Name ="bundled_jdk")]
+		[DataMember(Name = "bundled_jdk")]
 		public bool BundledJdk { get; internal set; }
 
-		[DataMember(Name ="using_bundled_jdk")]
-		public bool? UsingBundledJdk { get; internal set; }
-
-		[DataMember(Name ="count")]
+		[DataMember(Name = "count")]
 		public int Count { get; internal set; }
 
-		[DataMember(Name ="version")]
+		[DataMember(Name = "using_bundled_jdk")]
+		public bool? UsingBundledJdk { get; internal set; }
+
+		[DataMember(Name = "version")]
 		public string Version { get; internal set; }
 
-		[DataMember(Name ="vm_name")]
+		[DataMember(Name = "vm_name")]
 		public string VmName { get; internal set; }
 
-		[DataMember(Name ="vm_vendor")]
+		[DataMember(Name = "vm_vendor")]
 		public string VmVendor { get; internal set; }
 
-		[DataMember(Name ="vm_version")]
+		[DataMember(Name = "vm_version")]
 		public string VmVersion { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterJvmMemory
 	{
-		[DataMember(Name ="heap_max_in_bytes")]
+		[DataMember(Name = "heap_max_in_bytes")]
 		public long HeapMaxInBytes { get; internal set; }
 
-		[DataMember(Name ="heap_used_in_bytes")]
+		[DataMember(Name = "heap_used_in_bytes")]
 		public long HeapUsedInBytes { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterProcess
 	{
-		[DataMember(Name ="cpu")]
+		[DataMember(Name = "cpu")]
 		public ClusterProcessCpu Cpu { get; internal set; }
 
-		[DataMember(Name ="open_file_descriptors")]
+		[DataMember(Name = "open_file_descriptors")]
 		public ClusterProcessOpenFileDescriptors OpenFileDescriptors { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterProcessCpu
 	{
-		[DataMember(Name ="percent")]
+		[DataMember(Name = "percent")]
 		public int Percent { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterProcessOpenFileDescriptors
 	{
-		[DataMember(Name ="avg")]
+		[DataMember(Name = "avg")]
 		public long Avg { get; internal set; }
 
-		[DataMember(Name ="max")]
+		[DataMember(Name = "max")]
 		public long Max { get; internal set; }
 
-		[DataMember(Name ="min")]
+		[DataMember(Name = "min")]
 		public long Min { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterOperatingSystemStats
 	{
-		[DataMember(Name ="allocated_processors")]
+		[DataMember(Name = "allocated_processors")]
 		public int AllocatedProcessors { get; internal set; }
 
-		[DataMember(Name ="available_processors")]
+		[DataMember(Name = "available_processors")]
 		public int AvailableProcessors { get; internal set; }
 
-		[DataMember(Name ="mem")]
+		[DataMember(Name = "mem")]
 		public OperatingSystemMemoryInfo Memory { get; internal set; }
 
-		[DataMember(Name ="names")]
+		[DataMember(Name = "names")]
 		public IReadOnlyCollection<ClusterOperatingSystemName> Names { get; internal set; }
 
-		[DataMember(Name ="pretty_names")]
+		[DataMember(Name = "pretty_names")]
 		public IReadOnlyCollection<ClusterOperatingSystemPrettyNane> PrettyNames { get; internal set; }
 	}
 
 	[DataContract]
 	public class OperatingSystemMemoryInfo
 	{
-		[DataMember(Name ="free_in_bytes")]
+		[DataMember(Name = "free_in_bytes")]
 		public long FreeBytes { get; internal set; }
 
-		[DataMember(Name ="free_percent")]
+		[DataMember(Name = "free_percent")]
 		public int FreePercent { get; internal set; }
 
-		[DataMember(Name ="total_in_bytes")]
+		[DataMember(Name = "total_in_bytes")]
 		public long TotalBytes { get; internal set; }
 
-		[DataMember(Name ="used_in_bytes")]
+		[DataMember(Name = "used_in_bytes")]
 		public long UsedBytes { get; internal set; }
 
-		[DataMember(Name ="used_percent")]
+		[DataMember(Name = "used_percent")]
 		public int UsedPercent { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterOperatingSystemName
 	{
-		[DataMember(Name ="count")]
+		[DataMember(Name = "count")]
 		public int Count { get; internal set; }
 
-		[DataMember(Name ="name")]
+		[DataMember(Name = "name")]
 		public string Name { get; internal set; }
 	}
 
 	[DataContract]
 	public class ClusterNodeCount
 	{
-		[DataMember(Name ="coordinating_only")]
+		[DataMember(Name = "coordinating_only")]
 		public int CoordinatingOnly { get; internal set; }
 
-		[DataMember(Name ="data")]
+		[DataMember(Name = "data")]
 		public int Data { get; internal set; }
 
-		[DataMember(Name ="ingest")]
+		[DataMember(Name = "ingest")]
 		public int Ingest { get; internal set; }
 
-		[DataMember(Name ="master")]
+		[DataMember(Name = "master")]
 		public int Master { get; internal set; }
 
-		[DataMember(Name ="total")]
+		[DataMember(Name = "total")]
 		public int Total { get; internal set; }
+
+		[DataMember(Name = "voting_only")]
+		public int VotingOnly { get; internal set; }
 	}
 }

--- a/src/Nest/Cluster/NodesInfo/NodeRole.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeRole.cs
@@ -16,6 +16,9 @@ namespace Nest
 		Client,
 
 		[EnumMember(Value = "ingest")]
-		Ingest
+		Ingest,
+
+		[EnumMember(Value = "ml")]
+		MachineLearning
 	}
 }

--- a/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
+++ b/src/Nest/XPack/Info/XPackUsage/XPackUsageResponse.cs
@@ -64,6 +64,9 @@ namespace Nest
 
 		[DataMember(Name = "security")]
 		public SecurityUsage Security { get; internal set; }
+
+		[DataMember(Name = "voting_only")]
+		public XPackUsage VotingOnly { get; internal set; }
 	}
 
 	public class XPackUsage

--- a/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramAggregationUsageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using Elastic.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Extensions;
@@ -26,6 +27,104 @@ namespace Tests.Aggregations.Bucket.AutoDateHistogram
 	public class AutoDateHistogramAggregationUsageTests : ProjectsOnlyAggregationUsageTestBase
 	{
 		public AutoDateHistogramAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object AggregationJson => new
+		{
+			projects_started_per_month = new
+			{
+				auto_date_histogram = new
+				{
+					field = "startedOn",
+					buckets = 10,
+					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", //<1> Note the inclusion of `date_optional_time` to `format`
+					missing = FixedDate
+				},
+				aggs = new
+				{
+					project_tags = new
+					{
+						nested = new
+						{
+							path = "tags"
+						},
+						aggs = new
+						{
+							tags = new
+							{
+								terms = new { field = "tags.name" }
+							}
+						}
+					}
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.AutoDateHistogram("projects_started_per_month", date => date
+				.Field(p => p.StartedOn)
+				.Buckets(10)
+				.Format("yyyy-MM-dd'T'HH:mm:ss")
+				.Missing(FixedDate)
+				.Aggregations(childAggs => childAggs
+					.Nested("project_tags", n => n
+						.Path(p => p.Tags)
+						.Aggregations(nestedAggs => nestedAggs
+							.Terms("tags", avg => avg.Field(p => p.Tags.First().Name))
+						)
+					)
+				)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new AutoDateHistogramAggregation("projects_started_per_month")
+			{
+				Field = Field<Project>(p => p.StartedOn),
+				Buckets = 10,
+				Format = "yyyy-MM-dd'T'HH:mm:ss",
+				Missing = FixedDate,
+				Aggregations = new NestedAggregation("project_tags")
+				{
+					Path = Field<Project>(p => p.Tags),
+					Aggregations = new TermsAggregation("tags")
+					{
+						Field = Field<Project>(p => p.Tags.First().Name)
+					}
+				}
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			/** ==== Handling responses
+			* The `AggregateDictionary found on `.Aggregations` on `SearchResponse<T>` has several helper methods
+			* so we can fetch our aggregation results easily in the correct type.
+			 * <<handling-aggregate-response, Be sure to read more about these helper methods>>
+			*/
+			response.ShouldBeValid();
+
+			var dateHistogram = response.Aggregations.AutoDateHistogram("projects_started_per_month");
+			dateHistogram.Should().NotBeNull();
+			dateHistogram.Interval.Should().NotBeNull();
+			dateHistogram.Buckets.Should().NotBeNull();
+			dateHistogram.Buckets.Count.Should().BeGreaterThan(1);
+			foreach (var item in dateHistogram.Buckets)
+			{
+				item.Date.Should().NotBe(default);
+				item.DocCount.Should().BeGreaterThan(0);
+
+				var nested = item.Nested("project_tags");
+				nested.Should().NotBeNull();
+
+				var nestedTerms = nested.Terms("tags");
+				nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
+			}
+		}
+	}
+
+	// hide
+	[SkipVersion("<7.3.0", "minimum_interval introduced in 7.3.0")]
+	public class AutoDateHistogramAggregationWithMinimumIntervalUsageTests : ProjectsOnlyAggregationUsageTestBase
+	{
+		public AutoDateHistogramAggregationWithMinimumIntervalUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
 		protected override object AggregationJson => new
 		{

--- a/src/Tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Elastic.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Extensions;
@@ -13,10 +14,13 @@ namespace Tests.Aggregations.Bucket.RareTerms
 	 * A multi-bucket value source based aggregation which finds "rare" terms — terms that are at the long-tail of the
 	 * distribution and are not frequent. Conceptually, this is like a terms aggregation that is sorted by _count ascending.
 	 * As noted in the terms aggregation docs, actually ordering a terms agg by count ascending has unbounded error.
-	 * Instead, you should use the rare_terms aggregation
+	 * Instead, you should use the rare_terms aggregation.
+	 *
+	 * NOTE: Valid only in Elasticsearch 7.3.0+
 	 *
 	 * See the Elasticsearch documentation on {ref_current}/search-aggregations-bucket-rare-terms-aggregation.html[rare terms aggregation] for more detail.
 	 */
+	[SkipVersion("<7.3.0", "Introduced in 7.3.0")]
 	public class RareTermsAggregationUsageTests : AggregationUsageTestBase
 	{
 		public RareTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }

--- a/src/Tests/Tests/XPack/Info/XPackInfoApiTests.cs
+++ b/src/Tests/Tests/XPack/Info/XPackInfoApiTests.cs
@@ -2,10 +2,12 @@ using System.Threading.Tasks;
 using Elastic.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
+using Tests.Configuration;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Core.Xunit;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
+using Tests.Core.Extensions;
 
 namespace Tests.XPack.Info
 {
@@ -86,6 +88,9 @@ namespace Tests.XPack.Info
 			r.Alerting.Count.Should().NotBeNull();
 			r.Alerting.Execution.Should().NotBeNull();
 			r.Alerting.Watch.Should().NotBeNull();
+
+			if (TestConfiguration.Instance.InRange(">=7.3.0"))
+				r.VotingOnly.Should().NotBeNull();
 		});
 	}
 }


### PR DESCRIPTION
Relates: #4001

This commit adds voting_only to ClusterNodeStats and XPackUsageResponse.
VotingOnly is supported only in the default distribution