### PR TITLE
Build DebugInformation uri and method from Request or ApiCallDetails

### DIFF
--- a/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
+++ b/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
@@ -48,9 +48,9 @@ namespace Elasticsearch.Net
 				}
 				else if (Response != null)
 				{
-					sb.Append(Response.HttpMethod.GetStringValue());
-					sb.Append(" on ");
-					sb.AppendLine(Response.Uri.ToString());
+					sb.Append(Response.HttpMethod.GetStringValue())
+						.Append(" on ")
+						.AppendLine(Response.Uri.ToString());
 				}
 				else
 					sb.AppendLine("a request");
@@ -65,13 +65,13 @@ namespace Elasticsearch.Net
 
 				if (InnerException != null)
 				{
-					sb.Append("# Inner Exception: ");
-					sb.AppendLine(InnerException.Message);
-					sb.AppendLine(InnerException.ToString());
+					sb.Append("# Inner Exception: ")
+						.AppendLine(InnerException.Message)
+						.AppendLine(InnerException.ToString());
 				}
 
-				sb.AppendLine("# Exception:");
-				sb.AppendLine(ToString());
+				sb.AppendLine("# Exception:")
+					.AppendLine(ToString());
 				return sb.ToString();
 			}
 		}

--- a/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
+++ b/src/Elasticsearch.Net/Exceptions/ElasticsearchClientException.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Elasticsearch.Net.Extensions;
+using static Elasticsearch.Net.ResponseStatics;
 
 namespace Elasticsearch.Net
 {
@@ -31,26 +32,46 @@ namespace Elasticsearch.Net
 				var failureReason = FailureReason.GetStringValue();
 				if (FailureReason == PipelineFailure.Unexpected && AuditTrail.HasAny())
 					failureReason = "Unrecoverable/Unexpected " + AuditTrail.Last().Event.GetStringValue();
-				var path = Request.Uri != null
-					? Request.Uri.ToString()
-					: Request.PathAndQuery + " on an empty node, likely a node predicate on ConnectionSettings not matching ANY nodes";
 
-				sb.AppendLine($"# FailureReason: {failureReason} while attempting {EnumExtensions.GetStringValue(Request.Method)} on {path}");
+				sb.Append("# FailureReason: ")
+					.Append(failureReason)
+					.Append(" while attempting ");
+
+				if (Request != null)
+				{
+					sb.Append(Request.Method.GetStringValue()).Append(" on ");
+					if (Request.Uri != null)
+						sb.AppendLine(Request.Uri.ToString());
+					else
+						sb.Append(Request.PathAndQuery)
+							.AppendLine(" on an empty node, likely a node predicate on ConnectionSettings not matching ANY nodes");
+				}
+				else if (Response != null)
+				{
+					sb.Append(Response.HttpMethod.GetStringValue());
+					sb.Append(" on ");
+					sb.AppendLine(Response.Uri.ToString());
+				}
+				else
+					sb.AppendLine("a request");
+
 				if (Response != null)
-					ResponseStatics.DebugInformationBuilder(Response, sb);
+					DebugInformationBuilder(Response, sb);
 				else
 				{
-					ResponseStatics.DebugAuditTrail(AuditTrail, sb);
-					ResponseStatics.DebugAuditTrailExceptions(AuditTrail, sb);
+					DebugAuditTrail(AuditTrail, sb);
+					DebugAuditTrailExceptions(AuditTrail, sb);
 				}
+
 				if (InnerException != null)
 				{
-					sb.AppendLine($"# Inner Exception: {InnerException.Message}");
+					sb.Append("# Inner Exception: ");
+					sb.AppendLine(InnerException.Message);
 					sb.AppendLine(InnerException.ToString());
 				}
-				sb.AppendLine($"# Exception:");
-				sb.AppendLine(ToString());
 
+				sb.AppendLine("# Exception:");
+				sb.AppendLine(ToString());
 				return sb.ToString();
 			}
 		}

