### PR TITLE
Set Accept header when format set on Cat APIs

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Domain/Specification/QueryParameters.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/Specification/QueryParameters.cs
@@ -128,7 +128,7 @@ namespace ApiGenerator.Domain.Specification
 		}
 
 
-		public string InitializerGenerator(string type, string name, string key, string setter, params string[] doc) =>
-			CodeGenerator.Property(type, name, key, setter, Obsolete, doc);
+		public string InitializerGenerator(string @namespace, string type, string name, string key, string setter, params string[] doc) =>
+			CodeGenerator.Property(@namespace, type, name, key, setter, Obsolete, doc);
 	}
 }

--- a/src/CodeGeneration/ApiGenerator/Generator/CodeGenerator.cs
+++ b/src/CodeGeneration/ApiGenerator/Generator/CodeGenerator.cs
@@ -12,13 +12,7 @@ namespace ApiGenerator.Generator
 		public static string CatFormatPropertyGenerator(string type, string name, string key, string setter) =>
 			  $"public {type} {name} {{ "
 			+ $"	get => Q<{type}>(\"{key}\");"
-			+ $"	set {{ "
-			+ $"		Q(\"{key}\", {setter});"
-			+ $"		if (RequestConfiguration == null) "
-			+ $"			RequestConfiguration = new RequestConfiguration();"
-			+ $""
-			+ $"		RequestConfiguration.Accept = AcceptHeaderFromFormat({setter});"
-			+ $"	}}"
+			+ $"	set {{ Q(\"{key}\", {setter}); SetAcceptHeader({setter}); }}"
 			+ $"}}";
 
 		public static string PropertyGenerator(string type, string name, string key, string setter) =>

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/PlainRequestBase.cshtml
@@ -26,7 +26,7 @@ namespace Nest
 	{
 @foreach (var common in RestApiSpec.CommonApiQueryParameters.Values)
 {
-<text>		@Raw(common.InitializerGenerator(common.TypeHighLevel, common.ClsName, common.QueryStringKey, "value", common.DescriptionHighLevel.ToArray()))
+<text>		@Raw(common.InitializerGenerator(null, common.TypeHighLevel, common.ClsName, common.QueryStringKey, "value", common.DescriptionHighLevel.ToArray()))
 </text>
 }
 	}

--- a/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/HighLevel/Requests/RequestImplementations.cshtml
@@ -64,7 +64,7 @@
 		continue;
 	}
 	var doc = param.DescriptionHighLevel.ToArray();
-<text>		@Raw(param.InitializerGenerator(param.TypeHighLevel, param.ClsName, original, param.SetterHighLevel, doc))
+<text>		@Raw(param.InitializerGenerator(r.CsharpNames.Namespace, param.TypeHighLevel, param.ClsName, original, param.SetterHighLevel, doc))
 </text>
 }
 @if (names.DescriptorNotFoundInCodebase)

--- a/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
+++ b/src/CodeGeneration/ApiGenerator/Views/LowLevel/RequestParameters/RequestParameters.cshtml
@@ -35,7 +35,7 @@ namespace Elasticsearch.Net@(ns)
 		public override HttpMethod DefaultHttpMethod => HttpMethod.@r.HttpMethod;
 		@foreach (var param in r.Params)
 		{
-<text>		@Raw(param.InitializerGenerator(param.TypeLowLevel, param.ClsName, param.QueryStringKey, param.SetterLowLevel, param.Description))
+<text>		@Raw(param.InitializerGenerator(r.CsharpNames.Namespace, param.TypeLowLevel, param.ClsName, param.QueryStringKey, param.SetterLowLevel, param.Description))
 </text>
 		}
 	}</text>

--- a/src/Elasticsearch.Net/Api/RequestParameters/IRequestParameters.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/IRequestParameters.cs
@@ -38,5 +38,11 @@ namespace Elasticsearch.Net
 		/// Gets the stringified representation of a query string value as it would be sent to Elasticsearch.
 		/// </summary>
 		string GetResolvedQueryStringValue(string n, IConnectionConfigurationValues s);
