### PR TITLE
Fix spelling mistakes.

### DIFF
--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -78,7 +78,7 @@ However we encourage you to pass connection settings explicitly.
 ==== CloudConnectionPool
 
 A specialized subclass of `SingleNodeConnectionPool` that accepts a Cloud Id and credentials.
-When used the client will also pick Elastic Cloud optmized defaults for the connection settings.
+When used the client will also pick Elastic Cloud optimized defaults for the connection settings.
 
 A Cloud Id for your cluster can be fetched from your Elastic Cloud cluster administration console.
 

--- a/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
@@ -114,7 +114,6 @@ audit = await audit.TraceCall(
     }
 );
 ----
-<1> diable ping and sniff
-
+<1> disable ping and sniff
 <2> no ping or sniff before the call
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
@@ -47,7 +47,7 @@ var audit = new Auditor(() => VirtualClusterWith
 );
 ----
 
-healty cluster all nodes return healthy responses
+healthy cluster all nodes return healthy responses
 
 [source,csharp]
 ----

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -271,7 +271,7 @@ var settings = new ConnectionConfiguration(uri);
 ----
 
 but this can be awkward when using connection pooling with multiple nodes, especially when the connection pool
-used is one that is capable of reseeding iteslf. For this reason, we'd recommend specifying credentials
+used is one that is capable of reseeding itself. For this reason, we'd recommend specifying credentials
 on `ConnectionSettings`.
 
 ====

--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -296,7 +296,7 @@ ndexResponse = client.Index(indexRequest);
 ndexResponse.ApiCall.Uri.Query.Should().Contain("routing=1337");
 ----
 
-Its important to note that the routing is resolved at request time, not instantation time
+Its important to note that the routing is resolved at request time, not instantiation time
 here we update the `child`'s `JoinField` after already creating the index request for `child`
 
 [source,csharp]

--- a/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
@@ -44,7 +44,7 @@ public class MyPluginProperty : IProperty
 `PropertyNameAttribute` can be used to mark properties that should be serialized. Without this attribute,
 NEST won't pick up the property for serialization.
 
-Now that we have our own `IProperty` implementation we can add it to our propertes mapping when creating an index
+Now that we have our own `IProperty` implementation we can add it to our properties mapping when creating an index
 
 [source,csharp]
 ----

--- a/docs/client-concepts/low-level/lifetimes.asciidoc
+++ b/docs/client-concepts/low-level/lifetimes.asciidoc
@@ -74,7 +74,7 @@ private class AConnection : InMemoryConnection
 }
 ----
 
-`ConnectionSettings`, `IConnectionPool` and `IConnection` all explictily implement `IDisposable`
+`ConnectionSettings`, `IConnectionPool` and `IConnection` all explicitly implement `IDisposable`
 
 [source,csharp]
 ----

--- a/docs/client-concepts/low-level/post-data.asciidoc
+++ b/docs/client-concepts/low-level/post-data.asciidoc
@@ -62,7 +62,7 @@ fromByteArray.Type.Should().Be(PostType.ByteArray);
 [float]
 === Other types of PostData
 
-You can also pass the following objects directy to the low level client.
+You can also pass the following objects directly to the low level client.
 
 * A Serializable `object`
 

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -180,7 +180,7 @@ that accepts a factor and time unit, or specify a string with ms time units
 ==== Units of Time
 
 Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
-a `DateInterval` or `Time` may be passed which will be implicity converted to a
+a `DateInterval` or `Time` may be passed which will be implicitly converted to a
 `Union<DateInterval, Time>`, the serialized form of which represents the initial value
 passed
 

--- a/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/Connection/ConfigurationOptions.doc.cs
@@ -70,7 +70,7 @@ namespace Tests.ClientConcepts.Connection
 		}
 		/**
 		* but this can be awkward when using connection pooling with multiple nodes, especially when the connection pool
-		* used is one that is capable of reseeding iteslf. For this reason, we'd recommend specifying credentials
+		* used is one that is capable of reseeding itself. For this reason, we'd recommend specifying credentials
 		* on `ConnectionSettings`.
 		*====
 		*/

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/BuildingBlocks/ConnectionPooling.doc.cs
@@ -90,7 +90,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.BuildingBlocks
 		* ==== CloudConnectionPool
 		*
 		* A specialized subclass of `SingleNodeConnectionPool` that accepts a Cloud Id and credentials.
