### PR TITLE
Fix/7.x/bulk formatter

### DIFF
--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -122,6 +122,7 @@ Execution hints can be provided anywhere on the command line
             |> List.filter(fun x -> 
                x <> "skiptests" && 
                x <> "gendocs" && 
+               x <> "skipdocs" && 
                x <> "non-interactive" && 
                not (x.StartsWith("seed:")) && 
                not (x.StartsWith("random:")) && 
@@ -132,11 +133,12 @@ Execution hints can be provided anywhere on the command line
             | Some t -> t.Replace("-one", "")
             | _ -> "build"
         let skipTests = args |> List.exists (fun x -> x = "skiptests")
+        let skipDocs = args |> List.exists (fun x -> x = "skipdocs")
 
         let parsed = {
             NonInteractive = args |> List.exists (fun x -> x = "non-interactive")
             SkipTests = skipTests
-            GenDocs = (args |> List.exists (fun x -> x = "gendocs") || target = "build") 
+            GenDocs = not skipDocs && (args |> List.exists (fun x -> x = "gendocs") || target = "build") 
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
                 | Some t -> t.Replace("seed:", "")

--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
 	<packageSources>
 		<add key="nuget.org" value="https://www.nuget.org/api/v2/" />
 		<add key="Elastic Abstractions CI" value="https://ci.appveyor.com/nuget/elasticsearch-net-abstractions" />
+		<add key="Versioned Clients" value="https://ci.appveyor.com/nuget/elasticsearch-net" />
 		<add key="AssemblyRewriter" value="https://ci.appveyor.com/nuget/assemblyrewriter" />
 		<add key="AssemblyDiffer" value="https://ci.appveyor.com/nuget/assemblydiffer" />
 	</packageSources>

--- a/src/CodeGeneration/ApiGenerator/RestSpecDownloader.cs
+++ b/src/CodeGeneration/ApiGenerator/RestSpecDownloader.cs
@@ -92,7 +92,7 @@ namespace ApiGenerator
 		{
 			var f = Path.Combine(GeneratorLocations.RestSpecificationFolder, folder);
 			if (!Directory.Exists(f)) Directory.CreateDirectory(f);
-			File.WriteAllText(f + "\\" + filename, contents);
+			File.WriteAllText(f + Path.DirectorySeparatorChar  + filename, contents);
 		}
 
 		private class Specification

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -66,7 +66,7 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public ConnectionConfiguration(Uri uri = null)
 			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
-		
+
 		/// <summary>
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
@@ -179,7 +179,7 @@ namespace Elasticsearch.Net
 
 			_urlFormatter = new ElasticsearchUrlFormatter(this);
 			_statusCodeToResponseSuccess = (m, i) => HttpStatusCodeClassifier(m, i);
-			
+
 			if (connectionPool is CloudConnectionPool cloudPool)
 			{
 				_basicAuthCredentials = cloudPool.BasicCredentials;
@@ -504,7 +504,7 @@ namespace Elasticsearch.Net
 				.Assign(onRequestCompleted, (a, v) =>
 				{
 					var originalCompletedRequestHandler = _completedRequestHandler;
-					var debugCompletedRequestHandler = v ?? (d => Debug.WriteLine(d.DebugInformation));
+					var debugCompletedRequestHandler = v ?? (d => { });
 					_completedRequestHandler = d =>
 					{
 						originalCompletedRequestHandler?.Invoke(d);

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -158,6 +158,7 @@ namespace Elasticsearch.Net
 		private bool _sniffOnStartup;
 		private bool _throwExceptions;
 		private bool _transferEncodingChunked;
+		private IMemoryStreamFactory _memoryStreamFactory = RecyclableMemoryStreamFactory.Default;
 
 		private string _userAgent = ConnectionConfiguration.DefaultUserAgent;
 		private Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -209,7 +210,7 @@ namespace Elasticsearch.Net
 		TimeSpan? IConnectionConfigurationValues.MaxDeadTimeout => _maxDeadTimeout;
 		int? IConnectionConfigurationValues.MaxRetries => _maxRetries;
 		TimeSpan? IConnectionConfigurationValues.MaxRetryTimeout => _maxRetryTimeout;
-		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory { get; } = RecyclableMemoryStreamFactory.Default;
+		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory => _memoryStreamFactory;
 
 		Func<Node, bool> IConnectionConfigurationValues.NodePredicate => _nodePredicate;
 		Action<IApiCallDetails> IConnectionConfigurationValues.OnRequestCompleted => _completedRequestHandler;
@@ -556,6 +557,11 @@ namespace Elasticsearch.Net
 		/// Whether the request should be sent with chunked Transfer-Encoding. Default is <c>false</c>
 		/// </summary>
 		public T TransferEncodingChunked(bool transferEncodingChunked = true) => Assign(transferEncodingChunked, (a, v) => a._transferEncodingChunked = v);
+
+		/// <summary>
+		/// The memory stream factory to use, defaults to <see cref="RecyclableMemoryStreamFactory.Default"/>
+		/// </summary>
+		public T MemoryStreamFactory(IMemoryStreamFactory memoryStreamFactory) => Assign(memoryStreamFactory, (a, v) => a._memoryStreamFactory = v);
 
 		protected virtual void DisposeManagedResources()
 		{

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -26,17 +26,17 @@
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Nest" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase"/>
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase"/>
+    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" />
     
-    <InternalsVisibleTo Include="Tests"/>
-    <InternalsVisibleTo Include="Tests.Domain"/>
+    <InternalsVisibleTo Include="Tests" />
+    <InternalsVisibleTo Include="Tests.Domain" />
 
   </ItemGroup>
   <ItemGroup>

--- a/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
@@ -8,6 +8,8 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class MemoryStreamFactory : IMemoryStreamFactory
 	{
+		public static MemoryStreamFactory Default { get; } = new MemoryStreamFactory();
+
 		/// <inheritdoc />
 		public MemoryStream Create() => new MemoryStream();
 

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
@@ -21,13 +21,13 @@ namespace Elasticsearch.Net
 //			var maxBufferSize = 16 * largeBufferMultiple;
 //			_manager = new RecyclableMemoryStreamManager(blockSize, largeBufferMultiple, maxBufferSize)
 //			{
-//				//AggressiveBufferReturn = true,
+//				AggressiveBufferReturn = true,
 //				MaximumFreeLargePoolBytes = maxBufferSize * 4,
 //				MaximumFreeSmallPoolBytes = 100 * blockSize
 //			};
 			_manager = new RecyclableMemoryStreamManager()
 			{
-				//AggressiveBufferReturn = true,
+				AggressiveBufferReturn = true,
 			};
 		}
 

--- a/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace Elasticsearch.Net.Utf8Json
@@ -60,11 +61,10 @@ namespace Elasticsearch.Net.Utf8Json
             return formatter;
         }
 
+		private static readonly MethodInfo _getFormatterMethod = typeof(IJsonFormatterResolver).GetRuntimeMethod("GetFormatter", Type.EmptyTypes);
         public static object GetFormatterDynamic(this IJsonFormatterResolver resolver, Type type)
         {
-            var methodInfo = typeof(IJsonFormatterResolver).GetRuntimeMethod("GetFormatter", Type.EmptyTypes);
-
-            var formatter = methodInfo.MakeGenericMethod(type).Invoke(resolver, null);
+            var formatter = _getFormatterMethod.MakeGenericMethod(type).Invoke(resolver, null);
             return formatter;
         }
     }

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
@@ -35,9 +35,10 @@ namespace Elasticsearch.Net.Utf8Json.Internal
     {
         public static readonly bool Is32Bit = (IntPtr.Size == 4);
 
-        public static void WriteRaw(ref JsonWriter writer, byte[] src)
+        public static void WriteRaw(ref JsonWriter writer, byte[] src) => WriteRaw(ref writer, src, src.Length);
+        public static void WriteRaw(ref JsonWriter writer, byte[] src, int length)
         {
-            switch (src.Length)
+            switch (length)
             {
                 case 0: break;
                 case 1: if (Is32Bit) { UnsafeMemory32.WriteRaw1(ref writer, src); } else { UnsafeMemory64.WriteRaw1(ref writer, src); } break;
@@ -77,19 +78,20 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-        public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src)
+        public static void MemoryCopy(ref JsonWriter writer, byte[] src) => MemoryCopy(ref writer, src, src.Length);
+        public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src, int length)
         {
-            BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, src.Length);
+            BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, length);
 #if !NET45
             fixed (void* dstP = &writer.buffer[writer.offset])
             fixed (void* srcP = &src[0])
             {
-                Buffer.MemoryCopy(srcP, dstP, writer.buffer.Length - writer.offset, src.Length);
+                Buffer.MemoryCopy(srcP, dstP, writer.buffer.Length - writer.offset, length);
             }
 #else
-            Buffer.BlockCopy(src, 0, writer.buffer, writer.offset, src.Length);
+            Buffer.BlockCopy(src, 0, writer.buffer, writer.offset, length);
 #endif
-            writer.offset += src.Length;
+            writer.offset += length;
         }
     }
 

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
@@ -157,7 +157,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
     {
 		private static readonly string ModuleName =  $"{ResolverConfig.Namespace}.DynamicCompositeResolver";
 
-        static readonly DynamicAssembly assembly;
+		static readonly DynamicAssembly assembly;
 
         static DynamicCompositeResolver()
         {

--- a/src/Elasticsearch.sln
+++ b/src/Elasticsearch.sln
@@ -10,6 +10,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "RelatedFiles", "RelatedFile
 		..\src\Library.build.props = ..\src\Library.build.props
 		Directory.Build.props = Directory.Build.props
 		Tests.build.props = Tests.build.props
+		InternalsVisible.targets = InternalsVisible.targets
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "CodeGeneration", "CodeGeneration", "{93331BEE-0AA0-47B7-B1D2-BD5BD31634D1}"

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using Elasticsearch.Net.CrossPlatform;
 
 namespace Nest
 {
@@ -150,5 +151,9 @@ namespace Nest
 		}
 
 		internal delegate T ObjectActivator<out T>(params object[] args);
+
+		private static readonly Assembly NestAssembly = typeof(TypeExtensions).Assembly();
+
+		public static bool IsNestType(this Type type) => type.Assembly() == NestAssembly;
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
@@ -14,25 +14,17 @@ namespace Nest
 
 		public IJsonFormatterResolver FormatterResolver { get; }
 
-		public T Deserialize<T>(Stream stream)
-		{
-			return JsonSerializer.Deserialize<T>(stream, FormatterResolver);
-		}
+		public T Deserialize<T>(Stream stream) =>
+			JsonSerializer.Deserialize<T>(stream, FormatterResolver);
 
-		public object Deserialize(Type type, Stream stream)
-		{
-			return JsonSerializer.NonGeneric.Deserialize(type, stream, FormatterResolver);
-		}
+		public object Deserialize(Type type, Stream stream) =>
+			JsonSerializer.NonGeneric.Deserialize(type, stream, FormatterResolver);
 
-		public Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default)
-		{
-			return JsonSerializer.DeserializeAsync<T>(stream, FormatterResolver);
-		}
+		public Task<T> DeserializeAsync<T>(Stream stream, CancellationToken cancellationToken = default) =>
+			JsonSerializer.DeserializeAsync<T>(stream, FormatterResolver);
 
-		public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default)
-		{
-			return JsonSerializer.NonGeneric.DeserializeAsync(type, stream, FormatterResolver);
-		}
+		public Task<object> DeserializeAsync(Type type, Stream stream, CancellationToken cancellationToken = default) =>
+			JsonSerializer.NonGeneric.DeserializeAsync(type, stream, FormatterResolver);
 
 		public virtual void Serialize<T>(T data, Stream writableStream, SerializationFormatting formatting = SerializationFormatting.None) =>
 			JsonSerializer.Serialize(writableStream, data, FormatterResolver);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
@@ -37,8 +37,7 @@ namespace Nest
 			using (var ms = settings.MemoryStreamFactory.Create())
 			{
 				untypedDocumentRequest.WriteJson(serializer, ms, SerializationFormatting.None);
-				var v = ms.ToArray();
-				writer.WriteRaw(v);
+				writer.WriteRaw(ms);
 			}
 		}
 	}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -40,10 +40,7 @@ namespace Nest
 			var sourceSerializer = settings.SourceSerializer;
 			var f = ForceFormatting ?? SerializationFormatting.None;
 
-			using var ms = settings.MemoryStreamFactory.Create();
-			sourceSerializer.Serialize(value, ms, f);
-			writer.WriteRaw(ms);
-
+			writer.WriteSerialized(value, sourceSerializer, settings, f);
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -30,7 +30,8 @@ namespace Nest
 			var settings = formatterResolver.GetConnectionSettings();
 
 			// avoid serialization to bytes when not using custom source serializer
-			if (ReferenceEquals(settings.SourceSerializer, settings.RequestResponseSerializer))
+			if (ReferenceEquals(settings.SourceSerializer, settings.RequestResponseSerializer)
+				|| settings.SourceSerializer is IInternalSerializerWithFormatter s && s.FormatterResolver != null)
 			{
 				formatterResolver.GetFormatter<T>().Serialize(ref writer, value, formatterResolver);
 				return;
@@ -38,15 +39,11 @@ namespace Nest
 
 			var sourceSerializer = settings.SourceSerializer;
 			var f = ForceFormatting ?? SerializationFormatting.None;
-			byte[] bytes;
-			using (var ms = settings.MemoryStreamFactory.Create())
-			{
-				sourceSerializer.Serialize(value, ms, f);
-				// TODO: read each byte instead of creating and allocating an array
-				bytes = ms.ToArray();
-			}
 
-			writer.WriteRaw(bytes);
+			using var ms = settings.MemoryStreamFactory.Create();
+			sourceSerializer.Serialize(value, ms, f);
+			writer.WriteRaw(ms);
+
 		}
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
@@ -1,4 +1,3 @@
-using Elasticsearch.Net.CrossPlatform;
 using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
@@ -13,8 +12,7 @@ namespace Nest
 				return;
 			}
 
