### PR TITLE
Deserialize boolean strings to dynamic mapping

### DIFF
--- a/src/Nest/Mapping/TypeMapping.cs
+++ b/src/Nest/Mapping/TypeMapping.cs
@@ -27,6 +27,7 @@ namespace Nest
 		/// will result in an error if an unknown field is encountered in a document.
 		/// </summary>
 		[DataMember(Name = "dynamic")]
+		[JsonFormatter(typeof(DynamicMappingFormatter))]
 		Union<bool, DynamicMapping> Dynamic { get; set; }
 
 		/// <summary>

--- a/src/Nest/Mapping/Types/Complex/Object/ObjectProperty.cs
+++ b/src/Nest/Mapping/Types/Complex/Object/ObjectProperty.cs
@@ -16,6 +16,7 @@ namespace Nest
 		/// Default is <c>true</c>
 		/// </summary>
 		[DataMember(Name = "dynamic")]
+		[JsonFormatter(typeof(DynamicMappingFormatter))]
 		Union<bool, DynamicMapping> Dynamic { get; set; }
 
 		/// <summary>

--- a/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -227,6 +227,7 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 					.AutoMap()
 					.Name(p => p.Committer)
 					.Properties(DeveloperProperties)
+					.Dynamic()
 				)
 				.Text(t => t
 					.Name(p => p.ProjectName)


### PR DESCRIPTION
This commit introduces a custom formatter for Union<bool,DynamicMapping>. A boolean value may be returned as a "true" or "false" string, which should be handled correctly.

Closes #4124