+
+		/// <summary>
+		/// Gets the HTTP Accept Header value from the shortened name. If the shortened name is not recognized,
+		/// <c>null</c> is returned.
+		/// </summary>
+		string AcceptHeaderFromFormat(string format);
 	}
 }

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -35,9 +35,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -95,9 +93,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -155,9 +151,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -222,9 +216,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -282,9 +274,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -368,9 +358,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -449,9 +437,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -509,9 +495,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -569,9 +553,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -636,9 +618,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -696,9 +676,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -770,9 +748,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -830,9 +806,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -890,9 +864,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -936,9 +908,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -996,9 +966,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1070,9 +1038,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1133,9 +1099,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1193,9 +1157,7 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -32,7 +32,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -86,7 +92,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -140,7 +152,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -201,7 +219,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -255,7 +279,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -335,7 +365,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -410,7 +446,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -464,7 +506,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -518,7 +566,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Return the full node ID instead of the shortened version (default: false)</summary>
@@ -579,7 +633,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -633,7 +693,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -701,7 +767,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -755,7 +827,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -809,7 +887,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -849,7 +933,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -903,7 +993,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -971,7 +1067,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1028,7 +1130,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1082,7 +1190,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.cs
@@ -27,11 +27,11 @@ namespace Elasticsearch.Net
 		public TOut GetQueryStringValue<TOut>(string name)
 		{
 			if (!ContainsQueryString(name))
-				return default(TOut);
+				return default;
 
 			var value = Self.QueryString[name];
 			if (value == null)
-				return default(TOut);
+				return default;
 
 			return (TOut)value;
 		}
@@ -59,6 +59,15 @@ namespace Elasticsearch.Net
 			Self.QueryString.Remove(name);
 		}
 
+		protected void SetAcceptHeader(string format)
+		{
+			if (RequestConfiguration == null)
+				RequestConfiguration = new RequestConfiguration();
+
+			RequestConfiguration.Accept = AcceptHeaderFromFormat(format);
+		}
+
+		/// <inheritdoc />
 		public string AcceptHeaderFromFormat(string format)
 		{
 			if (format == null)

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.cs
@@ -58,5 +58,24 @@ namespace Elasticsearch.Net
 
 			Self.QueryString.Remove(name);
 		}
+
+		public string AcceptHeaderFromFormat(string format)
+		{
+			if (format == null)
+				return null;
+
+			var lowerFormat = format.ToLowerInvariant();
+
+			switch(lowerFormat)
+			{
+				case "smile":
+				case "yaml":
+				case "cbor":
+				case "json":
+					return $"application/{lowerFormat}";
+				default:
+					return null;
+			}
+		}
 	}
 }

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -115,6 +115,7 @@ namespace Elasticsearch.Net
 		public string ProxyAddress { get; }
 		public SecureString ProxyPassword { get; }
 		public string ProxyUsername { get; }
+		// TODO: rename to ContentType in 8.0.0
 		public string RequestMimeType { get; }
 		public TimeSpan RequestTimeout { get; }
 		public string RunAs { get; }

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -67,7 +67,7 @@ namespace Elasticsearch.Net
 						.StatusCodeToResponseSuccess(requestData.Method, statusCode.Value);
 			}
 			//mimeType can include charset information on .NET full framework
-			if (!string.IsNullOrEmpty(mimeType) && !mimeType.StartsWith(requestData.RequestMimeType))
+			if (!string.IsNullOrEmpty(mimeType) && !mimeType.StartsWith(requestData.Accept))
 				success = false;
 
 			var details = new ApiCallDetails
@@ -110,7 +110,7 @@ namespace Elasticsearch.Net
 				if (requestData.CustomResponseBuilder != null)
 					return requestData.CustomResponseBuilder.DeserializeResponse(serializer, details, responseStream) as TResponse;
 
