### PR TITLE
Adds versioned benchmarking

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -3,6 +3,7 @@
 	<packageSources>
 		<add key="nuget.org" value="https://www.nuget.org/api/v2/" />
 		<add key="Elastic Abstractions CI" value="https://ci.appveyor.com/nuget/elasticsearch-net-abstractions" />
+		<add key="Versioned Clients" value="https://ci.appveyor.com/nuget/elasticsearch-net" />
 		<add key="AssemblyRewriter" value="https://ci.appveyor.com/nuget/assemblyrewriter" />
 		<add key="AssemblyDiffer" value="https://ci.appveyor.com/nuget/assemblydiffer" />
 	</packageSources>

--- a/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
@@ -7,6 +7,8 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class MemoryStreamFactory : IMemoryStreamFactory
 	{
+		public static MemoryStreamFactory Default { get; } = new MemoryStreamFactory();
+
 		/// <inheritdoc />
 		public MemoryStream Create() => new MemoryStream();
 

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -21,12 +21,13 @@ namespace Tests.Benchmarking
 				.EnableHttpCompression(false)
 			);
 
-		private static readonly IElasticClient ClientNoRecyclableMemory =
-			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
-				.DefaultIndex("index")
-				.EnableHttpCompression(false)
-				.MemoryStreamFactory(MemoryStreamFactory.Default)
-			);
+		//TODO can uncomment when https://github.com/elastic/elasticsearch-net/pull/4202 lands
+//		private static readonly IElasticClient ClientNoRecyclableMemory =
+//			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+//				.DefaultIndex("index")
+//				.EnableHttpCompression(false)
+//				.MemoryStreamFactory(MemoryStreamFactory.Default)
+//			);
 
 		private static readonly Nest7.IElasticClient ClientV7 =
 			new Nest7.ElasticClient(new Nest7.ConnectionSettings(
@@ -41,8 +42,8 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "PR")]
 		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
 
-		[Benchmark(Description = "PR no recyclable")]
-		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
+//		[Benchmark(Description = "PR no recyclable")]
+//		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
 
 		[Benchmark(Description = "7.x")]
 		public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));

--- a/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/src/Tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -1,0 +1,77 @@
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Benchmarking.Framework;
+using Tests.Core.Client;
+using Tests.Domain;
+
+namespace Tests.Benchmarking
+{
+	[BenchmarkConfig(5)]
+	public class BulkBenchmarkTests
+	{
+		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
+		private static readonly byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+
+		private static readonly IElasticClient Client =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+			);
+
+		private static readonly IElasticClient ClientNoRecyclableMemory =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+				.MemoryStreamFactory(MemoryStreamFactory.Default)
+			);
+
+		private static readonly Nest7.IElasticClient ClientV7 =
+			new Nest7.ElasticClient(new Nest7.ConnectionSettings(
+					new Elasticsearch.Net7.InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+			);
+
+		[GlobalSetup]
+		public void Setup() { }
+
+		[Benchmark(Description = "PR")]
+		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
+
+		[Benchmark(Description = "PR no recyclable")]
+		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
+
+		[Benchmark(Description = "7.x")]
+		public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));
+
+		private static object BulkItemResponse(Project project) => new
+		{
+			index = new
+			{
+				_index = "nest-52cfd7aa",
+				_id = project.Name,
+				_version = 1,
+				_shards = new
+				{
+					total = 2,
+					successful = 1,
+					failed = 0
+				},
+				created = true,
+				status = 201
+			}
+		};
+
+		private static object ReturnBulkResponse(IList<Project> projects) => new
+		{
+			took = 276,
+			errors = false,
+			items = projects
+				.Select(p => BulkItemResponse(p))
+				.ToArray()
+		};
+	}
+}

--- a/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/src/Tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
+    <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Optimize>true</Optimize>
@@ -11,8 +12,9 @@
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.11.5" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Elastic.BenchmarkDotNetExporter" Version="0.1.0-ci20191017T152836" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
+    <PackageReference Include="NEST.v7" Version="7.5.0-ci20191031T180108" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/AlwaysInMemoryConnectionSettings.cs
@@ -13,6 +13,8 @@ namespace Tests.Core.Client.Settings
 	{
 		public AlwaysInMemoryConnectionSettings() : base(forceInMemory: true) { }
 
+		public AlwaysInMemoryConnectionSettings(byte[] bytes) : base(forceInMemory: true, response: bytes) { }
+
 		public AlwaysInMemoryConnectionSettings(
 			Func<ICollection<Uri>, IConnectionPool> createPool = null,
 			SourceSerializerFactory sourceSerializerFactory = null,
@@ -23,7 +25,7 @@ namespace Tests.Core.Client.Settings
 				createPool,
 				sourceSerializerFactory,
 				propertyMappingProvider,
-				true,
+				forceInMemory: true,
 				port
 			) { }
 	}

