### PR TITLE
Fix flaky histogram aggregation

### DIFF
--- a/src/Tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 				{
 					field = "numberOfCommits",
 					interval = 100.0,
-					missing = 0.0,
+					min_doc_count = 1,
 					order = new
 					{
 						_key = "desc"
@@ -35,7 +35,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 			.Histogram("commits", h => h
 				.Field(p => p.NumberOfCommits)
 				.Interval(100)
-				.Missing(0)
+				.MinimumDocumentCount(1)
 				.Order(HistogramOrder.KeyDescending)
 				.Offset(1.1)
 			);
@@ -45,7 +45,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 			{
 				Field = Field<Project>(p => p.NumberOfCommits),
 				Interval = 100,
-				Missing = 0,
+				MinimumDocumentCount = 1,
 				Order = HistogramOrder.KeyDescending,
 				Offset = 1.1
 			};


### PR DESCRIPTION
This commit updates the histogram aggregation usage test to only return buckets with a min_doc_count of 1.

Closes #4104