### PR TITLE
Add Search as you type to dynamic templates

### DIFF
--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -319,5 +319,9 @@ namespace Nest
 		public IProperty Scalar(Expression<Func<T, IpAddressRange>> field, Func<IpRangePropertyDescriptor<T>, IIpRangeProperty> selector = null) =>
 			selector.InvokeOrDefault(new IpRangePropertyDescriptor<T>().Name(field));
 #pragma warning restore CS3001 // Argument type is not CLS-compliant
+
+		/// <inheritdoc cref="ISearchAsYouTypeProperty"/>
+		public IProperty SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector) =>
+			selector?.Invoke(new SearchAsYouTypePropertyDescriptor<T>());
 	}
 }

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -158,6 +158,7 @@ namespace Nest
 
 		public PropertiesDescriptor<T> Text(Func<TextPropertyDescriptor<T>, ITextProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="ISearchAsYouTypeProperty"/>
 		public PropertiesDescriptor<T> SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector) => SetProperty(selector);
 
 		public PropertiesDescriptor<T> TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector) => SetProperty(selector);

--- a/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeSingleMappingPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Core/SearchAsYouType/SearchAsYouTypeSingleMappingPropertyTests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Core.SearchAsYouType
+{
+	[SkipVersion("<7.2.0", "Implemented in 7.2.0")]
+	public class SearchAsYouTypeSingleMappingPropertyTests : SingleMappingPropertyTestsBase
+	{
+		public SearchAsYouTypeSingleMappingPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object SingleMappingJson => new
+		{
+			max_shingle_size = 4,
+			type = "search_as_you_type",
+			analyzer = "standard",
+			copy_to = new[] { "other_field" },
+			index = true,
+			index_options = "offsets",
+			search_analyzer = "standard",
+			search_quote_analyzer = "standard",
+			similarity = "BM25",
+			store = true,
+			norms = false,
+			term_vector = "with_positions_offsets"
+		};
+
+		protected override Func<SingleMappingSelector<object>, IProperty> FluentSingleMapping => f => f
+			.SearchAsYouType(s => s
+				.MaxShingleSize(4)
+				.Analyzer("standard")
+				.CopyTo(c => c
+					.Field("other_field")
+				)
+				.Index()
+				.IndexOptions(IndexOptions.Offsets)
+				.SearchAnalyzer("standard")
+				.SearchQuoteAnalyzer("standard")
+				.Similarity("BM25")
+				.Store()
+				.Norms(false)
+				.TermVector(TermVectorOption.WithPositionsOffsets)
+			);
+
+
+		protected override IProperty InitializerSingleMapping =>
+			new SearchAsYouTypeProperty
+			{
+				MaxShingleSize = 4,
+				Analyzer = "standard",
+				CopyTo = "other_field",
+				Index = true,
+				IndexOptions = IndexOptions.Offsets,
+				SearchAnalyzer = "standard",
+				SearchQuoteAnalyzer = "standard",
+				Similarity = "BM25",
+				Store = true,
+				Norms = false,
+				TermVector = TermVectorOption.WithPositionsOffsets
+			};
+	}
+}

--- a/src/Tests/Tests/Mapping/Types/SingleMappingPropertyTestsBase.cs
+++ b/src/Tests/Tests/Mapping/Types/SingleMappingPropertyTestsBase.cs
@@ -9,10 +9,10 @@ using Tests.Framework.EndpointTests.TestState;
 namespace Tests.Mapping.Types
 {
 	public abstract class SingleMappingPropertyTestsBase
-		: ApiIntegrationTestBase<ReadOnlyCluster, PutIndexTemplateResponse, IPutIndexTemplateRequest, PutIndexTemplateDescriptor,
+		: ApiIntegrationTestBase<WritableCluster, PutIndexTemplateResponse, IPutIndexTemplateRequest, PutIndexTemplateDescriptor,
 			PutIndexTemplateRequest>
 	{
-		protected SingleMappingPropertyTestsBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		protected SingleMappingPropertyTestsBase(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override bool ExpectIsValid => true;
 

--- a/src/Tests/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
+++ b/src/Tests/Tests/Mapping/Types/Specialized/Generic/GenericPropertyTests.cs
@@ -9,7 +9,7 @@ namespace Tests.Mapping.Types.Specialized.Generic
 	{
 		private const string GenericType = "{dynamic_type}";
 
-		public GenericPropertyTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public GenericPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override Func<SingleMappingSelector<object>, IProperty> FluentSingleMapping => m => m
 			.Generic(g => g


### PR DESCRIPTION
This commit adds Search as you type property configuration to dynamic templates.
Update SingleMappingPropertyTestsBase  to use Writable cluster as it creates a
new index template.

Closes #4249