--- a/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/src/Tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -21,11 +21,12 @@ namespace Tests.Core.Client.Settings
 			SourceSerializerFactory sourceSerializerFactory = null,
 			IPropertyMappingProvider propertyMappingProvider = null,
 			bool forceInMemory = false,
-			int port = 9200
+			int port = 9200,
+			byte[] response = null
 		)
 			: base(
 				CreatePool(createPool, port),
-				TestConfiguration.Instance.CreateConnection(forceInMemory),
+				TestConfiguration.Instance.CreateConnection(forceInMemory, response),
 				CreateSerializerFactory(sourceSerializerFactory),
 				propertyMappingProvider
 			) =>
@@ -40,7 +41,7 @@ namespace Tests.Core.Client.Settings
 
 		private static string LocalHost => "localhost";
 
-		private void ApplyTestSettings() => 
+		private void ApplyTestSettings() =>
 			RerouteToProxyIfNeeded()
 			.EnableDebugMode()
 			.EnableHttpCompression(TestConfiguration.Instance.Random.HttpCompression)

--- a/src/Tests/Tests.Core/Client/TestClient.cs
+++ b/src/Tests/Tests.Core/Client/TestClient.cs
@@ -11,6 +11,12 @@ namespace Tests.Core.Client
 		public static readonly TestConfigurationBase Configuration = TestConfiguration.Instance;
 		public static readonly IElasticClient Default = new ElasticClient(new TestConnectionSettings().ApplyDomainSettings());
 		public static readonly IElasticClient DefaultInMemoryClient = new ElasticClient(new AlwaysInMemoryConnectionSettings().ApplyDomainSettings());
+		public static IElasticClient FixedInMemoryClient(byte[] response) => new ElasticClient(
+			new AlwaysInMemoryConnectionSettings(response)
+				.ApplyDomainSettings()
+				.DisableDirectStreaming()
+				.EnableHttpCompression(false)
+			);
 
 		public static readonly IElasticClient DisabledStreaming =
 			new ElasticClient(new TestConnectionSettings().ApplyDomainSettings().DisableDirectStreaming());

--- a/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
+++ b/src/Tests/Tests.Core/Extensions/TestConfigurationExtensions.cs
@@ -7,8 +7,12 @@ namespace Tests.Core.Extensions
 {
 	public static class TestConfigurationExtensions
 	{
-		public static IConnection CreateConnection(this TestConfigurationBase configuration, bool forceInMemory = false) =>
-			configuration.RunIntegrationTests && !forceInMemory ? (IConnection)new HttpConnection() : new InMemoryConnection();
+		public static IConnection CreateConnection(this TestConfigurationBase configuration, bool forceInMemory = false, byte[] response = null) =>
+			forceInMemory
+				? new InMemoryConnection(response)
+				: configuration.RunIntegrationTests
+					? (IConnection)new HttpConnection()
+					: new InMemoryConnection(response);
 
 		public static bool InRange(this TestConfigurationBase configuration, string range) =>
 			configuration.ElasticsearchVersion.InRange(range);

--- a/src/Tests/Tests.Domain/Project.cs
+++ b/src/Tests/Tests.Domain/Project.cs
@@ -78,7 +78,7 @@ namespace Tests.Domain
 				.RuleFor(p => p.DateString, (p, d) => d.StartedOn.ToString("yyyy-MM-ddTHH\\:mm\\:ss.fffffffzzz"))
 				.RuleFor(p => p.LastActivity, p => p.Date.Recent())
 				.RuleFor(p => p.LeadDeveloper, p => Developer.Developers[Gimme.Random.Number(0, Developer.Developers.Count - 1)])
-				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 50)))
+				.RuleFor(p => p.Tags, f => Tag.Generator.Generate(Gimme.Random.Number(2, 10)))
 				.RuleFor(p => p.CuratedTags, f => Tag.Generator.Generate(Gimme.Random.Number(1, 5)))
 				.RuleFor(p => p.LocationPoint, f => SimpleGeoPoint.Generator.Generate())
 				.RuleFor(p => p.LocationShape, f => new PointGeoShape(new GeoCoordinate(f.Address.Latitude(), f.Address.Latitude())))

--- a/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/src/Tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -3,9 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp3.0</TargetFramework>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <Optimize>true</Optimize>
+    <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />

--- a/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -160,10 +160,7 @@ namespace Tests.ClientConcepts.Connection
 			public int ClientCount => Clients.Count;
 			public HttpClientHandler LastHttpClientHandler => (HttpClientHandler)_handler.InnerHandler;
 
-			public TestableHttpConnection(Action<HttpResponseMessage> response)
-			{
-				_response = response;
-			}
+			public TestableHttpConnection(Action<HttpResponseMessage> response) => _response = response;
 
 			public TestableHttpConnection()
 			{


### PR DESCRIPTION
Allows the benchmarking project to reference Nest.v7 and so makes it easier for us to benchmark proposed changes.

Isolated from #4172 and #4191 which both grew to be too big to review