### PR TITLE
Fix #4289 low level client index http method generation wrong

### DIFF
--- a/src/CodeGeneration/ApiGenerator/Domain/Specification/ApiEndpoint.cs
+++ b/src/CodeGeneration/ApiGenerator/Domain/Specification/ApiEndpoint.cs
@@ -133,6 +133,10 @@ namespace ApiGenerator.Domain.Specification
 					var methodName = CsharpNames.PerPathMethodName(path.Path);
 					var parts = new List<UrlPart>(path.Parts);
 					var mapsApiArgumentHints = parts.Select(p => p.Name).ToList();
+					// TODO This is hack until we stop transforming the new spec format into the old
+					if (Name == "index" && !mapsApiArgumentHints.Contains("id"))
+						httpMethod = "POST";
+					else if (Name == "index") httpMethod = PreferredHttpMethod;
 
 					if (Body != null)
 					{

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.NoNamespace.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.NoNamespace.cs
@@ -622,28 +622,28 @@ namespace Elasticsearch.Net
 		[MapsApi("index", "index, id, body")]
 		public Task<TResponse> IndexAsync<TResponse>(string index, string id, PostData body, IndexRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"{index:index}/_doc/{id:id}"), ctx, body, RequestParams(requestParameters));
-		///<summary>PUT on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+		///<summary>POST on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "body">The document</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse Index<TResponse>(string index, PostData body, IndexRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(PUT, Url($"{index:index}/_doc"), body, RequestParams(requestParameters));
-		///<summary>PUT on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, Url($"{index:index}/_doc"), body, RequestParams(requestParameters));
+		///<summary>POST on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "body">The document</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("index", "index, body")]
 		public Task<TResponse> IndexAsync<TResponse>(string index, PostData body, IndexRequestParameters requestParameters = null, CancellationToken ctx = default)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"{index:index}/_doc"), ctx, body, RequestParams(requestParameters));
-		///<summary>PUT on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"{index:index}/_doc"), ctx, body, RequestParams(requestParameters));
+		///<summary>POST on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "type">The type of the document</param>
 		///<param name = "body">The document</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[Obsolete("Deprecated in version 7.0.0: Specifying types in urls has been deprecated")]
 		public TResponse IndexUsingType<TResponse>(string index, string type, PostData body, IndexRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(PUT, Url($"{index:index}/{type:type}"), body, RequestParams(requestParameters));
-		///<summary>PUT on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, Url($"{index:index}/{type:type}"), body, RequestParams(requestParameters));
+		///<summary>POST on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "type">The type of the document</param>
 		///<param name = "body">The document</param>
@@ -651,7 +651,7 @@ namespace Elasticsearch.Net
 		[Obsolete("Deprecated in version 7.0.0: Specifying types in urls has been deprecated")]
 		[MapsApi("index", "index, type, body")]
 		public Task<TResponse> IndexUsingTypeAsync<TResponse>(string index, string type, PostData body, IndexRequestParameters requestParameters = null, CancellationToken ctx = default)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(PUT, Url($"{index:index}/{type:type}"), ctx, body, RequestParams(requestParameters));
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"{index:index}/{type:type}"), ctx, body, RequestParams(requestParameters));
 		///<summary>PUT on /{index}/{type}/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "type">The type of the document</param>

--- a/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
+++ b/src/Elasticsearch.Net/IElasticLowLevelClient.Generated.cs
@@ -517,19 +517,19 @@ namespace Elasticsearch.Net
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> IndexAsync<TResponse>(string index, string id, PostData body, IndexRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new();
-		///<summary>PUT on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+		///<summary>POST on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "body">The document</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		TResponse Index<TResponse>(string index, PostData body, IndexRequestParameters requestParameters = null)
 			where TResponse : class, IElasticsearchResponse, new();
-		///<summary>PUT on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+		///<summary>POST on /{index}/_doc <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "body">The document</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		Task<TResponse> IndexAsync<TResponse>(string index, PostData body, IndexRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new();
-		///<summary>PUT on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+		///<summary>POST on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "type">The type of the document</param>
 		///<param name = "body">The document</param>
@@ -537,7 +537,7 @@ namespace Elasticsearch.Net
 		[Obsolete("Deprecated in version 7.0.0: Specifying types in urls has been deprecated")]
 		TResponse IndexUsingType<TResponse>(string index, string type, PostData body, IndexRequestParameters requestParameters = null)
 			where TResponse : class, IElasticsearchResponse, new();
-		///<summary>PUT on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
+		///<summary>POST on /{index}/{type} <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html</para></summary>
 		///<param name = "index">The name of the index</param>
 		///<param name = "type">The type of the document</param>
 		///<param name = "body">The document</param>

--- a/src/Tests/Tests/Document/Single/Index/IndexUrlTests.cs
+++ b/src/Tests/Tests/Document/Single/Index/IndexUrlTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Domain;
@@ -40,6 +41,20 @@ namespace Tests.Document.Single.Index
 				.Request(c => c.Index(new IndexRequest<Project>(project)))
 				.FluentAsync(c => c.IndexDocumentAsync(project))
 				.RequestAsync(c => c.IndexAsync(new IndexRequest<Project>(project)));
+		}
+
+		[U] public async Task LowLevelUrls()
+		{
+			var project = new Project { Name = "NEST" };
+
+			await POST("/index/_doc")
+				.LowLevel(c => c.Index<VoidResponse>("index", PostData.Empty))
+				.LowLevelAsync(c => c.IndexAsync<VoidResponse>("index", PostData.Empty));
+
+			await PUT("/index/_doc/id")
+				.LowLevel(c => c.Index<VoidResponse>("index", "id", PostData.Empty))
+				.LowLevelAsync(c => c.IndexAsync<VoidResponse>("index", "id", PostData.Empty));
+
 		}
 
 		[U] public async Task CanIndexUrlIds()

--- a/src/Tests/Tests/Framework/EndpointTests/UrlTests.cs
+++ b/src/Tests/Tests/Framework/EndpointTests/UrlTests.cs
@@ -71,6 +71,11 @@ namespace Tests.Framework.EndpointTests
 			var callDetails = call(Client.LowLevel);
 			return Assert("lowlevel", callDetails);
 		}
+		public async Task<UrlTester> LowLevelAsync(Func<IElasticLowLevelClient, Task<VoidResponse>> call)
+		{
+			var callDetails = await call(Client.LowLevel);
+			return Assert("lowlevel async", callDetails);
+		}
 
 		private UrlTester WhenCalling<TResponse>(Func<IElasticClient, TResponse> call, string typeOfCall)
 			where TResponse : IResponse


### PR DESCRIPTION
We used to always send POST which is not right either but the server
accepted it. Now that we have a new format and transform to the old
format in the interim we only picked up PUT for all which is not correct
for index operations without an id.

This bug affects the low level client only, NEST sends the right HttpMethod based on whether an Id is provided or not.