### PR TITLE
Add timing stats to machine learning job stats

### DIFF
--- a/src/Nest/XPack/MachineLearning/Job/Config/JobStats.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Config/JobStats.cs
@@ -1,6 +1,8 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 using Elasticsearch.Net;
+using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
@@ -57,6 +59,47 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name = "state")]
 		public JobState State { get; internal set; }
+
+		/// <summary>
+		/// Timing-related statistics about the job's progress
+		/// <para />
+		/// Valid only in Elasticsearch 7.3.0+
+		/// </summary>
+		[DataMember(Name = "timing_stats")]
+		public TimingStats TimingStats { get; internal set; }
+	}
+
+	public class TimingStats
+	{
+		[DataMember(Name = "job_id")]
+		public string JobId { get; internal set; }
+
+		[DataMember(Name = "bucket_count")]
+		public long BucketCount { get; internal set; }
+
+		/// <summary>
+		/// Minimum among all bucket processing times in milliseconds
+		/// </summary>
+		[DataMember(Name = "minimum_bucket_processing_time_ms")]
+		public double MinimumBucketProcessingTimeMilliseconds { get; internal set; }
+
+		/// <summary>
+		/// Maximum among all bucket processing times in milliseconds
+		/// </summary>
+		[DataMember(Name = "maximum_bucket_processing_time_ms")]
+		public double MaximumBucketProcessingTimeMilliseconds { get; internal set; }
+
+		/// <summary>
+		/// Average of all bucket processing times in milliseconds
+		/// </summary>
+		[DataMember(Name = "average_bucket_processing_time_ms")]
+		public double AverageBucketProcessingTimeMilliseconds { get; internal set; }
+
+		/// <summary>
+		/// Exponential moving average of all bucket processing times in milliseconds
+		/// </summary>
+		[DataMember(Name = "exponential_average_bucket_processing_time_ms")]
+		public double ExponentialAverageBucketProcessingTimeMilliseconds { get; internal set; }
 	}
 
 	public class JobForecastStatistics

--- a/src/Tests/Tests/XPack/MachineLearning/GetJobStats/GetJobStatsApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetJobStats/GetJobStatsApiTests.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Configuration;
 using Tests.Core.Extensions;
 using Tests.Framework.EndpointTests.TestState;
 
@@ -24,6 +25,11 @@ namespace Tests.XPack.MachineLearning.GetJobStats
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
 			foreach (var callUniqueValue in values) PutJob(client, callUniqueValue.Value);
+		}
+
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values) DeleteJob(client, callUniqueValue.Value);
 		}
 
 		protected override LazyResponses ClientUsage() => Calls(
@@ -65,6 +71,17 @@ namespace Tests.XPack.MachineLearning.GetJobStats
 			firstJob.ModelSizeStats.TotalByFieldCount.Should().Be(0);
 			firstJob.ModelSizeStats.TotalOverFieldCount.Should().Be(0);
 			firstJob.ModelSizeStats.TotalPartitionFieldCount.Should().Be(0);
+
+			if (TestConfiguration.Instance.InRange(">=7.3.0"))
+			{
+				firstJob.TimingStats.Should().NotBeNull();
+				firstJob.TimingStats.JobId.Should().Be(firstJob.JobId);
+				firstJob.TimingStats.BucketCount.Should().Be(0);
+				firstJob.TimingStats.MinimumBucketProcessingTimeMilliseconds.Should().Be(0);
+				firstJob.TimingStats.MaximumBucketProcessingTimeMilliseconds.Should().Be(0);
+				firstJob.TimingStats.AverageBucketProcessingTimeMilliseconds.Should().Be(0);
+				firstJob.TimingStats.ExponentialAverageBucketProcessingTimeMilliseconds.Should().Be(0);
+			}
 		}
 	}
 


### PR DESCRIPTION
Relates: #4001

This commit adds timing stats to Machine Learning job stats