### PR TITLE
normalize ifdefs in our source included UTF8Json

### DIFF
--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -2,11 +2,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildThisFileDirectory), build.bat))\src\PublishArtifacts.build.props" />
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <!-- Here to satisy UTF8JSON which defines NETSTANDARD also for anything > NET45 -->
-    <DefineConstants>$(DefineConstants);NETSTANDARD</DefineConstants>
     <LangVersion>8.0</LangVersion>
     <TieredCompilation>false</TieredCompilation>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/CollectionFormatters.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/CollectionFormatters.cs
@@ -504,11 +504,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 				{
 					var keyString = reader.ReadPropertyNameSegmentRaw();
 					int key;
-#if NETSTANDARD
 					CollectionFormatterHelper.groupingAutomata.TryGetValue(keyString, out key);
-#else
-                    CollectionFormatterHelper.groupingAutomata.TryGetValueSafe(keyString, out key);
-#endif
 
 					switch (key)
 					{
@@ -832,7 +828,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 	}
 
 
-#if NETSTANDARD
 
 	internal sealed class ObservableCollectionFormatter<T> : CollectionFormatterBase<T, ObservableCollection<T>>
 	{
@@ -968,9 +963,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			return stack;
 		}
 	}
-
-#endif
-
 
 	internal static class CollectionFormatterHelper
 	{

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
@@ -728,7 +728,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 
 	internal sealed class TimeSpanFormatter : IJsonFormatter<TimeSpan>
     {
-#if NETSTANDARD
         readonly string formatString;
 
         public TimeSpanFormatter()
@@ -740,21 +739,15 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
         {
             this.formatString = formatString;
         }
-#endif
 
         public void Serialize(ref JsonWriter writer, TimeSpan value, IJsonFormatterResolver formatterResolver)
         {
-#if NETSTANDARD
             writer.WriteString(value.ToString(formatString));
-#else
-            writer.WriteString(value.ToString());
-#endif
         }
 
         public TimeSpan Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
         {
             var str = reader.ReadString();
-#if NETSTANDARD
             if (formatString == null)
             {
                 return TimeSpan.Parse(str, CultureInfo.InvariantCulture);
@@ -763,9 +756,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
             {
                 return TimeSpan.ParseExact(str, formatString, CultureInfo.InvariantCulture);
             }
-#else
-            return TimeSpan.Parse(str);
-#endif
         }
     }
 
@@ -778,12 +768,10 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
             this.innerFormatter = new TimeSpanFormatter();
         }
 
-#if NETSTANDARD
         public NullableTimeSpanFormatter(string formatString)
         {
             this.innerFormatter = new TimeSpanFormatter(formatString);
         }
-#endif
 
         public void Serialize(ref JsonWriter writer, TimeSpan? value, IJsonFormatterResolver formatterResolver)
         {

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/DictionaryFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/DictionaryFormatter.cs
@@ -188,7 +188,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
             return intermediateCollection;
         }
     }
-	
+
 	internal sealed class DictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, Dictionary<TKey, TValue>.Enumerator, Dictionary<TKey, TValue>>
     {
         protected override void Add(ref Dictionary<TKey, TValue> collection, int index, TKey key, TValue value)
@@ -280,8 +280,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
         }
     }
 
-#if NETSTANDARD
-
 	internal sealed class ReadOnlyDictionaryFormatter<TKey, TValue> : DictionaryFormatterBase<TKey, TValue, Dictionary<TKey, TValue>, ReadOnlyDictionary<TKey, TValue>>
     {
         protected override void Add(ref Dictionary<TKey, TValue> collection, int index, TKey key, TValue value)
@@ -331,8 +329,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
             return new ConcurrentDictionary<TKey, TValue>();
         }
     }
-
-#endif
 
 	internal sealed class NonGenericDictionaryFormatter<T> : IJsonFormatter<T>
         where T : class, System.Collections.IDictionary, new()

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
@@ -38,7 +38,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 		{
 			var underlyingType = Enum.GetUnderlyingType(type);
 
-#if NETSTANDARD
 			isBoxed = false;
 			var dynamicMethod = new DynamicMethod("EnumSerializeByUnderlyingValue", null, new[] { typeof(JsonWriter).MakeByRefType(), type, typeof(IJsonFormatterResolver) }, type.Module, true);
 			var il = dynamicMethod.GetILGenerator();
@@ -47,55 +46,12 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			il.Emit(OpCodes.Call, typeof(JsonWriter).GetRuntimeMethod("Write" + underlyingType.Name, new[] { underlyingType }));
 			il.Emit(OpCodes.Ret);
 			return dynamicMethod.CreateDelegate(typeof(JsonSerializeAction<>).MakeGenericType(type));
-#else
-            // Boxed
-            isBoxed = true;
-            JsonSerializeAction<object> f;
-            if (underlyingType == typeof(byte))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteByte((byte)value);
-            }
-            else if (underlyingType == typeof(sbyte))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteSByte((sbyte)value);
-            }
-            else if (underlyingType == typeof(short))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteInt16((short)value);
-            }
-            else if (underlyingType == typeof(ushort))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteUInt16((ushort)value);
-            }
-            else if (underlyingType == typeof(int))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteInt32((int)value);
-            }
-            else if (underlyingType == typeof(uint))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteUInt32((uint)value);
-            }
-            else if (underlyingType == typeof(long))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteInt64((long)value);
-            }
-            else if (underlyingType == typeof(ulong))
-            {
-                f = (ref JsonWriter writer, object value, IJsonFormatterResolver _) => writer.WriteUInt64((ulong)value);
-            }
-            else
-            {
-                throw new InvalidOperationException("Type is not Enum. Type:" + type);
-            }
-            return f;
-#endif
 		}
 
 		public static object GetDeserializeDelegate(Type type, out bool isBoxed)
 		{
 			var underlyingType = Enum.GetUnderlyingType(type);
 
-#if NETSTANDARD
 			isBoxed = false;
 			var dynamicMethod = new DynamicMethod("EnumDeserializeByUnderlyingValue", type, new[] { typeof(JsonReader).MakeByRefType(), typeof(IJsonFormatterResolver) }, type.Module, true);
 			var il = dynamicMethod.GetILGenerator();
@@ -103,48 +59,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			il.Emit(OpCodes.Call, typeof(JsonReader).GetRuntimeMethod("Read" + underlyingType.Name, Type.EmptyTypes));
 			il.Emit(OpCodes.Ret);
 			return dynamicMethod.CreateDelegate(typeof(JsonDeserializeFunc<>).MakeGenericType(type));
-#else
-            // Boxed
-            isBoxed = true;
-            JsonDeserializeFunc<object> f;
-            if (underlyingType == typeof(byte))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadByte();
-            }
-            else if (underlyingType == typeof(sbyte))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadSByte();
-            }
-            else if (underlyingType == typeof(short))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadInt16();
-            }
-            else if (underlyingType == typeof(ushort))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadUInt16();
-            }
-            else if (underlyingType == typeof(int))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadInt32();
-            }
-            else if (underlyingType == typeof(uint))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadUInt32();
-            }
-            else if (underlyingType == typeof(long))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadInt64();
-            }
-            else if (underlyingType == typeof(ulong))
-            {
-                f = (ref JsonReader reader, IJsonFormatterResolver _) => (object)reader.ReadUInt64();
-            }
-            else
-            {
-                throw new InvalidOperationException("Type is not Enum. Type:" + type);
-            }
-            return f;
-#endif
 		}
 	}
 

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/StandardClassLibraryFormatters.cs
@@ -424,11 +424,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				StandardClassLibraryFormatterHelper.keyValuePairAutomata.TryGetValue(keyString, out key);
-#else
-                StandardClassLibraryFormatterHelper.keyValuePairAutomata.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -501,11 +497,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 	{
 		public static readonly TypeFormatter Default = new TypeFormatter();
 
-#if NETSTANDARD
 		static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+", RegexOptions.Compiled);
-#else
-        static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+");
-#endif
 
 		bool serializeAssemblyQualifiedName;
 		bool deserializeSubtractAssemblyQualifiedName;
@@ -551,8 +543,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 		}
 	}
 
