### PR TITLE
Fix Elasticsearch.Net.VirtualCluster lower bound version reference

### DIFF
--- a/build/Elasticsearch.Net.VirtualizedCluster.nuspec
+++ b/build/Elasticsearch.Net.VirtualizedCluster.nuspec
@@ -18,10 +18,10 @@
 		<repository type="git" url="https://github.com/elastic/elasticsearch-net.git" branch="$branch$" commit="$commit$" />
 		<dependencies>
 			<group targetFramework=".NETStandard2.0">
-				<dependency id="Elasticsearch.Net" version="[$currentMajorVersion$, $nextMajorVersion$)" />
+				<dependency id="Elasticsearch.Net" version="[$version$, $nextMajorVersion$)" />
 			</group>
 			<group targetFramework="net461">
-				<dependency id="Elasticsearch.Net" version="[$currentMajorVersion$, $nextMajorVersion$)" />
+				<dependency id="Elasticsearch.Net" version="[$version$, $nextMajorVersion$)" />
 			</group>
 		</dependencies>
 	</metadata>


### PR DESCRIPTION
nuspec should use version as lower end so that prereleases can refere…nce it