### PR TITLE
Read closing brace of extended stats aggregation

### DIFF
--- a/src/Nest/Aggregations/AggregateJsonConverter.cs
+++ b/src/Nest/Aggregations/AggregateJsonConverter.cs
@@ -413,10 +413,11 @@ namespace Nest
 				// std_deviation_bounds is an object, so we need to skip its properties
 				if (((string)reader.Value).Equals(Parser.StdDeviationBoundsAsString))
 				{
-					reader.Read();
-					reader.Read();
-					reader.Read();
-					reader.Read();
+					reader.Read(); // move to {
+					reader.Read(); // move to "upper"
+					reader.Read(); // move to upper date value
+					reader.Read(); // move to "lower"
+					reader.Read(); // move to lower date value. Subsequent 2 reads will read closing "std_deviation_bounds_as_string" } and next token
 				}
 				reader.Read();
 				reader.Read();

--- a/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
@@ -84,6 +84,10 @@ namespace Tests.Reproduce
 			extendedStats.StdDeviationBounds.Should().NotBeNull();
 			extendedStats.StdDeviationBounds.Upper.Should().Be(1569528353344.9695);
 			extendedStats.StdDeviationBounds.Lower.Should().Be(1569520576529.0305);
+
+			var sum = response.Aggregations.Sum("sum");
+			sum.Should().NotBeNull();
+			sum.Value.Should().Be(40);
 		}
 	}
 }

--- a/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue4103.cs
@@ -51,7 +51,10 @@ namespace Tests.Reproduce
 			            ""upper"": ""2019-09-26T20:05:53.344Z"",
 			            ""lower"": ""2019-09-26T17:56:16.529Z""
 			        }
-			      }
+			      },
+				  ""sum"" : {
+                    ""value"": 40
+                  }
 			  }
 			}";
 
@@ -65,6 +68,8 @@ namespace Tests.Reproduce
 			searchResponse.ShouldNotThrow();
 
 			var response = client.Search<object>(s => s.AllIndices());
+
+			response.Aggregations.Count.Should().Be(2);
 
 			var extendedStats = response.Aggregations.ExtendedStats("1");
 			extendedStats.Should().NotBeNull();


### PR DESCRIPTION
Relates: #4109

This commit fixes an issue with extended stats aggregation parsing whereby the closing brace of std_deviation_bounds_as_string
is not read when skipping over the object, leading to the reader exiting at this point, resulting in any subsequent aggregations
from not being read from the JSON response and added to SearchResponse.Aggregations.