### PR TITLE
Convert SLM API dates returned as long to DateTimeOffset

### DIFF
--- a/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
+++ b/src/Nest/XPack/Slm/SnapshotLifecyclePolicyMetadata.cs
@@ -11,29 +11,17 @@ namespace Nest
 	{
 		/// <summary>
 		/// The modified date.
-		/// Returned only when Human is set to <c>true</c> on the request
-		/// </summary>
-		[DataMember(Name = "modified_date")]
-		public DateTimeOffset? ModifiedDate { get; internal set; }
-
-		/// <summary>
-		/// The modified date in milliseconds
 		/// </summary>
 		[DataMember(Name = "modified_date_millis")]
-		public long ModifiedDateInMilliseconds { get; internal set; }
+		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
+		public DateTimeOffset ModifiedDate { get; internal set; }
 
 		/// <summary>
 		/// The next execution date.
-		/// Returned only when Human is set to <c>true</c> on the request
-		/// </summary>
-		[DataMember(Name = "next_execution")]
-		public DateTimeOffset? NextExecution { get; internal set; }
-
-		/// <summary>
-		/// The next execution date in milliseconds
 		/// </summary>
 		[DataMember(Name = "next_execution_millis")]
-		public long NextExecutionInMilliseconds { get; internal set; }
+		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
+		public DateTimeOffset NextExecution { get; internal set; }
 
 		/// <summary>
 		/// The snapshot lifecycle policy
@@ -51,7 +39,7 @@ namespace Nest
 		/// If a snapshot is currently in progress this will return information about the snapshot.
 		/// </summary>
 		[DataMember(Name = "in_progress")]
-		public LifecycleSnapshotInProgress InProgress { get; internal set; }
+		public SnapshotLifecycleInProgress InProgress { get; internal set; }
 
 		/// <summary>
 		///	 Information about the last time the policy successfully initiated a snapshot.
@@ -80,13 +68,13 @@ namespace Nest
 	/// If a snapshot is in progress when calling the Get Snapshot Lifecycle metadata
 	/// this will hold some minimal information about the in flight snapshot
 	/// </summary>
-	public class LifecycleSnapshotInProgress
+	public class SnapshotLifecycleInProgress
 	{
 		/// <summary> The name of the snapshot currently being taken </summary>
 		[DataMember(Name = "name")]
 		public string Name { get; internal set; }
 
-		/// <summary> The UUI of the snapshot currently being taken </summary>
+		/// <summary> The UUID of the snapshot currently being taken </summary>
 		[DataMember(Name = "uuid")]
 		public string UUID { get; internal set; }
 
@@ -98,6 +86,5 @@ namespace Nest
 		[DataMember(Name = "start_time_millis")]
 		[JsonFormatter(typeof(DateTimeOffsetEpochMillisecondsFormatter))]
 		public DateTimeOffset StartTime { get; internal set; }
-
 	}
 }

--- a/src/Tests/Tests/XPack/Slm/SlmApiTests.cs
+++ b/src/Tests/Tests/XPack/Slm/SlmApiTests.cs
@@ -153,9 +153,7 @@ namespace Tests.XPack.Slm
 
 			metadata.Version.Should().Be(1);
 			metadata.ModifiedDate.Should().BeAfter(DateTimeOffset.MinValue);
-			metadata.ModifiedDateInMilliseconds.Should().BeGreaterThan(0);
 			metadata.NextExecution.Should().BeAfter(DateTimeOffset.MinValue);
-			metadata.NextExecutionInMilliseconds.Should().BeGreaterThan(0);
 			metadata.Policy.Name.Should().Be(v);
 			metadata.Policy.Repository.Should().Be(v);
 			metadata.Policy.Schedule.Should().BeEquivalentTo(new CronExpression("0 0 0 1 1 ? *"));


### PR DESCRIPTION
This commit updates the SLM API responses to convert date properties that are returned long values representing milliseconds since epoch
to DateTimeOffset. This is consistent with other API responses where longs are returned. What is slightly different with
this API is that Human=true can be specified on the request to also return the properties as string values. With this change, the client
now effectively ignores these values as they serve little purpose, since both would end up being converted to DateTimeOffset when deserialized.