### PR TITLE
BulkDescriptor DeleteMany usable with IEnumerable<string> without specifying type.

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
@@ -57,19 +57,9 @@ namespace Nest
 			Func<BulkDeleteDescriptor<T>, T, IBulkDeleteOperation<T>> bulkDeleteSelector = null
 		)
 			where T : class =>
-			AddOperations(@objects, bulkDeleteSelector, o => new BulkDeleteDescriptor<T>().Document(o));
-
-		/// <summary>
-		/// DeleteMany, convenience method to delete many objects at once.
-		/// </summary>
-		/// <param name="ids">Enumerable of string ids to delete</param>
-		/// <param name="bulkDeleteSelector">A func called on each ids to describe the individual delete operation</param>
-		public BulkDescriptor DeleteMany<T>(
-			IEnumerable<string> ids,
-			Func<BulkDeleteDescriptor<T>, string, IBulkDeleteOperation<T>> bulkDeleteSelector = null
-		)
-			where T : class =>
-			AddOperations(ids, bulkDeleteSelector, id => new BulkDeleteDescriptor<T>().Id(id));
+			AddOperations(@objects, bulkDeleteSelector, o => o is string str ?
+				new BulkDeleteDescriptor<T>().Id(str) :
+				new BulkDeleteDescriptor<T>().Document(o));
 
 		/// <summary>
 		/// DeleteMany, convenience method to delete many objects at once.

--- a/src/Tests/Tests.Reproduce/GithubIssue3500.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3500.cs
@@ -1,0 +1,22 @@
+﻿using System.Linq;
+using System.Collections.Generic;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue3500
+	{
+		[U] public void BulkDescriptorDeleteManyCallableWithStringWithoutTypeDeclaration()
+		{
+			var ids = new List<string> { "1" };
+
+			var bulkDescriptor = new BulkDescriptor().DeleteMany(ids);
+
+			if (bulkDescriptor is IBulkRequest bulkRequest) {
+				bulkRequest.Operations.First().Id.Should().Be(ids.First());
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #3500 

My first PR here, hopefully you find this useful 😃

I think good solution here is to just simply check for string.

With other `Nest.Id` convertable types like `long` or `Guid` the correct overload will be called automatically because T cannot be a [value type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/value-types) (`where T : class`). With string we need to do an exception because it's a [reference type](https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/reference-types) like classes etc.

Included a very simple test.