### PR TITLE
Add support for clone index API

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -31,7 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bullseye" Version="3.0.0-rc.1" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190927T121631" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20191011T011411" />
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.15.0" />

--- a/src/CodeGeneration/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -45,7 +45,6 @@ namespace ApiGenerator.Configuration
 			"monitoring.bulk.json",
 			"snapshot.cleanup_repository.json",
 			"ml.estimate_memory_usage.json",
-			"indices.clone.json",
 
 			"slm.delete_lifecycle.json",
 			"slm.execute_lifecycle.json",

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -100,6 +100,32 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		}
 	}
 
+	///<summary>Request options for Clone <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</para></summary>
+	public class CloneIndexRequestParameters : RequestParameters<CloneIndexRequestParameters>
+	{
+		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
+		///<summary>Specify timeout for connection to master</summary>
+		public TimeSpan MasterTimeout
+		{
+			get => Q<TimeSpan>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout</summary>
+		public TimeSpan Timeout
+		{
+			get => Q<TimeSpan>("timeout");
+			set => Q("timeout", value);
+		}
+
+		///<summary>Set the number of active shards to wait for on the cloned index before the operation returns.</summary>
+		public string WaitForActiveShards
+		{
+			get => Q<string>("wait_for_active_shards");
+			set => Q("wait_for_active_shards", value);
+		}
+	}
+
 	///<summary>Request options for Close <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public class CloseIndexRequestParameters : RequestParameters<CloseIndexRequestParameters>
 	{

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Indices.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Indices.cs
@@ -83,6 +83,20 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public Task<TResponse> ClearCacheAsync<TResponse>(string index, ClearCacheRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"{index:index}/_cache/clear"), ctx, null, RequestParams(requestParameters));
+		///<summary>PUT on /{index}/_clone/{target} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</para></summary>
+		///<param name = "index">The name of the source index to clone</param>
+		///<param name = "target">The name of the target index to clone into</param>
+		///<param name = "body">The configuration for the target index (`settings` and `aliases`)</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		public TResponse Clone<TResponse>(string index, string target, PostData body, CloneIndexRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(PUT, Url($"{index:index}/_clone/{target:target}"), body, RequestParams(requestParameters));
+		///<summary>PUT on /{index}/_clone/{target} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</para></summary>
+		///<param name = "index">The name of the source index to clone</param>
+		///<param name = "target">The name of the target index to clone into</param>
+		///<param name = "body">The configuration for the target index (`settings` and `aliases`)</param>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		public Task<TResponse> CloneAsync<TResponse>(string index, string target, PostData body, CloneIndexRequestParameters requestParameters = null, CancellationToken ctx = default)
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"{index:index}/_clone/{target:target}"), ctx, body, RequestParams(requestParameters));
 		///<summary>POST on /{index}/_close <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 		///<param name = "index">A comma separated list of indices to close</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>

--- a/src/Nest/Descriptors.Indices.cs
+++ b/src/Nest/Descriptors.Indices.cs
@@ -99,6 +99,40 @@ namespace Nest
 		public ClearCacheDescriptor Request(bool? request = true) => Qs("request", request);
 	}
 
