### PR TITLE
Replace old github organisation (elasticsearch) urls with new organisation (elastic).

### DIFF
--- a/contributing.md
+++ b/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
 Contributing back to `Elasticsearch.Net` and `NEST` is very much appreciated. 
-Whether you [feel the need to change one character](https://github.com/elasticsearch/elasticsearch-net/pull/536) or have a go at 
-[mapping new APIs](http://github.com/elasticsearch/elasticsearch-net/pull/376), no pull request (PR) is too small or too big. 
+Whether you [feel the need to change one character](https://github.com/elastic/elasticsearch-net/pull/536) or have a go at 
+[mapping new APIs](http://github.com/elastic/elasticsearch-net/pull/376), no pull request (PR) is too small or too big. 
 
 In fact many of our most awesome features/fixes have been provided to us by 
-[these wonderful folks](https://github.com/elasticsearch/elasticsearch-net/graphs/contributors) to which we are forever indebted. 
+[these wonderful folks](https://github.com/elastic/elasticsearch-net/graphs/contributors) to which we are forever indebted. 
 
 It's usually best to open an issue first to discuss a feature or bug, before opening a pull request. Doing so can save time and help further ascertain the crux of an issue.
 

--- a/readme.md
+++ b/readme.md
@@ -118,9 +118,9 @@ Take a look at the [blog post for the GA release of Elasticsearch.Net and NEST 6
 
 Take a look at the [blog post for the GA release of Elasticsearch.Net and NEST 7.0](https://www.elastic.co/blog/nest-and-elasticsearch-net-7-0-now-ga). Please also see the [7.0.0 release notes](https://github.com/elastic/elasticsearch-net/releases/tag/7.0.0).
 
-# [NEST](https://github.com/elasticsearch/elasticsearch-net/tree/master/src/Nest)
+# [NEST](https://github.com/elastic/elasticsearch-net/tree/master/src/Nest)
 
-NEST is the official high-level .NET client of [Elasticsearch](https://github.com/elasticsearch/elasticsearch).
+NEST is the official high-level .NET client of [Elasticsearch](https://github.com/elastic/elasticsearch).
 
 It aims to be a solid, strongly typed client with a very concise API. The client internally uses the low-level **Elasticsearch.Net** client. It maps requests and responses to strongly-typed objects with both fluent interface and object initializer syntax. It also provides a very powerful query DSL that maps 1-to-1 with the Elasticsearch API. This client takes advantage of .NET features where they make sense (e.g. type and index inference and inferred mapping from POCO properties). All client method calls have asynchronous variants with support for cancellation.
 
@@ -226,7 +226,7 @@ var response = client.Search<Tweet>(request);
 
 ### Falling back to Elasticsearch.Net
 
-NEST also includes and exposes the low-level [Elasticsearch.Net](https://github.com/elasticsearch/elasticsearch-net/tree/master/src/Elasticsearch.Net) client that you can fall back to in case anything is missing:
+NEST also includes and exposes the low-level [Elasticsearch.Net](https://github.com/elastic/elasticsearch-net/tree/master/src/Elasticsearch.Net) client that you can fall back to in case anything is missing:
 
 ```csharp
 //.LowLevel is of type IElasticLowLevelClient
@@ -362,4 +362,4 @@ A small HTTP server will be spun up locally on port 8000 through which you can v
 
 This software is Copyright (c) 2014-2019 by Elasticsearch BV.
 
-This is free software, licensed under: [The Apache License Version 2.0](https://github.com/elasticsearch/elasticsearch-net/blob/master/license.txt).
+This is free software, licensed under: [The Apache License Version 2.0](https://github.com/elastic/elasticsearch-net/blob/master/license.txt).

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -206,7 +206,7 @@ namespace Elasticsearch.Net
 
 			//WebRequest won't send Content-Length: 0 for empty bodies
 			//which goes against RFC's and might break i.e IIS hen used as a proxy.
-			//see: https://github.com/elasticsearch/elasticsearch-net/issues/562
+			//see: https://github.com/elastic/elasticsearch-net/issues/562
 			var m = requestData.Method.GetStringValue();
 			request.Method = m;
 			if (m != "HEAD" && m != "GET" && requestData.PostData == null)

--- a/src/Nest/Document/Multiple/MultiGet/Request/MultiGetOperation.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Request/MultiGetOperation.cs
@@ -46,7 +46,7 @@ namespace Nest
 		/// when rest.action.multi.allow_explicit_index is set to false you can use this constructor to generate a multiget operation
 		/// with no index and type set
 		/// <pre>
-		/// See also: https://github.com/elasticsearch/elasticsearch/issues/3636
+		/// See also: https://github.com/elastic/elasticsearch/issues/3636
 		/// </pre>
 		/// </summary>
 		public MultiGetOperationDescriptor(bool allowExplicitIndex)


### PR DESCRIPTION
Not sure if this needs porting as there are only two code mentions.