### PR TITLE
Add support to retrieve all API keys if user has privilege.

### DIFF
--- a/src/Tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
@@ -25,6 +25,8 @@ namespace Tests.Framework.EndpointTests
 		protected async Task Assert<TResponse>(string name, Action<TResponse> assert)
 			where TResponse : class, IResponse
 		{
+			if (_coordinatedUsage.Skips(name)) return;
+
 			var lazyResponses = await ExecuteOnceInOrderUntil(name);
 			if (lazyResponses == null) throw new Exception($"{name} is defined but it yields no LazyResponses object");
 

--- a/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
+++ b/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
@@ -17,6 +17,7 @@ namespace Tests.XPack.Security.ApiKey
 		private const string CreateApiKeyWithRolesStep = nameof(CreateApiKeyWithRolesStep);
 		private const string CreateApiKeyWithNoRolesStep = nameof(CreateApiKeyWithNoRolesStep);
 		private const string GetApiKeyStep = nameof(GetApiKeyStep);
+		private const string GetAllApiKeysStep = nameof(GetAllApiKeysStep);
 		private const string InvalidateApiKeyStep = nameof(InvalidateApiKeyStep);
 
 		public SecurityApiKeyTests(XPackCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage)
@@ -121,6 +122,25 @@ namespace Tests.XPack.Security.ApiKey
 					)
 			},
 			{
+				GetAllApiKeysStep, u =>
+					u.Calls<GetApiKeyDescriptor, GetApiKeyRequest, IGetApiKeyRequest, GetApiKeyResponse>(
+						v => new GetApiKeyRequest
+						{
+							RequestConfiguration = new RequestConfiguration
+							{
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}", "password")
+							}
+						},
+						(v, d) => d
+							.RequestConfiguration(r => r.BasicAuthentication($"user-{v}", "password"))
+						,
+						(v, c, f) => c.Security.GetApiKey(f),
+						(v, c, f) => c.Security.GetApiKeyAsync(f),
+						(v, c, r) => c.Security.GetApiKey(r),
+						(v, c, r) => c.Security.GetApiKeyAsync(r)
+					)
+			},
+			{
 				GetApiKeyStep, u =>
 					u.Calls<GetApiKeyDescriptor, GetApiKeyRequest, IGetApiKeyRequest, GetApiKeyResponse>(
 						v => new GetApiKeyRequest
@@ -171,6 +191,11 @@ namespace Tests.XPack.Security.ApiKey
 			r.Name.Should().NotBeNullOrEmpty();
 			r.Expiration.Should().NotBeNull();
 			r.ApiKey.Should().NotBeNullOrEmpty();
+		});
+
+		[I] public async Task SecurityGetAllApiKeysResponse() => await Assert<GetApiKeyResponse>(GetAllApiKeysStep, r =>
+		{
+			r.IsValid.Should().BeTrue();
 		});
 
 		[I] public async Task SecurityGetApiKeyResponse() => await Assert<GetApiKeyResponse>(GetApiKeyStep, r =>

--- a/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
+++ b/src/Tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
@@ -122,7 +122,8 @@ namespace Tests.XPack.Security.ApiKey
 					)
 			},
 			{
-				GetAllApiKeysStep, u =>
+				// This was fixed in 7.5.0
+				GetAllApiKeysStep, ">=7.5.0", u =>
 					u.Calls<GetApiKeyDescriptor, GetApiKeyRequest, IGetApiKeyRequest, GetApiKeyResponse>(
 						v => new GetApiKeyRequest
 						{


### PR DESCRIPTION
Test to assert server returns a response when no parameters are specified.

Implements https://github.com/elastic/elasticsearch/pull/47274