--- a/src/Elasticsearch.Net/Responses/ResponseStatics.cs
+++ b/src/Elasticsearch.Net/Responses/ResponseStatics.cs
@@ -38,6 +38,8 @@ namespace Elasticsearch.Net
 
 		public static void DebugAuditTrailExceptions(List<Audit> auditTrail, StringBuilder sb)
 		{
+			if (auditTrail == null) return;
+
 			var auditExceptions = auditTrail.Select((audit, i) => new { audit, i }).Where(a => a.audit.Exception != null);
 			foreach (var a in auditExceptions)
 				sb.AppendLine($"# Audit exception in step {a.i + 1} {a.audit.Event.GetStringValue()}:\r\n{a.audit.Exception}");

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -210,7 +210,7 @@ namespace Elasticsearch.Net
 				: $"Status code {statusCode} from: {callDetails.HttpMethod} {callDetails.Uri.PathAndQuery}";
 
 
-			var exceptionMessage = innerException?.Message ?? $"Request failed to execute";
+			var exceptionMessage = innerException?.Message ?? "Request failed to execute";
 
 			var pipelineFailure = data.OnFailurePipelineFailure;
 			if (pipelineExceptions.HasAny())

--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -128,7 +128,6 @@ namespace Nest
 				.ConfigureAwait(false);
 
 			_compositeCancelToken.ThrowIfCancellationRequested();
-			
 			_bulkResponseCallback?.Invoke(response);
 
 			if (!response.ApiCall.Success)
@@ -166,7 +165,7 @@ namespace Nest
 
 			foreach (var dropped in droppedDocuments) _droppedDocumentCallBack(dropped.Item1, dropped.Item2);
 			if (!_partitionedBulkRequest.ContinueAfterDroppedDocuments)
-				throw ThrowOnBadBulk(response, $"BulkAll halted after receiving failures that can not be retried from _bulk");
+				throw ThrowOnBadBulk(response, $"{nameof(BulkAll)} halted after receiving failures that can not be retried from _bulk");
 		}
 
 		private async Task<BulkAllResponse> HandleBulkRequest(IList<T> buffer, long page, int backOffRetries, BulkResponse response)
@@ -178,7 +177,7 @@ namespace Nest
 			{
 				case PipelineFailure.MaxRetriesReached:
 					if (response.ApiCall.AuditTrail.Last().Event == AuditEvent.FailedOverAllNodes)
-						throw ThrowOnBadBulk(response, $"BulkAll halted after attempted bulk failed over all the active nodes");
+						throw ThrowOnBadBulk(response, $"{nameof(BulkAll)} halted after attempted bulk failed over all the active nodes");
 
 					ThrowOnExhaustedRetries();
 					return await RetryDocuments(page, ++backOffRetries, buffer).ConfigureAwait(false);
@@ -187,7 +186,7 @@ namespace Nest
 				case PipelineFailure.NoNodesAttempted:
 				case PipelineFailure.SniffFailure:
 				case PipelineFailure.Unexpected:
-					throw ThrowOnBadBulk(response, $"BulkAll halted after {nameof(PipelineFailure)}.{reason} from _bulk");
+					throw ThrowOnBadBulk(response, $"{nameof(BulkAll)} halted after {nameof(PipelineFailure)}.{reason} from _bulk");
 				case PipelineFailure.BadResponse:
 				case PipelineFailure.PingFailure:
 				case PipelineFailure.MaxTimeoutReached:
@@ -202,7 +201,7 @@ namespace Nest
 				if (_partitionedBulkRequest.ContinueAfterDroppedDocuments || backOffRetries < _backOffRetries) return;
 
 				throw ThrowOnBadBulk(response,
-					$"BulkAll halted after {nameof(PipelineFailure)}.{reason} from _bulk and exhausting retries ({backOffRetries})"
+					$"{nameof(BulkAll)} halted after {nameof(PipelineFailure)}.{reason} from _bulk and exhausting retries ({backOffRetries})"
 				);
 			}
 		}


### PR DESCRIPTION
This commit changes how DebugInformation is built in ElasticsearchClientException to use either Request
or ApiCallDetails to retrieve the Uri and method of the request. There are some usages of ElasticsearchClientException
where the Request property is not set, such as Throw() method in BulkAllObservable.

Fixes #3687