-			var nestType = value.GetType().Assembly() == typeof(SourceWriteFormatter<>).Assembly();
-			if (nestType)
+			if (value.GetType().IsNestType())
 				formatterResolver.GetFormatter<T>().Serialize(ref writer, value, formatterResolver);
 			else
 				base.Serialize(ref writer, value, formatterResolver);

--- a/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
@@ -8,6 +8,8 @@ namespace Nest
 	{
 		private const byte Newline = (byte)'\n';
 
+		private static SourceWriteFormatter<object> SourceWriter { get; } = new SourceWriteFormatter<object>();
+
 		public IBulkRequest Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver) =>
 			throw new NotSupportedException();
 
@@ -42,12 +44,7 @@ namespace Nest
 				if (body == null)
 					continue;
 
-				var bodySerializer = op.Operation == "update" || body is ILazyDocument
-					? requestResponseSerializer
-					: sourceSerializer;
-
-				var bodyBytes = bodySerializer.SerializeToBytes(body, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyBytes);
+				SourceWriter.Serialize(ref writer, body, formatterResolver);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
@@ -19,16 +19,13 @@ namespace Nest
 				return;
 
 			var settings = formatterResolver.GetConnectionSettings();
-			var memoryStreamFactory = settings.MemoryStreamFactory;
-			var requestResponseSerializer = settings.RequestResponseSerializer;
-			var sourceSerializer = settings.SourceSerializer;
 			var inferrer = settings.Inferrer;
 			var formatter = formatterResolver.GetFormatter<object>();
 
 			for (var index = 0; index < value.Operations.Count; index++)
 			{
 				var op = value.Operations[index];
-				op.Index = op.Index ?? value.Index ?? op.ClrType;
+				op.Index ??= value.Index ?? op.ClrType;
 				if (op.Index.Equals(value.Index)) op.Index = null;
 				op.Id = op.GetIdForOperation(inferrer);
 				op.Routing = op.GetRoutingForOperation(inferrer);

--- a/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
@@ -44,11 +44,9 @@ namespace Nest
 					ignore_unavailable = GetString("ignore_unavailable")
 				};
 
