### PR TITLE
Fix Stats aggregate sum change type to nullable

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -419,7 +419,7 @@ namespace Nest
 			reader.ReadNext(); // ,
 			reader.ReadNext(); // sum
 			reader.ReadNext(); // :
-			var sum = reader.ReadDouble();
+			var sum = reader.ReadNullableDouble();
 
 			var statsMetric = new StatsAggregate
 			{

--- a/src/Nest/Aggregations/Metric/Stats/StatsAggregate.cs
+++ b/src/Nest/Aggregations/Metric/Stats/StatsAggregate.cs
@@ -6,6 +6,6 @@
 		public long Count { get; set; }
 		public double? Max { get; set; }
 		public double? Min { get; set; }
-		public double Sum { get; set; }
+		public double? Sum { get; set; }
 	}
 }


### PR DESCRIPTION
Encountered a bug on production due to this response data. Note the production cluster is running Elasticsearch 6.8

```
{
          "key" : "Morning 0",
          "doc_count" : 17,
          "subStatsAgg" : {
            "meta" : {
              "aggType" : "Sum"
            },
            "count" : 0,
            "min" : null,
            "max" : null,
            "avg" : null,
            "sum" : null
          }
        }
```