-
-#if NETSTANDARD
 
 	internal sealed class BigIntegerFormatter : IJsonFormatter<BigInteger>
 	{
@@ -638,11 +628,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 
 			// deserialize immediately(no delay, because capture byte[] causes memory leak)
 			var v = formatterResolver.GetFormatterWithVerify<T>().Deserialize(ref reader, formatterResolver);
-#if NETSTANDARD
 			return new Lazy<T>(v.AsFunc());
-#else
-            return new Lazy<T>(() => v);
-#endif
 		}
 	}
 
@@ -686,7 +672,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 		}
 	}
 
-	#if VALUETASK
+	#if NETSTANDARD2_1
 	internal sealed class ValueTaskFormatter<T> : IJsonFormatter<ValueTask<T>>
 	{
 		public void Serialize(ref JsonWriter writer, ValueTask<T> value, IJsonFormatterResolver formatterResolver)
@@ -702,8 +688,6 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 		}
 	}
 	#endif
-
-#endif
 
 	internal static class StandardClassLibraryFormatterHelper
 	{

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/TupleFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/TupleFormatter.cs
@@ -24,7 +24,6 @@
 
 
 using Elasticsearch.Net.Utf8Json.Internal;
-#if NETSTANDARD
 using System;
 // These all proxy to TupleFormatterHelper
 // ReSharper disable StaticMemberInGenericType
@@ -202,11 +201,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -253,11 +248,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -310,11 +301,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -373,11 +360,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -442,11 +425,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -517,11 +496,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -598,11 +573,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -685,11 +656,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -728,4 +695,3 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 	}
 
 }
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/TupleFormatter.tt
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/TupleFormatter.tt
@@ -28,8 +28,6 @@
 // SOFTWARE.
 #endregion
 
-#if NETSTANDARD
-
 using System;
 
 namespace Elasticsearch.Net
@@ -105,11 +103,7 @@ namespace Elasticsearch.Net
             {
                 var keyString = reader.ReadPropertyNameSegmentRaw();
                 int key;
-#if NETSTANDARD
                 dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
                 switch (key)
                 {
@@ -131,4 +125,3 @@ namespace Elasticsearch.Net
 <# } #>
 }
 
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/ValueTupleFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/ValueTupleFormatter.cs
@@ -22,9 +22,7 @@
 // SOFTWARE.
 #endregion
 
-
 using Elasticsearch.Net.Utf8Json.Internal;
-#if NETSTANDARD
 using System;
 
 namespace Elasticsearch.Net.Utf8Json.Formatters
@@ -174,7 +172,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 		}
 	}
 
-	#if DOTNETCORE
+	#if NETSTANDARD
 	internal sealed class ValueTupleFormatter<T1> : IJsonFormatter<ValueTuple<T1>>
 	{
 		static readonly byte[][] cache = TupleFormatterHelper.nameCache1;
@@ -199,11 +197,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -248,11 +242,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -303,11 +293,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -364,11 +350,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -431,11 +413,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -504,11 +482,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -583,11 +557,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -668,11 +638,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 			{
 				var keyString = reader.ReadPropertyNameSegmentRaw();
 				int key;
-#if NETSTANDARD
 				dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
 				switch (key)
 				{
@@ -712,4 +678,3 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 	#endif
 
 }
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Formatters/ValueTupleFormatter.tt
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/ValueTupleFormatter.tt
@@ -28,8 +28,6 @@
 // SOFTWARE.
 #endregion
 
-#if NETSTANDARD
-
 using System;
 
 namespace Elasticsearch.Net
@@ -103,11 +101,7 @@ namespace Elasticsearch.Net
             {
                 var keyString = reader.ReadPropertyNameSegmentRaw();
                 int key;
-#if NETSTANDARD
                 dictionary.TryGetValue(keyString, out key);
-#else
-                dictionary.TryGetValueSafe(keyString, out key);
-#endif
 
                 switch (key)
                 {
@@ -129,4 +123,3 @@ namespace Elasticsearch.Net
 <# } #>
 }
 
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Internal/AutomataDictionary.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/AutomataDictionary.cs
@@ -44,7 +44,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             root = new AutomataNode(0);
         }
 
-#if NETSTANDARD
         public unsafe void Add(string str, int value)
         {
             Add(JsonWriter.GetEncodedPropertyNameWithoutQuotation(str), value);
@@ -104,38 +103,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal
                 }
             }
         }
