### PR TITLE
Add VotingOnly node role

### DIFF
--- a/src/Nest/Cluster/NodesInfo/NodeRole.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeRole.cs
@@ -19,6 +19,9 @@ namespace Nest
 		Ingest,
 
 		[EnumMember(Value = "ml")]
-		MachineLearning
+		MachineLearning,
+
+		[EnumMember(Value = "voting_only")]
+		VotingOnly,
 	}
 }


### PR DESCRIPTION
This commit adds the VotingOnly member to the NodeRole enum, in line
with

https://github.com/elastic/elasticsearch/blob/29f5c2d0ba0405680eb7dee806f9fa2c655932c7/x-pack/plugin/voting-only-node/src/main/java/org/elasticsearch/cluster/coordination/VotingOnlyNodePlugin.java#L63-L68

Fixes #4237