### PR TITLE
Fix Processor IgnoreFailure property name mapping

### DIFF
--- a/src/Nest/Ingest/Processor.cs
+++ b/src/Nest/Ingest/Processor.cs
@@ -34,7 +34,7 @@ namespace Nest
 		string Tag { get; set; }
 
 		/// <summary> When a failure happens, ignore it and proceed to the next processor </summary>
-		[DataMember(Name = "ignore_failue")]
+		[DataMember(Name = "ignore_failure")]
 		bool? IgnoreFailure { get; set; }
 	}
 


### PR DESCRIPTION
This fix the `Processor` `IgnoreFailure` property name mapping. A typo prevented the use of that property in the current NEST version.

```
processor [xxx] doesn't support one or more provided configuration parameters [ignore_failue]
```