### PR TITLE
Add support for SourceOnly snapshot repository

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
@@ -40,6 +40,7 @@ namespace Elasticsearch.Net.Utf8Json
 
         readonly byte[] bytes;
         int offset;
+		int initialOffset;
 
         public JsonReader(byte[] bytes)
             : this(bytes, 0)
@@ -60,6 +61,8 @@ namespace Elasticsearch.Net.Utf8Json
                     this.offset = offset += 3;
                 }
             }
+
+			this.initialOffset = offset;
         }
 
         JsonParsingException CreateParsingException(string expected)
@@ -113,9 +116,21 @@ namespace Elasticsearch.Net.Utf8Json
             }
         }
 
+		/// <summary>
+		/// Advances the offset by a specified amount
+		/// </summary>
+		/// <param name="offset">The amount to offset by</param>
         public void AdvanceOffset(int offset)
         {
             this.offset += offset;
+        }
+
+		/// <summary>
+		/// Resets the offset of the reader back to the original offset
+		/// </summary>
+		public void ResetOffset()
+        {
+            this.offset = this.initialOffset;
         }
 
         public byte[] GetBufferUnsafe()

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/AzureRepository.cs
@@ -3,8 +3,14 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository that stores snapshots in an Azure storage account
+	/// <para />
+	/// Requires the repository-azure plugin to be installed on the cluster
+	/// </summary>
 	public interface IAzureRepository : IRepository<IAzureRepositorySettings> { }
 
+	/// <inheritdoc />
 	public class AzureRepository : IAzureRepository
 	{
 		public AzureRepository() { }
@@ -16,32 +22,55 @@ namespace Nest
 		public string Type { get; } = "azure";
 	}
 
