### PR TITLE
Fix aggs integration tests where buckets can be empty

### DIFF
--- a/src/Tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
@@ -20,6 +20,7 @@ namespace Tests.Aggregations.Pipeline.BucketScript
 				{
 					field = "startedOn",
 					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -77,6 +78,7 @@ namespace Tests.Aggregations.Pipeline.BucketScript
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm
 						.Field(p => p.NumberOfCommits)
@@ -106,6 +108,7 @@ namespace Tests.Aggregations.Pipeline.BucketScript
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits") &&
 					new FilterAggregation("stable_state")

--- a/src/Tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
@@ -21,6 +21,7 @@ namespace Tests.Aggregations.Pipeline.Derivative
 				{
 					field = "startedOn",
 					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -47,6 +48,7 @@ namespace Tests.Aggregations.Pipeline.Derivative
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm
 						.Field(p => p.NumberOfCommits)
@@ -62,6 +64,7 @@ namespace Tests.Aggregations.Pipeline.Derivative
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits") &&
 					new DerivativeAggregation("commits_derivative", "commits")

--- a/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
@@ -23,6 +23,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				{
 					field = "startedOn",
 					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -54,6 +55,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm
 						.Field(p => p.NumberOfCommits)
@@ -74,6 +76,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits")
 					&& new MovingAverageAggregation("commits_moving_avg", "commits")

--- a/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
@@ -22,7 +22,8 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				date_histogram = new
 				{
 					field = "startedOn",
-					interval = "month"
+					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -55,6 +56,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm.Field(p => p.NumberOfCommits))
 					.MovingAverage("commits_moving_avg", mv => mv
@@ -74,6 +76,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits")
 					&& new MovingAverageAggregation("commits_moving_avg", "commits")

--- a/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
@@ -21,7 +21,8 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				date_histogram = new
 				{
 					field = "startedOn",
-					interval = "month"
+					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -59,6 +60,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm
 						.Field(p => p.NumberOfCommits)
@@ -85,6 +87,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits")
 					&& new MovingAverageAggregation("commits_moving_avg", "commits")
@@ -124,7 +127,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				var movingAverage = item.MovingAverage("commits_moving_avg");
 
 				// Moving Average specifies a window of 4 so
-				// moving average values should exist from 5th bucketr onwards
+				// moving average values should exist from 5th bucket onwards
 				if (bucketCount <= 4)
 					movingAverage.Should().BeNull();
 				else

--- a/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
@@ -22,7 +22,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 				date_histogram = new
 				{
 					field = "startedOn",
-					interval = "month",
+					interval = "month"
 				},
 				aggs = new
 				{
@@ -41,6 +41,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 							model = "simple",
 							window = 30,
 							predict = 10,
+							gap_policy = "insert_zeros",
 							settings = new { }
 						}
 					}
@@ -61,6 +62,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 						.BucketsPath("commits")
 						.Window(30)
 						.Predict(10)
+						.GapPolicy(GapPolicy.InsertZeros)
 						.Model(m => m
 							.Simple()
 						)
@@ -79,6 +81,7 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 					{
 						Window = 30,
 						Predict = 10,
+						GapPolicy = GapPolicy.InsertZeros,
 						Model = new SimpleModel()
 					}
 			};

--- a/src/Tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
+++ b/src/Tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
@@ -19,7 +19,8 @@ namespace Tests.Aggregations.Pipeline.SerialDifferencing
 				date_histogram = new
 				{
 					field = "startedOn",
-					interval = "month"
+					interval = "month",
+					min_doc_count = 1
 				},
 				aggs = new
 				{
@@ -47,6 +48,7 @@ namespace Tests.Aggregations.Pipeline.SerialDifferencing
 			.DateHistogram("projects_started_per_month", dh => dh
 				.Field(p => p.StartedOn)
 				.Interval(DateInterval.Month)
+				.MinimumDocumentCount(1)
 				.Aggregations(aa => aa
 					.Sum("commits", sm => sm
 						.Field(p => p.NumberOfCommits)
@@ -63,6 +65,7 @@ namespace Tests.Aggregations.Pipeline.SerialDifferencing
 			{
 				Field = "startedOn",
 				Interval = DateInterval.Month,
+				MinimumDocumentCount = 1,
 				Aggregations =
 					new SumAggregation("commits", "numberOfCommits")
 					&& new SerialDifferencingAggregation("second_difference", "commits")


### PR DESCRIPTION
This commit fixes integration tests for aggregations that use a date_histogram aggregation,
where a bucker may have no documents with a specific seed value. For example,

```
build.bat seed:41075 integrate 7.4.0 "readonly"
```