### PR TITLE
Deserialize anonymous bucket with only doc_count

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -877,6 +877,12 @@ namespace Nest
 		private IBucket GetFiltersBucket(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var docCount = reader.ReadNullableLong().GetValueOrDefault(0);
+			if (reader.GetCurrentJsonToken() == JsonToken.EndObject)
+				return new FiltersBucketItem(EmptyReadOnly<string, IAggregate>.Dictionary)
+				{
+					DocCount = docCount
+				};
+
 			reader.ReadNext(); // ,
 			var propertyName = reader.ReadPropertyName();
 			var subAggregates = GetSubAggregates(ref reader, propertyName, formatterResolver);

--- a/src/Tests/Tests.Reproduce/GithubIssue4197.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue4197.cs
@@ -1,0 +1,50 @@
+using System;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4197 : IClusterFixture<WritableCluster>
+	{
+		private readonly IElasticClient _client;
+
+		public GithubIssue4197(WritableCluster cluster) => _client = cluster.Client;
+
+		[I]
+		public void CanDeserializeAnonymousFiltersAggregation()
+		{
+			const string index = "github-issue-4197";
+
+			_client.Indices.Create(index);
+
+			_client.Index(new Doc { ModificationDate = DateTime.Parse("2019-10-09T10:43:07.8633456+02:00") },
+				i => i.Index(index).Refresh(Refresh.WaitFor));
+
+			var searchResponse = _client.Search<Doc>(s => s
+				.Index(index)
+				.Aggregations(a => a
+					.Filters("Modification date", f => f
+						.AnonymousFilters(q => q
+							.DateRange(dr => dr
+								.Field(d => d.ModificationDate)
+								.GreaterThan(DateMath.Now.Subtract(TimeSpan.FromDays(120)))
+							)
+						)
+					)
+				)
+			);
+
+			var filtersAggregate = searchResponse.Aggregations.Filters("Modification date");
+			filtersAggregate.AnonymousBuckets().Count.Should().Be(1);
+			filtersAggregate.AnonymousBuckets()[0].DocCount.Should().Be(1);
+		}
+
+		private class Doc
+		{
+			public DateTime ModificationDate { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
This commit deserializes an anonymous bucket that contains only a doc_count. Existing tests cover the case where the bucket has sub-aggregations, but did not handle the case where there are none.

Fixes #4197