### PR TITLE
Add option to stop machine learning datafeed that finds no data.

### DIFF
--- a/src/Nest/XPack/MachineLearning/Datafeed/DatafeedConfig.cs
+++ b/src/Nest/XPack/MachineLearning/Datafeed/DatafeedConfig.cs
@@ -75,5 +75,13 @@ namespace Nest
 		[DataMember(Name = "scroll_size")]
 		public int? ScrollSize { get; internal set; }
 
+		/// <summary>
+		/// If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop
+		/// itself and close its associated job after this many real-time searches that return no documents. In other words, it will
+		/// stop after <see cref="Frequency"/> times <see cref="MaximumEmptySearches"/> of real-time operation. If not set then a datafeed
+		/// with no end time that sees no data will remain started until it is explicitly stopped.
+		/// </summary>
+		[DataMember(Name ="max_empty_searches")]
+		public int? MaximumEmptySearches { get; set; }
 	}
 }

--- a/src/Nest/XPack/MachineLearning/PutDatafeed/PutDatafeedRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PutDatafeed/PutDatafeedRequest.cs
@@ -69,6 +69,17 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name ="scroll_size")]
 		int? ScrollSize { get; set; }
+
+		/// <summary>
+		/// If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop
+		/// itself and close its associated job after this many real-time searches that return no documents. In other words, it will
+		/// stop after <see cref="Frequency"/> times <see cref="MaximumEmptySearches"/> of real-time operation. If not set then a datafeed
+		/// with no end time that sees no data will remain started until it is explicitly stopped.
+		/// <para/>
+		/// By default this setting is not set.
+		/// </summary>
+		[DataMember(Name ="max_empty_searches")]
+		int? MaximumEmptySearches { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -101,6 +112,8 @@ namespace Nest
 		/// <inheritdoc />
 		public int? ScrollSize { get; set; }
 
+		/// <inheritdoc />
+		public int? MaximumEmptySearches { get; set; }
 	}
 
 	public partial class PutDatafeedDescriptor<TDocument> where TDocument : class
@@ -114,6 +127,7 @@ namespace Nest
 		Time IPutDatafeedRequest.QueryDelay { get; set; }
 		IScriptFields IPutDatafeedRequest.ScriptFields { get; set; }
 		int? IPutDatafeedRequest.ScrollSize { get; set; }
+		int? IPutDatafeedRequest.MaximumEmptySearches { get; set; }
 
 		/// <inheritdoc />
 		public PutDatafeedDescriptor<TDocument> Aggregations(Func<AggregationContainerDescriptor<TDocument>, IAggregationContainer> aggregationsSelector) =>
@@ -152,5 +166,8 @@ namespace Nest
 		/// <inheritdoc />
 		public PutDatafeedDescriptor<TDocument> ScrollSize(int? scrollSize) => Assign(scrollSize, (a, v) => a.ScrollSize = v);
 
+		/// <inheritdoc />
+		public PutDatafeedDescriptor<TDocument> MaximumEmptySearches(int? maximumEmptySearches) =>
+			Assign(maximumEmptySearches, (a, v) => a.MaximumEmptySearches = v);
 	}
 }

--- a/src/Nest/XPack/MachineLearning/PutDatafeed/PutDatafeedResponse.cs
+++ b/src/Nest/XPack/MachineLearning/PutDatafeed/PutDatafeedResponse.cs
@@ -64,5 +64,13 @@ namespace Nest
 		[DataMember(Name = "scroll_size")]
 		public int? ScrollSize { get; internal set; }
 
+		/// <summary>
+		/// If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop
+		/// itself and close its associated job after this many real-time searches that return no documents. In other words, it will
+		/// stop after <see cref="Frequency"/> times <see cref="MaximumEmptySearches"/> of real-time operation. If not set then a datafeed
+		/// with no end time that sees no data will remain started until it is explicitly stopped.
+		/// </summary>
+		[DataMember(Name ="max_empty_searches")]
+		public int? MaximumEmptySearches { get; set; }
 	}
 }

--- a/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedRequest.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedRequest.cs
@@ -68,6 +68,17 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name ="scroll_size")]
 		int? ScrollSize { get; set; }
+
+		/// <summary>
+		/// If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop
+		/// itself and close its associated job after this many real-time searches that return no documents. In other words, it will
+		/// stop after <see cref="Frequency"/> times <see cref="MaximumEmptySearches"/> of real-time operation. If not set then a datafeed
+		/// with no end time that sees no data will remain started until it is explicitly stopped.
+		/// <para/>
+		/// The special value `-1` unsets this setting.
+		/// </summary>
+		[DataMember(Name ="max_empty_searches")]
+		int? MaximumEmptySearches { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -100,6 +111,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public int? ScrollSize { get; set; }
+
+		/// <inheritdoc />
+		public int? MaximumEmptySearches { get; set; }
 	}
 
 	public partial class UpdateDatafeedDescriptor<TDocument> where TDocument : class
@@ -113,6 +127,7 @@ namespace Nest
 		Time IUpdateDatafeedRequest.QueryDelay { get; set; }
 		IScriptFields IUpdateDatafeedRequest.ScriptFields { get; set; }
 		int? IUpdateDatafeedRequest.ScrollSize { get; set; }
+		int? IUpdateDatafeedRequest.MaximumEmptySearches { get; set; }
 
 		/// <inheritdoc />
 		public UpdateDatafeedDescriptor<TDocument> Aggregations(Func<AggregationContainerDescriptor<TDocument>, IAggregationContainer> aggregationsSelector) =>
@@ -151,5 +166,9 @@ namespace Nest
 
 		/// <inheritdoc />
 		public UpdateDatafeedDescriptor<TDocument> ScrollSize(int? scrollSize) => Assign(scrollSize, (a, v) => a.ScrollSize = v);
+
+		/// <inheritdoc />
+		public UpdateDatafeedDescriptor<TDocument> MaximumEmptySearches(int? maximumEmptySearches) =>
+			Assign(maximumEmptySearches, (a, v) => a.MaximumEmptySearches = v);
 	}
 }

--- a/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedResponse.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateDataFeed/UpdateDatafeedResponse.cs
@@ -71,6 +71,14 @@ namespace Nest
 		/// </summary>
 		[DataMember(Name = "scroll_size")]
 		public int? ScrollSize { get; internal set; }
-	}
 
+		/// <summary>
+		/// If a real-time datafeed has never seen any data (including during any initial training period) then it will automatically stop
+		/// itself and close its associated job after this many real-time searches that return no documents. In other words, it will
+		/// stop after <see cref="Frequency"/> times <see cref="MaximumEmptySearches"/> of real-time operation. If not set then a datafeed
+		/// with no end time that sees no data will remain started until it is explicitly stopped.
+		/// </summary>
+		[DataMember(Name ="max_empty_searches")]
+		public int? MaximumEmptySearches { get; set; }
+	}
 }


### PR DESCRIPTION
Implements: https://github.com/elastic/elasticsearch/pull/47922