-				var headerBytes = serializer.SerializeToBytes(header, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(headerBytes);
+				writer.WriteSerialized(header, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
-				var bodyBytes = serializer.SerializeToBytes(operation, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyBytes);
+				writer.WriteSerialized(operation, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
+++ b/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
@@ -44,11 +44,9 @@ namespace Nest
 					ignore_unavailable = GetString("ignore_unavailable")
 				};
 
-				var headerBytes = serializer.SerializeToBytes(header, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(headerBytes);
+				writer.WriteSerialized(header, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
-				var bodyBytes = serializer.SerializeToBytes(operation, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyBytes);
+				writer.WriteSerialized(operation, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
@@ -63,14 +63,9 @@ namespace Nest
 
 			var settings = formatterResolver.GetConnectionSettings();
 			var sourceSerializer = settings.SourceSerializer;
-			var memoryStreamFactory = settings.MemoryStreamFactory;
 
 			foreach (var data in value.Data)
-			{
-				var bodyJson = sourceSerializer.SerializeToBytes(data, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyJson);
-				writer.WriteRaw(Newline);
-			}
+				writer.WriteSerialized(data, sourceSerializer, settings, SerializationFormatting.None);
 		}
 	}
 }

--- a/src/Tests/Tests.Benchmarking/BenchmarkProgram.cs
+++ b/src/Tests/Tests.Benchmarking/BenchmarkProgram.cs
@@ -63,9 +63,8 @@ namespace Tests.Benchmarking
 		{
 			var jobs = new[]
 			{
-				Job.ShortRun.With(Runtime.Core).With(Jit.RyuJit),
-				Job.ShortRun.With(Runtime.Clr).With(Jit.RyuJit),
-				Job.ShortRun.With(Runtime.Clr).With(Jit.LegacyJit),
+				Job.MediumRun.With(ClrRuntime.Net472).With(Jit.LegacyJit),
+				Job.MediumRun.With(CoreRuntime.Core30).With(Jit.RyuJit),
 			};
 			var config = DefaultConfig.Instance
 				.With(jobs)

--- a/src/Tests/Tests.Benchmarking/BenchmarkProgram.cs
+++ b/src/Tests/Tests.Benchmarking/BenchmarkProgram.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.InteropServices;
 using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Configs;
 using BenchmarkDotNet.Diagnosers;
@@ -30,21 +31,21 @@ namespace Tests.Benchmarking
 			if (!Directory.Exists(Path.Combine(dirInfo.FullName, ".git"))) Environment.Exit(2);
 
 			Console.WriteLine(dirInfo.FullName);
-			using (var repos = new Repository(dirInfo.FullName))
-			{
-				Commit = repos.Head.Tip.Sha;
-				CommitMessage = repos.Head.Tip.Message?.Trim(' ', '\t', '\r', '\n');
-				Branch = repos.Head.FriendlyName;
-				var remoteName = repos.Head.RemoteName;
-				Repository =
-					repos.Network.Remotes.FirstOrDefault(r => r.Name == remoteName)?.Url
-					?? repos.Network.Remotes.FirstOrDefault()?.Url;
-			}
+//			using (var repos = new Repository(dirInfo.FullName))
+//			{
+//				Commit = repos.Head.Tip.Sha;
+//				CommitMessage = repos.Head.Tip.Message?.Trim(' ', '\t', '\r', '\n');
+//				Branch = repos.Head.FriendlyName;
+//				var remoteName = repos.Head.RemoteName;
+//				Repository =
+//					repos.Network.Remotes.FirstOrDefault(r => r.Name == remoteName)?.Url
+//					?? repos.Network.Remotes.FirstOrDefault()?.Url;
+//			}
 		}
 
 		public static int Main(string[] arguments)
 		{
-			Console.WriteLine($"Tests.Benchmarking: [{Branch}]@({Commit}) on {Repository} : {CommitMessage} - ");
+			//Console.WriteLine($"Tests.Benchmarking: [{Branch}]@({Commit}) on {Repository} : {CommitMessage} - ");
 			var config = CreateDefaultConfig();
 			if (arguments.Any() && arguments[0].Equals("--all", StringComparison.OrdinalIgnoreCase))
 			{
@@ -61,13 +62,15 @@ namespace Tests.Benchmarking
 
 		private static IConfig CreateDefaultConfig()
 		{
-			var jobs = new[]
+			var jobs = new List<Job>
 			{
-				Job.MediumRun.With(ClrRuntime.Net472).With(Jit.LegacyJit),
 				Job.MediumRun.With(CoreRuntime.Core30).With(Jit.RyuJit),
 			};
+			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+				jobs.Add(Job.MediumRun.With(ClrRuntime.Net472).With(Jit.LegacyJit));
+
 			var config = DefaultConfig.Instance
-				.With(jobs)
+				.With(jobs.ToArray())
 				.With(MemoryDiagnoser.Default);
 			return config;
 		}

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -41,7 +41,7 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "PR")]
 		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
 
-		[Benchmark(Description = "PR no recyclable ")]
+		[Benchmark(Description = "PR no recyclable")]
 		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
 
 		[Benchmark(Description = "7.x")]

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Elasticsearch.Net;
+using Nest;
+using Newtonsoft.Json;
+using Tests.Benchmarking.Framework;
+using Tests.Core.Client;
+using Tests.Domain;
+
+namespace Tests.Benchmarking
+{
+	[BenchmarkConfig]
+	public class BulkBenchmarkTests
+	{
+		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
+		private static byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+		private static readonly IElasticClient Client = TestClient.FixedInMemoryClient(Response);
+
+		[GlobalSetup]
+		public void Setup() { }
+
+		[Benchmark(Description = "NEST Bulk()")]
+		public BulkResponse NestBulk() => Client.Bulk(b => b.IndexMany(Projects));
+
+
+
+		private static object BulkItemResponse(Project project) => new
+		{
+			index = new
+			{
+				_index = "nest-52cfd7aa",
+				_id = project.Name,
+				_version = 1,
+				_shards = new
+				{
+					total = 2,
+					successful = 1,
+					failed = 0
+				},
+				created = true,
+				status = 201
+			}
+		};
+
+		private static object ReturnBulkResponse(IList<Project> projects) => new
+		{
+			took = 276,
+			errors = false,
+			items = projects
+				.Select(p => BulkItemResponse(p))
+				.ToArray()
+		};
+	}
+}

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -9,21 +9,22 @@ using Tests.Domain;
 
 namespace Tests.Benchmarking
 {
-	[BenchmarkConfig]
+	[BenchmarkConfig(5)]
 	public class BulkBenchmarkTests
 	{
 		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
-		private static byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+		private static readonly byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
 
 		private static readonly IElasticClient Client =
 			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
-				.DisableDirectStreaming()
+				.DefaultIndex("index")
 				.EnableHttpCompression(false)
 			);
+
 		private static readonly Nest7.IElasticClient ClientV7 =
 			new Nest7.ElasticClient(new Nest7.ConnectionSettings(
 					new Elasticsearch.Net7.InMemoryConnection(Response, 200, null, null))
-				.DisableDirectStreaming()
+				.DefaultIndex("index")
 				.EnableHttpCompression(false)
 			);
 
@@ -33,7 +34,7 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "NEST updated Bulk()")]
 		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
 
-		[Benchmark(Description = "NEST current Bulk()")]
+		[Benchmark(Description = "NEST Bulk()")]
 		public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));
 
 		private static object BulkItemResponse(Project project) => new

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -21,6 +21,13 @@ namespace Tests.Benchmarking
 				.EnableHttpCompression(false)
 			);
 
