### PR TITLE
Implement snapshot records for last_success and last_failure on SnapshotLifecyclePolicyMetadata.

### DIFF
--- a/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
+++ b/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
@@ -52,6 +52,31 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name = "in_progress")]
 		public LifecycleSnapshotInProgress InProgress { get; internal set; }
+
+		/// <summary>
+		///	 Information about the last time the policy successfully initiated a snapshot.
+		/// </summary>
+		[DataMember(Name = "last_success")]
+		public SnapshotInvocationRecord LastSuccess { get; set; }
+
+		/// <summary>
+		///	 Information about the last time the policy failed to initiate a snapshot
+		/// </summary>
+		[DataMember(Name = "last_failure")]
+		public SnapshotInvocationRecord LastFailure { get; set; }
+	}
+
+	public class SnapshotInvocationRecord
+	{
+		[DataMember(Name = "snapshot_name")]
+		public string SnapshotName { get; set; }
+
+		[DataMember(Name = "time_string")]
+		public string TimeString { get; set; }
+
+		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
+		[DataMember(Name = "time")]
+		public DateTimeOffset Time { get; set; }
 	}
 
 	/// <summary>

--- a/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
+++ b/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
@@ -57,22 +57,19 @@ namespace Nest
 		///	 Information about the last time the policy successfully initiated a snapshot.
 		/// </summary>
 		[DataMember(Name = "last_success")]
-		public SnapshotInvocationRecord LastSuccess { get; set; }
+		public SnapshotLifecycleInvocationRecord LastSuccess { get; set; }
 
 		/// <summary>
 		///	 Information about the last time the policy failed to initiate a snapshot
 		/// </summary>
 		[DataMember(Name = "last_failure")]
-		public SnapshotInvocationRecord LastFailure { get; set; }
+		public SnapshotLifecycleInvocationRecord LastFailure { get; set; }
 	}
 
-	public class SnapshotInvocationRecord
+	public class SnapshotLifecycleInvocationRecord
 	{
 		[DataMember(Name = "snapshot_name")]
 		public string SnapshotName { get; set; }
-
-		[DataMember(Name = "time_string")]
-		public string TimeString { get; set; }
 
 		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
 		[DataMember(Name = "time")]


### PR DESCRIPTION
Relates to: https://github.com/elastic/elasticsearch/pull/45245

https://github.com/elastic/elasticsearch/blob/7.4/client/rest-high-level/src/main/java/org/elasticsearch/client/slm/SnapshotLifecyclePolicyMetadata.java