### PR TITLE
Fix test for random initialized node

### DIFF
--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -7,6 +7,7 @@ using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Configuration;
 using Tests.Framework;
 using Tests.XPack.Security.Privileges;
 
@@ -216,20 +217,30 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 			}
 		}
 
+		//hide
+		private class SeededRandomConectionPool : StaticConnectionPool
+		{
+			public SeededRandomConectionPool(IEnumerable<Node> nodes, int seed)
+				: base(nodes, randomize: true, randomizeSeed: seed, dateTimeProvider: null)
+			{}
+		}
+
 		// hide
 		[U] public void RandomizedInitialNodes()
 		{
-			IEnumerable<StaticConnectionPool> CreatStaticConnectionPools()
+			IEnumerable<StaticConnectionPool> CreateSeededPools(int nodeCount, int pools)
 			{
-				Thread.Sleep(1);
-				var uris = Enumerable.Range(1, 50).Select(i => new Uri($"https://10.0.0.{i}:9200/"));
-				yield return new StaticConnectionPool(uris);
+				var seed = TestConfiguration.Instance.Seed;
+				var nodes = Enumerable.Range(1, nodeCount)
+					.Select(i => new Node(new Uri($"https://10.0.0.{i}:9200/")))
+					.ToList();
+				for(var i = 0; i < nodeCount; i++)
+					yield return new SeededRandomConectionPool(nodes, seed + i);
 			}
 
-			// assertion works on the probability of seeing a Uri other than https://10.0.0.1:9200/
-			// as the first value over 50 runs, when randomized.
-			CreatStaticConnectionPools()
-				.Take(50)
+			var connectionPools = CreateSeededPools(100, 100).ToList();
+			connectionPools.Should().HaveCount(100);
+			connectionPools
 				.Select(p => p.CreateView().First().Uri.ToString())
 				.All(uri => uri == "https://10.0.0.1:9200/")
 				.Should()


### PR DESCRIPTION
The test was using a local method that yielded a single pool while later
.Take(50) was requested on this sequence. This always yields an
enumeration with 1 element which increases the chances for the assertion
to turn false.

Rather than relying on Thread.Sleep to create different seeded randoms
the StaticConnectionPool now defines a protected constructor that allows
one to pass in a seed value.

Continuation of #4112 