-#else
-        // for Unity, use safe only.
-
-        public void Add(string str, int value)
-        {
-            Add(JsonWriter.GetEncodedPropertyNameWithoutQuotation(str), value);
-        }
-
-        public unsafe void Add(byte[] bytes, int value)
-        {
-            var offset = 0;
-
-            var node = root;
-
-            var rest = bytes.Length;
-            while (rest != 0)
-            {
-                var key = AutomataKeyGen.GetKeySafe(bytes, ref offset, ref rest);
-
-                if (rest == 0)
-                {
-                    node = node.Add(key, value, Encoding.UTF8.GetString(bytes));
-                }
-                else
-                {
-                    node = node.Add(key);
-                }
-            }
-        }
-
-#endif
-
 
         public bool TryGetValueSafe(ArraySegment<byte> key, out int value)
         {

--- a/src/Elasticsearch.Net/Utf8Json/Internal/BinaryUtil.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/BinaryUtil.cs
@@ -31,9 +31,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
     {
         const int ArrayMaxSize = 0x7FFFFFC7; // https://msdn.microsoft.com/en-us/library/system.array
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static void EnsureCapacity(ref byte[] bytes, int offset, int appendLength)
         {
             var newLength = offset + appendLength;
@@ -80,9 +78,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         }
 
         // Buffer.BlockCopy version of Array.Resize
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static void FastResize(ref byte[] array, int newSize)
         {
             if (newSize < 0) throw new ArgumentOutOfRangeException("newSize");
@@ -102,14 +98,8 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-        public static
-#if NETSTANDARD
-            unsafe
-#endif
-            byte[] FastCloneWithResize(byte[] src, int newSize)
+        public static unsafe byte[] FastCloneWithResize(byte[] src, int newSize)
         {
             if (newSize < 0) throw new ArgumentOutOfRangeException("newSize");
             if (src.Length < newSize) throw new ArgumentException("length < newSize");
@@ -118,27 +108,17 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
             byte[] dst = new byte[newSize];
 
-#if NETSTANDARD && !NET45
             fixed (byte* pSrc = &src[0])
             fixed (byte* pDst = &dst[0])
             {
                 Buffer.MemoryCopy(pSrc, pDst, dst.Length, newSize);
             }
-#else
-            Buffer.BlockCopy(src, 0, dst, 0, newSize);
-#endif
 
             return dst;
         }
 
-#if NETSTANDARD
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
-		public static
-#if NETSTANDARD
-			unsafe
-#endif
-			byte[] ToArray(ref ArraySegment<byte> src)
+		public static unsafe byte[] ToArray(ref ArraySegment<byte> src)
 		{
 			if (src == null) throw new ArgumentNullException("src");
 
@@ -147,15 +127,11 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 			if (src.Count == 0)
 				return dst;
 
-#if NETSTANDARD && !NET45
 			fixed (byte* pSrc = &src.Array[src.Offset])
 			fixed (byte* pDst = &dst[0])
 			{
 				Buffer.MemoryCopy(pSrc, pDst, dst.Length, src.Count);
 			}
-#else
-            Buffer.BlockCopy(src.Array, src.Offset, dst, 0, src.Count);
-#endif
 
 			return dst;
 		}

--- a/src/Elasticsearch.Net/Utf8Json/Internal/ByteArrayComparer.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/ByteArrayComparer.cs
@@ -23,18 +23,15 @@
 #endregion
 
 using System;
+using System.Runtime.CompilerServices;
 
 namespace Elasticsearch.Net.Utf8Json.Internal
 {
 	internal static class ByteArrayComparer
     {
-#if NETSTANDARD
-
-#if NETSTANDARD
-
         static readonly bool Is32Bit = (IntPtr.Size == 4);
 
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static int GetHashCode(byte[] bytes, int offset, int count)
         {
             if (Is32Bit)
@@ -47,19 +44,13 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-#endif
-
-#if NETSTANDARD
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
-        public static unsafe bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys)
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys)
         {
             return Equals(xs, xsOffset, xsCount, ys, 0, ys.Length);
         }
 
-#if NETSTANDARD
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static unsafe bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys, int ysOffset, int ysCount)
         {
             if (xs == null || ys == null || xsCount != ysCount)
@@ -118,45 +109,5 @@ namespace Elasticsearch.Net.Utf8Json.Internal
                 }
             }
         }
-
-#else
-#if NETSTANDARD
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
-        public static bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys)
-        {
-            if (xs == null || ys == null || xsCount != ys.Length)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < ys.Length; i++)
-            {
-                if (xs[xsOffset++] != ys[i]) return false;
-            }
-
-            return true;
-        }
-
-#if NETSTANDARD
-        [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
-        public static bool Equals(byte[] xs, int xsOffset, int xsCount, byte[] ys, int ysOffset, int ysCount)
-        {
-            if (xs == null || ys == null || xsCount != ysCount)
-            {
-                return false;
-            }
-
-            for (int i = 0; i < xsCount; i++)
-            {
-                if (xs[xsOffset++] != ys[ysOffset++]) return false;
-            }
-
-            return true;
-        }
-
-#endif
-
     }
 }

--- a/src/Elasticsearch.Net/Utf8Json/Internal/ByteArrayStringHashTable.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/ByteArrayStringHashTable.cs
@@ -129,16 +129,11 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             return false;
         }
 
-#if NETSTANDARD
         static readonly bool Is32Bit = (IntPtr.Size == 4);
-#endif
 
-#if NETSTANDARD
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
         static ulong ByteArrayGetHashCode(byte[] x, int offset, int count)
         {
-#if NETSTANDARD
             // FarmHash https://github.com/google/farmhash
             if (x == null || x.Length == 0 || count == 0) return 0;
 
@@ -151,24 +146,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal
                 return FarmHash.Hash64(x, offset, count);
             }
 