+	///<summary>Descriptor for Clone <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</para></summary>
+	public partial class CloneIndexDescriptor : RequestDescriptorBase<CloneIndexDescriptor, CloneIndexRequestParameters, ICloneIndexRequest>, ICloneIndexRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesClone;
+		///<summary>/{index}/_clone/{target}</summary>
+		///<param name = "index">this parameter is required</param>
+		///<param name = "target">this parameter is required</param>
+		public CloneIndexDescriptor(IndexName index, IndexName target): base(r => r.Required("index", index).Required("target", target))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected CloneIndexDescriptor(): base()
+		{
+		}
+
+		// values part of the url path
+		IndexName ICloneIndexRequest.Index => Self.RouteValues.Get<IndexName>("index");
+		IndexName ICloneIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
+		///<summary>The name of the source index to clone</summary>
+		public CloneIndexDescriptor Index(IndexName index) => Assign(index, (a, v) => a.RouteValues.Required("index", v));
+		///<summary>a shortcut into calling Index(typeof(TOther))</summary>
+		public CloneIndexDescriptor Index<TOther>()
+			where TOther : class => Assign(typeof(TOther), (a, v) => a.RouteValues.Required("index", (IndexName)v));
+		// Request parameters
+		///<summary>Specify timeout for connection to master</summary>
+		public CloneIndexDescriptor MasterTimeout(Time mastertimeout) => Qs("master_timeout", mastertimeout);
+		///<summary>Explicit operation timeout</summary>
+		public CloneIndexDescriptor Timeout(Time timeout) => Qs("timeout", timeout);
+		///<summary>Set the number of active shards to wait for on the cloned index before the operation returns.</summary>
+		public CloneIndexDescriptor WaitForActiveShards(string waitforactiveshards) => Qs("wait_for_active_shards", waitforactiveshards);
+	}
+
 	///<summary>Descriptor for Close <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</para></summary>
 	public partial class CloseIndexDescriptor : RequestDescriptorBase<CloseIndexDescriptor, CloseIndexRequestParameters, ICloseIndexRequest>, ICloseIndexRequest
 	{

--- a/src/Nest/ElasticClient.Indices.cs
+++ b/src/Nest/ElasticClient.Indices.cs
@@ -85,6 +85,30 @@ namespace Nest.Specification.IndicesApi
 		/// </summary>
 		public Task<ClearCacheResponse> ClearCacheAsync(IClearCacheRequest request, CancellationToken ct = default) => DoRequestAsync<IClearCacheRequest, ClearCacheResponse>(request, request.RequestParameters, ct);
 		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</a>
+		/// </summary>
+		public CloneIndexResponse Clone(IndexName index, IndexName target, Func<CloneIndexDescriptor, ICloneIndexRequest> selector = null) => Clone(selector.InvokeOrDefault(new CloneIndexDescriptor(index: index, target: target)));
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</a>
+		/// </summary>
+		public Task<CloneIndexResponse> CloneAsync(IndexName index, IndexName target, Func<CloneIndexDescriptor, ICloneIndexRequest> selector = null, CancellationToken ct = default) => CloneAsync(selector.InvokeOrDefault(new CloneIndexDescriptor(index: index, target: target)), ct);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</a>
+		/// </summary>
+		public CloneIndexResponse Clone(ICloneIndexRequest request) => DoRequest<ICloneIndexRequest, CloneIndexResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>PUT</c> request to the <c>indices.clone</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</a>
+		/// </summary>
+		public Task<CloneIndexResponse> CloneAsync(ICloneIndexRequest request, CancellationToken ct = default) => DoRequestAsync<ICloneIndexRequest, CloneIndexResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>POST</c> request to the <c>indices.close</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-open-close.html</a>

--- a/src/Nest/Indices/IndexManagement/CloneIndex/CloneIndexRequest.cs
+++ b/src/Nest/Indices/IndexManagement/CloneIndex/CloneIndexRequest.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	/// <summary>
+	/// A request to the clone index API
+	/// </summary>
+	[MapsApi("indices.clone")]
+	[ReadAs(typeof(CloneIndexRequest))]
+	public partial interface ICloneIndexRequest
+	{
+		/// <summary>
+		/// The aliases to apply to the target index
+		/// </summary>
+		[DataMember(Name ="aliases")]
+		IAliases Aliases { get; set; }
+
+		/// <summary>
+		/// The settings to apply to the target index
+		/// </summary>
+		[DataMember(Name ="settings")]
+		IIndexSettings Settings { get; set; }
+	}
+
+	/// <inheritdoc cref="ICloneIndexRequest" />
+	public partial class CloneIndexRequest
+	{
+		/// <inheritdoc />
+		public IAliases Aliases { get; set; }
+
+		/// <inheritdoc />
+		public IIndexSettings Settings { get; set; }
+	}
+
+	/// <inheritdoc cref="ICloneIndexRequest" />
+	public partial class CloneIndexDescriptor
+	{
+		IAliases ICloneIndexRequest.Aliases { get; set; }
+		IIndexSettings ICloneIndexRequest.Settings { get; set; }
+
+		/// <inheritdoc cref="ICloneIndexRequest.Settings"/>
+		public CloneIndexDescriptor Settings(Func<IndexSettingsDescriptor, IPromise<IIndexSettings>> selector) =>
+			Assign(selector, (a, v) => a.Settings = v?.Invoke(new IndexSettingsDescriptor())?.Value);
+
+		/// <inheritdoc cref="ICloneIndexRequest.Aliases"/>
+		public CloneIndexDescriptor Aliases(Func<AliasesDescriptor, IPromise<IAliases>> selector) =>
+			Assign(selector, (a, v) => a.Aliases = v?.Invoke(new AliasesDescriptor())?.Value);
+	}
+}