+		private static readonly IElasticClient ClientNoRecyclableMemory =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+				.MemoryStreamFactory(MemoryStreamFactory.Default)
+			);
+
 		private static readonly Nest7.IElasticClient ClientV7 =
 			new Nest7.ElasticClient(new Nest7.ConnectionSettings(
 					new Elasticsearch.Net7.InMemoryConnection(Response, 200, null, null))
@@ -31,10 +38,13 @@ namespace Tests.Benchmarking
 		[GlobalSetup]
 		public void Setup() { }
 
-		[Benchmark(Description = "NEST updated Bulk()")]
+		[Benchmark(Description = "PR")]
 		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
 
-		[Benchmark(Description = "NEST Bulk()")]
+		[Benchmark(Description = "PR no recyclable ")]
+		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
+
+		[Benchmark(Description = "7.x")]
 		public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));
 
 		private static object BulkItemResponse(Project project) => new

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Optimize>true</Optimize>

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -14,6 +14,6 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20191017T152836" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
-    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191031T101859" />
+    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191031T180108" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -14,5 +14,6 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
     <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20191017T152836" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
+    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191030T135150" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -11,9 +11,9 @@
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20191017T152836" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
-    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191030T135150" />
+    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191031T101859" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -18,10 +18,10 @@ elasticsearch_version: latest-7
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
 
