### PR TITLE
Modify SLM execute lifecycle to use POST method as opposed to PUT.

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Generator/ApiEndpointFactory.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/ApiEndpointFactory.cs
@@ -94,8 +94,13 @@ namespace ApiGenerator.Generator
 
 			if (pathsOverride != null) original.SelectToken("*.url.paths").Replace(pathsOverride);
 
-			var paramsOverride = patchedJson.SelectToken("*.params");
+			var methodsOverride = patchedJson.SelectToken("*.methods");
+			if (methodsOverride != null)
+			{
+				original.SelectToken("*.methods").Replace(methodsOverride);
+			}
 
+			var paramsOverride = patchedJson.SelectToken("*.params");
 			var originalParams = original.SelectToken("*.url.params") as JObject;
 			originalParams?.Merge(paramsOverride, new JsonMergeSettings
 			{

--- a/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/slm.execute_lifecycle.json
+++ b/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/slm.execute_lifecycle.json
@@ -9,7 +9,7 @@
         {
           "path":"/_slm/policy/{policy_id}/_execute",
           "methods":[
-            "POST","PUT"
+            "PUT"
           ],
           "parts":{
             "policy_id":{

--- a/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/slm.execute_lifecycle.json
+++ b/src/CodeGeneration/ApiGenerator/RestSpecification/XPack/slm.execute_lifecycle.json
@@ -9,7 +9,7 @@
         {
           "path":"/_slm/policy/{policy_id}/_execute",
           "methods":[
-            "PUT"
+            "POST","PUT"
           ],
           "parts":{
             "policy_id":{

--- a/src/CodeGeneration/ApiGenerator/RestSpecification/_Patches/slm.execute_lifecycle.patch.json
+++ b/src/CodeGeneration/ApiGenerator/RestSpecification/_Patches/slm.execute_lifecycle.patch.json
@@ -1,0 +1,7 @@
+{
+  "slm.execute_lifecycle": {
+    "methods": [
+      "POST", "PUT"
+    ]
+  }
+}

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.SnapshotLifecycleManagement.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.SnapshotLifecycleManagement.cs
@@ -33,7 +33,7 @@ namespace Elasticsearch.Net.Specification.SnapshotLifecycleManagementApi
 	///<summary>Request options for ExecuteSnapshotLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</para></summary>
 	public class ExecuteSnapshotLifecycleRequestParameters : RequestParameters<ExecuteSnapshotLifecycleRequestParameters>
 	{
-		public override HttpMethod DefaultHttpMethod => HttpMethod.PUT;
+		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
 	}
 
 	///<summary>Request options for GetSnapshotLifecycle <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html</para></summary>

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.SnapshotLifecycleManagement.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.SnapshotLifecycleManagement.cs
@@ -54,17 +54,17 @@ namespace Elasticsearch.Net.Specification.SnapshotLifecycleManagementApi
 		[MapsApi("slm.delete_lifecycle", "policy_id")]
 		public Task<TResponse> DeleteSnapshotLifecycleAsync<TResponse>(string policyId, DeleteSnapshotLifecycleRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(DELETE, Url($"_slm/policy/{policyId:policyId}"), ctx, null, RequestParams(requestParameters));
-		///<summary>PUT on /_slm/policy/{policy_id}/_execute <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</para></summary>
+		///<summary>POST on /_slm/policy/{policy_id}/_execute <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</para></summary>
 		///<param name = "policyId">The id of the snapshot lifecycle policy to be executed</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse ExecuteSnapshotLifecycle<TResponse>(string policyId, ExecuteSnapshotLifecycleRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(PUT, Url($"_slm/policy/{policyId:policyId}/_execute"), null, RequestParams(requestParameters));
-		///<summary>PUT on /_slm/policy/{policy_id}/_execute <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, Url($"_slm/policy/{policyId:policyId}/_execute"), null, RequestParams(requestParameters));
+		///<summary>POST on /_slm/policy/{policy_id}/_execute <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</para></summary>
 		///<param name = "policyId">The id of the snapshot lifecycle policy to be executed</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("slm.execute_lifecycle", "policy_id")]
 		public Task<TResponse> ExecuteSnapshotLifecycleAsync<TResponse>(string policyId, ExecuteSnapshotLifecycleRequestParameters requestParameters = null, CancellationToken ctx = default)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"_slm/policy/{policyId:policyId}/_execute"), ctx, null, RequestParams(requestParameters));
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"_slm/policy/{policyId:policyId}/_execute"), ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_slm/policy/{policy_id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-get.html</para></summary>
 		///<param name = "policyId">Comma-separated list of snapshot lifecycle policies to retrieve</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>

--- a/src/Nest/ElasticClient.SnapshotLifecycleManagement.cs
+++ b/src/Nest/ElasticClient.SnapshotLifecycleManagement.cs
@@ -61,25 +61,25 @@ namespace Nest.Specification.SnapshotLifecycleManagementApi
 		/// </summary>
 		public Task<DeleteSnapshotLifecycleResponse> DeleteSnapshotLifecycleAsync(IDeleteSnapshotLifecycleRequest request, CancellationToken ct = default) => DoRequestAsync<IDeleteSnapshotLifecycleRequest, DeleteSnapshotLifecycleResponse>(request, request.RequestParameters, ct);
 		/// <summary>
-		/// <c>PUT</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</a>
 		/// </summary>
 		public ExecuteSnapshotLifecycleResponse ExecuteSnapshotLifecycle(Id policyId, Func<ExecuteSnapshotLifecycleDescriptor, IExecuteSnapshotLifecycleRequest> selector = null) => ExecuteSnapshotLifecycle(selector.InvokeOrDefault(new ExecuteSnapshotLifecycleDescriptor(policyId: policyId)));
 		/// <summary>
-		/// <c>PUT</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</a>
 		/// </summary>
 		public Task<ExecuteSnapshotLifecycleResponse> ExecuteSnapshotLifecycleAsync(Id policyId, Func<ExecuteSnapshotLifecycleDescriptor, IExecuteSnapshotLifecycleRequest> selector = null, CancellationToken ct = default) => ExecuteSnapshotLifecycleAsync(selector.InvokeOrDefault(new ExecuteSnapshotLifecycleDescriptor(policyId: policyId)), ct);
 		/// <summary>
-		/// <c>PUT</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</a>
 		/// </summary>
 		public ExecuteSnapshotLifecycleResponse ExecuteSnapshotLifecycle(IExecuteSnapshotLifecycleRequest request) => DoRequest<IExecuteSnapshotLifecycleRequest, ExecuteSnapshotLifecycleResponse>(request, request.RequestParameters);
 		/// <summary>
-		/// <c>PUT</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
+		/// <c>POST</c> request to the <c>slm.execute_lifecycle</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/slm-api-execute.html</a>
 		/// </summary>

--- a/src/Tests/Tests/XPack/Slm/ExecuteLifecycle/ExecuteLifecycleUrlTests.cs
+++ b/src/Tests/Tests/XPack/Slm/ExecuteLifecycle/ExecuteLifecycleUrlTests.cs
@@ -9,7 +9,7 @@ namespace Tests.XPack.Slm.ExecuteLifecycle
 	public class ExecuteLifecycleUrlTests : UrlTestsBase
 	{
 		[U] public override async Task Urls() =>
-			await PUT("/_slm/policy/policy_id/_execute")
+			await POST("/_slm/policy/policy_id/_execute")
 				.Fluent(c => c.SnapshotLifecycleManagement.ExecuteSnapshotLifecycle("policy_id"))
 				.Request(c => c.SnapshotLifecycleManagement.ExecuteSnapshotLifecycle(new ExecuteSnapshotLifecycleRequest("policy_id")))
 				.FluentAsync(c => c.SnapshotLifecycleManagement.ExecuteSnapshotLifecycleAsync("policy_id"))


### PR DESCRIPTION
Local patch for implementation in https://github.com/elastic/elasticsearch/pull/47061 and subsequent PR https://github.com/elastic/elasticsearch/pull/49233