### PR TITLE
Replace links to elasticsearch.org with elastic.co

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -4,11 +4,12 @@ Contributing back to `Elasticsearch.Net` and `NEST` is very much appreciated.
 Whether you [feel the need to change one character](https://github.com/elasticsearch/elasticsearch-net/pull/536) or have a go at 
 [mapping new API's](http://github.com/elasticsearch/elasticsearch-net/pull/376) no PR is too small or too big. 
 
-In fact many of our most awesome features/fixes have been provided to us by [these wonderful folks](https://github.com/elasticsearch/elasticsearch-net/graphs/contributors) to which we are forever indebted 
+In fact many of our most awesome features/fixes have been provided to us by 
+[these wonderful folks](https://github.com/elasticsearch/elasticsearch-net/graphs/contributors) to which we are forever indebted. 
 
 ## Sign the CLA
 
-We do ask that you sign the [Elasticsearch CLA](http://www.elasticsearch.org/contributor-agreement/) before we can accept pull requests from you. 
+We do ask that you sign the [Elasticsearch CLA](https://www.elastic.co/contributor-agreement) before we can accept pull requests from you. 
 
 ## Coding Styleguide
 
@@ -20,13 +21,14 @@ In most cases we won't shun a PR just because it uses the wrong indentation sett
 
 ## Tests
 
-PR's with tests are more likely to be reviewed faster because it makes the job or reviewing the PR much easier. That being said,
-we respect that you are fixing a bug in your own time and might not have the time/energy to submit a PR with complete tests. 
+PRs with tests are more likely to be reviewed faster because it makes the job or reviewing the PR much easier. That being said,
+we respect that you may be fixing a bug in your own time and may not have the time/energy to submit a PR with complete tests. 
 In those cases we tend to pull your bits locally and write tests ourselves, but this may mean your PR might sit idle longer than you would like.
 
 ## Branches
 
-- `master` for the latest client (currently _7.x alpha_)
+- `master` for the latest client (currently _8.x alpha_)
+- `7.x` for 7.x compatible client
 - `6.x` for 6.x compatible client
 - `5.x` for 5.x compatible client
 - `2.x` for 2.x compatible client (no longer maintained)
@@ -45,31 +47,21 @@ Please submit your [Pull Requests](https://help.github.com/articles/creating-a-p
 
 # Building the solution
 
-The solution uses a number of awesome Open Source software tools to ease development:
-
-## Paket
-
-[Paket](https://fsprojects.github.io/Paket/) is the dependency manager of choice for handling dependencies of both the solution and the build automation system. It works for both .NET and Mono, with an ability to reference packages from Nuget and also files directly from github.
-
-## FAKE
-
-[FAKE (F# MAKE)](http://fsharp.github.io/FAKE/) is used as the build automation system for the solution. To get started after cloning the solution, it's best to run the build script in the root
-
 for Windows 
 
 ```
-build.bat
+.\build.bat
 ```
 
 for OSX/Linux
 
 ```
-build.sh
+./build.sh
 ```
 
 This will
 
-- Pull down all the paket dependencies for the build process as well as the solution
+- Pull down all the dependencies for the build process as well as the solution
 - Run the default build target for the solution
 
 You can also compile the solution within Visual Studio if you prefer, but the build script is going to be _much_ faster.
@@ -82,26 +74,27 @@ The `Tests` project contains both xunit unit and integration tests. A `tests.yam
 - `i` for integration tests
 - `m` for mixed mode i.e. unit and integration tests
 
-The build script has a number of different build targets to run different types of tests, see the [`Targets.fsx` script in the `scripts` project](https://github.com/elastic/elasticsearch-net/blob/master/build/scripts/Targets.fsx) for the complete list, but the main ones are:
+The build script has a number of different build targets to run different types of tests, see the [`Targets.fs` file in the `scripts` project](https://github.com/elastic/elasticsearch-net/blob/master/build/scripts/Targets.fs) for the complete list, but the main ones are:
 
 ### Compile and run unit tests
 
-```bash
-build.bat
+```bat
+.\build.bat
 ```
 with no target will run the `Build` target, compiling the solution and running unit tests
 
 ### Compile
 
-```bash
-build.bat skiptests
+```bat
+.\build.bat skiptests
 ```
+
 This compiles the solution and skips running tests
 
 ### Quick Compile and run integration tests
 
-```bash
-build.bat integrate [Elasticsearch Version Number e.g. 5.0.0]
+```bat
+.\build.bat integrate [Elasticsearch Version Number e.g. 5.0.0]
 ```
 will quick compile the solution and run integration tests against the target Elasticsearch version. The first time this is run for a version of Elasticsearch, it will download Elasticsearch and unzip Elasticsearch, install the plugins necessary to run the integration tests, and start the node. Because of this, the first run may take some time to start.
 

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -66,7 +66,7 @@ namespace Elasticsearch.Net
 		[SuppressMessage("Microsoft.Reliability", "CA2000:Dispose objects before losing scope")]
 		public ConnectionConfiguration(Uri uri = null)
 			: this(new SingleNodeConnectionPool(uri ?? new Uri("http://localhost:9200"))) { }
-		
+
 		/// <summary>
 		/// Sets up the client to communicate to Elastic Cloud using <paramref name="cloudId"/>,
 		/// <para><see cref="CloudConnectionPool"/> documentation for more information on how to obtain your Cloud Id</para>
@@ -180,7 +180,7 @@ namespace Elasticsearch.Net
 
 			_urlFormatter = new ElasticsearchUrlFormatter(this);
 			_statusCodeToResponseSuccess = (m, i) => HttpStatusCodeClassifier(m, i);
-			
+
 			if (connectionPool is CloudConnectionPool cloudPool)
 			{
 				_basicAuthCredentials = cloudPool.BasicCredentials;
@@ -309,7 +309,7 @@ namespace Elasticsearch.Net
 		/// <summary>
 		/// Enables gzip compressed requests and responses.
 		/// <para>IMPORTANT: You need to configure http compression on Elasticsearch to be able to use this</para>
-		/// <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html</para>
+		/// <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html</para>
 		/// </summary>
 		public T EnableHttpCompression(bool enabled = true) => Assign(enabled, (a, v) => a._enableHttpCompression = v);
 

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -81,7 +81,7 @@ namespace Elasticsearch.Net
 
 		/// <summary>
 		/// Enable gzip compressed requests and responses, do note that you need to configure Elasticsearch to set this
-		/// <para>http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/modules-http.html</para>
+		/// <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/modules-http.html</para>
 		/// </summary>
 		bool EnableHttpCompression { get; }
 
@@ -231,7 +231,7 @@ namespace Elasticsearch.Net
 		/// versions that initiate requests to Elasticsearch
 		/// </summary>
 		string UserAgent { get; }
-		
+
 		/// <summary>
 		/// Allow you to override the status code inspection that sets <see cref="ElasticsearchResponseBase.Success"/>
 		/// <para>

--- a/src/Nest/Document/Multiple/Bulk/ElasticClient-DeleteMany.cs
+++ b/src/Nest/Document/Multiple/Bulk/ElasticClient-DeleteMany.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <summary>
 		/// Shortcut into the Bulk call that deletes the specified objects
 		/// <para> </para>
-		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 		/// </summary>
 		/// <param name="client"></param>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
@@ -31,7 +31,7 @@ namespace Nest
 		/// <summary>
 		/// Shortcut into the Bulk call that deletes the specified objects
 		/// <para> </para>
-		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 		/// </summary>
 		/// <param name="client"></param>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>

--- a/src/Nest/Document/Multiple/Bulk/ElasticClient-IndexMany.cs
+++ b/src/Nest/Document/Multiple/Bulk/ElasticClient-IndexMany.cs
@@ -13,7 +13,7 @@ namespace Nest
 		/// <summary>
 		/// Shortcut into the Bulk call that indexes the specified objects
 		/// <para> </para>
-		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 		/// </summary>
 		/// <param name="client"></param>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
@@ -30,7 +30,7 @@ namespace Nest
 		/// <summary>
 		/// Shortcut into the Bulk call that indexes the specified objects
 		/// <para> </para>
-		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-bulk.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html
 		/// </summary>
 		/// <param name="client"></param>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
@@ -16,7 +16,7 @@ namespace Nest
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -39,7 +39,7 @@ namespace Nest
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -54,7 +54,7 @@ namespace Nest
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -80,7 +80,7 @@ namespace Nest
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
 		/// provided by the get API.
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
@@ -19,7 +19,7 @@ namespace Nest
 		/// provided by the get API.
 		/// </para>
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -44,7 +44,7 @@ namespace Nest
 		/// provided by the get API.
 		/// </para>
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -61,7 +61,7 @@ namespace Nest
 		/// provided by the get API.
 		/// </para>
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>
@@ -88,7 +88,7 @@ namespace Nest
 		/// provided by the get API.
 		/// </para>
 		/// <para> </para>
-		/// >http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-multi-get.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-multi-get.html
 		/// </summary>
 		/// <typeparam name="T">The type used to infer the default index and typename</typeparam>
 		/// <param name="client"></param>

--- a/src/Nest/Document/Single/Index/ElasticClient-Index.cs
+++ b/src/Nest/Document/Single/Index/ElasticClient-Index.cs
@@ -8,7 +8,8 @@ namespace Nest
 		/// <summary>
 		/// Adds or updates a typed JSON document in a specific index, making it searchable.
 		/// <para> </para>
-		/// <a href="http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html">http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/docs-index_.html</a>
+		/// <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html">
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-index_.html</a>
 		/// </summary>
 		/// <typeparam name="TDocument">The document type used to infer the default index, type and id</typeparam>
 		/// <param name="document">

--- a/src/Nest/Indices/MappingManagement/PutMapping/ElasticClient-Map.cs
+++ b/src/Nest/Indices/MappingManagement/PutMapping/ElasticClient-Map.cs
@@ -9,7 +9,7 @@ namespace Nest
 		/// <summary>
 		/// The put mapping API allows to register specific mapping definition for a specific type.
 		/// <para> </para>
-		/// http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/indices-put-mapping.html
+		/// https://www.elastic.co/guide/en/elasticsearch/reference/current/indices-put-mapping.html
 		/// </summary>
 		/// <typeparam name="T">The type we want to map in Elasticsearch</typeparam>
 		/// <param name="selector">A descriptor to describe the mapping of our type</param>

--- a/src/Tests/Tests/XPack/MachineLearning/MachineLearningCluster.cs
+++ b/src/Tests/Tests/XPack/MachineLearning/MachineLearningCluster.cs
@@ -39,7 +39,7 @@ namespace Tests.XPack.MachineLearning
 			var to = Path.Combine(cluster.FileSystem.LocalFolder, "server_metrics.tar.gz");
 			if (!File.Exists(to))
 			{
-				var from = "https://download.elasticsearch.org/demos/machine_learning/gettingstarted/server_metrics.tar.gz";
+				var from = "https://download.elastic.co/demos/machine_learning/gettingstarted/server_metrics.tar.gz";
 				W($"Download machine learning sample data from: {from}");
 				DownloadFile(from, to);
 				W($"Downloaded machine learning sample data to: {to}");


### PR DESCRIPTION
This commit replaces the remaining links to elasticsearch.org with their elastic.co counterparts.

Closes #3915