-		* When used the client will also pick Elastic Cloud optmized defaults for the connection settings.
+		* When used the client will also pick Elastic Cloud optimized defaults for the connection settings.
 		 *
 		 * A Cloud Id for your cluster can be fetched from your Elastic Cloud cluster administration console.
 		 *

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/RequestOverrides/DisableSniffPingPerRequest.doc.cs
@@ -90,7 +90,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.RequestOverrides
 			);
 
 			audit = await audit.TraceCall(
-				new ClientCall(r=>r.DisableSniffing().DisablePing()) // <1> diable ping and sniff
+				new ClientCall(r=>r.DisableSniffing().DisablePing()) // <1> disable ping and sniff
 				{
 					{ HealthyResponse, 9200 } // <2> no ping or sniff before the call
 				}

--- a/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/ConnectionPooling/Sniffing/OnStaleClusterState.doc.cs
@@ -47,7 +47,7 @@ namespace Tests.ClientConcepts.ConnectionPooling.Sniffing
 					.SniffLifeSpan(TimeSpan.FromMinutes(30))
 				)
 			);
-			/** healty cluster all nodes return healthy responses*/
+			/** healthy cluster all nodes return healthy responses*/
 			audit = await audit.TraceCalls(
 				new ClientCall { { HealthyResponse, 9200 } },
 				new ClientCall { { HealthyResponse, 9201 } },

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Mapping/ParentChildRelationships.doc.cs
@@ -296,7 +296,7 @@ namespace Tests.ClientConcepts.HighLevel.Mapping
 			ndexResponse = client.Index(indexRequest);
 			ndexResponse.ApiCall.Uri.Query.Should().Contain("routing=1337");
 			/**
-			 * Its important to note that the routing is resolved at request time, not instantation time
+			 * Its important to note that the routing is resolved at request time, not instantiation time
 			 * here we update the `child`'s `JoinField` after already creating the index request for `child`
 			 */
 			child.MyJoinField = JoinField.Link<MyChild>(parentId: "something-else");

--- a/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/HighLevel/Serialization/ExtendingNestTypes.doc.cs
@@ -48,7 +48,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 			[PropertyName("numeric")]
 			public bool Numeric { get; set; }
 		}
-		
+
 
 		[U (Skip = "TODO: Does not work with utf8json")]
 		// hide
@@ -58,7 +58,7 @@ namespace Tests.ClientConcepts.HighLevel.Serialization
 			 * `PropertyNameAttribute` can be used to mark properties that should be serialized. Without this attribute,
 			 * NEST won't pick up the property for serialization.
 			 *
-			 * Now that we have our own `IProperty` implementation we can add it to our propertes mapping when creating an index
+			 * Now that we have our own `IProperty` implementation we can add it to our properties mapping when creating an index
 			 */
 			var createIndexResponse = _client.Indices.Create("myindex", c => c
 				.Map<Project>(m => m

--- a/src/Tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/LowLevel/Lifetimes.doc.cs
@@ -73,7 +73,7 @@ namespace Tests.ClientConcepts.LowLevel
 		}
 
 		/**
-		* `ConnectionSettings`, `IConnectionPool` and `IConnection` all explictily implement `IDisposable`
+		* `ConnectionSettings`, `IConnectionPool` and `IConnection` all explicitly implement `IDisposable`
 		*/
 		[U] public void InitialDisposeState()
 		{

--- a/src/Tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs
+++ b/src/Tests/Tests/ClientConcepts/LowLevel/PostData.doc.cs
@@ -81,7 +81,7 @@ namespace Tests.ClientConcepts.LowLevel
 			/**[float]
 			* === Other types of PostData
 			*
-			* You can also pass the following objects directy to the low level client.
+			* You can also pass the following objects directly to the low level client.
 			*
 			* - A Serializable `object`
 			* - A collection of `object` as multi line json

--- a/src/Tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
+++ b/src/Tests/Tests/CommonOptions/TimeUnit/TimeUnits.doc.cs
@@ -268,7 +268,7 @@ namespace Tests.CommonOptions.TimeUnit
 			* ==== Units of Time
 			*
 			* Where Units of Time can be specified as a union of either a `DateInterval` or `Time`,
-			* a `DateInterval` or `Time` may be passed which will be implicity converted to a
+			* a `DateInterval` or `Time` may be passed which will be implicitly converted to a
 			* `Union<DateInterval, Time>`, the serialized form of which represents the initial value
 			* passed
 			*/


### PR DESCRIPTION
I ran a spell check crawler over our docs and fixed up the errors it found.

Port to `master` and `7.4`.