### PR TITLE
Use MemoryStreamFactory everywhere

### DIFF
--- a/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/MockResponses/SniffResponseBytes.cs
+++ b/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/MockResponses/SniffResponseBytes.cs
@@ -17,17 +17,17 @@ namespace Elasticsearch.Net.VirtualizedCluster.MockResponses
 				cluster_name = ClusterName,
 				nodes = SniffResponseNodes(nodes, elasticsearchVersion, publishAddressOverride, randomFqdn)
 			};
-			using (var ms = new MemoryStream())
+			using (var ms = RecyclableMemoryStreamFactory.Default.Create())
 			{
-				new LowLevelRequestResponseSerializer().Serialize(response, ms);
+				LowLevelRequestResponseSerializer.Instance.Serialize(response, ms);
 				return ms.ToArray();
 			}
 		}
 
 		private static IDictionary<string, object> SniffResponseNodes(
-			IEnumerable<Node> nodes, 
+			IEnumerable<Node> nodes,
 			string elasticsearchVersion,
-			string publishAddressOverride, 
+			string publishAddressOverride,
 			bool randomFqdn
 		) =>
 			(from node in nodes

--- a/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
+++ b/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
@@ -50,9 +50,9 @@ namespace Elasticsearch.Net.VirtualizedCluster.Rules
 			where T : class
 		{
 			byte[] r;
-			using (var ms = new MemoryStream())
+			using (var ms = RecyclableMemoryStreamFactory.Default.Create())
 			{
-				new LowLevelRequestResponseSerializer().Serialize(response, ms);
+				LowLevelRequestResponseSerializer.Instance.Serialize(response, ms);
 				r = ms.ToArray();
 			}
 			Self.ReturnResponse = r;

--- a/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/VirtualClusterConnection.cs
+++ b/src/Auxiliary/Elasticsearch.Net.VirtualizedCluster/VirtualClusterConnection.cs
@@ -264,9 +264,9 @@ namespace Elasticsearch.Net.VirtualizedCluster
 			if (_defaultResponseBytes != null) return _defaultResponseBytes;
 
 			var response = DefaultResponse;
-			using (var ms = new MemoryStream())
+			using (var ms = RecyclableMemoryStreamFactory.Default.Create())
 			{
-				new LowLevelRequestResponseSerializer().Serialize(response, ms);
+				LowLevelRequestResponseSerializer.Instance.Serialize(response, ms);
 				_defaultResponseBytes = ms.ToArray();
 			}
 			return _defaultResponseBytes;

--- a/src/Elasticsearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
@@ -61,7 +61,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal.Emit
         }
 
         public ILStreamReader(byte[] ilByteArray)
-            : base(new MemoryStream(ilByteArray))
+            : base(RecyclableMemoryStreamFactory.Default.Create(ilByteArray))
         {
             this.endPosition = ilByteArray.Length;
         }


### PR DESCRIPTION
Found a few places, that still new'ed MemoryStream directly (outside of client mainly)

Isolated from #4172 and #4191 which both grew to be too big to review