### PR TITLE
Fix GeoDistance serialization

### DIFF
--- a/src/Nest/CommonOptions/Sorting/SortFormatter.cs
+++ b/src/Nest/CommonOptions/Sorting/SortFormatter.cs
@@ -103,7 +103,7 @@ namespace Nest
 					for (var i = buffer.Offset; i < buffer.Count - 1; i++)
 						writer.WriteRawUnsafe(buffer.Array[i]);
 
-					if (buffer.Count > 0)
+					if (buffer.Count - buffer.Offset > 1)
 						writer.WriteValueSeparator();
 
 					writer.WritePropertyName(settings.Inferrer.Field(geo.Field));


### PR DESCRIPTION
Fixes issue where unintended value separator is added. Example:
"sort":[{"_geo_distance":{,"some.coordinate":[{"lat":1.0,"lon":1.0}]
The "," is incorrectly added causing deserialization issues on the server.