### PR TITLE
Fix Extended stats deserialization

### DIFF
--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -311,18 +311,26 @@ namespace Nest
 			if (reader.TokenType == JsonToken.EndObject) return new GeoCentroidAggregate { Count = count };
 
 			reader.Read();
-			var min = reader.Value as double?;
+			var min = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
 			reader.Read();
-			var max = reader.Value as double?;
+			var max = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
 			reader.Read();
-			var average = reader.Value as double?;
+			var average = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
 			reader.Read();
-			var sum = reader.Value as double?;
+			var sum = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 
-			var statsMetric = new StatsAggregate()
+			var statsMetric = new StatsAggregate
 			{
 				Average = average,
 				Count = count,
@@ -336,7 +344,7 @@ namespace Nest
 			if (reader.TokenType == JsonToken.EndObject)
 				return statsMetric;
 
-			while (reader.TokenType != JsonToken.EndObject && ((string)reader.Value).Contains(Parser.AsStringSuffix))
+			while (reader.TokenType != JsonToken.EndObject && ((string)reader.Value).EndsWith(Parser.AsStringSuffix))
 			{
 				reader.Read();
 				reader.Read();
@@ -350,7 +358,7 @@ namespace Nest
 
 		private IAggregate GetExtendedStatsAggregate(StatsAggregate statsMetric, JsonReader reader)
 		{
-			var extendedStatsMetric = new ExtendedStatsAggregate()
+			var extendedStatsMetric = new ExtendedStatsAggregate
 			{
 				Average = statsMetric.Average,
 				Count = statsMetric.Count,
@@ -360,16 +368,20 @@ namespace Nest
 			};
 
 			reader.Read();
-			extendedStatsMetric.SumOfSquares = reader.Value as double?;
+			extendedStatsMetric.SumOfSquares = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
 			reader.Read();
-			extendedStatsMetric.Variance = reader.Value as double?;
+			extendedStatsMetric.Variance = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
 			reader.Read();
-			extendedStatsMetric.StdDeviation = reader.Value as double?;
+			extendedStatsMetric.StdDeviation = reader.TokenType == JsonToken.Integer
+				? reader.Value as long?
+				: reader.Value as double?;
 			reader.Read();
-
-			string propertyName;
 
 			if (reader.TokenType != JsonToken.EndObject)
 			{
@@ -377,7 +389,7 @@ namespace Nest
 				reader.Read();
 				reader.Read();
 
-				propertyName = (string)reader.Value;
+				var propertyName = (string)reader.Value;
 				if (propertyName == Parser.Upper)
 				{
 					reader.Read();
@@ -396,7 +408,7 @@ namespace Nest
 				reader.Read();
 			}
 
-			while (reader.TokenType != JsonToken.EndObject && ((string)reader.Value).Contains(Parser.AsStringSuffix))
+			while (reader.TokenType != JsonToken.EndObject && ((string)reader.Value).EndsWith(Parser.AsStringSuffix))
 			{
 				// std_deviation_bounds is an object, so we need to skip its properties
 				if (((string)reader.Value).Equals(Parser.StdDeviationBoundsAsString))

--- a/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4013
+	{
+		[U]
+		public void CanDeserializeExtendedStats()
+		{
+			var json = @"{
+			  ""took"" : 1,
+				  ""timed_out"" : false,
+				  ""_shards"" : {
+				    ""total"" : 2,
+				    ""successful"" : 2,
+				    ""skipped"" : 0,
+				    ""failed"" : 0
+				  },
+				  ""hits"" : {
+				    ""total"" : 1100,
+				    ""max_score"" : 0.0,
+				    ""hits"" : [ ]
+				  },
+			  ""aggregations"": {
+				  ""extended_stats#1"": {
+			        ""count"": 3,
+			        ""min"": 1569521764937,
+			        ""max"": 1569526264937,
+			        ""avg"": 1569524464937,
+			        ""sum"": 4708573394811,
+			        ""min_as_string"": ""2019-09-26T18:16:04.937Z"",
+			        ""max_as_string"": ""2019-09-26T19:31:04.937Z"",
+			        ""avg_as_string"": ""2019-09-26T19:01:04.937Z"",
+			        ""sum_as_string"": ""2119-03-18T09:03:14.811Z"",
+			        ""sum_of_squares"": 7.390221138118668e+24,
+			        ""variance"": 3779929134421.3335,
+			        ""std_deviation"": 1944203.9847766317,
+			        ""std_deviation_bounds"": {
+			            ""upper"": 1569528353344.9695,
+			            ""lower"": 1569520576529.0305
+			        },
+			        ""sum_of_squares_as_string"": ""292278994-08-17T07:12:55.807Z"",
+			        ""variance_as_string"": ""2089-10-12T04:18:54.421Z"",
+			        ""std_deviation_as_string"": ""1970-01-01T00:32:24.203Z"",
+			        ""std_deviation_bounds_as_string"": {
+			            ""upper"": ""2019-09-26T20:05:53.344Z"",
+			            ""lower"": ""2019-09-26T17:56:16.529Z""
+			        }
+			      }
+			  }
+			}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes));
+			var client = new ElasticClient(connectionSettings);
+
+			Action searchResponse = () => client.Search<object>(s => s.AllIndices());
+
+			searchResponse.ShouldNotThrow();
+
+			var response = client.Search<object>(s => s.AllIndices());
+
+			var extendedStats = response.Aggregations.ExtendedStats("1");
+			extendedStats.Should().NotBeNull();
+			extendedStats.Count.Should().Be(3);
+			extendedStats.Min.Should().Be(1569521764937);
+			extendedStats.Max.Should().Be(1569526264937);
+			extendedStats.Average.Should().Be(1569524464937);
+			extendedStats.Sum.Should().Be(4708573394811);
+			extendedStats.SumOfSquares.Should().Be(7.390221138118668e+24);
+			extendedStats.Variance.Should().Be(3779929134421.3335);
+			extendedStats.StdDeviation.Should().Be(1944203.9847766317);
+			extendedStats.StdDeviationBounds.Should().NotBeNull();
+			extendedStats.StdDeviationBounds.Upper.Should().Be(1569528353344.9695);
+			extendedStats.StdDeviationBounds.Lower.Should().Be(1569520576529.0305);
+		}
+	}
+}


### PR DESCRIPTION
Supersedes: #4103 

Adds a unit test to assert that the change to `AggregateJsonConverter` for ExtendedStats aggregation
can deserialize the provided response.