### PR TITLE
Add support for WKT with GeoLocation type

### DIFF
--- a/src/Nest/QueryDsl/Geo/GeoLocation.cs
+++ b/src/Nest/QueryDsl/Geo/GeoLocation.cs
@@ -46,6 +46,9 @@ namespace Nest
 		[DataMember(Name = "lon")]
 		public double Longitude { get; }
 
+		[IgnoreDataMember]
+		internal GeoFormat Format { get; set; }
+
 		public bool Equals(GeoLocation other)
 		{
 			if (ReferenceEquals(null, other))

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -17,7 +17,7 @@ namespace Nest
 		string Type { get; }
 	}
 
-	internal enum GeoShapeFormat
+	internal enum GeoFormat
 	{
 		GeoJson,
 		WellKnownText
@@ -48,7 +48,7 @@ namespace Nest
 		/// <inheritdoc />
 		public string Type { get; protected set; }
 
-		internal GeoShapeFormat Format { get; set; }
+		internal GeoFormat Format { get; set; }
 	}
 
 	internal class GeoShapeFormatter<TShape> : IJsonFormatter<TShape>
@@ -93,7 +93,7 @@ namespace Nest
 				return;
 			}
 
-			if (value is GeoShapeBase shapeBase && shapeBase.Format == GeoShapeFormat.WellKnownText)
+			if (value is GeoShapeBase shapeBase && shapeBase.Format == GeoFormat.WellKnownText)
 			{
 				writer.WriteString(GeoWKTWriter.Write(shapeBase));
 				return;

--- a/src/Nest/QueryDsl/Geo/WKT/GeoWKTReader.cs
+++ b/src/Nest/QueryDsl/Geo/WKT/GeoWKTReader.cs
@@ -36,35 +36,35 @@ namespace Nest
 			{
 				case GeoShapeType.Point:
 					var point = ParsePoint(tokenizer);
-					point.Format = GeoShapeFormat.WellKnownText;
+					point.Format = GeoFormat.WellKnownText;
 					return point;
 				case GeoShapeType.MultiPoint:
 					var multiPoint = ParseMultiPoint(tokenizer);
-					multiPoint.Format = GeoShapeFormat.WellKnownText;
+					multiPoint.Format = GeoFormat.WellKnownText;
 					return multiPoint;
 				case GeoShapeType.LineString:
 					var lineString = ParseLineString(tokenizer);
-					lineString.Format = GeoShapeFormat.WellKnownText;
+					lineString.Format = GeoFormat.WellKnownText;
 					return lineString;
 				case GeoShapeType.MultiLineString:
 					var multiLineString = ParseMultiLineString(tokenizer);
-					multiLineString.Format = GeoShapeFormat.WellKnownText;
+					multiLineString.Format = GeoFormat.WellKnownText;
 					return multiLineString;
 				case GeoShapeType.Polygon:
 					var polygon = ParsePolygon(tokenizer);
-					polygon.Format = GeoShapeFormat.WellKnownText;
+					polygon.Format = GeoFormat.WellKnownText;
 					return polygon;
 				case GeoShapeType.MultiPolygon:
 					var multiPolygon = ParseMultiPolygon(tokenizer);
-					multiPolygon.Format = GeoShapeFormat.WellKnownText;
+					multiPolygon.Format = GeoFormat.WellKnownText;
 					return multiPolygon;
 				case GeoShapeType.BoundingBox:
 					var envelope = ParseBoundingBox(tokenizer);
-					envelope.Format = GeoShapeFormat.WellKnownText;
+					envelope.Format = GeoFormat.WellKnownText;
 					return envelope;
 				case GeoShapeType.GeometryCollection:
 					var geometryCollection = ParseGeometryCollection(tokenizer);
-					geometryCollection.Format = GeoShapeFormat.WellKnownText;
+					geometryCollection.Format = GeoFormat.WellKnownText;
 					return geometryCollection;
 				default:
 					throw new GeoWKTException($"Unknown geometry type: {type}");
@@ -217,7 +217,7 @@ namespace Nest
 				: new GeoCoordinate(lat, lon, z.Value);
 		}
 
-		private static void NextCloser(WellKnownTextTokenizer tokenizer)
+		internal static void NextCloser(WellKnownTextTokenizer tokenizer)
 		{
 			if (tokenizer.NextToken() != TokenType.RParen)
 				throw new GeoWKTException(
@@ -234,7 +234,7 @@ namespace Nest
 					tokenizer.Position);
 		}
 
-		private static TokenType NextEmptyOrOpen(WellKnownTextTokenizer tokenizer)
+		internal static TokenType NextEmptyOrOpen(WellKnownTextTokenizer tokenizer)
 		{
 			var token = tokenizer.NextToken();
 			if (token == TokenType.LParen ||
@@ -257,7 +257,7 @@ namespace Nest
 				$"but found: {tokenizer.TokenString()}", tokenizer.LineNumber, tokenizer.Position);
 		}
 
-		private static double NextNumber(WellKnownTextTokenizer tokenizer)
+		internal static double NextNumber(WellKnownTextTokenizer tokenizer)
 		{
 			if (tokenizer.NextToken() == TokenType.Word)
 			{

--- a/src/Tests/Tests/CodeStandards/Serialization/GeoLocationTests.cs
+++ b/src/Tests/Tests/CodeStandards/Serialization/GeoLocationTests.cs
@@ -1,0 +1,31 @@
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.CodeStandards.Serialization
+{
+	public class GeoLocationTests
+	{
+		[U]
+		public void CanDeserializeAndSerializeToWellKnownText()
+		{
+			var wkt = "{\"location\":\"POINT (-90 90)\"}";
+			var client = TestClient.DisabledStreaming;
+
+			Doc deserialized;
+			using (var stream = MemoryStreamFactory.Default.Create(Encoding.UTF8.GetBytes(wkt)))
+				deserialized = client.RequestResponseSerializer.Deserialize<Doc>(stream);
+
+			deserialized.Location.Should().Be(new GeoLocation(90, -90));
+			client.RequestResponseSerializer.SerializeToString(deserialized).Should().Be(wkt);
+		}
+
+		private class Doc
+		{
+			public GeoLocation Location { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/pull/44107

This commit adds support for Well Known Text (WKT) representations for GeoLocation, the type used
to represent geo_point in the client. Similar to WKT support in IGeoShape, an internal format field
is used to store whether an instance was deserialized from JSON or WKT, so that re-serialization
honours the original form deserialized from.