### PR TITLE
Fix breaking changes on the 7.x branch before release

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
+++ b/src/CodeGeneration/ApiGenerator/Configuration/Overrides/GlobalOverrides.cs
@@ -43,8 +43,7 @@ namespace ApiGenerator.Configuration.Overrides
 			"copy_settings", //this still needs a PR?
 			"source", // allows the body to be specified as a request param, we do not want to advertise this with a strongly typed method
 			"timestamp",
-			"time",
-			"bytes"
+			"time"
 		};
 	}
 }

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Cat.cs
@@ -86,6 +86,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatAllocationRequestParameters : RequestParameters<CatAllocationRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -202,6 +209,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatFielddataRequestParameters : RequestParameters<CatFielddataRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>A comma-separated list of fields to return in the output</summary>
 		public string[] Fields
 		{
@@ -351,6 +365,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatIndicesRequestParameters : RequestParameters<CatIndicesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -546,6 +567,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatNodesRequestParameters : RequestParameters<CatNodesRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -734,6 +762,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 			set => Q("active_only", value);
 		}
 
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>If `true`, the response includes detailed information about shard recoveries</summary>
 		public bool? Detailed
 		{
@@ -857,6 +892,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatSegmentsRequestParameters : RequestParameters<CatSegmentsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -901,6 +943,13 @@ namespace Elasticsearch.Net.Specification.CatApi
 	public class CatShardsRequestParameters : RequestParameters<CatShardsRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{

--- a/src/Nest/Descriptors.Cat.cs
+++ b/src/Nest/Descriptors.Cat.cs
@@ -86,6 +86,8 @@ namespace Nest
 		///<summary>A comma-separated list of node IDs or names to limit the returned information</summary>
 		public CatAllocationDescriptor NodeId(NodeIds nodeId) => Assign(nodeId, (a, v) => a.RouteValues.Optional("node_id", v));
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatAllocationDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatAllocationDescriptor Format(string format) => Qs("format", format);
 		///<summary>Comma-separated list of column names to display</summary>
@@ -165,6 +167,8 @@ namespace Nest
 		///<summary>A comma-separated list of fields to return the fielddata size</summary>
 		public CatFielddataDescriptor Fields<T>(params Expression<Func<T, object>>[] fields) => Assign(fields, (a, v) => a.RouteValues.Optional("fields", (Fields)v));
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatFielddataDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatFielddataDescriptor Format(string format) => Qs("format", format);
 		///<summary>Comma-separated list of column names to display</summary>
@@ -242,6 +246,8 @@ namespace Nest
 		///<summary>A shortcut into calling Index(Indices.All)</summary>
 		public CatIndicesDescriptor AllIndices() => Index(Indices.All);
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatIndicesDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatIndicesDescriptor Format(string format) => Qs("format", format);
 		///<summary>Comma-separated list of column names to display</summary>
@@ -314,6 +320,8 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatNodes;
 		// values part of the url path
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatNodesDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatNodesDescriptor Format(string format) => Qs("format", format);
 		///<summary>Return the full node ID instead of the shortened version (default: false)</summary>
@@ -403,6 +411,8 @@ namespace Nest
 		// Request parameters
 		///<summary>If `true`, the response only includes ongoing shard recoveries</summary>
 		public CatRecoveryDescriptor ActiveOnly(bool? activeonly = true) => Qs("active_only", activeonly);
+		///<summary>The unit in which to display byte values</summary>
+		public CatRecoveryDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>If `true`, the response includes detailed information about shard recoveries</summary>
 		public CatRecoveryDescriptor Detailed(bool? detailed = true) => Qs("detailed", detailed);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
@@ -466,6 +476,8 @@ namespace Nest
 		///<summary>A shortcut into calling Index(Indices.All)</summary>
 		public CatSegmentsDescriptor AllIndices() => Index(Indices.All);
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatSegmentsDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatSegmentsDescriptor Format(string format) => Qs("format", format);
 		///<summary>Comma-separated list of column names to display</summary>
@@ -503,6 +515,8 @@ namespace Nest
 		///<summary>A shortcut into calling Index(Indices.All)</summary>
 		public CatShardsDescriptor AllIndices() => Index(Indices.All);
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public CatShardsDescriptor Bytes(Bytes? bytes) => Qs("bytes", bytes);
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public CatShardsDescriptor Format(string format) => Qs("format", format);
 		///<summary>Comma-separated list of column names to display</summary>

--- a/src/Nest/Requests.Cat.cs
+++ b/src/Nest/Requests.Cat.cs
@@ -145,6 +145,13 @@ namespace Nest
 		[IgnoreDataMember]
 		NodeIds ICatAllocationRequest.NodeId => Self.RouteValues.Get<NodeIds>("node_id");
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -313,6 +320,13 @@ namespace Nest
 		[IgnoreDataMember]
 		Fields ICatFielddataRequest.Fields => Self.RouteValues.Get<Fields>("fields");
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -497,6 +511,13 @@ namespace Nest
 		[IgnoreDataMember]
 		Indices ICatIndicesRequest.Index => Self.RouteValues.Get<Indices>("index");
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -716,6 +737,13 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.CatNodes;
 		// values part of the url path
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -946,6 +974,13 @@ namespace Nest
 			set => Q("active_only", value);
 		}
 
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>If `true`, the response includes detailed information about shard recoveries</summary>
 		public bool? Detailed
 		{
@@ -1096,6 +1131,13 @@ namespace Nest
 		[IgnoreDataMember]
 		Indices ICatSegmentsRequest.Index => Self.RouteValues.Get<Indices>("index");
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{
@@ -1166,6 +1208,13 @@ namespace Nest
 		[IgnoreDataMember]
 		Indices ICatShardsRequest.Index => Self.RouteValues.Get<Indices>("index");
 		// Request parameters
+		///<summary>The unit in which to display byte values</summary>
+		public Bytes? Bytes
+		{
+			get => Q<Bytes? >("bytes");
+			set => Q("bytes", value);
+		}
+
 		///<summary>a short version of the Accept header, e.g. json, yaml</summary>
 		public string Format
 		{


### PR DESCRIPTION
Attached are the diffs from `build.bat release 7.5.0` after this change

[Elasticsearch.Net.txt](https://github.com/elastic/elasticsearch-net/files/3974409/Elasticsearch.Net.txt)
[Nest.txt](https://github.com/elastic/elasticsearch-net/files/3974410/Nest.txt)
