### PR TITLE
DateMath has ToString() value for DateTime.MinValue

### DIFF
--- a/src/Nest/CommonOptions/DateMath/DateMath.cs
+++ b/src/Nest/CommonOptions/DateMath/DateMath.cs
@@ -83,7 +83,7 @@ namespace Nest
 
 		internal static bool IsValidDateMathString(string dateMath) => dateMath != null && DateMathRegex.IsMatch(dateMath);
 
-		internal bool IsValid => Self.Anchor.Match(d => d != default, s => !s.IsNullOrEmpty());
+		internal bool IsValid => Self.Anchor.Match(_ => true, s => !s.IsNullOrEmpty());
 
 		public override string ToString()
 		{

--- a/src/Tests/Tests.Reproduce/GithubIssue4228.cs
+++ b/src/Tests/Tests.Reproduce/GithubIssue4228.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+using Tests.Core.Extensions;
+using Tests.Core.Serialization;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4228
+	{
+		[U]
+		public void CanSerializeDateMathDateTimeMinValue() {
+
+			var searchResponse = TestClient.DefaultInMemoryClient.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.DateRange(d => d
+						.GreaterThanOrEquals(DateTime.MinValue)
+						.Field("date")
+					)
+				)
+			);
+
+			Encoding.UTF8.GetString(searchResponse.ApiCall.RequestBodyInBytes)
+				.Should().Be("{\"query\":{\"range\":{\"date\":{\"gte\":\"0001-01-01T00:00:00\"}}}}");
+		}
+	}
+}

--- a/src/Tests/Tests/CommonOptions/DateMath/DateMathTests.cs
+++ b/src/Tests/Tests/CommonOptions/DateMath/DateMathTests.cs
@@ -23,14 +23,14 @@ namespace Tests.CommonOptions.DateMath
 		}
 
 		[U] // F# backticks would be great in C# :)
-		public void ImplicitConversionFromDefaultDateTimeIsNotNullButEmptyString()
+		public void ImplicitConversionFromDefaultDateTimeIsMinValue()
 		{
 			// in 6.x DateMath is backed by a DateTime instance
 			// for 7.x we will adress this
 			DateTime nullableDateTime = default;
 			Nest.DateMath dateMath = nullableDateTime;
 			dateMath.Should().NotBeNull();
-			dateMath.ToString().Should().BeEmpty();
+			dateMath.ToString().Should().Be("0001-01-01T00:00:00");
 		}
 
 		[U]


### PR DESCRIPTION
This commit updates the ToString() implementation of DateMath to emit a value
when DateTime.MinValue is passed.

Update IsValid property to allow any DateTime to be valid.

Fixes #4228