-#else
-
-            // FNV1-1a 32bit https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
-            uint hash = 0;
-            if (x != null)
-            {
-                var max = offset + count;
-
-                hash = 2166136261;
-                for (int i = offset; i < max; i++)
-                {
-                    hash = unchecked((x[i] ^ hash) * 16777619);
-                }
-            }
-
-            return (ulong)hash;
-
-#endif
         }
 
         static int CalculateCapacity(int collectionSize, float loadFactor)

--- a/src/Elasticsearch.Net/Utf8Json/Internal/Emit/DynamicAssembly.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/Emit/DynamicAssembly.cs
@@ -32,9 +32,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal.Emit
 	{
 		private static readonly byte[] PublicKey = Assembly.GetExecutingAssembly().GetName().GetPublicKey();
 
-#if NET45 || NET47
-        readonly string moduleName;
-#endif
         readonly AssemblyBuilder assemblyBuilder;
         readonly ModuleBuilder moduleBuilder;
 
@@ -73,28 +70,8 @@ namespace Elasticsearch.Net.Utf8Json.Internal.Emit
         {
 			var assemblyName = new AssemblyName(moduleName);
 			assemblyName.SetPublicKey(PublicKey);
-#if NET45 || NET47
-            this.moduleName = moduleName;
-            this.assemblyBuilder = System.AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.RunAndSave);
-			this.moduleBuilder = assemblyBuilder.DefineDynamicModule(moduleName, moduleName + ".dll");
-#else
-#if NETSTANDARD
             this.assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-#else
-            this.assemblyBuilder = System.AppDomain.CurrentDomain.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
-#endif
             this.moduleBuilder = assemblyBuilder.DefineDynamicModule(moduleName);
-#endif
         }
-
-#if NET45 || NET47
-
-        public AssemblyBuilder Save()
-        {
-            assemblyBuilder.Save(moduleName + ".dll");
-            return assemblyBuilder;
-        }
-
-#endif
     }
 }

--- a/src/Elasticsearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/Emit/ILViewer.cs
@@ -86,7 +86,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal.Emit
         }
     }
 
-#if DEBUG && NETSTANDARD
+#if DEBUG
 
     // not yet completed so only for debug.
 	internal static class ILViewer

--- a/src/Elasticsearch.Net/Utf8Json/Internal/FarmHash.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/FarmHash.cs
@@ -1,18 +1,18 @@
 #region Utf8Json License https://github.com/neuecc/Utf8Json/blob/master/LICENSE
 // MIT License
-// 
+//
 // Copyright (c) 2017 Yoshifumi Kawai
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,8 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #endregion
-
-#if NETSTANDARD
 
 using System.Runtime.CompilerServices;
 
@@ -624,5 +622,3 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         #endregion
     }
 }
-
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Internal/FuncExtensions.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/FuncExtensions.cs
@@ -1,18 +1,18 @@
 #region Utf8Json License https://github.com/neuecc/Utf8Json/blob/master/LICENSE
 // MIT License
-// 
+//
 // Copyright (c) 2017 Yoshifumi Kawai
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -21,8 +21,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 #endregion
-
-#if NETSTANDARD
 
 using System;
 // ReSharper disable All
@@ -56,5 +54,3 @@ namespace Elasticsearch.Net.Utf8Json.Internal
     }
 }
 
-
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Internal/GuidBits.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/GuidBits.cs
@@ -1,18 +1,18 @@
 #region Utf8Json License https://github.com/neuecc/Utf8Json/blob/master/LICENSE
 // MIT License
-// 
+//
 // Copyright (c) 2017 Yoshifumi Kawai
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -184,17 +184,13 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             throw new ArgumentException("Invalid Guid Pattern.");
         }
 
-#if NETSTANDARD
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
         static byte Parse(byte[] bytes, int highOffset)
         {
             return unchecked((byte)(SwitchParse(bytes[highOffset]) * 16 + SwitchParse(bytes[highOffset + 1])));
         }
 