-#random_source_serializer: true
+#random_source_serializer: false
 #random_old_connection: true
 #random_http_compresssion: true
-#seed: 74337
+seed: 86883
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.
 # Can also help keep the noise down in case of test failures

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -18,10 +18,10 @@ elasticsearch_version: latest-7
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
 
-random_source_serializer: false
+#random_source_serializer: false
 #random_old_connection: true
 #random_http_compresssion: true
-seed: 86883
+#seed: 86883
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.
 # Can also help keep the noise down in case of test failures

--- a/src/Tests/Tests.Configuration/tests.default.yaml
+++ b/src/Tests/Tests.Configuration/tests.default.yaml
@@ -18,7 +18,7 @@ elasticsearch_version: latest-7
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
 
-#random_source_serializer: false
+random_source_serializer: false
 #random_old_connection: true
 #random_http_compresssion: true
 seed: 86883

--- a/src/Tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
@@ -13,6 +13,8 @@ namespace Tests.Core.Client.Settings
 	{
 		public AlwaysInMemoryConnectionSettings() : base(forceInMemory: true) { }
 
+		public AlwaysInMemoryConnectionSettings(byte[] bytes) : base(forceInMemory: true, response: bytes) { }
+
 		public AlwaysInMemoryConnectionSettings(
 			Func<ICollection<Uri>, IConnectionPool> createPool = null,
 			SourceSerializerFactory sourceSerializerFactory = null,
@@ -23,7 +25,7 @@ namespace Tests.Core.Client.Settings
 				createPool,
 				sourceSerializerFactory,
 				propertyMappingProvider,
-				true,
+				forceInMemory: true,
 				port
 			) { }
 	}

