### PR TITLE
Added support for enums as keys for KeyedBucket.

### DIFF
--- a/src/Nest/Aggregations/AggregateDictionary.cs
+++ b/src/Nest/Aggregations/AggregateDictionary.cs
@@ -269,7 +269,9 @@ namespace Nest
 			foreach (var bucket in buckets)
 				yield return new KeyedBucket<TKey>(bucket.BackingDictionary)
 				{
-					Key = (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
+					Key = typeof(TKey).IsEnum
+						? (TKey)Enum.Parse(typeof(TKey), bucket.Key.ToString())
+						: (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
 					KeyAsString = bucket.KeyAsString,
 					DocCount = bucket.DocCount,
 					DocCountErrorUpperBound = bucket.DocCountErrorUpperBound
@@ -283,7 +285,9 @@ namespace Nest
 			foreach (var bucket in buckets)
 				yield return new SignificantTermsBucket<TKey>(bucket.BackingDictionary)
 				{
-					Key = (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
+					Key = typeof(TKey).IsEnum
+						? (TKey)Enum.Parse(typeof(TKey), bucket.Key.ToString())
+						: (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
 					BgCount = bucket.BgCount,
 					DocCount = bucket.DocCount,
 					Score = bucket.Score
@@ -297,7 +301,9 @@ namespace Nest
 			foreach (var bucket in buckets)
 				yield return new RareTermsBucket<TKey>(bucket.BackingDictionary)
 				{
-					Key = (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
+					Key = typeof(TKey).IsEnum
+						? (TKey)Enum.Parse(typeof(TKey), bucket.Key.ToString())
+						: (TKey)Convert.ChangeType(bucket.Key, typeof(TKey)),
 					DocCount = bucket.DocCount.GetValueOrDefault(0)
 				};
 		}


### PR DESCRIPTION
Given a document
```json
{
    "color": "1"
}
```
and an enum definition
```c#
enum Color {
    Red = 1
}
```
an invalid cast exception would be throw when attempting
```c#
aggs.Terms<Color>(agg.Name).Buckets
```