### PR TITLE
Add max_docs to ReindexOnServer API

### DIFF
--- a/src/Nest/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
+++ b/src/Nest/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
@@ -20,6 +20,12 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name ="slice")]
 		ISlicedScroll Slice { get; set; }
+
+		/// <summary>
+		/// Limit the number of processed documents
+		/// </summary>
+		[DataMember(Name ="max_docs")]
+		long? MaximumDocuments { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -34,6 +40,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public ISlicedScroll Slice { get; set; }
+
+		/// <inheritdoc />
+		public long? MaximumDocuments { get; set; }
 	}
 
 	/// <inheritdoc cref="IDeleteByQueryRequest" />
@@ -49,6 +58,7 @@ namespace Nest
 	{
 		QueryContainer IDeleteByQueryRequest.Query { get; set; }
 		ISlicedScroll IDeleteByQueryRequest.Slice { get; set; }
+		long? IDeleteByQueryRequest.MaximumDocuments { get; set; }
 
 		/// <summary>
 		/// A match_all query to select all documents. Convenient shorthand for specifying
@@ -56,17 +66,16 @@ namespace Nest
 		/// </summary>
 		public DeleteByQueryDescriptor<TDocument> MatchAll() => Assign(new QueryContainerDescriptor<TDocument>().MatchAll(), (a, v) => a.Query = v);
 
-		/// <summary>
-		/// The query to use to select documents for deletion
-		/// </summary>
+		/// <inheritdoc cref="IDeleteByQueryRequest.Query"/>
 		public DeleteByQueryDescriptor<TDocument> Query(Func<QueryContainerDescriptor<TDocument>, QueryContainer> querySelector) =>
 			Assign(querySelector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<TDocument>()));
 
-		/// <summary>
-		/// Parallelize the deleting process. This parallelization can improve efficiency and
-		/// provide a convenient way to break the request down into smaller parts.
-		/// </summary>
+		/// <inheritdoc cref="IDeleteByQueryRequest.Slice"/>
 		public DeleteByQueryDescriptor<TDocument> Slice(Func<SlicedScrollDescriptor<TDocument>, ISlicedScroll> selector) =>
 			Assign(selector, (a, v) => a.Slice = v?.Invoke(new SlicedScrollDescriptor<TDocument>()));
+
+		/// <inheritdoc cref="IDeleteByQueryRequest.MaximumDocuments"/>
+		public DeleteByQueryDescriptor<TDocument> MaximumDocuments(long? maximumDocuments) =>
+			Assign(maximumDocuments, (a, v) => a.MaximumDocuments = v);
 	}
 }

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexOnServerRequest.cs
@@ -38,8 +38,16 @@ namespace Nest
 		/// <summary>
 		/// Limit the number of processed documents
 		/// </summary>
+		// TODO: Remove in 8.0
 		[DataMember(Name ="size")]
+		[Obsolete("Deprecated. Use MaximumDocuments")]
 		long? Size { get; set; }
+
+		/// <summary>
+		/// Limit the number of processed documents
+		/// </summary>
+		[DataMember(Name ="max_docs")]
+		long? MaximumDocuments { get; set; }
 
 		/// <summary>
 		/// The source for the reindex operation
@@ -51,19 +59,23 @@ namespace Nest
 	/// <inheritdoc cref="IReindexOnServerRequest" />
 	public partial class ReindexOnServerRequest
 	{
-		/// <inheritdoc cref="IReindexOnServerRequest.Conflicts" />
+		/// <inheritdoc />
 		public Conflicts? Conflicts { get; set; }
 
-		/// <inheritdoc cref="IReindexOnServerRequest.Destination" />
+		/// <inheritdoc />
 		public IReindexDestination Destination { get; set; }
 
-		/// <inheritdoc cref="IReindexOnServerRequest.Script" />
+		/// <inheritdoc />
 		public IScript Script { get; set; }
 
-		/// <inheritdoc cref="IReindexOnServerRequest.Size" />
+		/// <inheritdoc />
+		[Obsolete("Deprecated. Use MaximumDocuments")]
 		public long? Size { get; set; }
 
-		/// <inheritdoc cref="IReindexOnServerRequest.Source" />
+		/// <inheritdoc />
+		public long? MaximumDocuments { get; set; }
+
+		/// <inheritdoc />
 		public IReindexSource Source { get; set; }
 	}
 
@@ -72,8 +84,10 @@ namespace Nest
 		Conflicts? IReindexOnServerRequest.Conflicts { get; set; }
 		IReindexDestination IReindexOnServerRequest.Destination { get; set; }
 		IScript IReindexOnServerRequest.Script { get; set; }
+		[Obsolete("Deprecated. Use MaximumDocuments")]
 		long? IReindexOnServerRequest.Size { get; set; }
 		IReindexSource IReindexOnServerRequest.Source { get; set; }
+		long? IReindexOnServerRequest.MaximumDocuments { get; set; }
 
 		/// <inheritdoc cref="IReindexOnServerRequest.Source" />
 		public ReindexOnServerDescriptor Source(Func<ReindexSourceDescriptor, IReindexSource> selector = null) =>