--- a/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -21,11 +21,12 @@ namespace Tests.Core.Client.Settings
 			SourceSerializerFactory sourceSerializerFactory = null,
 			IPropertyMappingProvider propertyMappingProvider = null,
 			bool forceInMemory = false,
-			int port = 9200
+			int port = 9200,
+			byte[] response = null
 		)
 			: base(
 				CreatePool(createPool, port),
-				TestConfiguration.Instance.CreateConnection(forceInMemory),
+				TestConfiguration.Instance.CreateConnection(forceInMemory, response),
 				CreateSerializerFactory(sourceSerializerFactory),
 				propertyMappingProvider
 			) =>
@@ -40,7 +41,7 @@ namespace Tests.Core.Client.Settings
 
 		private static string LocalHost => "localhost";
 
-		private void ApplyTestSettings() => 
+		private void ApplyTestSettings() =>
 			RerouteToProxyIfNeeded()
 			.EnableDebugMode()
 			.EnableHttpCompression(TestConfiguration.Instance.Random.HttpCompression)

--- a/src/Tests/Tests.Core/Client/TestClient.cs
+++ b/src/Tests/Tests.Core/Client/TestClient.cs
@@ -11,6 +11,12 @@ namespace Tests.Core.Client
 		public static readonly TestConfigurationBase Configuration = TestConfiguration.Instance;
 		public static readonly IElasticClient Default = new ElasticClient(new TestConnectionSettings().ApplyDomainSettings());
 		public static readonly IElasticClient DefaultInMemoryClient = new ElasticClient(new AlwaysInMemoryConnectionSettings().ApplyDomainSettings());
