### PR TITLE
Diff release version against previous version from Nuget

### DIFF
--- a/build/scripts/Differ.fs
+++ b/build/scripts/Differ.fs
@@ -1,15 +1,86 @@
 ﻿namespace Scripts
 
+open System.Collections.Generic
+open System.IO
+open System.Threading
 open Fake.Core
+open Fake.IO
+open Fake.IO.Globbing.Operators
+open NuGet.Common
+open NuGet.Protocol.Core.Types
+open NuGet.Protocol
+open NuGet.Configuration
+open NuGet.Versioning
 open Commandline
+open Projects
 
-module Differ =
-
-    let Run args =
-       Tooling.DotNet.Exec ["tool"; "restore"]
+module Differ =    
+    let private nestJsonNetSerializerNugetId = (Project NestJsonNetSerializer).NugetId
+    
+    let private netStandard20Identifier = DotNetFramework.NetStandard2_0.Identifier.Nuget
+    
+    let private findPreviousVersionOnNuget (version:string) =         
+        let nugetVersion = new NuGetVersion(version)        
+        let providers = new List<Lazy<INuGetResourceProvider>>();
+        providers.AddRange(Repository.Provider.GetCoreV3());
+        let packageSource = new PackageSource("https://api.nuget.org/v3/index.json")
+        let sourceRepository = new SourceRepository(packageSource, providers)      
+        let metadata = sourceRepository.GetResource<PackageMetadataResource>()
+        let searchMetadata =
+            metadata.GetMetadataAsync(nestJsonNetSerializerNugetId, false, false, NullLogger.Instance, CancellationToken.None)
+            |> Async.AwaitTask
+            |> Async.RunSynchronously
+            
+        let previousPackage = searchMetadata
+                              |> Seq.cast<PackageSearchMetadata>
+                              |> Seq.sortByDescending (fun p -> p.Version)
+                              |> Seq.filter (fun p -> p.Version < nugetVersion)
+                              |> Seq.tryHead
+                           
+        match previousPackage with
+        | Some p -> Some(p.Version.ToFullString())
+        | None -> None
+   
+    let private unzipReleasePackages () =
+        !! (Fake.IO.Path.combine Paths.NugetOutput "*.nupkg")
+        |> Seq.iter(fun f ->
+            let name = Path.GetFileNameWithoutExtension(f)
+            let directory = Path.Combine(Paths.NugetOutput, name)
+            Zip.unzip directory f
+        )
         
+        let tmp = Fake.IO.Path.combine Paths.NugetOutput "tmp"     
+        if Directory.Exists tmp then Directory.delete tmp
+        Directory.create tmp
+                
+        Directory.EnumerateDirectories(Paths.NugetOutput)
+        |> Seq.filter (fun d -> d <> tmp)
+        |> Seq.iter(fun d ->
+            let netstandard20Dlls = System.IO.Path.Combine(d, "lib", netStandard20Identifier)
+            Directory.EnumerateFiles(netstandard20Dlls, "*.dll") |> Shell.copyFiles tmp
+        )
+        
+        tmp |> Path.GetFullPath
+              
+    let Run args =
+       Tooling.DotNet.Exec ["tool"; "restore"]       
        let differ = "assembly-differ"
        let args = args.RemainingArguments |> String.concat " "
        let command = sprintf @"%s %s -o ../../%s" differ args Paths.BuildOutput
        Environment.setEnvironVar "NUGET" Tooling.nugetFile
        Tooling.DotNet.ExecIn Paths.TargetsFolder [command] |> ignore
+       
+    let DiffWithPreviousNugetVersion args =       
+        match args.CommandArguments with
+        | SetVersion v ->
+            let previousVersion = findPreviousVersionOnNuget v.Version           
+            match previousVersion with
+            | Some p ->           
+                let directory = unzipReleasePackages ()             
+                let command = [ sprintf "nuget|%s|%s|%s" nestJsonNetSerializerNugetId p netStandard20Identifier;
+                                sprintf "directory|%s" directory ]
+                               
+                System.Console.WriteLine("Running diff of {0}, {1} from Nuget against local {2}", netStandard20Identifier, p, v.Version)             
+                Run { args with RemainingArguments = command }
+            | None -> failwithf "Could not find previous version on Nuget for version %s" v.Version
+        | _ -> failwith "DiffWithPreviousNugetVersion can only be run with SetVersion arguments"

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -75,7 +75,9 @@ module Main =
 
         conditional (parsed.Target = "canary" && not isMono) "nuget-pack-versioned" <| fun _ -> Release.NugetPackVersioned artifactsVersion
 
-        conditional (parsed.Target <> "canary") "generate-release-notes" <| fun _ -> ReleaseNotes.GenerateNotes buildVersions 
+        conditional (parsed.Target <> "canary") "generate-release-notes" <| fun _ -> ReleaseNotes.GenerateNotes buildVersions
+        
+        conditional (parsed.Target <> "canary") "diff-against-nuget" <| fun _ -> Differ.DiffWithPreviousNugetVersion parsed
 
         target "validate-artifacts" <| fun _ -> Versioning.ValidateArtifacts artifactsVersion
         
@@ -93,7 +95,12 @@ module Main =
         command "integrate" [ "clean"; "restore"; "full-build";] <| fun _ -> Tests.RunIntegrationTests parsed
 
         command "release" [ 
-           "build"; "nuget-pack"; "nuget-pack-versioned"; "validate-artifacts"; "generate-release-notes"
+           "build";
+           "nuget-pack";
+           "nuget-pack-versioned";
+           "validate-artifacts";
+           "diff-against-nuget";
+           "generate-release-notes"
         ] (fun _ -> printfn "Finished Release Build %O" artifactsVersion)
 
         command "diff" [ "clean"; ] <| fun _ -> Differ.Run parsed

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -42,11 +42,13 @@
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />
     <PackageReference Include="Fake.IO.FileSystem" Version="5.15.0" />
     <PackageReference Include="Fake.IO.Zip" Version="5.15.0" />
-
     
     <PackageReference Include="ILRepack" Version="2.1.0-beta1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="4.9.4" />
+    <PackageReference Include="NuGet.PackageManagement" Version="5.3.1" />
+    <PackageReference Include="NuGet.Protocol.Core.v3" Version="4.2.0" />
+
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Proc" Version="0.6.1" />
   </ItemGroup>


### PR DESCRIPTION
This commit adds a new build target to diff the release version against the previous version on Nuget, to identify breaking API changes. This new build target is added as a dependent target of the release target.