+	/// <summary>
+	/// Snapshot repository settings for <see cref="IAzureRepository"/>
+	/// </summary>
 	public interface IAzureRepositorySettings : IRepositorySettings
 	{
+		/// <summary>
+		/// The path within the container on which to store the snapshot data.
+		/// </summary>
 		[DataMember(Name ="base_path")]
 		string BasePath { get; set; }
 
+		/// <summary>
+		///  Big files can be broken down into chunks during the snapshot process, if needed.
+		///  The chunk size can be specified in bytes or by using size value notation,
+		///  i.e. 1g, 10m, 5k. Defaults to 64m (64m max)
+		/// </summary>
 		[DataMember(Name ="chunk_size")]
 		string ChunkSize { get; set; }
 
+		/// <summary>
+		/// When set to true metadata files are stored in compressed format. This setting doesn't
+		/// affect index files that are already compressed by default. Defaults to <c>false</c>.
+		/// </summary>
 		[DataMember(Name ="compress")]
 		bool? Compress { get; set; }
 
+		/// <summary>
+		/// Tha name of the container
+		/// </summary>
 		[DataMember(Name ="container")]
 		string Container { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class AzureRepositorySettings : IAzureRepositorySettings
 	{
+		/// <inheritdoc />
 		[DataMember(Name ="base_path")]
 		public string BasePath { get; set; }
 
+		/// <inheritdoc />
 		[DataMember(Name ="chunk_size")]
 		public string ChunkSize { get; set; }
 
+		/// <inheritdoc />
 		[DataMember(Name ="compress")]
 		public bool? Compress { get; set; }
 
+		/// <inheritdoc />
 		[DataMember(Name ="container")]
 		public string Container { get; set; }
 	}
@@ -54,35 +83,20 @@ namespace Nest
 		bool? IAzureRepositorySettings.Compress { get; set; }
 		string IAzureRepositorySettings.Container { get; set; }
 
-		/// <summary>
-		/// Container name. Defaults to elasticsearch-snapshots
-		/// </summary>
-		/// <param name="container"></param>
+		/// <inheritdoc cref="IAzureRepositorySettings.Container"/>
 		public AzureRepositorySettingsDescriptor Container(string container) => Assign(container, (a, v) => a.Container = v);
 
-		/// <summary>
-		/// Specifies the path within container to repository data. Defaults to empty (root directory).
-		/// </summary>
-		/// <param name="basePath"></param>
-		/// <returns></returns>
+		/// <inheritdoc cref="IAzureRepositorySettings.BasePath"/>
 		public AzureRepositorySettingsDescriptor BasePath(string basePath) => Assign(basePath, (a, v) => a.BasePath = v);
 
-		/// <summary>
-		/// When set to true metadata files are stored in compressed format. This setting doesn't
-		/// affect index files that are already compressed by default. Defaults to false.
-		/// </summary>
-		/// <param name="compress"></param>
+		/// <inheritdoc cref="IAzureRepositorySettings.Compress"/>
 		public AzureRepositorySettingsDescriptor Compress(bool? compress = true) => Assign(compress, (a, v) => a.Compress = v);
 
-		/// <summary>
-		///  Big files can be broken down into chunks during snapshotting if needed.
-		///  The chunk size can be specified in bytes or by using size value notation,
-		///  i.e. 1g, 10m, 5k. Defaults to 64m (64m max)
-		/// </summary>
-		/// <param name="chunkSize"></param>
+		/// <inheritdoc cref="IAzureRepositorySettings.ChunkSize"/>
 		public AzureRepositorySettingsDescriptor ChunkSize(string chunkSize) => Assign(chunkSize, (a, v) => a.ChunkSize = v);
 	}
 
+	/// <inheritdoc cref="IAzureRepository"/>
 	public class AzureRepositoryDescriptor
 		: DescriptorBase<AzureRepositoryDescriptor, IAzureRepository>, IAzureRepository
 	{
@@ -90,6 +104,7 @@ namespace Nest
 		string ISnapshotRepository.Type { get; } = "azure";
 		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 
+		/// <inheritdoc cref="IAzureRepositorySettings"/>
 		public AzureRepositoryDescriptor Settings(Func<AzureRepositorySettingsDescriptor, IAzureRepositorySettings> settingsSelector) =>
 			Assign(settingsSelector, (a, v) => a.Settings = v?.Invoke(new AzureRepositorySettingsDescriptor()));
 	}

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryRequest.cs
@@ -3,52 +3,52 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Creates a snapshot repository
+	/// </summary>
 	[MapsApi("snapshot.create_repository.json")]
 	[JsonFormatter(typeof(CreateRepositoryFormatter))]
 	public partial interface ICreateRepositoryRequest
 	{
+		/// <summary>
+		/// The snapshot repository
+		/// </summary>
 		ISnapshotRepository Repository { get; set; }
 	}
 
+	/// <inheritdoc cref="ICreateRepositoryRequest" />
 	public partial class CreateRepositoryRequest
 	{
+		/// <inheritdoc />
 		public ISnapshotRepository Repository { get; set; }
 	}
 
+	/// <inheritdoc cref="ICreateRepositoryRequest" />
 	public partial class CreateRepositoryDescriptor
 	{
 		ISnapshotRepository ICreateRepositoryRequest.Repository { get; set; }
 
-		/// <summary>
-		/// 	The shared file system repository ("type": "fs") is using shared file system to store snapshot.
-		///  The path specified in the location parameter should point to the same location in the shared
-		///  filesystem and be accessible on all data and master nodes.
-		/// </summary>
+		/// <inheritdoc cref="IFileSystemRepository"/>
 		public CreateRepositoryDescriptor FileSystem(Func<FileSystemRepositoryDescriptor, IFileSystemRepository> selector) =>
 			Assign(selector, (a, v) => a.Repository = v?.Invoke(new FileSystemRepositoryDescriptor()));
 
-		/// <summary>
-		/// The URL repository ("type": "url") can be used as an alternative read-only way to access data
-		/// created by shared file system repository is using shared file system to store snapshot.
-		/// </summary>
+		/// <inheritdoc cref="IReadOnlyUrlRepository" />
 		public CreateRepositoryDescriptor ReadOnlyUrl(Func<ReadOnlyUrlRepositoryDescriptor, IReadOnlyUrlRepository> selector) =>
 			Assign(selector, (a, v) => a.Repository = v?.Invoke(new ReadOnlyUrlRepositoryDescriptor()));
 
-		/// <summary>
-		/// Specify an azure storage container to snapshot and restore to. (defaults to a container named elasticsearch-snapshots)
-		/// </summary>
+		/// <inheritdoc cref="IAzureRepository" />
 		public CreateRepositoryDescriptor Azure(Func<AzureRepositoryDescriptor, IAzureRepository> selector = null) =>
 			Assign(selector.InvokeOrDefault(new AzureRepositoryDescriptor()), (a, v) => a.Repository = v);
 
-		/// <summary> Create an snapshot/restore repository that points to an HDFS filesystem </summary>
+		/// <inheritdoc cref="IHdfsRepository" />
 		public CreateRepositoryDescriptor Hdfs(Func<HdfsRepositoryDescriptor, IHdfsRepository> selector) =>
 			Assign(selector, (a, v) => a.Repository = v?.Invoke(new HdfsRepositoryDescriptor()));
 
-		/// <summary> Snapshot and restore to an Amazon S3 bucket </summary>
+		/// <inheritdoc cref="IS3Repository" />
 		public CreateRepositoryDescriptor S3(Func<S3RepositoryDescriptor, IS3Repository> selector) =>
 			Assign(selector, (a, v) => a.Repository = v?.Invoke(new S3RepositoryDescriptor()));
 
-		/// <summary> Snapshot and restore to an Amazon S3 bucket </summary>
+		/// <inheritdoc cref="ISourceOnlyRepository" />
 		public CreateRepositoryDescriptor SourceOnly(Func<SourceOnlyRepositoryDescriptor, ISourceOnlyRepository> selector) =>
 			Assign(selector, (a, v) => a.Repository = v?.Invoke(new SourceOnlyRepositoryDescriptor()));
 

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/FileSystemRepository.cs
@@ -4,8 +4,14 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository that uses a shared file system to store snapshot data.
+	/// The path specified in the location parameter should point to the same location in the shared
+	/// filesystem and be accessible on all data and master nodes.
+	/// </summary>
 	public interface IFileSystemRepository : IRepository<IFileSystemRepositorySettings> { }
 
+	/// <inheritdoc />
 	public class FileSystemRepository : IFileSystemRepository
 	{
 		public FileSystemRepository(FileSystemRepositorySettings settings) => Settings = settings;
@@ -15,29 +21,53 @@ namespace Nest
 		public string Type { get; } = "fs";
 	}
 
+	/// <summary>
+	/// Repository settings for <see cref="IFileSystemRepository"/>
+	/// </summary>
 	public interface IFileSystemRepositorySettings : IRepositorySettings
 	{
+		/// <summary>
+		/// Big files can be broken down into chunks during the snapshot process, if needed.
+		/// The chunk size can be specified in bytes or by using size value notation, i.e. 1g, 10m, 5k.
+		/// Defaults to null (unlimited chunk size).
+		/// </summary>
 		[DataMember(Name ="chunk_size")]
 		string ChunkSize { get; set; }
 
+		/// <summary>
+		/// Turns on compression of the snapshot files. Defaults to true.
+		/// </summary>
 		[DataMember(Name ="compress")]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? Compress { get; set; }
 
+		/// <summary>
+		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
+		/// </summary>
 		[DataMember(Name ="concurrent_streams")]
 		[JsonFormatter(typeof(NullableStringIntFormatter))]
 		int? ConcurrentStreams { get; set; }
 
+		/// <summary>
+		/// Location of the snapshots. Mandatory.
+		/// </summary>
 		[DataMember(Name ="location")]
 		string Location { get; set; }
 
+		/// <summary>
+		/// Throttles per node restore rate. Defaults to 20mb per second.
+		/// </summary>
 		[DataMember(Name ="max_restore_bytes_per_second")]
 		string RestoreBytesPerSecondMaximum { get; set; }
 
+		/// <summary>
+		/// Throttles per node snapshot rate. Defaults to 20mb per second.
+		/// </summary>
 		[DataMember(Name ="max_snapshot_bytes_per_second")]
 		string SnapshotBytesPerSecondMaximum { get; set; }
 	}
 
+	/// <inheritdoc cref="IFileSystemRepositorySettings"/>
 	public class FileSystemRepositorySettings : IFileSystemRepositorySettings
 	{
 		internal FileSystemRepositorySettings() { }
@@ -57,6 +87,7 @@ namespace Nest
 		public string SnapshotBytesPerSecondMaximum { get; set; }
 	}
 
+	/// <inheritdoc cref="IFileSystemRepositorySettings"/>
 	public class FileSystemRepositorySettingsDescriptor
 		: DescriptorBase<FileSystemRepositorySettingsDescriptor, IFileSystemRepositorySettings>, IFileSystemRepositorySettings
 	{
@@ -67,48 +98,29 @@ namespace Nest
 		string IFileSystemRepositorySettings.RestoreBytesPerSecondMaximum { get; set; }
 		string IFileSystemRepositorySettings.SnapshotBytesPerSecondMaximum { get; set; }
 
-		/// <summary>
-		/// Location of the snapshots. Mandatory.
-		/// </summary>
-		/// <param name="location"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.Location"/>
 		public FileSystemRepositorySettingsDescriptor Location(string location) => Assign(location, (a, v) => a.Location = v);
 
-		/// <summary>
-		/// Turns on compression of the snapshot files. Defaults to true.
-		/// </summary>
-		/// <param name="compress"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.Compress"/>
 		public FileSystemRepositorySettingsDescriptor Compress(bool? compress = true) => Assign(compress, (a, v) => a.Compress = v);
 
-		/// <summary>
-		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
-		/// </summary>
-		/// <param name="concurrentStreams"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.ConcurrentStreams"/>
 		public FileSystemRepositorySettingsDescriptor ConcurrentStreams(int? concurrentStreams) =>
 			Assign(concurrentStreams, (a, v) => a.ConcurrentStreams = v);
 
-		/// <summary>
-		/// Big files can be broken down into chunks during snapshotting if needed.
-		/// The chunk size can be specified in bytes or by using size value notation, i.e. 1g, 10m, 5k.
-		/// Defaults to null (unlimited chunk size).
-		/// </summary>
-		/// <param name="chunkSize"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.ChunkSize"/>
 		public FileSystemRepositorySettingsDescriptor ChunkSize(string chunkSize) => Assign(chunkSize, (a, v) => a.ChunkSize = v);
 
-		/// <summary>
-		/// Throttles per node restore rate. Defaults to 20mb per second.
-		/// </summary>
-		/// <param name="maximumBytesPerSecond"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.RestoreBytesPerSecondMaximum"/>
 		public FileSystemRepositorySettingsDescriptor RestoreBytesPerSecondMaximum(string maximumBytesPerSecond) =>
 			Assign(maximumBytesPerSecond, (a, v) => a.RestoreBytesPerSecondMaximum = v);
 
-		/// <summary>
-		/// Throttles per node snapshot rate. Defaults to 20mb per second.
-		/// </summary>
-		/// <param name="maximumBytesPerSecond"></param>
+		/// <inheritdoc cref="IFileSystemRepositorySettings.SnapshotBytesPerSecondMaximum"/>
 		public FileSystemRepositorySettingsDescriptor SnapshotBytesPerSecondMaximum(string maximumBytesPerSecond) =>
 			Assign(maximumBytesPerSecond, (a, v) => a.SnapshotBytesPerSecondMaximum = v);
 	}
 
+	/// <inheritdoc cref="IFileSystemRepository"/>
 	public class FileSystemRepositoryDescriptor
 		: DescriptorBase<FileSystemRepositoryDescriptor, IFileSystemRepository>, IFileSystemRepository
 	{
@@ -116,6 +128,7 @@ namespace Nest
 		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type { get; } = "fs";
 
+		/// <inheritdoc cref="IFileSystemRepositorySettings"/>
 		public FileSystemRepositoryDescriptor Settings(string location,
 			Func<FileSystemRepositorySettingsDescriptor, IFileSystemRepositorySettings> settingsSelector = null
 		) =>

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryResponseFormatter.cs
@@ -87,6 +87,13 @@ namespace Nest
 							var hdfs = GetRepository<HdfsRepository, HdfsRepositorySettings>(settings, formatterResolver);
 							repositories.Add(name, hdfs);
 							break;
+						case "source":
+							// reset the offset
+							snapshotSegmentReader.ResetOffset();
+							var source = formatterResolver.GetFormatter<ISourceOnlyRepository>()
+								.Deserialize(ref snapshotSegmentReader, formatterResolver);
+							repositories.Add(name, source);
+							break;
 					}
 				}
 			}

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/HdfsRepository.cs
@@ -4,8 +4,14 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository that stores snapshot data within a Hadoop HDFS filesystem
+	/// <para />
+	/// Requires the repository-hdfs plugin to be installed on the cluster
+	/// </summary>
 	public interface IHdfsRepository : IRepository<IHdfsRepositorySettings> { }
 