+		public static IElasticClient FixedInMemoryClient(byte[] response) => new ElasticClient(
+			new AlwaysInMemoryConnectionSettings(response)
+				.ApplyDomainSettings()
+				.DisableDirectStreaming()
+				.EnableHttpCompression(false)
+			);
 
 		public static readonly IElasticClient DisabledStreaming =
 			new ElasticClient(new TestConnectionSettings().ApplyDomainSettings().DisableDirectStreaming());

--- a/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
@@ -7,8 +7,12 @@ namespace Tests.Core.Extensions
 {
 	public static class TestConfigurationExtensions
 	{
-		public static IConnection CreateConnection(this TestConfigurationBase configuration, bool forceInMemory = false) =>
-			configuration.RunIntegrationTests && !forceInMemory ? (IConnection)new HttpConnection() : new InMemoryConnection();
+		public static IConnection CreateConnection(this TestConfigurationBase configuration, bool forceInMemory = false, byte[] response = null) =>
+			forceInMemory
+				? new InMemoryConnection(response)
+				: configuration.RunIntegrationTests
+					? (IConnection)new HttpConnection()
+					: new InMemoryConnection(response);
 
 		public static bool InRange(this TestConfigurationBase configuration, string range) =>
 			configuration.ElasticsearchVersion.InRange(range);

--- a/src/Tests/Tests.Core/Serialization/SerializationTester.cs
+++ b/src/Tests/Tests.Core/Serialization/SerializationTester.cs
@@ -215,7 +215,7 @@ namespace Tests.Core.Serialization
 
 		private static bool MatchJson<T>(JToken expectedJson, string actualJson, RoundTripResult<T> result, string message)
 		{
-			var actualJsonToken = JToken.Parse(actualJson));
+			var actualJsonToken = JToken.Parse(actualJson);
 			var matches = JToken.DeepEquals(expectedJson, actualJsonToken);
 			if (matches) return true;
 

--- a/src/Tests/Tests.Core/Serialization/SerializationTester.cs
+++ b/src/Tests/Tests.Core/Serialization/SerializationTester.cs
@@ -215,7 +215,7 @@ namespace Tests.Core.Serialization
 
 		private static bool MatchJson<T>(JToken expectedJson, string actualJson, RoundTripResult<T> result, string message)
 		{
-			var actualJsonToken = JToken.Parse(actualJson);
+			var actualJsonToken = JToken.Parse(actualJson.Trim('\0'));
 			var matches = JToken.DeepEquals(expectedJson, actualJsonToken);
 			if (matches) return true;
 

--- a/src/Tests/Tests.Domain/Project.cs
+++ b/src/Tests/Tests.Domain/Project.cs
@@ -78,7 +78,7 @@ namespace Tests.Domain
 				.RuleFor(p => p.DateString, (p, d) => d.StartedOn.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"))
 				.RuleFor(p => p.LastActivity, p => p.Date.Recent())
 				.RuleFor(p => p.LeadDeveloper, p => Developer.Developers[Gimme.Random.Number(0, Developer.Developers.Count - 1)])
-				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 50)))
+				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 10)))
 				.RuleFor(p => p.CuratedTags, f => Tag.Generator.Generate(Gimme.Random.Number(1, 5)))
 				.RuleFor(p => p.LocationPoint, f => SimpleGeoPoint.Generator.Generate())
 				.RuleFor(p => p.LocationShape, f => new PointGeoShape(new GeoCoordinate(f.Address.Latitude(), f.Address.Latitude())))

--- a/src/Tests/Tests.ScratchPad/Program.cs
+++ b/src/Tests/Tests.ScratchPad/Program.cs
@@ -3,10 +3,13 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
 using BenchmarkDotNet.Running;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Diagnostics;
 using Nest;
