### PR TITLE
Expose q querystring parameter on search

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/SearchOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/Endpoints/SearchOverrides.cs
@@ -12,7 +12,6 @@ namespace ApiGenerator.Configuration.Overrides.Endpoints
 			"timeout",
 			"explain",
 			"version",
-			"q", //we dont support GET searches
 			"sort",
 			"_source",
 			"_source_includes",

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.NoNamespace.cs
@@ -1660,6 +1660,13 @@ namespace Elasticsearch.Net
 			set => Q("preference", value);
 		}
 
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string QueryOnQueryString
+		{
+			get => Q<string>("q");
+			set => Q("q", value);
+		}
+
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public bool? RequestCache
 		{

--- a/src/Nest/Descriptors.NoNamespace.cs
+++ b/src/Nest/Descriptors.NoNamespace.cs
@@ -1278,6 +1278,8 @@ namespace Nest
 		public SearchDescriptor<TInferDocument> PreFilterShardSize(long? prefiltershardsize) => Qs("pre_filter_shard_size", prefiltershardsize);
 		///<summary>Specify the node or shard the operation should be performed on (default: random)</summary>
 		public SearchDescriptor<TInferDocument> Preference(string preference) => Qs("preference", preference);
+		///<summary>Query in the Lucene query string syntax</summary>
+		public SearchDescriptor<TInferDocument> QueryOnQueryString(string queryonquerystring) => Qs("q", queryonquerystring);
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public SearchDescriptor<TInferDocument> RequestCache(bool? requestcache = true) => Qs("request_cache", requestcache);
 		///<summary>

--- a/src/Nest/Requests.NoNamespace.cs
+++ b/src/Nest/Requests.NoNamespace.cs
@@ -2744,6 +2744,13 @@ namespace Nest
 			set => Q("preference", value);
 		}
 
+		///<summary>Query in the Lucene query string syntax</summary>
+		public string QueryOnQueryString
+		{
+			get => Q<string>("q");
+			set => Q("q", value);
+		}
+
 		///<summary>Specify if request cache should be used for this request or not, defaults to index level setting</summary>
 		public bool? RequestCache
 		{

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -155,7 +155,7 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name = "track_scores")]
 		bool? TrackScores { get; set; }
-		
+
 		/// <summary>
 		/// Return a version for each search hit
 		/// </summary>
@@ -224,7 +224,7 @@ namespace Nest
 		public bool? Version { get; set; }
 
 		protected override HttpMethod HttpMethod =>
-			RequestState.RequestParameters?.ContainsQueryString("source") == true || RequestState.RequestParameters?.ContainsQueryString("q") == true
+			RequestState.RequestParameters?.ContainsQueryString("source") == true
 				? HttpMethod.GET
 				: HttpMethod.POST;
 
@@ -246,7 +246,7 @@ namespace Nest
 	public partial class SearchDescriptor<TInferDocument> where TInferDocument : class
 	{
 		protected override HttpMethod HttpMethod =>
-			RequestState.RequestParameters?.ContainsQueryString("source") == true || RequestState.RequestParameters?.ContainsQueryString("q") == true
+			RequestState.RequestParameters?.ContainsQueryString("source") == true
 				? HttpMethod.GET
 				: HttpMethod.POST;
 


### PR DESCRIPTION
This ended up on our skip list in `SearchOverrides.cs` in the code generator but other API's already expose it.
