### PR TITLE
Fix shape serialisation tests

### DIFF
--- a/src/Tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
+++ b/src/Tests/Tests.Domain/Extensions/ConnectionSettingsExtensions.cs
@@ -27,6 +27,9 @@ namespace Tests.Domain.Extensions
 			.DefaultMappingFor<Metric>(map => map
 				.IndexName("server-metrics")
 			)
+			.DefaultMappingFor<GeoShape>(map => map
+				.IndexName("geoshapes")
+			)
 			.DefaultMappingFor<Shape>(map => map
 				.IndexName("shapes")
 			);

--- a/src/Tests/Tests.Domain/GeoShape.cs
+++ b/src/Tests/Tests.Domain/GeoShape.cs
@@ -7,13 +7,14 @@ using Tests.Configuration;
 
 namespace Tests.Domain
 {
-	public class Shape
+	public class GeoShape
 	{
 		private static int _idState;
+		public ICircleGeoShape Circle { get; set; }
 		public IEnvelopeGeoShape Envelope { get; set; }
 
-		public static Faker<Shape> Generator { get; } =
-			new Faker<Shape>()
+		public static Faker<GeoShape> Generator { get; } =
+			new Faker<GeoShape>()
 				.UseSeed(TestConfiguration.Instance.Seed)
 				.RuleFor(p => p.Id, p => Interlocked.Increment(ref _idState))
 				.RuleFor(p => p.GeometryCollection, p =>
@@ -31,13 +32,14 @@ namespace Tests.Domain
 				{
 					new GeoCoordinate(45, 0),
 					new GeoCoordinate(0, 45)
-				}));
+				}))
+				.RuleFor(p => p.Circle, p => new CircleGeoShape(GenerateGeoCoordinate(p), $"{p.Random.Int(1, 100)}km"));
 
 		public IGeometryCollection GeometryCollection { get; set; }
 
 		public int Id { get; set; }
 
-		public static IList<Shape> Shapes { get; } = Generator.Clone().Generate(10);
+		public static IList<GeoShape> Shapes { get; } = Generator.Clone().Generate(10);
 
 		private static IPointGeoShape GenerateRandomPoint(Faker p) =>
 			new PointGeoShape(GenerateGeoCoordinate(p));