+using Tests.Core.Client;
+using Tests.Domain;
 using Xunit.Sdk;
 
 namespace Tests.ScratchPad
@@ -46,33 +49,54 @@ namespace Tests.ScratchPad
 			}
 		}
 
+		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
+		private static byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+		private static readonly IElasticClient Client = TestClient.FixedInMemoryClient(Response);
+
+
 		private static async Task Main(string[] args)
 		{
-			DiagnosticListener.AllListeners.Subscribe(new ListenerObserver());
+			var response = Client.Bulk(b => b.IndexMany(Projects));
 
-			using (var node = new Elastic.Managed.Ephemeral.EphemeralCluster("7.0.0"))
+
+			await Task.Delay(TimeSpan.FromSeconds(6));
+			Console.WriteLine($"Kicking off");
+
+			for (var i = 0; i < 10_000; i++)
 			{
-				node.Start();
-
-				var settings = new ConnectionSettings(new StaticConnectionPool(new[] { node.NodesUris("ipv4.fiddler").First() }))
-					.EnableHttpCompression()
-					.Proxy(new Uri("http://127.0.0.1:8080"), (string)null, (string)null)
-					;
-				var client = new ElasticClient(settings);
-
-				var x = client.Search<object>(s=>s.AllIndices());
-
-				await Task.Delay(TimeSpan.FromSeconds(7));
-
-				Console.WriteLine(new string('-', Console.WindowWidth - 1));
-
-				var y = client.Search<object>(s=>s.Index("does-not-exist"));
-
-				await Task.Delay(TimeSpan.FromSeconds(7));
-
-
+				var r = Client.Bulk(b => b.IndexMany(Projects));
+				Console.Write($"\r{i}: {r.IsValid} {r.Items.Count}");
 			}
 		}
+
+
+		private static object BulkItemResponse(Project project) => new
+		{
+			index = new
+			{
+				_index = "nest-52cfd7aa",
+				_type = "_doc",
+				_id = project.Name,
+				_version = 1,
+				_shards = new
+				{
+					total = 2,
+					successful = 1,
+					failed = 0
+				},
+				created = true,
+				status = 201
+			}
+		};
+
+		private static object ReturnBulkResponse(IList<Project> projects) => new
+		{
+			took = 276,
+			errors = false,
+			items = projects
+				.Select(p => BulkItemResponse(p))
+				.ToArray()
+		};
 
 		private static void Bench<TBenchmark>() where TBenchmark : RunBase => BenchmarkRunner.Run<TBenchmark>();
 

--- a/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -3,9 +3,9 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <TieredCompilation>false</TieredCompilation>
     <Optimize>true</Optimize>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -160,10 +160,7 @@ namespace Tests.ClientConcepts.Connection
 			public int ClientCount => Clients.Count;
 			public HttpClientHandler LastHttpClientHandler => (HttpClientHandler)_handler.InnerHandler;
 
-			public TestableHttpConnection(Action<HttpResponseMessage> response)
-			{
-				_response = response;
-			}
+			public TestableHttpConnection(Action<HttpResponseMessage> response) => _response = response;
 
 			public TestableHttpConnection()
 			{


### PR DESCRIPTION
Continuation of #3797 

this consolidates someof the places we either serialize to bytes or call `ToArray()`. 

This also references `Nest7` from our nuget feed, this is a versioned package where all types live in `Nest7` and `Easticsearch.Net7` . This has been around for a while see: https://www.elastic.co/blog/nest-and-elasticsearch-net-upgrading-your-codebase

Here we use it to profile against the integration branch.

On bulk the write path is still a lot hotter then the read path, this does not fix that but does improve allocations.

|                Method |       Jit |       Runtime |     Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Gen 2 |   Allocated |
|---------------------- |---------- |-------------- |---------:|---------:|---------:|-----------:|----------:|------:|------------:|
| 'NEST updated Bulk()' | LegacyJit |    .NET 4.7.2 | 511.0 ms |  6.89 ms |  9.89 ms |  8000.0000 | 2000.0000 |     - |           - |
|         'NEST Bulk()' | LegacyJit |    .NET 4.7.2 | 470.4 ms | 10.76 ms | 15.44 ms | 16000.0000 | 4000.0000 |     - |           - |
| 'NEST updated Bulk()' |    RyuJit | .NET Core 3.0 | 304.8 ms |  4.38 ms |  6.56 ms |  8000.0000 | 2000.0000 |     - | 153176144 B |
|         'NEST Bulk()' |    RyuJit | .NET Core 3.0 | 317.4 ms |  4.23 ms |  5.93 ms | 16000.0000 | 4000.0000 |     - | 199605512 B |