-#if NETSTANDARD
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveInlining)]
-#endif
         static byte SwitchParse(byte b)
         {
             // '0'(48) ~ '9'(57) => -48

--- a/src/Elasticsearch.Net/Utf8Json/Internal/NumberConverter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/NumberConverter.cs
@@ -36,9 +36,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 		/// <summary>
 		/// e or E
 		/// </summary>
-#if NETSTANDARD
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
 		public static bool IsENotation(byte c)
 		{
 			return c == (byte)'E' || c == (byte)'e';
@@ -47,9 +45,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         /// <summary>
         /// 0 ~ 9
         /// </summary>
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsNumber(byte c)
         {
             return (byte)'0' <= c && c <= (byte)'9';
@@ -58,9 +54,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         /// <summary>
         /// Is 0 ~ 9, '.', '+', '-'?
         /// </summary>
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool IsNumberRepresentation(byte c)
         {
             switch (c)
@@ -86,30 +80,22 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static sbyte ReadSByte(byte[] bytes, int offset, out int readCount)
         {
             return checked((sbyte)ReadInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static short ReadInt16(byte[] bytes, int offset, out int readCount)
         {
             return checked((short)ReadInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int ReadInt32(byte[] bytes, int offset, out int readCount)
         {
             return checked((int)ReadInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static long ReadInt64(byte[] bytes, int offset, out int readCount)
         {
             var value = 0L;
@@ -136,30 +122,22 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             END:
             return unchecked(value * sign);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static byte ReadByte(byte[] bytes, int offset, out int readCount)
         {
             return checked((byte)ReadUInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static ushort ReadUInt16(byte[] bytes, int offset, out int readCount)
         {
             return checked((ushort)ReadUInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static uint ReadUInt32(byte[] bytes, int offset, out int readCount)
         {
             return checked((uint)ReadUInt64(bytes, offset, out readCount));
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static ulong ReadUInt64(byte[] bytes, int offset, out int readCount)
         {
             var value = 0UL;
@@ -179,44 +157,32 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             END:
             return value;
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static float ReadSingle(byte[] bytes, int offset, out int readCount)
         {
             return StringToDoubleConverter.ToSingle(bytes, offset, out readCount);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static double ReadDouble(byte[] bytes, int offset, out int readCount)
         {
             return StringToDoubleConverter.ToDouble(bytes, offset, out readCount);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteByte(ref byte[] buffer, int offset, byte value)
         {
             return WriteUInt64(ref buffer, offset, (ulong)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteUInt16(ref byte[] buffer, int offset, ushort value)
         {
             return WriteUInt64(ref buffer, offset, (ulong)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteUInt32(ref byte[] buffer, int offset, uint value)
         {
             return WriteUInt64(ref buffer, offset, (ulong)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteUInt64(ref byte[] buffer, int offset, ulong value)
         {
             var startOffset = offset;
@@ -336,30 +302,22 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
             return offset - startOffset;
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteSByte(ref byte[] buffer, int offset, sbyte value)
         {
             return WriteInt64(ref buffer, offset, (long)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteInt16(ref byte[] buffer, int offset, short value)
         {
             return WriteInt64(ref buffer, offset, (long)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteInt32(ref byte[] buffer, int offset, int value)
         {
             return WriteInt64(ref buffer, offset, (long)value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteInt64(ref byte[] buffer, int offset, long value)
         {
             var startOffset = offset;
@@ -514,16 +472,12 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
             return offset - startOffset;
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteSingle(ref byte[] bytes, int offset, float value)
         {
             return DoubleToStringConverter.GetBytes(ref bytes, offset, value);
         }
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static int WriteDouble(ref byte[] bytes, int offset, double value)
         {
             return DoubleToStringConverter.GetBytes(ref bytes, offset, value);
@@ -531,9 +485,7 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
         // boolean is not number:)
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public static bool ReadBoolean(byte[] bytes, int offset, out int readCount)
         {
             if (bytes[offset] == 't')

--- a/src/Elasticsearch.Net/Utf8Json/Internal/ReflectionExtensions.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/ReflectionExtensions.cs
@@ -1,18 +1,18 @@
 #region Utf8Json License https://github.com/neuecc/Utf8Json/blob/master/LICENSE
 // MIT License
-// 
+//
 // Copyright (c) 2017 Yoshifumi Kawai
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -118,8 +118,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-#if NETSTANDARD
-
         public static bool IsConstructedGenericType(this TypeInfo type)
         {
             return type.AsType().IsConstructedGenericType;
@@ -134,7 +132,5 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         {
             return propInfo.SetMethod;
         }
-
-#endif
     }
 }

--- a/src/Elasticsearch.Net/Utf8Json/Internal/ThreadsafeTypeKeyHashTable.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/ThreadsafeTypeKeyHashTable.cs
@@ -1,18 +1,18 @@
 #region Utf8Json License https://github.com/neuecc/Utf8Json/blob/master/LICENSE
 // MIT License
-// 
+//
 // Copyright (c) 2017 Yoshifumi Kawai
-// 
+//
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
 // in the Software without restriction, including without limitation the rights
 // to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
 // copies of the Software, and to permit persons to whom the Software is
 // furnished to do so, subject to the following conditions:
-// 
+//
 // The above copyright notice and this permission notice shall be included in all
 // copies or substantial portions of the Software.
-// 
+//
 // THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
 // IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 // FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -205,26 +205,12 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
         static void VolatileWrite(ref Entry location, Entry value)
         {
-#if NETSTANDARD
             System.Threading.Volatile.Write(ref location, value);
-#elif UNITY_METRO || UNITY_WSA
-            System.Threading.Volatile.Write(ref location, value);
-#else
-            System.Threading.Thread.MemoryBarrier();
-            location = value;
-#endif
         }
 
         static void VolatileWrite(ref Entry[] location, Entry[] value)
         {
-#if NETSTANDARD
             System.Threading.Volatile.Write(ref location, value);
-#elif UNITY_METRO || UNITY_WSA
-            System.Threading.Volatile.Write(ref location, value);
-#else
-            System.Threading.Thread.MemoryBarrier();
-            location = value;
-#endif
         }
 
         class Entry

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
@@ -24,7 +24,6 @@
 
 
 using System.Runtime.CompilerServices;
-#if NETSTANDARD
 using System;
 
 namespace Elasticsearch.Net.Utf8Json.Internal
@@ -80,15 +79,11 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src)
         {
             BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, src.Length);
-#if !NET45
             fixed (void* dstP = &writer.buffer[writer.offset])
             fixed (void* srcP = &src[0])
             {
                 Buffer.MemoryCopy(srcP, dstP, writer.buffer.Length - writer.offset, src.Length);
             }
-#else
-            Buffer.BlockCopy(src, 0, writer.buffer, writer.offset, src.Length);
-#endif
             writer.offset += src.Length;
         }
     }
@@ -244,5 +239,3 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         }
     }
 }
-
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.cs
@@ -22,8 +22,6 @@
 // SOFTWARE.
 #endregion
 
-#if NETSTANDARD
-
 using System.Runtime.CompilerServices;
 
 namespace Elasticsearch.Net.Utf8Json.Internal
@@ -914,5 +912,3 @@ namespace Elasticsearch.Net.Utf8Json.Internal
 
     }
 }
-
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.tt
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.tt
@@ -31,8 +31,6 @@
 // SOFTWARE.
 #endregion
 
-#if NETSTANDARD
-
 using System.Runtime.CompilerServices;
 
 namespace Elasticsearch.Net
@@ -87,5 +85,3 @@ namespace Elasticsearch.Net
 <# } #>
     }
 }
-
-#endif

--- a/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
@@ -286,9 +286,7 @@ namespace Elasticsearch.Net.Utf8Json
             }
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void SkipWhiteSpace()
         {
             // eliminate array bound check
@@ -727,17 +725,13 @@ namespace Elasticsearch.Net.Utf8Json
             }
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         static int GetCodePoint(char a, char b, char c, char d)
         {
             return (((((ToNumber(a) * 16) + ToNumber(b)) * 16) + ToNumber(c)) * 16) + ToNumber(d);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         static int ToNumber(char x)
         {
             if ('0' <= x && x <= '9')
@@ -1006,9 +1000,7 @@ namespace Elasticsearch.Net.Utf8Json
             ReadNextCore(token);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         void ReadNextCore(JsonToken token)
         {
             switch (token)

--- a/src/Elasticsearch.Net/Utf8Json/JsonSerializer.NonGeneric.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonSerializer.NonGeneric.cs
@@ -121,7 +121,6 @@ namespace Elasticsearch.Net.Utf8Json
                 GetOrAdd(type).serialize2.Invoke(stream, value, resolver);
             }
 
-#if NETSTANDARD
 
             /// <summary>
             /// Serialize to stream.
@@ -157,7 +156,6 @@ namespace Elasticsearch.Net.Utf8Json
                 return GetOrAdd(type).serializeAsync.Invoke(stream, value, resolver);
             }
 
-#endif
 
             public static void Serialize(ref JsonWriter writer, object value, IJsonFormatterResolver resolver)
             {
@@ -300,8 +298,6 @@ namespace Elasticsearch.Net.Utf8Json
                 return GetOrAdd(type).deserialize4.Invoke(ref reader, resolver);
             }
 
-#if NETSTANDARD
-
             public static System.Threading.Tasks.Task<object> DeserializeAsync(Type type, Stream stream)
             {
                 return DeserializeAsync(type, stream, defaultResolver);
@@ -311,8 +307,6 @@ namespace Elasticsearch.Net.Utf8Json
             {
                 return GetOrAdd(type).deserializeAsync.Invoke(stream, resolver);
             }
-
-#endif
 
             class CompiledMethods
             {
@@ -326,10 +320,8 @@ namespace Elasticsearch.Net.Utf8Json
                 public readonly Func<Stream, IJsonFormatterResolver, object> deserialize3;
                 public readonly DeserializeJsonReader deserialize4;
 
-#if NETSTANDARD
                 public readonly Func<Stream, object, IJsonFormatterResolver, System.Threading.Tasks.Task> serializeAsync;
                 public readonly Func<Stream, IJsonFormatterResolver, System.Threading.Tasks.Task<object>> deserializeAsync;
-#endif
 
                 public CompiledMethods(Type type)
                 {
@@ -445,8 +437,6 @@ namespace Elasticsearch.Net.Utf8Json
                         deserialize4 = CreateDelegate<DeserializeJsonReader>(dm);
                     }
 
-#if NETSTANDARD
-
                     {
                         var dm = new DynamicMethod("SerializeAsync", typeof(System.Threading.Tasks.Task), new[] { typeof(Stream), typeof(object), typeof(IJsonFormatterResolver) }, type.Module, true);
                         var il = dm.GetILGenerator();
@@ -473,18 +463,13 @@ namespace Elasticsearch.Net.Utf8Json
 
                         deserializeAsync = CreateDelegate<Func<Stream, IJsonFormatterResolver, System.Threading.Tasks.Task<object>>>(dm);
                     }
-#endif
                 }
-
-#if NETSTANDARD
 
                 static async System.Threading.Tasks.Task<object> TaskCast<T>(System.Threading.Tasks.Task<T> task)
                 {
                     var t = await task.ConfigureAwait(false);
                     return (object)t;
                 }
-
-#endif
 
                 static T CreateDelegate<T>(DynamicMethod dm)
                 {

--- a/src/Elasticsearch.Net/Utf8Json/JsonSerializer.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonSerializer.cs
@@ -135,8 +135,6 @@ namespace Elasticsearch.Net.Utf8Json
             stream.Write(buffer.Array, buffer.Offset, buffer.Count);
         }
 
-#if NETSTANDARD
-
         /// <summary>
         /// Serialize to stream(write async).
         /// </summary>
@@ -166,8 +164,6 @@ namespace Elasticsearch.Net.Utf8Json
                 MemoryPool.Return(buf);
             }
         }
-
-#endif
 
         /// <summary>
         /// Serialize to binary. Get the raw memory pool byte[]. The result can not share across thread and can not hold, so use quickly.
@@ -292,7 +288,6 @@ namespace Elasticsearch.Net.Utf8Json
             if (resolver == null)
 				resolver = DefaultResolver;
 
-#if NETSTANDARD && !NET45
 			if (stream is MemoryStream ms)
             {
 				if (ms.TryGetBuffer(out var buf2))
@@ -309,7 +304,6 @@ namespace Elasticsearch.Net.Utf8Json
                     return Deserialize<T>(buf2.Array, buf2.Offset, resolver);
                 }
             }
-#endif
             var buf = MemoryPool.Rent();
 			var poolBuf = buf;
 			try
@@ -334,8 +328,6 @@ namespace Elasticsearch.Net.Utf8Json
 			}
         }
 
-#if NETSTANDARD
-
         public static Task<T> DeserializeAsync<T>(Stream stream)
         {
             return DeserializeAsync<T>(stream, defaultResolver);
@@ -349,7 +341,6 @@ namespace Elasticsearch.Net.Utf8Json
             if (resolver == null)
 				resolver = DefaultResolver;
 
-#if NETSTANDARD && !NET45
 			if (stream is MemoryStream ms)
             {
 				if (ms.TryGetBuffer(out var buf2))
@@ -366,7 +357,6 @@ namespace Elasticsearch.Net.Utf8Json
                     return Deserialize<T>(buf2.Array, buf2.Offset, resolver);
                 }
             }
-#endif
 
             var buffer = MemoryPool.Rent();
             var buf = buffer;
@@ -398,8 +388,6 @@ namespace Elasticsearch.Net.Utf8Json
                 MemoryPool.Return(buffer);
             }
         }
-
-#endif
 
         public static string PrettyPrint(byte[] json) => PrettyPrint(json, 0);
 

--- a/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
@@ -38,14 +38,8 @@ namespace Elasticsearch.Net.Utf8Json
         static readonly byte[] emptyBytes = new byte[0];
 
         // write direct from UnsafeMemory
-#if NETSTANDARD
-        internal
-#endif
-        byte[] buffer;
-#if NETSTANDARD
-        internal
-#endif
-        int offset;
+        internal byte[] buffer;
+        internal int offset;
 
         public int CurrentOffset
         {
@@ -117,84 +111,60 @@ namespace Elasticsearch.Net.Utf8Json
             return Encoding.UTF8.GetString(buffer, 0, offset);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void EnsureCapacity(int appendLength)
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, appendLength);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteRaw(byte rawValue)
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = rawValue;
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteRaw(byte[] rawValue)
         {
-#if NETSTANDARD
             UnsafeMemory.WriteRaw(ref this, rawValue);
-#else
-            BinaryUtil.EnsureCapacity(ref buffer, offset, rawValue.Length);
-            Buffer.BlockCopy(rawValue, 0, buffer, offset, rawValue.Length);
-            offset += rawValue.Length;
-#endif
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteRawUnsafe(byte rawValue)
         {
             buffer[offset++] = rawValue;
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteBeginArray()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = (byte)'[';
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteEndArray()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = (byte)']';
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteBeginObject()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = (byte)'{';
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteEndObject()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = (byte)'}';
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteValueSeparator()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
@@ -202,9 +172,7 @@ namespace Elasticsearch.Net.Utf8Json
         }
 
         /// <summary>:</summary>
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteNameSeparator()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
@@ -212,27 +180,21 @@ namespace Elasticsearch.Net.Utf8Json
         }
 
         /// <summary>WriteString + WriteNameSeparator</summary>
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WritePropertyName(string propertyName)
         {
             WriteString(propertyName);
             WriteNameSeparator();
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteQuotation()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 1);
             buffer[offset++] = (byte)'\"';
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteNull()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 4);
@@ -243,9 +205,7 @@ namespace Elasticsearch.Net.Utf8Json
             offset += 4;
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteBoolean(bool value)
         {
             if (value)
@@ -269,9 +229,7 @@ namespace Elasticsearch.Net.Utf8Json
             }
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteTrue()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 4);
@@ -282,9 +240,7 @@ namespace Elasticsearch.Net.Utf8Json
             offset += 4;
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteFalse()
         {
             BinaryUtil.EnsureCapacity(ref buffer, offset, 5);
@@ -296,41 +252,31 @@ namespace Elasticsearch.Net.Utf8Json
             offset += 5;
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteSingle(float value)
         {
             offset += DoubleToStringConverter.GetBytes(ref buffer, offset, value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteDouble(double value)
         {
             offset += DoubleToStringConverter.GetBytes(ref buffer, offset, value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteByte(byte value)
         {
             WriteUInt64((ulong)value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteUInt16(ushort value)
         {
             WriteUInt64((ulong)value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteUInt32(uint value)
         {
             WriteUInt64((ulong)value);
@@ -341,25 +287,19 @@ namespace Elasticsearch.Net.Utf8Json
             offset += NumberConverter.WriteUInt64(ref buffer, offset, value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteSByte(sbyte value)
         {
             WriteInt64((long)value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteInt16(short value)
         {
             WriteInt64((long)value);
         }
 
-#if NETSTANDARD
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-#endif
         public void WriteInt32(int value)
         {
             WriteInt64((long)value);

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/AttributeFormatterResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/AttributeFormatterResolver.cs
@@ -51,11 +51,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 
             static FormatterCache()
             {
-#if (UNITY_METRO || UNITY_WSA) && !NETFX_CORE
-                var attr = (JsonFormatterAttribute)typeof(T).GetCustomAttributes(typeof(JsonFormatterAttribute), true).FirstOrDefault();
-#else
                 var attr = typeof(T).GetTypeInfo().GetCustomAttribute<JsonFormatterAttribute>(true);
-#endif
                 if (attr == null)
                 {
                     return;

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/BuiltinResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/BuiltinResolver.cs
@@ -146,14 +146,12 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
                 { typeof(ArraySegment<byte>), ByteArraySegmentFormatter.Default },
                 { typeof(ArraySegment<byte>?),new StaticNullableFormatter<ArraySegment<byte>>(ByteArraySegmentFormatter.Default) },
 
-    #if NETSTANDARD
                 {typeof(System.Numerics.BigInteger), BigIntegerFormatter.Default},
                 {typeof(System.Numerics.BigInteger?), new StaticNullableFormatter<System.Numerics.BigInteger>(BigIntegerFormatter.Default)},
                 {typeof(System.Numerics.Complex), ComplexFormatter.Default},
                 {typeof(System.Numerics.Complex?), new StaticNullableFormatter<System.Numerics.Complex>(ComplexFormatter.Default)},
                 {typeof(System.Dynamic.ExpandoObject), ExpandoObjectFormatter.Default },
                 {typeof(System.Threading.Tasks.Task), TaskUnitFormatter.Default},
-    #endif
             };
 
             internal static object GetFormatter(Type t)

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
@@ -164,13 +164,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
             assembly = new DynamicAssembly(ModuleName);
         }
 
-#if DEBUG && (NET45 || NET47)
-        public static AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
         public static IJsonFormatterResolver Create(IJsonFormatter[] formatters, IJsonFormatterResolver[] resolvers)
         {
             var id = Guid.NewGuid().ToString().Replace("-", "");

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
@@ -78,7 +78,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 			{typeof(SortedList<,>), typeof(SortedListFormatter<,>)},
 			{typeof(ILookup<,>), typeof(InterfaceLookupFormatter<,>)},
 			{typeof(IGrouping<,>), typeof(InterfaceGroupingFormatter<,>)},
-#if NETSTANDARD
 			{typeof(ObservableCollection<>), typeof(ObservableCollectionFormatter<>)},
 			{typeof(ReadOnlyObservableCollection<>),(typeof(ReadOnlyObservableCollectionFormatter<>))},
 			{typeof(IReadOnlyList<>), typeof(InterfaceReadOnlyListFormatter<>)},
@@ -92,7 +91,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 			{typeof(System.Collections.Concurrent.ConcurrentDictionary<,>), typeof(ConcurrentDictionaryFormatter<,>)},
 			{typeof(Lazy<>), typeof(LazyFormatter<>)},
 			{typeof(Task<>), typeof(TaskValueFormatter<>)},
-#endif
 		};
 
 		// Reduce IL2CPP code generate size(don't write long code in <T>)
@@ -145,10 +143,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 					return CreateInstance(typeof(NullableFormatter<>), new[] { nullableElementType });
 				}
 
-#if NETSTANDARD
-
-				//TODO: VALUETASK is not defined.
-#if VALUETASK
+#if NETSTANDARD2_1
 				// ValueTask
 				else if (genericType == typeof(ValueTask<>))
 				{
@@ -197,7 +192,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 					return CreateInstance(tupleFormatterType, ti.GenericTypeArguments);
 				}
 
-#if DOTNETCORE
+#if NETSTANDARD
 				// ValueTuple
 				else if (ti.FullName.StartsWith("System.ValueTuple"))
 				{
@@ -234,8 +229,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 
 					return CreateInstance(tupleFormatterType, ti.GenericTypeArguments);
 				}
-#endif
-
 #endif
 
 				// ArraySegement

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicObjectResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicObjectResolver.cs
@@ -73,11 +73,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 
-	internal sealed class CustomDynamicObjectResolver
-		: IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-			, ISave
-#endif
+	internal sealed class CustomDynamicObjectResolver : IJsonFormatterResolver
 	{
 		private readonly Func<MemberInfo, JsonProperty> _propertyMapper;
 		private readonly Lazy<Func<string, string>> _mutator;
@@ -101,13 +97,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 			_excludeNull = excludeNull;
 		}
 
-#if DEBUG && (NET45 || NET47)
-		public AssemblyBuilder Save()
-		{
-			return assembly.Save();
-		}
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return (IJsonFormatter<T>)_formatters.GetOrAdd(typeof(T), type =>
@@ -115,19 +104,10 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		}
 	}
 
-#if DEBUG && (NET45 || NET47)
-    public interface ISave
-    {
-        AssemblyBuilder Save();
-    }
-#endif
 
 	#region DynamicAssembly
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISave
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal();
@@ -146,13 +126,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		{
 		}
 
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return FormatterCache<T>.formatter;
@@ -170,9 +143,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISave
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase();
@@ -191,13 +161,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		{
 		}
 
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return FormatterCache<T>.formatter;
@@ -215,9 +178,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISaveD
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase();
@@ -236,13 +196,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		{
 		}
 
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return FormatterCache<T>.formatter;
@@ -260,9 +213,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISave
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal();
@@ -281,13 +231,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		{
 		}
 
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return FormatterCache<T>.formatter;
@@ -305,9 +248,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISave
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase();
@@ -326,13 +266,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		{
 		}
 
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
-
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
 			return FormatterCache<T>.formatter;
@@ -350,9 +283,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 	}
 
 	internal sealed class DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase : IJsonFormatterResolver
-#if DEBUG && (NET45 || NET47)
-            , ISave
-#endif
 	{
 		// configuration
 		public static readonly IJsonFormatterResolver Instance = new DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase();
@@ -370,13 +300,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase()
 		{
 		}
-
-#if DEBUG && (NET45 || NET47)
-        public AssemblyBuilder Save()
-        {
-            return assembly.Save();
-        }
-#endif
 
 		public IJsonFormatter<T> GetFormatter<T>()
 		{
@@ -540,12 +463,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 
 	internal static class DynamicObjectTypeBuilder
 	{
-#if NETSTANDARD
 		static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+", RegexOptions.Compiled);
-#else
-        static readonly Regex SubtractFullNameRegex = new Regex(@", Version=\d+.\d+.\d+.\d+, Culture=\w+, PublicKeyToken=\w+");
-#endif
-
 
 		static int nameSequence;
 
@@ -1166,7 +1084,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 				emitStringByteKeys();
 				il.EmitLdc_I4(index);
 				il.Emit(OpCodes.Ldelem_Ref);
-#if NETSTANDARD
 				// same as in constructor
 				byte[] rawField;
 				if (excludeNull || hasShouldSerialize)
@@ -1192,9 +1109,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 				{
 					il.EmitCall(EmitInfo.UnsafeMemory_MemoryCopy);
 				}
-#else
-                il.EmitCall(EmitInfo.JsonWriter.WriteRaw);
-#endif
 
 				// EmitValue
 				EmitSerializeValue(typeInfo, item, il, index, tryEmitLoadCustomFormatter, argWriter, argValue, argResolver);
@@ -1680,9 +1594,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 			public static readonly ConstructorInfo ObjectCtor = typeof(object).GetTypeInfo().DeclaredConstructors.First(x => x.GetParameters().Length == 0);
 
 			public static readonly MethodInfo GetFormatterWithVerify = typeof(JsonFormatterResolverExtensions).GetRuntimeMethod("GetFormatterWithVerify", new[] { typeof(IJsonFormatterResolver) });
-#if NETSTANDARD
 			public static readonly MethodInfo UnsafeMemory_MemoryCopy = ExpressionUtility.GetMethodInfo((Utf8Json.JsonWriter writer, byte[] src) => UnsafeMemory.MemoryCopy(ref writer, src));
-#endif
 			public static readonly ConstructorInfo InvalidOperationExceptionConstructor = typeof(System.InvalidOperationException).GetTypeInfo().DeclaredConstructors.First(x => { var p = x.GetParameters(); return p.Length == 1 && p[0].ParameterType == typeof(string); });
 			public static readonly MethodInfo GetTypeFromHandle = ExpressionUtility.GetMethodInfo(() => Type.GetTypeFromHandle(default(RuntimeTypeHandle)));
 

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/StandardResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/StandardResolver.cs
@@ -61,9 +61,6 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 		internal static readonly IJsonFormatterResolver[] CompositeResolverBase = new[]
 		{
 			BuiltinResolver.Instance, // Builtin
-#if !NETSTANDARD
-            Utf8Json.Unity.UnityResolver.Instance,
-#endif
 			EnumResolver.Default,     // Enum(default => string)
 			DynamicGenericResolver.Instance, // T[], List<T>, etc...
 			AttributeFormatterResolver.Instance // [JsonFormatter]


### PR DESCRIPTION
Removes most of the compiler directives known to be false for the TFM's we publish.

Removes the need to define `NETSTANDARD` for our `net41` TFM.