--- a/src/Tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeSerializationTests.cs
+++ b/src/Tests/Tests/QueryDsl/Geo/GeoShape/GeoShapeSerializationTests.cs
@@ -16,13 +16,13 @@ namespace Tests.QueryDsl.Geo.GeoShape
 {
 	public abstract class GeoShapeSerializationTestsBase
 		: ApiIntegrationTestBase<IntrusiveOperationCluster,
-			ISearchResponse<Domain.Shape>,
+			ISearchResponse<Domain.GeoShape>,
 			ISearchRequest,
-			SearchDescriptor<Domain.Shape>,
-			SearchRequest<Domain.Shape>>
+			SearchDescriptor<Domain.GeoShape>,
+			SearchRequest<Domain.GeoShape>>
 	{
 		private readonly IEnumerable<GeoCoordinate> _coordinates =
-			Domain.Shape.Shapes.First().Envelope.Coordinates;
+			Domain.GeoShape.Shapes.First().Envelope.Coordinates;
 
 		protected GeoShapeSerializationTestsBase(IntrusiveOperationCluster cluster, EndpointUsage usage)
 			: base(cluster, usage) { }
@@ -53,7 +53,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 
 		protected override int ExpectStatusCode => 200;
 
-		protected override Func<SearchDescriptor<Domain.Shape>, ISearchRequest> Fluent => s => s
+		protected override Func<SearchDescriptor<Domain.GeoShape>, ISearchRequest> Fluent => s => s
 			.Index(Index)
 			.Query(q => q
 				.GeoShape(c => c
@@ -72,13 +72,13 @@ namespace Tests.QueryDsl.Geo.GeoShape
 
 		protected abstract string Index { get; }
 
-		protected override SearchRequest<Domain.Shape> Initializer => new SearchRequest<Domain.Shape>(Index)
+		protected override SearchRequest<Domain.GeoShape> Initializer => new SearchRequest<Domain.GeoShape>(Index)
 		{
 			Query = new GeoShapeQuery
 			{
 				Name = "named_query",
 				Boost = 1.1,
-				Field = Infer.Field<Domain.Shape>(p => p.Envelope),
+				Field = Infer.Field<Domain.GeoShape>(p => p.Envelope),
 				Shape = new EnvelopeGeoShape(_coordinates),
 				Relation = GeoShapeRelation.Intersects,
 				IgnoreUnmapped = true,
@@ -90,11 +90,11 @@ namespace Tests.QueryDsl.Geo.GeoShape
 		protected override LazyResponses ClientUsage() => Calls(
 			(client, f) => client.Search(f),
 			(client, f) => client.SearchAsync(f),
-			(client, r) => client.Search<Domain.Shape>(r),
-			(client, r) => client.SearchAsync<Domain.Shape>(r)
+			(client, r) => client.Search<Domain.GeoShape>(r),
+			(client, r) => client.SearchAsync<Domain.GeoShape>(r)
 		);
 
-		protected override void ExpectResponse(ISearchResponse<Domain.Shape> response)
+		protected override void ExpectResponse(ISearchResponse<Domain.GeoShape> response)
 		{
 			response.IsValid.Should().BeTrue();
 			response.Documents.Count.Should().Be(10);
@@ -118,7 +118,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 					.NumberOfShards(1)
 					.NumberOfReplicas(0)
 				)
-				.Map<Domain.Shape>(mm => mm
+				.Map<Domain.GeoShape>(mm => mm
 					.AutoMap()
 					.Properties(p => p
 						.GeoShape(g => g
@@ -140,7 +140,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 
 			var bulkResponse = Client.Bulk(b => b
 				.Index(Index)
-				.IndexMany(Domain.Shape.Shapes)
+				.IndexMany(Domain.GeoShape.Shapes)
 				.Refresh(Refresh.WaitFor)
 			);
 
@@ -167,7 +167,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 					.NumberOfShards(1)
 					.NumberOfReplicas(0)
 				)
-				.Map<Domain.Shape>(mm => mm
+				.Map<Domain.GeoShape>(mm => mm
 					.AutoMap()
 					.Properties(p => p
 						.GeoShape(g => g
@@ -189,7 +189,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 
 			var bulk = new List<object>();
 
-			foreach (var shape in Domain.Shape.Shapes)
+			foreach (var shape in Domain.GeoShape.Shapes)
 			{
 				bulk.Add(new { index = new { _index = Index, _id = shape.Id } });
 				bulk.Add(new
@@ -210,7 +210,7 @@ namespace Tests.QueryDsl.Geo.GeoShape
 				throw new Exception($"Error indexing shapes for integration test: {bulkResponse.DebugInformation}");
 		}
 
-		protected override void ExpectResponse(ISearchResponse<Domain.Shape> response)
+		protected override void ExpectResponse(ISearchResponse<Domain.GeoShape> response)
 		{
 			base.ExpectResponse(response);
 

--- a/src/Tests/Tests/QueryDsl/Specialized/Shape/ShapeSerializationTests.cs
+++ b/src/Tests/Tests/QueryDsl/Specialized/Shape/ShapeSerializationTests.cs
@@ -108,7 +108,7 @@ namespace Tests.QueryDsl.Specialized.Shape
 		public ShapeSerializationTests(IntrusiveOperationCluster cluster, EndpointUsage usage)
 			: base(cluster, usage) { }
 
-		protected override string Index => "geoshapes";
+		protected override string Index => "shapes";
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
@@ -123,15 +123,11 @@ namespace Tests.QueryDsl.Specialized.Shape
 				.Map<Domain.Shape>(mm => mm
 					.AutoMap()
 					.Properties(p => p
-						.GeoShape(g => g
+						.Shape(g => g
 							.Name(n => n.GeometryCollection)
 						)
-						.GeoShape(g => g
+						.Shape(g => g
 							.Name(n => n.Envelope)
-						)
-						.GeoShape(g => g
-							.Name(n => n.Circle)
-							.Strategy(GeoStrategy.Recursive)
 						)
 					)
 				)
@@ -157,7 +153,7 @@ namespace Tests.QueryDsl.Specialized.Shape
 		public ShapeGeoWKTSerializationTests(IntrusiveOperationCluster cluster, EndpointUsage usage)
 			: base(cluster, usage) { }
 
-		protected override string Index => "wkt-geoshapes";
+		protected override string Index => "wkt-shapes";
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
@@ -172,15 +168,11 @@ namespace Tests.QueryDsl.Specialized.Shape
 				.Map<Domain.Shape>(mm => mm
 					.AutoMap()
 					.Properties(p => p
-						.GeoShape(g => g
+						.Shape(g => g
 							.Name(n => n.GeometryCollection)
 						)
-						.GeoShape(g => g
+						.Shape(g => g
 							.Name(n => n.Envelope)
-						)
-						.GeoShape(g => g
-							.Name(n => n.Circle)
-							.Strategy(GeoStrategy.Recursive)
 						)
 					)
 				)
@@ -198,8 +190,7 @@ namespace Tests.QueryDsl.Specialized.Shape
 				{
 					id = shape.Id,
 					geometryCollection = GeoWKTWriter.Write(shape.GeometryCollection),
-					envelope = GeoWKTWriter.Write(shape.Envelope),
-					circle = shape.Circle
+					envelope = GeoWKTWriter.Write(shape.Envelope)
 				});
 			}
 
@@ -245,7 +236,6 @@ namespace Tests.QueryDsl.Specialized.Shape
 					jValue.Value.Should().BeOfType<string>();
 					jValue = (JValue)jObject["envelope"];
 					jValue.Value.Should().BeOfType<string>();
-					jObject["circle"].Should().BeOfType<JObject>();
 				}
 			}
 		}


### PR DESCRIPTION
 - Remove circle from Shape tests
 - Change integration test setup to use Shape() instead of GeoShape()
 - Change default index for Shape types to be `shapes`