@@ -90,10 +104,15 @@ namespace Nest
 		public ReindexOnServerDescriptor Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
 			Assign(scriptSelector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
 
+		[Obsolete("Deprecated. Use MaximumDocuments")]
 		/// <inheritdoc cref="IReindexOnServerRequest.Size" />
 		public ReindexOnServerDescriptor Size(long? size) => Assign(size, (a, v) => a.Size = v);
 
 		/// <inheritdoc cref="IReindexOnServerRequest.Conflicts" />
 		public ReindexOnServerDescriptor Conflicts(Conflicts? conflicts) => Assign(conflicts, (a, v) => a.Conflicts = v);
+
+		/// <inheritdoc cref="IReindexOnServerRequest.MaximumDocuments"/>
+		public ReindexOnServerDescriptor MaximumDocuments(long? maximumDocuments) =>
+			Assign(maximumDocuments, (a, v) => a.MaximumDocuments = v);
 	}
 }

--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -28,7 +28,7 @@ namespace Nest
 		IRemoteSource Remote { get; set; }
 
 		/// <summary>
-		/// Limit the number of processed documents
+		/// The batch size of documents
 		/// </summary>
 		[DataMember(Name ="size")]
 		int? Size { get; set; }

--- a/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
+++ b/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
@@ -5,11 +5,30 @@ namespace Nest
 {
 	public partial interface IUpdateByQueryRequest
 	{
+		/// <summary>
+		/// Parallelize the update process by splitting a query into
+		/// multiple slices.
+		/// </summary>
+		[DataMember(Name ="slice")]
+		ISlicedScroll Slice { get; set; }
+
+		/// <summary>
+		/// Query to select documents to update
+		/// </summary>
 		[DataMember(Name ="query")]
 		QueryContainer Query { get; set; }
 
+		/// <summary>
+		/// A script specifying the update to make
+		/// </summary>
 		[DataMember(Name ="script")]
 		IScript Script { get; set; }
+
+		/// <summary>
+		/// Limit the number of processed documents
+		/// </summary>
+		[DataMember(Name ="max_docs")]
+		long? MaximumDocuments { get; set; }
 	}
 
 	// ReSharper disable once UnusedMember.Global
@@ -18,8 +37,14 @@ namespace Nest
 
 	public partial class UpdateByQueryRequest
 	{
+		/// <inheritdoc />
+		public ISlicedScroll Slice { get; set; }
+		/// <inheritdoc />
 		public QueryContainer Query { get; set; }
+		/// <inheritdoc />
 		public IScript Script { get; set; }
+		/// <inheritdoc />
+		public long? MaximumDocuments { get; set; }
 	}
 
 	// ReSharper disable once UnusedTypeParameter
@@ -32,15 +57,31 @@ namespace Nest
 	{
 		QueryContainer IUpdateByQueryRequest.Query { get; set; }
 		IScript IUpdateByQueryRequest.Script { get; set; }
+		long? IUpdateByQueryRequest.MaximumDocuments { get; set; }
+		ISlicedScroll IUpdateByQueryRequest.Slice { get; set; }
 
+		/// <summary>
+		/// Query that selects all documents
+		/// </summary>
 		public UpdateByQueryDescriptor<TDocument> MatchAll() => Assign(new QueryContainerDescriptor<TDocument>().MatchAll(), (a, v) => a.Query = v);
 
+		/// <inheritdoc cref="IUpdateByQueryRequest.Query"/>
 		public UpdateByQueryDescriptor<TDocument> Query(Func<QueryContainerDescriptor<TDocument>, QueryContainer> querySelector) =>
 			Assign(querySelector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<TDocument>()));
 
+		/// <inheritdoc cref="IUpdateByQueryRequest.Script"/>
 		public UpdateByQueryDescriptor<TDocument> Script(string script) => Assign((InlineScript)script, (a, v) => a.Script = v);
 
+		/// <inheritdoc cref="IUpdateByQueryRequest.Script"/>
 		public UpdateByQueryDescriptor<TDocument> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
 			Assign(scriptSelector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
+
+		/// <inheritdoc cref="IUpdateByQueryRequest.MaximumDocuments"/>
+		public UpdateByQueryDescriptor<TDocument> MaximumDocuments(long? maximumDocuments) =>
+			Assign(maximumDocuments, (a, v) => a.MaximumDocuments = v);
+
+		/// <inheritdoc cref="IUpdateByQueryRequest.Slice"/>
+		public UpdateByQueryDescriptor<TDocument> Slice(Func<SlicedScrollDescriptor<TDocument>, ISlicedScroll> selector) =>
+			Assign(selector, (a, v) => a.Slice = v?.Invoke(new SlicedScrollDescriptor<TDocument>()));
 	}
 }


### PR DESCRIPTION
- Add `MaximumDocuments` to ReindexOnServer API and deprecate `Size`
- Add `MaximumDocuments` and support for SlicedScroll to UpdateByQuery and DeleteByQuery