### PR TITLE
Support MemberExpression and specific MethodCallExpression

### DIFF
--- a/src/Nest/CommonAbstractions/Infer/Field/Field.cs
+++ b/src/Nest/CommonAbstractions/Infer/Field/Field.cs
@@ -56,6 +56,7 @@ namespace Nest
 		/// </remarks>
 		public string Format { get; set; }
 
+		// TODO: Rename to CacheableExpression in 8.0.0
 		public bool CachableExpression { get; }
 
 		/// <summary>

--- a/src/Tests/Tests/Tests.csproj
+++ b/src/Tests/Tests/Tests.csproj
@@ -16,6 +16,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
+    <PackageReference Include="FSharp.Core" Version="4.7.0" />
       
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
     <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />


### PR DESCRIPTION
This commit adds support for MemberExpression and specific MethodCallExpression
as Expressions that can be passed to Field and PropertyName, in order to resolve
a string value from the expression.

The specific MethodCallExpression support is to allow F# quotations enclosing
Lambda expressions to be supported, when converted using

Microsoft.FSharp.Linq.RuntimeHelpers.LeafExpressionConverter.QuotationToExpression

Fixes #4240