-				return mimeType == null || !mimeType.StartsWith(requestData.RequestMimeType, StringComparison.Ordinal)
+				return mimeType == null || !mimeType.StartsWith(requestData.Accept, StringComparison.Ordinal)
 					? null
 					: serializer.Deserialize<TResponse>(responseStream);
 			}
@@ -142,7 +142,7 @@ namespace Elasticsearch.Net
 				if (requestData.CustomResponseBuilder != null)
 					return await requestData.CustomResponseBuilder.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken).ConfigureAwait(false) as TResponse;
 
-				return mimeType == null || !mimeType.StartsWith(requestData.RequestMimeType, StringComparison.Ordinal)
+				return mimeType == null || !mimeType.StartsWith(requestData.Accept, StringComparison.Ordinal)
 					? null
 					: await serializer
 						.DeserializeAsync<TResponse>(responseStream, cancellationToken)

--- a/src/Nest/CommonAbstractions/Request/RequestBase.cs
+++ b/src/Nest/CommonAbstractions/Request/RequestBase.cs
@@ -88,8 +88,13 @@ namespace Nest
 
 		protected void Q(string name, object value) => RequestState.RequestParameters.SetQueryString(name, value);
 
-		protected string AcceptHeaderFromFormat(string format) =>
-			RequestState.RequestParameters.AcceptHeaderFromFormat(format);
+		protected void SetAcceptHeader(string format)
+		{
+			if (RequestState.RequestParameters.RequestConfiguration == null)
+				RequestState.RequestParameters.RequestConfiguration = new RequestConfiguration();
+
+			RequestState.RequestParameters.RequestConfiguration.Accept = RequestState.RequestParameters.AcceptHeaderFromFormat(format);
+		}
 	}
 
 	public abstract partial class PlainRequestBase<TParameters> : RequestBase<TParameters>

--- a/src/Nest/CommonAbstractions/Request/RequestBase.cs
+++ b/src/Nest/CommonAbstractions/Request/RequestBase.cs
@@ -87,6 +87,9 @@ namespace Nest
 		protected TOut Q<TOut>(string name) => RequestState.RequestParameters.GetQueryStringValue<TOut>(name);
 
 		protected void Q(string name, object value) => RequestState.RequestParameters.SetQueryString(name, value);
+
+		protected string AcceptHeaderFromFormat(string format) =>
+			RequestState.RequestParameters.AcceptHeaderFromFormat(format);
 	}
 
 	public abstract partial class PlainRequestBase<TParameters> : RequestBase<TParameters>

--- a/src/Nest/Requests.Cat.cs
+++ b/src/Nest/Requests.Cat.cs
@@ -65,7 +65,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -145,7 +151,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -225,7 +237,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -305,7 +323,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -367,7 +391,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -481,7 +511,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -564,7 +600,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -626,7 +668,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -688,7 +736,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Return the full node ID instead of the shortened version (default: false)</summary>
@@ -757,7 +811,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -819,7 +879,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -913,7 +979,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -968,7 +1040,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1048,7 +1126,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1114,7 +1198,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1194,7 +1284,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1270,7 +1366,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1353,7 +1455,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>
@@ -1433,7 +1541,13 @@ namespace Nest
 		public string Format
 		{
 			get => Q<string>("format");
-			set => Q("format", value);
+			set
+			{
+				Q("format", value);
+				if (RequestConfiguration == null)
+					RequestConfiguration = new RequestConfiguration();
+				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+			}
 		}
 
 		///<summary>Comma-separated list of column names to display</summary>

