### PR TITLE
Add updateable property to Synonym token filters

### DIFF
--- a/src/Nest/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/Synonym/SynonymGraphTokenFilter.cs
@@ -33,6 +33,18 @@ namespace Nest
 
 		[DataMember(Name ="tokenizer")]
 		string Tokenizer { get; set; }
+
+		/// <summary>
+		/// Whether this token filter can reload changes to synonym files
+		/// on demand.
+		/// Marking as updateable means this component is only usable at search time
+		/// </summary>
+		/// <remarks>
+		/// Supported in Elasticsearch 7.3.0+
+		/// </remarks>
+		[DataMember(Name = "updateable")]
+		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
+		bool? Updateable { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -57,6 +69,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public string Tokenizer { get; set; }
+
+		/// <inheritdoc />
+		public bool? Updateable { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -66,33 +81,34 @@ namespace Nest
 		protected override string Type => "synonym_graph";
 		bool? ISynonymGraphTokenFilter.Expand { get; set; }
 		SynonymFormat? ISynonymGraphTokenFilter.Format { get; set; }
-
 		bool? ISynonymGraphTokenFilter.Lenient { get; set; }
-
 		IEnumerable<string> ISynonymGraphTokenFilter.Synonyms { get; set; }
 		string ISynonymGraphTokenFilter.SynonymsPath { get; set; }
 		string ISynonymGraphTokenFilter.Tokenizer { get; set; }
+		bool? ISynonymGraphTokenFilter.Updateable { get; set; }
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Expand"/>
 		public SynonymGraphTokenFilterDescriptor Expand(bool? expand = true) => Assign(expand, (a, v) => a.Expand = v);
 
-		/// <inheritdoc cref="ISynonymTokenFilter.Lenient" />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Lenient" />
 		public SynonymGraphTokenFilterDescriptor Lenient(bool? lenient = true) => Assign(lenient, (a, v) => a.Lenient = v);
 
-
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Tokenizer"/>
 		public SynonymGraphTokenFilterDescriptor Tokenizer(string tokenizer) => Assign(tokenizer, (a, v) => a.Tokenizer = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.SynonymsPath"/>
 		public SynonymGraphTokenFilterDescriptor SynonymsPath(string path) => Assign(path, (a, v) => a.SynonymsPath = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Format"/>
 		public SynonymGraphTokenFilterDescriptor Format(SynonymFormat? format) => Assign(format, (a, v) => a.Format = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Synonyms"/>
 		public SynonymGraphTokenFilterDescriptor Synonyms(IEnumerable<string> synonymGraphs) => Assign(synonymGraphs, (a, v) => a.Synonyms = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Synonyms"/>
 		public SynonymGraphTokenFilterDescriptor Synonyms(params string[] synonymGraphs) => Assign(synonymGraphs, (a, v) => a.Synonyms = v);
+
+		/// <inheritdoc cref="ISynonymGraphTokenFilter.Updateable"/>
+		public SynonymGraphTokenFilterDescriptor Updateable(bool? updateable = true) => Assign(updateable, (a, v) => a.Updateable = v);
 	}
 }

--- a/src/Nest/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/Synonym/SynonymTokenFilter.cs
@@ -35,6 +35,18 @@ namespace Nest
 
 		[DataMember(Name ="tokenizer")]
 		string Tokenizer { get; set; }
+
+		/// <summary>
+		/// Whether this token filter can reload changes to synonym files
+		/// on demand.
+		/// Marking as updateable means this component is only usable at search time
+		/// </summary>
+		/// <remarks>
+		/// Supported in Elasticsearch 7.3.0+
+		/// </remarks>
+		[DataMember(Name = "updateable")]
+		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
+		bool? Updateable { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -59,6 +71,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public string Tokenizer { get; set; }
+
+		/// <inheritdoc />
+		public bool? Updateable { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -72,26 +87,30 @@ namespace Nest
 		IEnumerable<string> ISynonymTokenFilter.Synonyms { get; set; }
 		string ISynonymTokenFilter.SynonymsPath { get; set; }
 		string ISynonymTokenFilter.Tokenizer { get; set; }
+		bool? ISynonymTokenFilter.Updateable { get; set; }
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.Expand"/>
 		public SynonymTokenFilterDescriptor Expand(bool? expand = true) => Assign(expand, (a, v) => a.Expand = v);
 
 		/// <inheritdoc cref="ISynonymTokenFilter.Lenient" />
 		public SynonymTokenFilterDescriptor Lenient(bool? lenient = true) => Assign(lenient, (a, v) => a.Lenient = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.Tokenizer"/>
 		public SynonymTokenFilterDescriptor Tokenizer(string tokenizer) => Assign(tokenizer, (a, v) => a.Tokenizer = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.SynonymsPath"/>
 		public SynonymTokenFilterDescriptor SynonymsPath(string path) => Assign(path, (a, v) => a.SynonymsPath = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.Format"/>
 		public SynonymTokenFilterDescriptor Format(SynonymFormat? format) => Assign(format, (a, v) => a.Format = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.Synonyms"/>
 		public SynonymTokenFilterDescriptor Synonyms(IEnumerable<string> synonyms) => Assign(synonyms, (a, v) => a.Synonyms = v);
 
-		/// <inheritdoc />
+		/// <inheritdoc cref="ISynonymTokenFilter.Synonyms"/>
 		public SynonymTokenFilterDescriptor Synonyms(params string[] synonyms) => Assign(synonyms, (a, v) => a.Synonyms = v);
+
+		/// <inheritdoc cref="ISynonymTokenFilter.Updateable"/>
+		public SynonymTokenFilterDescriptor Updateable(bool? updateable = true) => Assign(updateable, (a, v) => a.Updateable = v);
 	}
 }

--- a/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
+++ b/src/Tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
@@ -689,7 +689,7 @@ namespace Tests.Analysis.TokenFilters
 		}
 
 		[SkipVersion("<6.4.0", "Lenient is an option introduced in 6.4.0")]
-		public class SynonymLenientTests : TokenFilterAssertionBase<SynonymTests>
+		public class SynonymLenientTests : TokenFilterAssertionBase<SynonymLenientTests>
 		{
 			private readonly string[] _synonyms = { "foo", "bar => baz" };
 
@@ -714,6 +714,32 @@ namespace Tests.Analysis.TokenFilters
 			};
 
 			public override string Name => "syn_lenient";
+		}
+
+		[SkipVersion("<7.3.0", "updateable introduced in 7.3.0")]
+		public class SynonymUpdateableTests : TokenFilterAssertionBase<SynonymTests>
+		{
+			public override FuncTokenFilters Fluent => (n, tf) => tf
+				.Synonym(n, t => t
+					.SynonymsPath("analysis/stopwords.txt")
+					.Updateable()
+				);
+
+			public override ITokenFilter Initializer =>
+				new SynonymTokenFilter
+				{
+					SynonymsPath = "analysis/stopwords.txt",
+					Updateable = true
+				};
+
+			public override object Json => new
+			{
+				type = "synonym",
+				synonyms_path = "analysis/stopwords.txt",
+				updateable = true
+			};
+
+			public override string Name => "syn_updateable";
 		}
 
 		public class SynonymGraphTests : TokenFilterAssertionBase<SynonymGraphTests>
@@ -748,6 +774,32 @@ namespace Tests.Analysis.TokenFilters
 			};
 
 			public override string Name => "syn_graph";
+		}
+
+		[SkipVersion("<7.3.0", "updateable introduced in 7.3.0")]
+		public class SynonymGraphUpdateableTests : TokenFilterAssertionBase<SynonymGraphUpdateableTests>
+		{
+			public override FuncTokenFilters Fluent => (n, tf) => tf
+				.SynonymGraph(n, t => t
+					.SynonymsPath("analysis/stopwords.txt")
+					.Updateable()
+				);
+
+			public override ITokenFilter Initializer =>
+				new SynonymGraphTokenFilter
+				{
+					SynonymsPath = "analysis/stopwords.txt",
+					Updateable = true
+				};
+
+			public override object Json => new
+			{
+				type = "synonym_graph",
+				synonyms_path = "analysis/stopwords.txt",
+				updateable = true,
+			};
+
+			public override string Name => "syn_graph_updateable";
 		}
 
 		public class TrimTests : TokenFilterAssertionBase<TrimTests>


### PR DESCRIPTION
This commit adds the updateable property to the Synonym and
SynonymGraph token filters.

Closes #4252