### PR TITLE
Serialize own IProperty implementations

### DIFF
--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -190,6 +190,10 @@ Instead of following a c/go like error checking on response.IsValid do throw an 
 +
 Reasons for such exceptions could be search parser errors, index missing exceptions, etc...
 
+`TransferEncodingChunked`::
+
+Whether the request should be sent with chunked Transfer-Encoding. Default is `false`
+
 `UserAgent`::
 
 The user agent string to send with requests. Useful for debugging purposes to understand client and framework versions that initiate requests to Elasticsearch

--- a/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
@@ -15,8 +15,16 @@ please modify the original csharp file found at the link and submit the PR with 
 [[extending-nest-types]]
 === Extending NEST types
 
-Sometimes you might want to provide a custom implementation of a type perhaps to work around an issue or because
+Sometimes you might want to provide a custom implementation of a type, perhaps to work around an issue or because
 you're using a third-party plugin that extends the features of Elasticsearch, and NEST does not provide support out of the box.
+
+NEST allows extending its types in some scenarios, discussed here.
+
+==== Creating your own property mapping
+
+As an example, let's imagine we're using a third party plugin that provides support for additional data type
+for field mapping. We can implement a custom `IProperty` implementation so that we can use the field mapping
+type with NEST.
 
 [source,csharp]
 ----
@@ -48,7 +56,7 @@ Now that we have our own `IProperty` implementation we can add it to our propert
 
 [source,csharp]
 ----
-var createIndexResponse = _client.Indices.Create("myindex", c => c
+var createIndexResponse = client.Indices.Create("myindex", c => c
     .Map<Project>(m => m
         .Properties(props => props
             .Custom(new MyPluginProperty("fieldName", "dutch"))
@@ -75,5 +83,5 @@ which will serialize to the following JSON request
 ----
 
 Whilst NEST can _serialize_ our `my_plugin_property`, it does not know how to _deserialize_ it;
-We plan to make this more pluggable in the future
+We plan to make this more pluggable in the future.
 

--- a/docs/high-level.asciidoc
+++ b/docs/high-level.asciidoc
@@ -105,7 +105,7 @@ include::client-concepts/high-level/serialization/extending-nest-types.asciidoc[
 [[mapping]]
 == Mapping
 
-To interact with Elasticsearch using NEST, we need to be able to contol how POCO types in our solution
+To interact with Elasticsearch using NEST, we need to be able to control how POCO types in our solution
 map to JSON documents and fields stored within the inverted index in Elasticsearch. This section
 describes all of the different functionality available within NEST that makes working with POCOs and Elasticsearch
 a breeze. 

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -94,7 +94,7 @@ namespace Nest
 				case FieldType.RankFeatures: return Deserialize<RankFeaturesProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Flattened: return Deserialize<FlattenedProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
-					// no "type" field in the property mapping
+					// no "type" field in the property mapping, or FieldType enum could not be parsed from typeString
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
 				default:
 					throw new ArgumentOutOfRangeException(nameof(type), type, "mapping property converter does not know this value");
@@ -210,7 +210,7 @@ namespace Nest
 						Serialize<IGenericProperty>(ref writer, genericProperty, formatterResolver);
 					else
 					{
-						var formatter = DynamicObjectResolver.ExcludeNullCamelCase.GetFormatter<IProperty>();
+						var formatter = formatterResolver.GetFormatter<object>();
 						formatter.Serialize(ref writer, value, formatterResolver);
 					}
 					break;

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs
@@ -16,19 +16,22 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 	/**[[extending-nest-types]]
 	 * === Extending NEST types
 	 *
-	 * Sometimes you might want to provide a custom implementation of a type perhaps to work around an issue or because
+	 * Sometimes you might want to provide a custom implementation of a type, perhaps to work around an issue or because
 	 * you're using a third-party plugin that extends the features of Elasticsearch, and NEST does not provide support out of the box.
+	 *
+	 * NEST allows extending its types in some scenarios, discussed here.
+	 *
+	 * ==== Creating your own property mapping
+	 *
+	 * As an example, let's imagine we're using a third party plugin that provides support for additional data type
+	 * for field mapping. We can implement a custom `IProperty` implementation so that we can use the field mapping
+	 * type with NEST.
 	 */
 	public class ExtendingNestTypes
 	{
-		private readonly IElasticClient _client = TestClient.DisabledStreaming;
+		// keep field name as client, for documentation purposes
+		private readonly IElasticClient client = TestClient.DisabledStreaming;
 
-		/* ==== Creating your own property mapping
-		 *
-		 * As an example, let's imagine we're using a third party plugin that provides support for additional data type
-		 * for field mapping. We can implement a custom `IProperty` implementation so that we can use the field mapping
-		 * type with NEST.
-		 */
 		public class MyPluginProperty : IProperty
 		{
 			IDictionary<string, object> IProperty.LocalMetadata { get; set; }
@@ -48,10 +51,9 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 			[PropertyName("numeric")]
 			public bool Numeric { get; set; }
 		}
-		
 
-		[U (Skip = "TODO: Does not work with utf8json")]
-		// hide
+
+		[U]
 		public void InjectACustomIPropertyImplementation()
 		{
 			/**
@@ -60,7 +62,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 			 *
 			 * Now that we have our own `IProperty` implementation we can add it to our propertes mapping when creating an index
 			 */
-			var createIndexResponse = _client.Indices.Create("myindex", c => c
+			var createIndexResponse = client.Indices.Create("myindex", c => c
 				.Map<Project>(m => m
 					.Properties(props => props
 						.Custom(new MyPluginProperty("fieldName", "dutch"))
@@ -90,7 +92,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 
 			/**
 			 * Whilst NEST can _serialize_ our `my_plugin_property`, it does not know how to _deserialize_ it;
-			 * We plan to make this more pluggable in the future
+			 * We plan to make this more pluggable in the future.
 			 */
 			// hide
 			Expect(expected).FromRequest(createIndexResponse);

--- a/src/Tests/Tests/high-level.asciidoc
+++ b/src/Tests/Tests/high-level.asciidoc
@@ -74,7 +74,7 @@ own serializer, or by modifying how NEST's serializer behaves.
 [[mapping]]
 == Mapping
 
-To interact with Elasticsearch using NEST, we need to be able to contol how POCO types in our solution
+To interact with Elasticsearch using NEST, we need to be able to control how POCO types in our solution
 map to JSON documents and fields stored within the inverted index in Elasticsearch. This section
 describes all of the different functionality available within NEST that makes working with POCOs and Elasticsearch
 a breeze. 


### PR DESCRIPTION
This commit fixes the ability to serialize own IProperty types within PropertyFormatter, using utf8json. Initially, this feature was not originally available in utf8json due to how enums with the same underlying values but different field names were serialized, and how this interacts with internal enums of attribute runtime types. Since this is now fixed in #elastic/elasticsearch-net/4032, custom IProperty implementations will now serialize correctly.

Closes #3655 
Closes #4217