### PR TITLE
Add average_search_time_per_bucket_ms and total_bucket_processing_tim…

### DIFF
--- a/src/Nest/XPack/MachineLearning/Datafeed/DatafeedStats.cs
+++ b/src/Nest/XPack/MachineLearning/Datafeed/DatafeedStats.cs
@@ -5,16 +5,44 @@ namespace Nest
 	[DataContract]
 	public class DatafeedStats
 	{
-		[DataMember(Name ="assignment_explanation")]
+		[DataMember(Name = "assignment_explanation")]
 		public string AssignmentExplanation { get; internal set; }
 
-		[DataMember(Name ="datafeed_id")]
+		[DataMember(Name = "datafeed_id")]
 		public string DatafeedId { get; internal set; }
 
-		[DataMember(Name ="node")]
+		[DataMember(Name = "node")]
 		public DiscoveryNode Node { get; internal set; }
 
-		[DataMember(Name ="state")]
+		[DataMember(Name = "state")]
 		public DatafeedState State { get; internal set; }
+
+		[DataMember(Name = "timing_stats")]
+		public DatafeedTimingStats TimingStats { get; internal set; }
+	}
+
+	[DataContract]
+	public class DatafeedTimingStats
+	{
+		[DataMember(Name = "bucket_count")]
+		public long BucketCount { get; internal set; }
+
+		[DataMember(Name = "exponential_average_search_time_per_hour_ms")]
+		public double ExponentialAverageSearchTimePerHourMilliseconds { get; internal set; }
+
+		[DataMember(Name = "job_id")]
+		public string JobId { get; internal set; }
+
+		[DataMember(Name = "search_count")]
+		public long SearchCount { get; internal set; }
+
+		/// <summary>
+		/// Total search time in milliseconds
+		/// </summary>
+		/// <remarks>
+		/// Valid only in Elasticsearch 7.4.0+
+		/// </remarks>
+		[DataMember(Name = "total_search_time_ms")]
+		public double TotalSearchTimeMilliseconds { get; internal set; }
 	}
 }

--- a/src/Nest/XPack/MachineLearning/Job/Config/JobStats.cs
+++ b/src/Nest/XPack/MachineLearning/Job/Config/JobStats.cs
@@ -100,6 +100,13 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name = "exponential_average_bucket_processing_time_ms")]
 		public double ExponentialAverageBucketProcessingTimeMilliseconds { get; internal set; }
+
+		/// <summary>
+		/// Exponential moving average of all bucket processing times in milliseconds
+		/// </summary>
+		/// <remarks>Valid in Elasticsearch 7.4.0+</remarks>
+		[DataMember(Name = "exponential_average_bucket_processing_time_per_hour_ms")]
+		public double ExponentialAverageBucketProcessingTimePerHourMilliseconds { get; internal set; }
 	}
 
 	public class JobForecastStatistics

--- a/src/Tests/Tests/XPack/MachineLearning/GetDatafeedStats/GetDatafeedStatsApiTests.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/GetDatafeedStats/GetDatafeedStatsApiTests.cs
@@ -40,7 +40,9 @@ namespace Tests.XPack.MachineLearning.GetDatafeedStats
 		{
 			response.ShouldBeValid();
 			response.Count.Should().BeGreaterOrEqualTo(1);
-			response.Datafeeds.First().State.Should().Be(DatafeedState.Stopped);
+			var datafeedStats = response.Datafeeds.First();
+			datafeedStats.State.Should().Be(DatafeedState.Stopped);
+			datafeedStats.TimingStats.Should().NotBeNull();
 		}
 	}
 


### PR DESCRIPTION
…e_ms to ml stats

Relates: https://github.com/elastic/elasticsearch/pull/44125

This commit adds DatafeedTimingStats to DatafeedStats, and ExponentialAverageBucketProcessingTimePerHourMilliseconds to
JobStats.