### PR TITLE
Skip max_docs query string params

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/DeleteByQueryOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/DeleteByQueryOverrides.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace ApiGenerator.Configuration.Overrides.Endpoints
+{
+	public class DeleteByQueryOverrides : EndpointOverridesBase
+	{
+		public override IEnumerable<string> SkipQueryStringParams => new[] { "max_docs", };
+	}
+}

--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/ReindexOnServerOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/ReindexOnServerOverrides.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace ApiGenerator.Configuration.Overrides.Endpoints
+{
+	public class ReindexOnServerOverrides : EndpointOverridesBase
+	{
+		public override IEnumerable<string> SkipQueryStringParams => new[] { "max_docs", };
+	}
+}

--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/UpdateByQueryOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/UpdateByQueryOverrides.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace ApiGenerator.Configuration.Overrides.Endpoints
+{
+	public class UpdateByQueryOverrides : EndpointOverridesBase
+	{
+		public override IEnumerable<string> SkipQueryStringParams => new[] { "max_docs", };
+	}
+}

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -417,13 +417,6 @@ namespace Elasticsearch.Net
 			set => Q("lenient", value);
 		}
 
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
-		}
-
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference
 		{
@@ -1422,13 +1415,6 @@ namespace Elasticsearch.Net
 	public class ReindexOnServerRequestParameters : RequestParameters<ReindexOnServerRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
-		}
-
 		///<summary>Should the effected indexes be refreshed?</summary>
 		public bool? Refresh
 		{
@@ -2129,13 +2115,6 @@ namespace Elasticsearch.Net
 		{
 			get => Q<bool? >("lenient");
 			set => Q("lenient", value);
-		}
-
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
 		}
 
 		///<summary>Ingest pipeline to set on index requests made by this action. (default: none)</summary>

--- a/src/Nest/Descriptors.NoNamespace.cs
+++ b/src/Nest/Descriptors.NoNamespace.cs
@@ -316,8 +316,6 @@ namespace Nest
 		public DeleteByQueryDescriptor<TDocument> IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
 		public DeleteByQueryDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public DeleteByQueryDescriptor<TDocument> MaxDocs(long? maxdocs) => Qs("max_docs", maxdocs);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public DeleteByQueryDescriptor<TDocument> Preference(string preference) => Qs("preference", preference);
 		///<summary>Query in the Lucene query string syntax</summary>
@@ -1140,8 +1138,6 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceReindexOnServer;
 		// values part of the url path
 		// Request parameters
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public ReindexOnServerDescriptor MaxDocs(long? maxdocs) => Qs("max_docs", maxdocs);
 		///<summary>Should the effected indexes be refreshed?</summary>
 		public ReindexOnServerDescriptor Refresh(bool? refresh = true) => Qs("refresh", refresh);
 		///<summary>The throttle to set on this request in sub-requests per second. -1 means no throttle.</summary>
@@ -1596,8 +1592,6 @@ namespace Nest
 		public UpdateByQueryDescriptor<TDocument> IgnoreUnavailable(bool? ignoreunavailable = true) => Qs("ignore_unavailable", ignoreunavailable);
 		///<summary>Specify whether format-based query failures (such as providing text to a numeric field) should be ignored</summary>
 		public UpdateByQueryDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public UpdateByQueryDescriptor<TDocument> MaxDocs(long? maxdocs) => Qs("max_docs", maxdocs);
 		///<summary>Ingest pipeline to set on index requests made by this action. (default: none)</summary>
 		public UpdateByQueryDescriptor<TDocument> Pipeline(string pipeline) => Qs("pipeline", pipeline);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>

--- a/src/Nest/Requests.NoNamespace.cs
+++ b/src/Nest/Requests.NoNamespace.cs
@@ -674,13 +674,6 @@ namespace Nest
 			set => Q("lenient", value);
 		}
 
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
-		}
-
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public string Preference
 		{
@@ -2413,13 +2406,6 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.NoNamespaceReindexOnServer;
 		// values part of the url path
 		// Request parameters
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
-		}
-
 		///<summary>Should the effected indexes be refreshed?</summary>
 		public bool? Refresh
 		{
@@ -3469,13 +3455,6 @@ namespace Nest
 		{
 			get => Q<bool? >("lenient");
 			set => Q("lenient", value);
-		}
-
-		///<summary>Maximum number of documents to process (default: all documents)</summary>
-		public long? MaxDocs
-		{
-			get => Q<long? >("max_docs");
-			set => Q("max_docs", value);
 		}
 
 		///<summary>Ingest pipeline to set on index requests made by this action. (default: none)</summary>

--- a/src/Tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryApiTests.cs
+++ b/src/Tests/Tests/Document/Multiple/DeleteByQuery/DeleteByQueryApiTests.cs
@@ -24,6 +24,7 @@ namespace Tests.Document.Multiple.DeleteByQuery
 
 		protected override object ExpectJson { get; } = new
 		{
+			max_docs = Project.Projects.Count,
 			query = new
 			{
 				ids = new
@@ -38,6 +39,7 @@ namespace Tests.Document.Multiple.DeleteByQuery
 		protected override Func<DeleteByQueryDescriptor<Project>, IDeleteByQueryRequest> Fluent => d => d
 			.Index(Indices)
 			.IgnoreUnavailable()
+			.MaximumDocuments(Project.Projects.Count)
 			.Query(q => q
 				.Ids(ids => ids
 					.Values(Project.First.Name, "x")
@@ -49,6 +51,7 @@ namespace Tests.Document.Multiple.DeleteByQuery
 		protected override DeleteByQueryRequest Initializer => new DeleteByQueryRequest(Indices)
 		{
 			IgnoreUnavailable = true,
+			MaximumDocuments = Project.Projects.Count,
 			Query = new IdsQuery
 			{
 				Values = new Id[] { Project.First.Name, "x" }


### PR DESCRIPTION
This commit skips max_docs as query string params on DeleteByQuery,UpdateByQuery and ReindexOnServer.

The parameter can also be defined in the request body, so prefer this.