### PR TITLE
Fix null ref DynamicResponse when host not available

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -166,7 +166,7 @@ namespace Elasticsearch.Net
 			else if (responseType == typeof(DynamicResponse))
 			{
 				//if not json store the result under "body"
-				if (!mimeType.StartsWith(RequestData.MimeType))
+				if (mimeType == null || !mimeType.StartsWith(RequestData.MimeType))
 				{
 					var dictionary = new DynamicDictionary();
 					dictionary["body"] = new DynamicValue(bytes.Utf8String());
@@ -174,11 +174,9 @@ namespace Elasticsearch.Net
 				}
 				else
 				{
-					using (var ms = memoryStreamFactory.Create(bytes))
-					{
-						var body = LowLevelRequestResponseSerializer.Instance.Deserialize<DynamicDictionary>(ms);
-						cs = new DynamicResponse(body) as TResponse;
-					}
+					using var ms = memoryStreamFactory.Create(bytes);
+					var body = LowLevelRequestResponseSerializer.Instance.Deserialize<DynamicDictionary>(ms);
+					cs = new DynamicResponse(body) as TResponse;
 				}
 			}
 			return cs != null;


### PR DESCRIPTION
When using the low levelclient and asking for a DyamicResponse while the
server is unreachable you would get a NRE

>Unhandled exception. Elasticsearch.Net.UnexpectedElasticsearchClientException: Object reference not set to an instance of an object.
 ---> System.NullReferenceException: Object reference not set to an instance of an object.
   at Elasticsearch.Net.ResponseBuilder.SetSpecialTypes[TResponse](String mimeType, Byte[] bytes, IMemoryStreamFactory memoryStreamFactory, TResponse& cs) in /home/mpdreamz/projects/elastic/net-7/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs:line 169

This hit the sockets exception as can be seen after applying this fix:

```
 Unsuccessful () low level call on GET: /
 # Audit trail of this API call:
  - [1] BadRequest: Node: http://localhost:9200/ Took: 00:00:00.0657238
 # OriginalException: System.Net.Http.HttpRequestException: Connection refused
  ---> System.Net.Sockets.SocketException (111): Connection refused
    at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
    --- End of inner exception stack trace ---
```