### PR TITLE
remove hardcoded \r\n from code generator strings

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
@@ -7,7 +8,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 {
 	public class Constructor
 	{
-		private const string Indent = "\r\n\t\t";
+		private static readonly string Indent = $"{Environment.NewLine}\t\t";
 		public string AdditionalCode { get; set; } = string.Empty;
 		public bool Parameterless { get; set; }
 		public string Body { get; set; }
@@ -28,15 +29,15 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 			var generateGeneric = CodeConfiguration.GenericOnlyInterfaces.Contains(names.RequestInterfaceName) || !inheritsFromPlainRequestBase;
 			return GenerateConstructors(url, inheritsFromPlainRequestBase, generateGeneric, names.RequestName, generic);
 		}
-		
-		private static string FirstGeneric(string fullGenericString) => 
+
+		private static string FirstGeneric(string fullGenericString) =>
 			fullGenericString?.Replace("<", "").Replace(">", "").Split(",").First().Trim();
 
 		private static IEnumerable<Constructor> GenerateConstructors(
 			UrlInformation url,
 			bool inheritsFromPlainRequestBase,
 			bool generateGeneric,
-			string typeName, 
+			string typeName,
 			string generic
 		)
 		{
@@ -64,8 +65,8 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 				ctors.AddRange(from path in paths.Where(path => path.HasResolvableArguments)
 					let baseArgs = path.AutoResolveBaseArguments(generic)
 					let constructorArgs = path.AutoResolveConstructorArguments
-					let baseOrThis = inheritsFromPlainRequestBase  
-						? "this" 
+					let baseOrThis = inheritsFromPlainRequestBase
+						? "this"
 						: "base"
 					let generated = $"public {typeName}({constructorArgs}) : {baseOrThis}({baseArgs})"
 					select new Constructor
@@ -84,7 +85,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 					{
 						Parameterless = string.IsNullOrEmpty(docPathConstArgs),
 						Generated = $"public {typeName}({docPathConstArgs}) : this({docPathBaseArgs})",
-		
+
 						AdditionalCode = $"partial void DocumentFromPath({generic} document);",
 						Description = docPath.GetXmlDocs(Indent, skipResolvable: true, documentConstructor: true),
 						Body = "=> DocumentFromPath(documentWithId);"

--- a/src/CodeGeneration/ApiGenerator/Generator/CodeGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/CodeGenerator.cs
@@ -19,7 +19,7 @@ namespace ApiGenerator.Generator
 			if (!string.IsNullOrWhiteSpace(obsolete)) A($"[Obsolete(\"Scheduled to be removed in 7.0, {obsolete}\")]");
 
 			A(PropertyGenerator(type, name, key, setter));
-			return string.Join("\r\n\t\t", components);
+			return string.Join($"{Environment.NewLine}\t\t", components);
 
 			void A(string s)
 			{
@@ -36,7 +36,7 @@ namespace ApiGenerator.Generator
 			A(generated);
 			if (!c.Body.IsNullOrEmpty()) A(c.Body);
 			if (!c.AdditionalCode.IsNullOrEmpty()) A(c.AdditionalCode);
-			return string.Join("\r\n\t\t", components);
+			return string.Join($"{Environment.NewLine}\t\t", components);
 
 			void A(string s)
 			{

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Descriptors/XmlDocs.cshtml
@@ -6,7 +6,7 @@
 @inherits ApiGenerator.CodeTemplatePage<List<string>>
 @{
 	List<string> summary = Model;
-	var description = summary.Count == 1 ? summary.First() : string.Join("\r\n\t\t", summary.Select(d => "/// " + d));
+	var description = summary.Count == 1 ? summary.First() : string.Join($"{Environment.NewLine}\t\t", summary.Select(d => "/// " + d));
 	if (summary.Count == 1)
 	{
 <text>		///<summary>@Raw(description)</summary></text>

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/Enums.Generated.cshtml
@@ -18,7 +18,7 @@
 		var enumCsharp = string.Format("[EnumMember(Value = \"{0}\")] {1}{2}", value, enumValue, i.HasValue ? " = 1 << " + i.Value : null);
 		if (GlobalOverrides.ObsoleteEnumMembers.TryGetValue(enumName, out var d) && d.TryGetValue(value, out var obsolete))
 		{
-			return string.Format("[Obsolete(\"{0}\")]\r\n\t\t{1}", obsolete, enumCsharp);
+			return string.Format("[Obsolete(\"{0}\")]{2}\t\t{1}", obsolete, enumCsharp, Environment.NewLine);
 		}
 		return enumCsharp;
 	}
@@ -62,7 +62,7 @@ namespace Elasticsearch.Net
 	<text>
 	@(isFlag ? "[Flags, StringEnum]" : "[StringEnum]")public enum @e.Name
 	{
-		@Raw(string.Join(",\r\n\t\t", e.Options.OrderBy(s => s == "_all" ? 1 : 0).Select((s, i) => CreateEnum(e.Name, s, isFlag ? (int?)i : null))))
+		@Raw(string.Join(","+ Environment.NewLine + "\t\t", e.Options.OrderBy(s => s == "_all" ? 1 : 0).Select((s, i) => CreateEnum(e.Name, s, isFlag ? (int?)i : null))))
 	}</text>
 }
 
@@ -124,7 +124,7 @@ namespace Elasticsearch.Net
 		{
 			<text>	switch (enumValue)
 			{
-				@Raw(string.Join("\r\n\t\t\t\t", e.Options.Select(o => CreateCase(e.Name, o))))
+				@Raw(string.Join(Environment.NewLine + "\t\t\t\t", e.Options.Select(o => CreateCase(e.Name, o))))
 			}
 			throw new ArgumentException($"'{enumValue.ToString()}' is not a valid value for enum '@(e.Name)'");
 		}</text>

--- a/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
@@ -75,11 +75,12 @@ namespace DocGenerator.AsciiDoc
 			var originalFile = Regex.Replace(_source.FullName.Replace("\\", "/"), @"^(.*Tests/)",
 				$"{github}/tree/{Program.BranchName}/src/Tests/Tests/");
 
+			var eol = Environment.NewLine;
 			_newDocument.Insert(0, new Comment
 			{
 				Style = CommentStyle.MultiLine,
-				Text = $"IMPORTANT NOTE\r\n==============\r\nThis file has been generated from {originalFile}. \r\n" +
-					"If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,\r\n" +
+				Text = $"IMPORTANT NOTE{eol}=============={eol}This file has been generated from {originalFile}. {eol}" +
+					$"If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,{eol}" +
 					"please modify the original csharp file found at the link and submit the PR with that change. Thanks!"
 			});
 

--- a/src/CodeGeneration/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
@@ -31,11 +31,12 @@ namespace DocGenerator.AsciiDoc
 			var github = "https://github.com/elastic/elasticsearch-net";
 			var originalFile = Regex.Replace(_source.FullName.Replace("\\", "/"),
 				@"^(.*Tests/)", $"{github}/tree/{Program.BranchName}/src/Tests/Tests/");
+			var eol = Environment.NewLine;
 			document.Insert(0, new Comment
 			{
 				Style = CommentStyle.MultiLine,
-				Text = $"IMPORTANT NOTE\r\n==============\r\nThis file has been generated from {originalFile}. \r\n" +
-					"If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,\r\n" +
+				Text = $"IMPORTANT NOTE{eol}=============={eol}This file has been generated from {originalFile}. {eol}" +
+					$"If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,{eol}" +
 					"please modify the original csharp file found at the link and submit the PR with that change. Thanks!"
 			});
 

--- a/src/CodeGeneration/DocGenerator/XmlDocs/XmlDocsVisitor.cs
+++ b/src/CodeGeneration/DocGenerator/XmlDocs/XmlDocsVisitor.cs
@@ -17,7 +17,7 @@ namespace DocGenerator.XmlDocs
 	{
 		// AsciiDocNet does not currently have a type for list item continuations, so mimic here
 		// for the moment
-		private const string ListItemContinuation = "\r\n+\r\n";
+		private static readonly string ListItemContinuation = Environment.NewLine + "+" + Environment.NewLine;
 		private readonly Type _type;
 		private LabeledListItem _labeledListItem;
 

--- a/src/Elasticsearch.Net/Responses/ResponseStatics.cs
+++ b/src/Elasticsearch.Net/Responses/ResponseStatics.cs
@@ -30,8 +30,8 @@ namespace Elasticsearch.Net
 
 			var response = r.ResponseBodyInBytes?.Utf8String() ?? ResponseAlreadyCaptured;
 			var request = r.RequestBodyInBytes?.Utf8String() ?? RequestAlreadyCaptured;
-			sb.AppendLine($"# Request:\r\n{request}");
-			sb.AppendLine($"# Response:\r\n{response}");
+			sb.AppendLine($"# Request:{Environment.NewLine}{request}");
+			sb.AppendLine($"# Response:{Environment.NewLine}{response}");
 
 			return sb.ToString();
 		}
@@ -42,7 +42,7 @@ namespace Elasticsearch.Net
 
 			var auditExceptions = auditTrail.Select((audit, i) => new { audit, i }).Where(a => a.audit.Exception != null);
 			foreach (var a in auditExceptions)
-				sb.AppendLine($"# Audit exception in step {a.i + 1} {a.audit.Event.GetStringValue()}:\r\n{a.audit.Exception}");
+				sb.AppendLine($"# Audit exception in step {a.i + 1} {a.audit.Event.GetStringValue()}:{Environment.NewLine}{a.audit.Exception}");
 		}
 
 		public static void DebugAuditTrail(List<Audit> auditTrail, StringBuilder sb)

--- a/src/Tests/Tests.Core/Extensions/DiffExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/DiffExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -81,8 +82,9 @@ namespace Tests.Core.Extensions
 
 		private static string AppendCsharpApproximation(string expected, string actual, string diff)
 		{
-			diff += "\r\n C# approximation of actual ------ ";
-			diff += "\r\n new ";
+			var eol = Environment.NewLine;
+			diff += $"{eol} C# approximation of actual ------ ";
+			diff += $"{eol} new ";
 			var approx = Regex.Replace(actual, @"^(?=.*:.*)[^:]+:", (s) => s
 							.Value.Replace("\"", "")
 							.Replace(":", " =")
@@ -93,8 +95,8 @@ namespace Tests.Core.Extensions
 			approx = Regex.Replace(approx, @"^\s*\],?.*$", s => s.Value.Replace("]", "}"), RegexOptions.Multiline);
 			diff += approx + ";";
 
-			diff += "\r\n C# approximation of expected ------ ";
-			diff += "\r\n new ";
+			diff += $"{eol} C# approximation of expected ------ ";
+			diff += $"{eol} new ";
 			approx = Regex.Replace(expected, @"^(?=.*:.*)[^:]+:", (s) => s
 							.Value.Replace("\"", "")
 							.Replace(":", " =")

--- a/src/Tests/Tests.Core/ManagedElasticsearch/Tasks/WriteAnalysisFiles.cs
+++ b/src/Tests/Tests.Core/ManagedElasticsearch/Tasks/WriteAnalysisFiles.cs
@@ -1,3 +1,4 @@
+using System;
 using System.IO;
 using Elastic.Managed.ConsoleWriters;
 using Elastic.Managed.Ephemeral;
@@ -38,8 +39,8 @@ namespace Tests.Core.ManagedElasticsearch.Tasks
 			if (File.Exists(hunspellPrefix + ".dic")) return;
 
 			Directory.CreateDirectory(hunspellFolder);
-			File.WriteAllText(hunspellPrefix + ".dic", "1\r\nabcdegf");
-			File.WriteAllText(hunspellPrefix + ".aff", "SET UTF8\r\nSFX P Y 1\r\nSFX P 0 s");
+			File.WriteAllText(hunspellPrefix + ".dic", $"1{Environment.NewLine}abcdegf");
+			File.WriteAllText(hunspellPrefix + ".aff", $"SET UTF8{Environment.NewLine}SFX P Y 1{Environment.NewLine}SFX P 0 s");
 		}
 
 		private static void SetupIcuFiles(string configPath)

--- a/src/Tests/Tests/Framework/Extensions/UriExtensions.cs
+++ b/src/Tests/Tests/Framework/Extensions/UriExtensions.cs
@@ -34,16 +34,16 @@ namespace Tests.Framework.Extensions
 
 		private static void AssertQueryString(Uri actualUri, Uri expectedUri, string origin)
 		{
-			var because = $"\r\nExpected query string from {origin}: {expectedUri.Query} on {expectedUri.PathAndQuery}";
-			because += $"\r\nActual querystring from {origin}  : {actualUri.Query} on {actualUri.PathAndQuery}\r\n";
+			var eol = Environment.NewLine;
+			var because = $"{eol} query string from {origin}: {expectedUri.Query} on {expectedUri.PathAndQuery}";
+			because += $"{eol}Actual querystring from {origin}  : {actualUri.Query} on {actualUri.PathAndQuery}{eol}";
 
 			var actualParameters = ExplodeQueryString(actualUri);
 			var expectedParameters = ExplodeQueryString(expectedUri);
 
 			actualParameters.Keys.Should()
-				.BeEquivalentTo(expectedParameters.Keys, "All query string parameters need to be asserted.\r\n{0}", because);
+				.BeEquivalentTo(expectedParameters.Keys, $"All query string parameters need to be asserted.{eol}{{0}}", because);
 
-			//actualParameters.Count.Should().Be(expectedParameters.Count, "All query string parameters need to be asserted.\r\n{0}", because);
 			if (actualParameters.Count == 0) return;
 
 			actualParameters.Should().ContainKeys(expectedParameters.Keys.ToArray(), because);
@@ -58,8 +58,9 @@ namespace Tests.Framework.Extensions
 			string origin
 		)
 		{
-			var because = $"\r\nExpected query string from {origin}: {expectedUri.Query} on {expectedUri.PathAndQuery}";
-			because += $"\r\nActual query string from {origin}: {actualUri.Query} on {actualUri.PathAndQuery}\r\n";
+			var eol = Environment.NewLine;
+			var because = $"{eol}Expected query string from {origin}: {expectedUri.Query} on {expectedUri.PathAndQuery}";
+			because += $"{eol}Actual query string from {origin}: {actualUri.Query} on {actualUri.PathAndQuery}{eol}";
 
 			//only assert these if they appear in expectedUri
 			var specialQueryStringParameters = new[] { "pretty", "typed_keys", "error_trace" };
@@ -68,9 +69,9 @@ namespace Tests.Framework.Extensions
 				if (!expectedParameters.ContainsKey(key)) continue;
 
 				var expected = expectedParameters[key];
-				actualParameters.Should().ContainKey(key, "query value for '{0}' expected to exist\r\n{1}", key, because);
+				actualParameters.Should().ContainKey(key, $"query value for '{{0}}' expected to exist{eol}{{1}}", key, because);
 				var actual = actualParameters[key];
-				new[] { key, actual }.Should().BeEquivalentTo(new[] { key, expected }, "query value for '{0}' should be equal\r\n{1}", key, because);
+				new[] { key, actual }.Should().BeEquivalentTo(new[] { key, expected }, $"query value for '{{0}}' should be equal{eol}{{1}}", key, because);
 			}
 
 			foreach (var key in specialQueryStringParameters)
@@ -82,8 +83,9 @@ namespace Tests.Framework.Extensions
 
 		private static void ComparePaths(Uri actualUri, Uri expectedUri, string origin)
 		{
-			var because = $"\r\nExpected from {origin}: {expectedUri.PathAndQuery}";
-			because += $"\r\nActual from {origin}: {actualUri.PathAndQuery}\r\n";
+			var eol = Environment.NewLine;
+			var because = $"{eol}Expected from {origin}: {expectedUri.PathAndQuery}";
+			because += $"{eol}Actual from {origin}: {actualUri.PathAndQuery}{eol}";
 			actualUri.AbsolutePath.Should().Be(expectedUri.AbsolutePath, because);
 		}
 


### PR DESCRIPTION
This is in preperation of adding `dotnet-format` to our build.

Currently the doc and code gen end up generating mixed line ending files.