### PR TITLE
Fix initial randomization of nodes (#4112)

### DIFF
--- a/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/SniffingConnectionPool.cs
@@ -17,7 +17,7 @@ namespace Elasticsearch.Net
 			: base(nodes, randomize, dateTimeProvider) { }
 
 		public SniffingConnectionPool(IEnumerable<Node> nodes, Func<Node, float> nodeScorer, IDateTimeProvider dateTimeProvider = null)
-			: base(nodes, nodeScorer, dateTimeProvider) { }
+			: base(nodes, nodeScorer, false, dateTimeProvider) { }
 
 		/// <inheritdoc />
 		public override IReadOnlyCollection<Node> Nodes

--- a/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
+++ b/src/Elasticsearch.Net/ConnectionPool/StaticConnectionPool.cs
@@ -15,24 +15,29 @@ namespace Elasticsearch.Net
 			: this(uris.Select(uri => new Node(uri)), randomize, dateTimeProvider) { }
 
 		public StaticConnectionPool(IEnumerable<Node> nodes, bool randomize = true, IDateTimeProvider dateTimeProvider = null)
-			: this(nodes, null, dateTimeProvider) => Randomize = randomize;
+			: this(nodes, null, randomize, dateTimeProvider) { }
 
 		//this constructor is protected because nodeScorer only makes sense on subclasses that support reseeding
 		//otherwise just manually sort `nodes` before instantiating.
-		protected StaticConnectionPool(IEnumerable<Node> nodes, Func<Node, float> nodeScorer, IDateTimeProvider dateTimeProvider = null)
+		protected StaticConnectionPool(IEnumerable<Node> nodes, Func<Node, float> nodeScorer = null, bool randomize = true, IDateTimeProvider dateTimeProvider = null)
 		{
 			nodes.ThrowIfEmpty(nameof(nodes));
+			string scheme = null;
+			foreach (var node in nodes)
+			{
+				if (scheme == null)
+				{
+					scheme = node.Uri.Scheme;
+					UsingSsl = scheme == "https";
+				}
+				else if (scheme != node.Uri.Scheme)
+					throw new ArgumentException("Trying to instantiate a connection pool with mixed URI Schemes");
+			}
+
 			DateTimeProvider = dateTimeProvider ?? Net.DateTimeProvider.Default;
-
-			var nn = nodes.ToList();
-			var uris = nn.Select(n => n.Uri).ToList();
-			if (uris.Select(u => u.Scheme).Distinct().Count() > 1)
-				throw new ArgumentException("Trying to instantiate a connection pool with mixed URI Schemes");
-
-			UsingSsl = uris.Any(uri => uri.Scheme == "https");
-
+			Randomize = randomize;
 			_nodeScorer = nodeScorer;
-			InternalNodes = SortNodes(nn)
+			InternalNodes = SortNodes(nodes)
 				.DistinctBy(n => n.Uri)
 				.ToList();
 			LastUpdate = DateTimeProvider.Now();

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -222,14 +222,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			IEnumerable<StaticConnectionPool> CreatStaticConnectionPools()
 			{
 				Thread.Sleep(1);
-
-				var uris = new[]
-				{
-					new Uri("https://10.0.0.1:9200/"),
-					new Uri("https://10.0.0.2:9200/"),
-					new Uri("https://10.0.0.3:9200/")
-				};
-
+				var uris = Enumerable.Range(1, 50).Select(i => new Uri($"https://10.0.0.{i}:9200/"));
 				yield return new StaticConnectionPool(uris);
 			}
 


### PR DESCRIPTION
This commit fixes the initial randomization of nodes in a StaticConnectionPool. The protected ctor also now takes a `randomize` parameter

