### PR TITLE
Deprecate the ability to update datafeed's job_id

### DIFF
--- a/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedRequest.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedRequest.cs
@@ -38,6 +38,7 @@ namespace Nest
 		/// <summary>
 		/// A numerical character string that uniquely identifies the job.
 		/// </summary>
+		[Obsolete("As of 7.4.0 the ability to associate a feed with a different job is being deprecated as it adds unnecessary complexity")]
 		[DataMember(Name ="job_id")]
 		Id JobId { get; set; }
 
@@ -85,6 +86,7 @@ namespace Nest
 		public Indices Indices { get; set; }
 
 		/// <inheritdoc />
+		[Obsolete("As of 7.4.0 the ability to associate a feed with a different job is being deprecated as it adds unnecessary complexity")]
 		public Id JobId { get; set; }
 
 		/// <inheritdoc />
@@ -133,6 +135,7 @@ namespace Nest
 		public UpdateDatafeedDescriptor<TDocument> AllIndices() => Indices(Nest.Indices.All);
 
 		/// <inheritdoc />
+		[Obsolete("As of 7.4.0 the ability to associate a feed with a different job is being deprecated as it adds unnecessary complexity")]
 		public UpdateDatafeedDescriptor<TDocument> JobId(Id jobId) => Assign(jobId, (a, v) => a.JobId = v);
 
 		/// <inheritdoc />

--- a/src/Tests/Tests/XPack/MachineLearning/UpdateDatafeed/UpdateDatafeedApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/UpdateDatafeed/UpdateDatafeedApiTests.cs
@@ -19,7 +19,6 @@ namespace Tests.XPack.MachineLearning.UpdateDatafeed
 		protected override object ExpectJson => new
 		{
 			indices = new[] { "server-metrics" },
-			job_id = CallIsolatedValue,
 			query = new
 			{
 				match_all = new
@@ -33,7 +32,6 @@ namespace Tests.XPack.MachineLearning.UpdateDatafeed
 
 		protected override Func<UpdateDatafeedDescriptor<Metric>, IUpdateDatafeedRequest> Fluent => f => f
 			.Indices("server-metrics") //goes on body not in the url
-			.JobId(CallIsolatedValue)
 			.Query(q => q
 				.MatchAll(m => m.Boost(2))
 			);
@@ -43,7 +41,6 @@ namespace Tests.XPack.MachineLearning.UpdateDatafeed
 		protected override UpdateDatafeedRequest Initializer =>
 			new UpdateDatafeedRequest(CallIsolatedValue + "-datafeed")
 			{
-				JobId = CallIsolatedValue,
 				Indices = "server-metrics",
 				Query = new MatchAllQuery
 				{


### PR DESCRIPTION
adresses elastic/elasticsearch#44691