### PR TITLE
Write null when ISort or SortKey is null

### DIFF
--- a/src/Nest/CommonOptions/Sorting/SortFormatter.cs
+++ b/src/Nest/CommonOptions/Sorting/SortFormatter.cs
@@ -75,7 +75,10 @@ namespace Nest
 		public void Serialize(ref JsonWriter writer, ISort value, IJsonFormatterResolver formatterResolver)
 		{
 			if (value?.SortKey == null)
+			{
+				writer.WriteNull();
 				return;
+			}
 
 			writer.WriteBeginObject();
 			var settings = formatterResolver.GetConnectionSettings();


### PR DESCRIPTION
This commit writes null when ISort or ISort.SortKey is null. Simply returning without writing a value can result in incorrectly formatted JSON.

Closes #4128