### PR TITLE
Share random seed between test framework and build scripts

### DIFF
--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -93,7 +93,7 @@ Execution hints can be provided anywhere on the command line
         NonInteractive: bool;
         SkipTests: bool;
         GenDocs: bool;
-        Seed: string;
+        Seed: int option;
         RandomArguments: string list;
         DocsBranch: string;
         ReferenceBranch: string;
@@ -141,8 +141,8 @@ Execution hints can be provided anywhere on the command line
             GenDocs = not skipDocs && (args |> List.exists (fun x -> x = "gendocs") || target = "build") 
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
-                | Some t -> t.Replace("seed:", "")
-                | _ -> ""
+                | Some t -> Some <| Int32.Parse (t.Replace("seed:", ""))
+                | _ -> None
             RandomArguments = 
                 args 
                 |> List.filter (fun x -> (x.StartsWith("random:")))

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -93,7 +93,7 @@ Execution hints can be provided anywhere on the command line
         NonInteractive: bool;
         SkipTests: bool;
         GenDocs: bool;
-        Seed: int option;
+        Seed: int;
         RandomArguments: string list;
         DocsBranch: string;
         ReferenceBranch: string;
@@ -141,8 +141,8 @@ Execution hints can be provided anywhere on the command line
             GenDocs = not skipDocs && (args |> List.exists (fun x -> x = "gendocs") || target = "build") 
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
-                | Some t -> Some <| Int32.Parse (t.Replace("seed:", ""))
-                | _ -> None
+                | Some t -> Int32.Parse (t.Replace("seed:", ""))
+                | _ -> Random().Next(1, 100_000)
             RandomArguments = 
                 args 
                 |> List.filter (fun x -> (x.StartsWith("random:")))

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -36,6 +36,8 @@ module Main =
         
         let parsed = Commandline.parse (args |> Array.toList)
         
+        
+        let seed = parsed.Seed;
         let buildVersions = Versioning.BuildVersioning parsed
         let artifactsVersion = Versioning.ArtifactsVersion buildVersions
         Versioning.Validate parsed.Target buildVersions
@@ -69,7 +71,7 @@ module Main =
         target "test-nuget-package" <| fun _ -> 
             // run release unit tests puts packages in the system cache prevent this from happening locally
             if not Commandline.runningOnCi then ignore ()
-            else Tests.RunReleaseUnitTests artifactsVersion |> ignore
+            else Tests.RunReleaseUnitTests artifactsVersion seed |> ignore
             
         target "nuget-pack" <| fun _ -> Release.NugetPack artifactsVersion
 

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -24,10 +24,7 @@ module Tests =
         
         env "NEST_INTEGRATION_CLUSTER" clusterFilter
         env "NEST_TEST_FILTER" testFilter
-        let seed =
-            match args.Seed with
-            | Some i -> Some <| i.ToString(CultureInfo.InvariantCulture)
-            | None -> None
+        let seed = Some <| args.Seed.ToString(CultureInfo.InvariantCulture)
         env "NEST_TEST_SEED" seed 
 
         for random in args.RandomArguments do 
@@ -49,7 +46,7 @@ module Tests =
                 printfn "Running on linux defaulting tests to .NET Core only" 
                 ["--framework"; "netcoreapp3.0"] |> List.append p
             | (Commandline.MultiTarget.One, _) ->
-                let random = match seed with | Some i -> Random(i) | None -> Random()
+                let random = Random(seed)
                 let fw = DotNetFramework.AllTests |> List.sortBy (fun _ -> random.Next()) |> List.head
                 let tfm = fw.Identifier.MSBuild
                 printfn "Running on non linux system randomly selected '%s' for tests" tfm

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -45,11 +45,15 @@ module Tests =
             let p = ["test"; "."; "-c"; "RELEASE"]
             //make sure we only test netcoreapp on linux or requested on the command line to only test-one
             match (target, Environment.isLinux) with 
-            | (_, true) -> ["--framework"; "netcoreapp3.0"] |> List.append p
+            | (_, true) ->
+                printfn "Running on linux defaulting tests to .NET Core only" 
+                ["--framework"; "netcoreapp3.0"] |> List.append p
             | (Commandline.MultiTarget.One, _) ->
                 let random = match seed with | Some i -> Random(i) | None -> Random()
                 let fw = DotNetFramework.AllTests |> List.sortBy (fun _ -> random.Next()) |> List.head
-                ["--framework"; fw.Identifier.MSBuild] |> List.append p
+                let tfm = fw.Identifier.MSBuild
+                printfn "Running on non linux system randomly selected '%s' for tests" tfm
+                ["--framework"; tfm] |> List.append p
             | _  -> p
         let commandWithCodeCoverage =
             // TODO /p:CollectCoverage=true /p:CoverletOutputFormat=cobertura


### PR DESCRIPTION
Our build scripts allow you to suffix certain targets with `-one` so that they will test one TFM. 

We use this on our CI to minimize run time e.g we have multiple integration tests for each minor, we only run one random TFM per minor on each run. This is a trade-off between full coverage vs sane CI run time.

Our test framework has a lot of randomness as well and decided on a seed when run to ensure we can reproduce failures using the exact same randomness. When tests fail a reproduce line is printed (and surfaced as Github Checks).

This PR now decides the seed in the build scripts so that the randomness in the build script and test framework are both based on the same seed.