+	/// <inheritdoc />
 	public class HdfsRepository : IHdfsRepository
 	{
 		public HdfsRepository(HdfsRepositorySettings settings) => Settings = settings;
@@ -15,49 +21,89 @@ namespace Nest
 		public string Type { get; } = "hdfs";
 	}
 
+	/// <summary>
+	/// Snapshot repository settings for <see cref="IHdfsRepository"/>
+	/// </summary>
 	public interface IHdfsRepositorySettings : IRepositorySettings
 	{
+		/// <summary>
+		///  Big files can be broken down into chunks during snapshotting if needed.
+		///  The chunk size can be specified in bytes or by using size value notation,
+		///  i.e. 1g, 10m, 5k. Disabled by default
+		/// </summary>
 		[DataMember(Name ="chunk_size")]
 		string ChunkSize { get; set; }
 
+		/// <summary>
+		/// When set to true metadata files are stored in compressed format. This setting doesn't
+		/// affect index files that are already compressed by default. Defaults to <c>false</c>.
+		/// </summary>
 		[DataMember(Name ="compress")]
 		bool? Compress { get; set; }
 
+		/// <summary>
+		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
+		/// </summary>
 		[DataMember(Name ="concurrent_streams")]
 		int? ConcurrentStreams { get; set; }
 
+		/// <summary>
+		/// Hadoop configuration XML to be loaded (use commas for multi values)
+		/// </summary>
 		[DataMember(Name ="conf_location")]
 		string ConfigurationLocation { get; set; }
 
+		/// <summary>
+		/// 'inlined' key=value added to the Hadoop configuration
+		/// </summary>
 		[IgnoreDataMember]
 		Dictionary<string, object> InlineHadoopConfiguration { get; set; }
 
+		/// <summary>
+		/// Whether to load the default Hadoop configuration (default) or not
+		/// </summary>
 		[DataMember(Name ="load_defaults")]
 		bool? LoadDefaults { get; set; }
 
+		/// <summary>
+		/// The path with the file-system where data is stored/loaded. Required
+		/// </summary>
 		[DataMember(Name ="path")]
 		string Path { get; set; }
 
+		/// <summary>
+		/// The Hadoop file-system URI. Optional
+		/// </summary>
 		[DataMember(Name ="uri")]
 		string Uri { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class HdfsRepositorySettings : IHdfsRepositorySettings
 	{
 		internal HdfsRepositorySettings() { }
 
 		public HdfsRepositorySettings(string path) => Path = path;
 
+		/// <inheritdoc />
 		public string ChunkSize { get; set; }
+		/// <inheritdoc />
 		public bool? Compress { get; set; }
+		/// <inheritdoc />
 		public int? ConcurrentStreams { get; set; }
+		/// <inheritdoc />
 		public string ConfigurationLocation { get; set; }
+		/// <inheritdoc />
 		public Dictionary<string, object> InlineHadoopConfiguration { get; set; }
+		/// <inheritdoc />
 		public bool? LoadDefaults { get; set; }
+		/// <inheritdoc />
 		public string Path { get; set; }
+		/// <inheritdoc />
 		public string Uri { get; set; }
 	}
 
+	/// <inheritdoc cref="IHdfsRepositorySettings"/>
 	public class HdfsRepositorySettingsDescriptor
 		: DescriptorBase<HdfsRepositorySettingsDescriptor, IHdfsRepositorySettings>, IHdfsRepositorySettings
 	{
@@ -70,58 +116,35 @@ namespace Nest
 		string IHdfsRepositorySettings.Path { get; set; }
 		string IHdfsRepositorySettings.Uri { get; set; }
 
-		/// <summary>
-		/// optional - Hadoop file-system URI
-		/// </summary>
+		/// <inheritdoc cref="IHdfsRepositorySettings.Uri"/>
 		public HdfsRepositorySettingsDescriptor Uri(string uri) => Assign(uri, (a, v) => a.Uri = v);
 
-		/// <summary>
-		/// required - path with the file-system where data is stored/loaded
-		/// </summary>
+		/// <inheritdoc cref="IHdfsRepositorySettings.Path"/>
 		public HdfsRepositorySettingsDescriptor Path(string path) => Assign(path, (a, v) => a.Path = v);
 
-		/// <summary>
-		/// whether to load the default Hadoop configuration (default) or not
-		/// </summary>
-		/// <param name="loadDefaults"></param>
+		/// <inheritdoc cref="IHdfsRepositorySettings.LoadDefaults"/>
 		public HdfsRepositorySettingsDescriptor LoadDefaults(bool? loadDefaults = true) => Assign(loadDefaults, (a, v) => a.LoadDefaults = v);
 
-		/// <summary>
-		/// Hadoop configuration XML to be loaded (use commas for multi values)
-		/// </summary>
-		/// <param name="configurationLocation"></param>
+		/// <inheritdoc cref="IHdfsRepositorySettings.ConfigurationLocation"/>
 		public HdfsRepositorySettingsDescriptor ConfigurationLocation(string configurationLocation) =>
 			Assign(configurationLocation, (a, v) => a.ConfigurationLocation = v);
 
-		/// <summary>
-		/// 'inlined' key=value added to the Hadoop configuration
-		/// </summary>
+		/// <inheritdoc cref="IHdfsRepositorySettings.InlineHadoopConfiguration"/>
 		public HdfsRepositorySettingsDescriptor InlinedHadoopConfiguration(
 			Func<FluentDictionary<string, object>, FluentDictionary<string, object>> inlineConfig
 		) => Assign(inlineConfig, (a, v) => a.InlineHadoopConfiguration = v(new FluentDictionary<string, object>()));
 
-		/// <summary>
-		/// When set to true metadata files are stored in compressed format. This setting doesn't
-		/// affect index files that are already compressed by default. Defaults to false.
-		/// </summary>
-		/// <param name="compress"></param>
+		/// <inheritdoc cref="IHdfsRepositorySettings.Compress"/>
 		public HdfsRepositorySettingsDescriptor Compress(bool? compress = true) => Assign(compress, (a, v) => a.Compress = v);
 
-		/// <summary>
-		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
-		/// </summary>
-		/// <param name="concurrentStreams"></param>
+		/// <inheritdoc cref="IHdfsRepositorySettings.ConcurrentStreams"/>
 		public HdfsRepositorySettingsDescriptor ConcurrentStreams(int? concurrentStreams) => Assign(concurrentStreams, (a, v) => a.ConcurrentStreams = v);
 
-		/// <summary>
-		///  Big files can be broken down into chunks during snapshotting if needed.
-		///  The chunk size can be specified in bytes or by using size value notation,
-		///  i.e. 1g, 10m, 5k. Disabled by default
-		/// </summary>
-		/// <param name="chunkSize"></param>
+		/// <inheritdoc cref="IHdfsRepositorySettings.ChunkSize"/>
 		public HdfsRepositorySettingsDescriptor ChunkSize(string chunkSize) => Assign(chunkSize, (a, v) => a.ChunkSize = v);
 	}
 
+	/// <inheritdoc cref="IHdfsRepository"/>
 	public class HdfsRepositoryDescriptor
 		: DescriptorBase<HdfsRepositoryDescriptor, IHdfsRepository>, IHdfsRepository
 	{
@@ -129,6 +152,7 @@ namespace Nest
 		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type => "hdfs";
 
+		/// <inheritdoc cref="IHdfsRepositorySettings"/>
 		public HdfsRepositoryDescriptor Settings(string path, Func<HdfsRepositorySettingsDescriptor, IHdfsRepositorySettings> settingsSelector = null
 		) =>
 			Assign(settingsSelector.InvokeOrDefault(new HdfsRepositorySettingsDescriptor().Path(path)), (a, v) => a.Settings = v);

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/ISnapshotRepository.cs
@@ -2,24 +2,42 @@
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository
+	/// </summary>
 	public interface ISnapshotRepository
 	{
 		[DataMember(Name ="type")]
 		string Type { get; }
 	}
 
+	/// <summary>
+	/// A snapshot repository with settings
+	/// </summary>
 	public interface IRepositoryWithSettings: ISnapshotRepository
 	{
+		/// <summary>
+		/// The repository settings
+		/// </summary>
 		[IgnoreDataMember]
 		object DelegateSettings { get; }
 	}
 
+	/// <summary>
+	/// A snapshot repository with typed settings
+	/// </summary>
 	public interface IRepository<TSettings> : IRepositoryWithSettings
 		where TSettings : class, IRepositorySettings
 	{
+		/// <summary>
+		/// The repository settings
+		/// </summary>
 		[DataMember(Name ="settings")]
 		TSettings Settings { get; set; }
 	}
 
+	/// <summary>
+	/// Snapshot repository settings
+	/// </summary>
 	public interface IRepositorySettings { }
 }

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/ReadOnlyUrlRepository.cs
@@ -3,8 +3,13 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository that can be used as an alternative read-only way to access data created by the <see cref="IFileSystemRepository"/>.
+	/// The URL specified in the url parameter should point to the root of the shared filesystem repository.
+	/// </summary>
 	public interface IReadOnlyUrlRepository : IRepository<IReadOnlyUrlRepositorySettings> { }
 
+	/// <inheritdoc />
 	public class ReadOnlyUrlRepository : IReadOnlyUrlRepository
 	{
 		public ReadOnlyUrlRepository(ReadOnlyUrlRepositorySettings settings) => Settings = settings;
@@ -14,46 +19,54 @@ namespace Nest
 		public string Type { get; } = "url";
 	}
 
+	/// <summary>
+	/// Snapshot repository settings for <see cref="IReadOnlyUrlRepository"/>
+	/// </summary>
 	public interface IReadOnlyUrlRepositorySettings : IRepositorySettings
 	{
+		/// <summary>
+		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
+		/// </summary>
 		[DataMember(Name ="concurrent_streams")]
 		int? ConcurrentStreams { get; set; }
 
+		/// <summary>
+		/// Location of the snapshots. Required
+		/// </summary>
 		[DataMember(Name ="location")]
 		string Location { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class ReadOnlyUrlRepositorySettings : IReadOnlyUrlRepositorySettings
 	{
 		internal ReadOnlyUrlRepositorySettings() { }
 
 		public ReadOnlyUrlRepositorySettings(string location) => Location = location;
 
+		/// <inheritdoc />
 		public int? ConcurrentStreams { get; set; }
 
+		/// <inheritdoc />
 		public string Location { get; set; }
 	}
 
+	/// <inheritdoc cref="IReadOnlyUrlRepositorySettings"/>
 	public class ReadOnlyUrlRepositorySettingsDescriptor
 		: DescriptorBase<ReadOnlyUrlRepositorySettingsDescriptor, IReadOnlyUrlRepositorySettings>, IReadOnlyUrlRepositorySettings
 	{
 		int? IReadOnlyUrlRepositorySettings.ConcurrentStreams { get; set; }
 		string IReadOnlyUrlRepositorySettings.Location { get; set; }
 
-		/// <summary>
-		/// Location of the snapshots. Mandatory.
-		/// </summary>
-		/// <param name="location"></param>
+		/// <inheritdoc cref="IReadOnlyUrlRepositorySettings.Location"/>
 		public ReadOnlyUrlRepositorySettingsDescriptor Location(string location) => Assign(location, (a, v) => a.Location = v);
 
-		/// <summary>
-		/// Throttles the number of streams (per node) preforming snapshot operation. Defaults to 5
-		/// </summary>
-		/// <param name="concurrentStreams"></param>
+		/// <inheritdoc cref="IReadOnlyUrlRepositorySettings.ConcurrentStreams"/>
 		public ReadOnlyUrlRepositorySettingsDescriptor ConcurrentStreams(int? concurrentStreams) =>
 			Assign(concurrentStreams, (a, v) => a.ConcurrentStreams = v);
 	}
 
+	/// <inheritdoc cref="IReadOnlyUrlRepository"/>
 	public class ReadOnlyUrlRepositoryDescriptor
 		: DescriptorBase<ReadOnlyUrlRepositoryDescriptor, IReadOnlyUrlRepository>, IReadOnlyUrlRepository
 	{
@@ -61,6 +74,7 @@ namespace Nest
 		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type => "url";
 
+		/// <inheritdoc cref="IReadOnlyUrlRepositorySettings"/>
 		public ReadOnlyUrlRepositoryDescriptor Settings(string location,
 			Func<ReadOnlyUrlRepositorySettingsDescriptor, IReadOnlyUrlRepositorySettings> settingsSelector = null
 		) =>

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
@@ -3,8 +3,14 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	/// <summary>
+	/// A snapshot repository that stores snapshots in an Amazon S3 bucket
+	/// <para />
+	/// Requires the repository-s3 plugin to be installed on the cluster
+	/// </summary>
 	public interface IS3Repository : IRepository<IS3RepositorySettings> { }
 
+	/// <inheritdoc />
 	public class S3Repository : IS3Repository
 	{
 		public S3Repository(IS3RepositorySettings settings) => Settings = settings;
@@ -14,6 +20,9 @@ namespace Nest
 		public string Type { get; } = "s3";
 	}
 
+	/// <summary>
+	/// Snapshot repository settings for <see cref="IS3Repository"/>
+	/// </summary>
 	public interface IS3RepositorySettings : IRepositorySettings
 	{
 		/// <summary>
@@ -85,6 +94,7 @@ namespace Nest
 		string StorageClass { get; set; }
 	}
 
+	/// <inheritdoc />
 	public class S3RepositorySettings : IS3RepositorySettings
 	{
 		internal S3RepositorySettings() { }
@@ -119,6 +129,7 @@ namespace Nest
 		public string StorageClass { get; set; }
 	}
 
+	/// <inheritdoc cref="IS3RepositorySettings"/>
 	public class S3RepositorySettingsDescriptor
 		: DescriptorBase<S3RepositorySettingsDescriptor, IS3RepositorySettings>, IS3RepositorySettings
 	{
@@ -163,6 +174,7 @@ namespace Nest
 		public S3RepositorySettingsDescriptor StorageClass(string storageClass) => Assign(storageClass, (a, v) => a.StorageClass = v);
 	}
 
+	/// <inheritdoc cref="IS3Repository"/>
 	public class S3RepositoryDescriptor
 		: DescriptorBase<S3RepositoryDescriptor, IS3Repository>, IS3Repository
 	{
@@ -170,6 +182,7 @@ namespace Nest
 		object IRepositoryWithSettings.DelegateSettings => Self.Settings;
 		string ISnapshotRepository.Type { get; } = "s3";
 
+		/// <inheritdoc cref="IS3RepositorySettings"/>
 		public S3RepositoryDescriptor Settings(string bucket, Func<S3RepositorySettingsDescriptor, IS3RepositorySettings> settingsSelector = null) =>
 			Assign(settingsSelector.InvokeOrDefault(new S3RepositorySettingsDescriptor(bucket)), (a, v) => a.Settings = v);
 	}

--- a/src/Tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
+++ b/src/Tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
@@ -129,7 +129,6 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 		protected override CreateRepositoryDescriptor NewDescriptor() => new CreateRepositoryDescriptor(_name);
 	}
 
-	[SkipVersion("<6.5.0", "new feature")]
 	public class CreateSourceOnlyRepositoryApiTests
 		: ApiTestBase<WritableCluster, CreateRepositoryResponse, ICreateRepositoryRequest, CreateRepositoryDescriptor, CreateRepositoryRequest>
 	{
@@ -137,7 +136,7 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 
 		public CreateSourceOnlyRepositoryApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
-		protected override object ExpectJson { get; } = new
+		protected override object ExpectJson => new
 		{
 			type = "source",
 			settings = new

--- a/src/Tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryApiTests.cs
+++ b/src/Tests/Tests/Modules/SnapshotAndRestore/Repositories/GetRepository/GetRepositoryApiTests.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Elasticsearch.Net;
+using FluentAssertions;
 using Nest;
+using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
@@ -8,20 +10,55 @@ using Tests.Framework.EndpointTests.TestState;
 namespace Tests.Modules.SnapshotAndRestore.Repositories.GetRepository
 {
 	public class GetRepositoryApiTests
-		: ApiTestBase<ReadOnlyCluster, GetRepositoryResponse, IGetRepositoryRequest, GetRepositoryDescriptor, GetRepositoryRequest>
+		: ApiIntegrationTestBase<WritableCluster, GetRepositoryResponse, IGetRepositoryRequest, GetRepositoryDescriptor, GetRepositoryRequest>
 	{
-		private static readonly string _name = "repository1";
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+			{
+				var createRepositoryResponse = client.Snapshot.CreateRepository(callUniqueValue.Value, d => d
+					.SourceOnly(so => so
+						.FileSystem(fs => fs
+							.Settings("some/location", s => s
+								.Compress()
+								.ConcurrentStreams(5)
+								.ChunkSize("64mb")
+								.RestoreBytesPerSecondMaximum("100mb")
+								.SnapshotBytesPerSecondMaximum("200mb")
+							)
+						)
+					)
+				);
 
-		public GetRepositoryApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+				if (!createRepositoryResponse.IsValid)
+					throw new Exception($"Error in integration setup: {createRepositoryResponse.DebugInformation}");
+			}
+		}
 
-		protected override Func<GetRepositoryDescriptor, IGetRepositoryRequest> Fluent => d => d.RepositoryName(_name);
+		protected override void IntegrationTeardown(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var callUniqueValue in values)
+			{
+				var deleteRepositoryResponse = client.Snapshot.DeleteRepository(callUniqueValue.Value);
+
+				if (!deleteRepositoryResponse.IsValid)
+					throw new Exception($"Error in integration teardown: {deleteRepositoryResponse.DebugInformation}");
+			}
+		}
+
+		public GetRepositoryApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override Func<GetRepositoryDescriptor, IGetRepositoryRequest> Fluent => d => d.RepositoryName(CallIsolatedValue);
 
 		protected override HttpMethod HttpMethod => HttpMethod.GET;
 
-		protected override GetRepositoryRequest Initializer => new GetRepositoryRequest(_name);
+		protected override bool ExpectIsValid => true;
+
+		protected override int ExpectStatusCode => 200;
+		protected override GetRepositoryRequest Initializer => new GetRepositoryRequest(CallIsolatedValue);
 
 		protected override bool SupportsDeserialization => false;
-		protected override string UrlPath => $"/_snapshot/{_name}";
+		protected override string UrlPath => $"/_snapshot/{CallIsolatedValue}";
 
 		protected override LazyResponses ClientUsage() => Calls(
 			(client, f) => client.Snapshot.GetRepository(f),
@@ -29,5 +66,20 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.GetRepository
 			(client, r) => client.Snapshot.GetRepository(r),
 			(client, r) => client.Snapshot.GetRepositoryAsync(r)
 		);
+
+		protected override void ExpectResponse(GetRepositoryResponse response)
+		{
+			response.ShouldBeValid();
+
+			response.Repositories.Should().ContainKey(CallIsolatedValue);
+
+			var repository = response.Repositories[CallIsolatedValue];
+			repository.Type.Should().Be("source");
+
+			var sourceOnlyRespository = repository as ISourceOnlyRepository;
+			sourceOnlyRespository.Should().NotBeNull();
+			sourceOnlyRespository.DelegateType.Should().Be("fs");
+			sourceOnlyRespository.DelegateSettings.Should().BeAssignableTo<IFileSystemRepositorySettings>();
+		}
 	}
 }


### PR DESCRIPTION
This commit adds support for SourceOnly repository.
Introduce a ResetOffset() method on JsonReader to reset the offset back to the initial offset
Tidy up XML docs on repositories