--- a/src/Nest/Indices/IndexManagement/CloneIndex/CloneIndexResponse.cs
+++ b/src/Nest/Indices/IndexManagement/CloneIndex/CloneIndexResponse.cs
@@ -1,0 +1,16 @@
+﻿using System.Runtime.Serialization;
+
+namespace Nest
+{
+	public class CloneIndexResponse : AcknowledgedResponseBase
+	{
+		[DataMember(Name = "shards_acknowledged")]
+		public bool ShardsAcknowledged { get; set; }
+
+		/// <summary>
+		/// The target index created
+		/// </summary>
+		[DataMember(Name = "index")]
+		public string Index { get; set; }
+	}
+}

--- a/src/Nest/Requests.Indices.cs
+++ b/src/Nest/Requests.Indices.cs
@@ -147,6 +147,68 @@ namespace Nest
 	}
 
 	[InterfaceDataContract]
+	public partial interface ICloneIndexRequest : IRequest<CloneIndexRequestParameters>
+	{
+		[IgnoreDataMember]
+		IndexName Index
+		{
+			get;
+		}
+
+		[IgnoreDataMember]
+		IndexName Target
+		{
+			get;
+		}
+	}
+
+	///<summary>Request for Clone <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-clone-index.html</para></summary>
+	public partial class CloneIndexRequest : PlainRequestBase<CloneIndexRequestParameters>, ICloneIndexRequest
+	{
+		protected ICloneIndexRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesClone;
+		///<summary>/{index}/_clone/{target}</summary>
+		///<param name = "index">this parameter is required</param>
+		///<param name = "target">this parameter is required</param>
+		public CloneIndexRequest(IndexName index, IndexName target): base(r => r.Required("index", index).Required("target", target))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected CloneIndexRequest(): base()
+		{
+		}
+
+		// values part of the url path
+		[IgnoreDataMember]
+		IndexName ICloneIndexRequest.Index => Self.RouteValues.Get<IndexName>("index");
+		[IgnoreDataMember]
+		IndexName ICloneIndexRequest.Target => Self.RouteValues.Get<IndexName>("target");
+		// Request parameters
+		///<summary>Specify timeout for connection to master</summary>
+		public Time MasterTimeout
+		{
+			get => Q<Time>("master_timeout");
+			set => Q("master_timeout", value);
+		}
+
+		///<summary>Explicit operation timeout</summary>
+		public Time Timeout
+		{
+			get => Q<Time>("timeout");
+			set => Q("timeout", value);
+		}
+
+		///<summary>Set the number of active shards to wait for on the cloned index before the operation returns.</summary>
+		public string WaitForActiveShards
+		{
+			get => Q<string>("wait_for_active_shards");
+			set => Q("wait_for_active_shards", value);
+		}
+	}
+
+	[InterfaceDataContract]
 	public partial interface ICloseIndexRequest : IRequest<CloseIndexRequestParameters>
 	{
 		[IgnoreDataMember]

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -87,6 +87,7 @@ namespace Nest
 		internal static ApiUrls NoNamespaceIndex = new ApiUrls(new[]{"{index}/_doc/{id}", "{index}/_doc"});
 		internal static ApiUrls IndicesAnalyze = new ApiUrls(new[]{"_analyze", "{index}/_analyze"});
 		internal static ApiUrls IndicesClearCache = new ApiUrls(new[]{"_cache/clear", "{index}/_cache/clear"});
+		internal static ApiUrls IndicesClone = new ApiUrls(new[]{"{index}/_clone/{target}"});
 		internal static ApiUrls IndicesClose = new ApiUrls(new[]{"{index}/_close"});
 		internal static ApiUrls IndicesCreate = new ApiUrls(new[]{"{index}"});
 		internal static ApiUrls IndicesDelete = new ApiUrls(new[]{"{index}"});

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
-    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20190927T121631" />
+    <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20191011T011411" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Core/Tests.Core.csproj
+++ b/src/Tests/Tests.Core/Tests.Core.csproj
@@ -13,7 +13,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Domain\Tests.Domain.csproj" />
-    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20190927T121631" />
+    <PackageReference Include="Elastic.Xunit" Version="0.1.0-ci20191011T011411" />
     <PackageReference Include="Proc" Version="0.6.1" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20190927T121631" />
+    <PackageReference Include="Elastic.Managed" Version="0.1.0-ci20191011T011411" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="..\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>

--- a/src/Tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexApiTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexApiTests.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Indices.IndexManagement.CloneIndex
+{
+	[SkipVersion("<7.4.0", "clone index introduced in 7.4.0")]
+	public class CloneIndexApiTests
+		: ApiIntegrationTestBase<WritableCluster, CloneIndexResponse, ICloneIndexRequest, CloneIndexDescriptor, CloneIndexRequest>
+	{
+		private const string CloneSuffix = "_clone";
+
+		public CloneIndexApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
+		{
+			foreach (var value in values)
+			{
+				var createIndexResponse = client.Indices.Create(value.Value, c => c
+					.Settings(s => s
+						.NumberOfShards(1)
+						.NumberOfReplicas(0)
+					)
+				);
+
+				if (!createIndexResponse.IsValid)
+					throw new Exception($"exception whilst setting up integration test: {createIndexResponse.DebugInformation}");
+
+				var updateSettings = client.Indices.UpdateSettings(value.Value, s => s
+					.IndexSettings(i => i
+						.BlocksWrite()
+					)
+				);
+
+				if (!updateSettings.IsValid)
+					throw new Exception($"exception whilst setting up integration test: {updateSettings.DebugInformation}");
+			}
+		}
+
+		protected override bool ExpectIsValid => true;
+
+		protected override object ExpectJson => new
+		{
+			settings = new Dictionary<string, object>
+			{
+				{ "index.number_of_replicas", 0 },
+				{ "index.number_of_shards", 1 },
+				{ "index.queries.cache.enabled", true }
+			},
+			aliases = new Dictionary<string, object>
+			{
+				{ CallIsolatedValue + "-alias", new { is_write_index = true } }
+			}
+		};
+
+		protected override int ExpectStatusCode => 200;
+
+		protected override Func<CloneIndexDescriptor, ICloneIndexRequest> Fluent => d => d
+			.Settings(s => s
+				.NumberOfReplicas(0)
+				.NumberOfShards(1)
+				.Queries(q => q
+					.Cache(c => c
+						.Enabled()
+					)
+				)
+			)
+			.Aliases(a => a
+				.Alias(CallIsolatedValue + "-alias", aa => aa
+					.IsWriteIndex()
+				)
+			);
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+
+		protected override CloneIndexRequest Initializer => new CloneIndexRequest(CallIsolatedValue, CallIsolatedValue + CloneSuffix)
+		{
+			Settings = new Nest.IndexSettings
+			{
+				NumberOfReplicas = 0,
+				NumberOfShards = 1,
+				Queries = new QueriesSettings
+				{
+					Cache = new QueriesCacheSettings
+					{
+						Enabled = true
+					}
+				}
+			},
+			Aliases = new Aliases
+			{
+				{ CallIsolatedValue + "-alias", new Alias { IsWriteIndex = true } }
+			}
+		};
+
+		protected override string UrlPath => $"/{CallIsolatedValue}/_clone/{CallIsolatedValue + CloneSuffix}";
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.Indices.Clone(CallIsolatedValue, CallIsolatedValue + CloneSuffix, f),
+			(client, f) => client.Indices.CloneAsync(CallIsolatedValue, CallIsolatedValue + CloneSuffix, f),
+			(client, r) => client.Indices.Clone(r),
+			(client, r) => client.Indices.CloneAsync(r)
+		);
+
+		protected override CloneIndexDescriptor NewDescriptor() => new CloneIndexDescriptor(CallIsolatedValue, CallIsolatedValue + CloneSuffix);
+
+		protected override void ExpectResponse(CloneIndexResponse response)
+		{
+			response.ShouldBeValid();
+			response.Acknowledged.Should().BeTrue();
+			response.ShardsAcknowledged.Should().BeTrue();
+			response.Index.Should().Be(CallIsolatedValue + CloneSuffix);
+		}
+	}
+}

--- a/src/Tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexUrlTests.cs
+++ b/src/Tests/Tests/Indices/IndexManagement/CloneIndex/CloneIndexUrlTests.cs
@@ -1,0 +1,23 @@
+﻿using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+using static Tests.Framework.EndpointTests.UrlTester;
+
+namespace Tests.Indices.IndexManagement.CloneIndex
+{
+	public class CloneIndexUrlTests
+	{
+		[U] public async Task Urls()
+		{
+			var index = "index1";
+			var target = "target";
+			await PUT($"/{index}/_clone/{target}")
+					.Fluent(c => c.Indices.Clone(index, target))
+					.Request(c => c.Indices.Clone(new CloneIndexRequest(index, target)))
+					.FluentAsync(c => c.Indices.CloneAsync(index, target))
+					.RequestAsync(c => c.Indices.CloneAsync(new CloneIndexRequest(index, target)))
+				;
+		}
+	}
+}


### PR DESCRIPTION
This commit adds support for the clone index API, introduced in Elasticsearch 7.4.0