--- a/src/Nest/Requests.Cat.cs
+++ b/src/Nest/Requests.Cat.cs
@@ -68,9 +68,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -154,9 +152,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -240,9 +236,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -326,9 +320,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -394,9 +386,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -514,9 +504,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -603,9 +591,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -671,9 +657,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -739,9 +723,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -814,9 +796,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -882,9 +862,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -982,9 +960,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1043,9 +1019,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1129,9 +1103,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1201,9 +1173,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1287,9 +1257,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1369,9 +1337,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1458,9 +1424,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 
@@ -1544,9 +1508,7 @@ namespace Nest
 			set
 			{
 				Q("format", value);
-				if (RequestConfiguration == null)
-					RequestConfiguration = new RequestConfiguration();
-				RequestConfiguration.Accept = AcceptHeaderFromFormat(value);
+				SetAcceptHeader(value);
 			}
 		}
 

--- a/src/Tests/Tests.Reproduce/GithubIssue3907.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue3907.cs
@@ -8,7 +8,7 @@ using Tests.Domain;
 
 namespace Tests.Reproduce
 {
-	public class GithubIssue3907 : IClusterFixture<ReadOnlyCluster>
+	public class GithubIssue3907 : IClusterFixture<IntrusiveOperationCluster>
 	{
 		private readonly IntrusiveOperationCluster _cluster;
 

--- a/src/Tests/Tests.Reproduce/GithubIssue4243.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue4243.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using Elasticsearch.Net.Specification.CatApi;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4243 : IClusterFixture<ReadOnlyCluster>
+	{
+		private readonly ReadOnlyCluster _cluster;
+
+		// use intrusive operation cluster because we're changing the underlying http handler
+		// and this cluster runs with a max concurrency of 1, so changing http handler
+		// will not affect other integration tests
+		public GithubIssue4243(ReadOnlyCluster cluster) => _cluster = cluster;
+
+		[I]
+		public async Task UsingFormatJsonIsSuccessfulResponse()
+		{
+			var connectionConfiguration = new ConnectionConfiguration(_cluster.Client.ConnectionSettings.ConnectionPool);
+			var lowLevelClient = new ElasticLowLevelClient(connectionConfiguration);
+			var response = await lowLevelClient.Cat.MasterAsync<StringResponse>(new CatMasterRequestParameters { Format = "JSON" });
+
+			response.Success.Should().BeTrue();
+			response.ApiCall.HttpStatusCode.Should().Be(200);
+			response.OriginalException.Should().BeNull();
+		}
+	}
+}

--- a/src/Tests/Tests.Reproduce/GithubIssue4243.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue4243.cs
@@ -16,9 +16,6 @@ namespace Tests.Reproduce
 	{
 		private readonly ReadOnlyCluster _cluster;
 
-		// use intrusive operation cluster because we're changing the underlying http handler
-		// and this cluster runs with a max concurrency of 1, so changing http handler
-		// will not affect other integration tests
 		public GithubIssue4243(ReadOnlyCluster cluster) => _cluster = cluster;
 
 		[I]

--- a/src/Tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
+++ b/src/Tests/Tests/Cat/CatIndices/CatIndicesApiTests.cs
@@ -20,8 +20,8 @@ namespace Tests.Cat.CatIndices
 		protected override string UrlPath => "/_cat/indices";
 
 		protected override LazyResponses ClientUsage() => Calls(
-			(client, f) => client.Cat.Indices(),
-			(client, f) => client.Cat.IndicesAsync(),
+			(client, f) => client.Cat.Indices(f),
+			(client, f) => client.Cat.IndicesAsync(f),
 			(client, r) => client.Cat.Indices(r),
 			(client, r) => client.Cat.IndicesAsync(r)
 		);


### PR DESCRIPTION
This commit updates the ApiGenerator to set the Accept HTTP header when the format
header is specified. To determine whether an API call is successful, the Content-Type header
of the response is checked against the Accept header of the request.

The format parameter only really makes sense for the low level client and associated
ElasticsearchResponse<T> types, as the high level client always expects to deserialize
from JSON; any other format will result in an exception at deserialization.

Fixes #4243