### PR TITLE
Documentation generation improvements 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,5 @@ project.lock.json
 .idea/
 *.sln.iml
 /src/.vs/restore.dg
+# temporary location for doc generation
+docs-temp

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -8,13 +8,6 @@ jobs:
        version: '3.0.100'
   - script: ./build.sh documentation
     displayName: 'Generate Documentation'
-  - task: PublishTestResults@2
-            inputs:
-                testRunner: VSTest
-                testResultsFiles: 'tests/**/*.trx'
-                testRunTitle: Linux Unit Tests
-  # Generate the report using ReportGenerator (https://github.com/danielpalme/ReportGenerator)
-  # First install the tool on the machine, then run it
   - script: |
       if [ -n "$(git status --porcelain)" ]; then echo Error: changes found after running documentation; git status; exit 1; fi
     displayName: 'Ensure no uncommitted docs'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,4 +1,23 @@
 jobs:
+- job: Documentation
+  pool:
+    vmImage: 'ubuntu-16.04'
+  steps:
+  - task: UseDotNet@2
+    inputs:
+       version: '3.0.100'
+  - script: ./build.sh documentation
+    displayName: 'Generate Documentation'
+  - task: PublishTestResults@2
+            inputs:
+                testRunner: VSTest
+                testResultsFiles: 'tests/**/*.trx'
+                testRunTitle: Linux Unit Tests
+  # Generate the report using ReportGenerator (https://github.com/danielpalme/ReportGenerator)
+  # First install the tool on the machine, then run it
+  - script: |
+      if [ -n "$(git status --porcelain)" ]; then echo Error: changes found after running documentation; git status; exit 1; fi
+    displayName: 'Ensure no uncommitted docs'
 - job: LinuxUnitTests
   pool:
     vmImage: 'ubuntu-16.04'

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -33,7 +33,11 @@ Targets:
 * benchmark [non-interactive] [url] [username] [password] 
   - Runs a benchmark from Tests.Benchmarking and indexes the results to [url] when provided.
     If non-interactive runs all benchmarks without prompting
-
+* codegen
+  - runs the code generator interactively
+* documentation
+  - runs the doc generation, without running any tests
+  
 NOTE: both the `test` and `integrate` targets can be suffixed with `-all` to force the tests against all suported TFM's
 
 Execution hints can be provided anywhere on the command line
@@ -126,13 +130,13 @@ Execution hints can be provided anywhere on the command line
             match (filteredArgs |> List.tryHead) with
             | Some t -> t.Replace("-one", "")
             | _ -> "build"
-        let skipTests = args |> List.exists (fun x -> x = "skiptests")
+        let skipTests = args |> List.exists (fun x -> x = "skiptests") || target = "documentation"
         let skipDocs = args |> List.exists (fun x -> x = "skipdocs")
 
         let parsed = {
             NonInteractive = args |> List.exists (fun x -> x = "non-interactive")
             SkipTests = skipTests
-            GenDocs = not skipDocs && (args |> List.exists (fun x -> x = "gendocs") || target = "build") 
+            GenDocs = not skipDocs && (args |> List.exists (fun x -> x = "gendocs") || target = "build" || target = "documentation") 
             Seed = 
                 match args |> List.tryFind (fun x -> x.StartsWith("seed:")) with
                 | Some t -> Int32.Parse (t.Replace("seed:", ""))
@@ -179,6 +183,7 @@ Execution hints can be provided anywhere on the command line
         | ["clean"]
         | ["benchmark"]
         | ["codegen"; ] 
+        | ["documentation"; ] 
         | ["profile"] -> parsed
         | "rest-spec-tests" :: tail -> { parsed with RemainingArguments = tail }
         

--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -14,6 +14,8 @@ module Paths =
     
     let InplaceBuildOutput project tfm = 
         sprintf "src/%s/bin/Release/%s" project tfm
+    let MagicDocumentationFile  = 
+        "src/Elasticsearch.Net/obj/Release/netstandard2.1/Elasticsearch.Net.csprojAssemblyReference.cache" 
   
     let Tool tool = sprintf "packages/build/%s" tool
     let CheckedInToolsFolder = "build/tools"

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -75,7 +75,7 @@ module Main =
 
         target "inherit-doc" <| InheritDoc.PatchInheritDocs
         
-        conditional "documentation" (parsed.GenDocs)  <| fun _ -> Documentation.Generate parsed
+        conditionalCommand "documentation" testChain (parsed.GenDocs)  <| fun _ -> Documentation.Generate parsed
         
         //BUILD
         command "build" buildChain <| fun _ -> printfn "STARTING BUILD"

--- a/src/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
+++ b/src/DocGenerator/AsciiDoc/RawAsciidocVisitor.cs
@@ -54,7 +54,7 @@ namespace DocGenerator.AsciiDoc
 
 				foreach (var directory in directories)
 				{
-					foreach (var file in Directory.EnumerateFiles(Path.Combine(Program.OutputDirPath, directory), "*.asciidoc",
+					foreach (var file in Directory.EnumerateFiles(Path.Combine(Program.TmpOutputDirPath, directory), "*.asciidoc",
 						SearchOption.AllDirectories))
 					{
 						var fileInfo = new FileInfo(file);
@@ -80,7 +80,7 @@ namespace DocGenerator.AsciiDoc
 
 				foreach (var directory in directories)
 				{
-					foreach (var file in Directory.EnumerateFiles(Path.Combine(Program.OutputDirPath, directory), "*.asciidoc",
+					foreach (var file in Directory.EnumerateFiles(Path.Combine(Program.TmpOutputDirPath, directory), "*.asciidoc",
 						SearchOption.AllDirectories))
 					{
 						var fileInfo = new FileInfo(file);

--- a/src/DocGenerator/Documentation/Files/DocumentationFile.cs
+++ b/src/DocGenerator/Documentation/Files/DocumentationFile.cs
@@ -44,7 +44,7 @@ namespace DocGenerator.Documentation.Files
 					.TrimEnd("Tests")
 					.PascalToHyphen() + ".asciidoc";
 
-			var documentationTargetPath = Path.GetFullPath(Path.Combine(Program.OutputDirPath, testInDocumentationFolder));
+			var documentationTargetPath = Path.GetFullPath(Path.Combine(Program.TmpOutputDirPath, testInDocumentationFolder));
 			var fileInfo = new FileInfo(documentationTargetPath);
 
 			if (fileInfo.Directory != null)

--- a/src/DocGenerator/Documentation/Files/ImageDocumentationFile.cs
+++ b/src/DocGenerator/Documentation/Files/ImageDocumentationFile.cs
@@ -16,7 +16,7 @@ namespace DocGenerator.Documentation.Files
 			var copyRelativeTask = CopyFileAsync(FileLocation.FullName, docFileName.FullName);
 
 			// copy to the root as well, for the doc generation process (path is relative to root)
-			var copyRootTask = CopyFileAsync(FileLocation.FullName, Path.Combine(Program.OutputDirPath, docFileName.Name));
+			var copyRootTask = CopyFileAsync(FileLocation.FullName, Path.Combine(Program.TmpOutputDirPath, docFileName.Name));
 
 			await copyRelativeTask;
 			await copyRootTask;
@@ -30,7 +30,7 @@ namespace DocGenerator.Documentation.Files
 			var testInDocumenationFolder = Regex.Replace(testFullPath, $@"(^.+{p}Tests{p}|\" + Extension + "$)", "")
 				.PascalToHyphen() + Extension;
 
-			var documentationTargetPath = Path.GetFullPath(Path.Combine(Program.OutputDirPath, testInDocumenationFolder));
+			var documentationTargetPath = Path.GetFullPath(Path.Combine(Program.TmpOutputDirPath, testInDocumenationFolder));
 
 			var fileInfo = new FileInfo(documentationTargetPath);
 			if (fileInfo.Directory != null)

--- a/src/DocGenerator/Documentation/Files/RawDocumentationFile.cs
+++ b/src/DocGenerator/Documentation/Files/RawDocumentationFile.cs
@@ -30,10 +30,10 @@ namespace DocGenerator.Documentation.Files
 		{
 			var testFullPath = FileLocation.FullName;
 			var p = "\\" + Path.DirectorySeparatorChar.ToString();
-			var testInDocumenationFolder = Regex.Replace(testFullPath, $@"(^.+{p}Tests{p}|\" + Extension + "$)", "").PascalToHyphen() + Extension;
+			var testInDocumentationFolder = Regex.Replace(testFullPath, $@"(^.+{p}Tests{p}|\" + Extension + "$)", "").PascalToHyphen() + Extension;
 
-			var documenationTargetPath = Path.GetFullPath(Path.Combine(Program.OutputDirPath, testInDocumenationFolder));
-			var fileInfo = new FileInfo(documenationTargetPath);
+			var documentationTargetPath = Path.GetFullPath(Path.Combine(Program.TmpOutputDirPath, testInDocumentationFolder));
+			var fileInfo = new FileInfo(documentationTargetPath);
 			if (fileInfo.Directory != null)
 				Directory.CreateDirectory(fileInfo.Directory.FullName);
 			return fileInfo;

--- a/src/DocGenerator/LitUp.cs
+++ b/src/DocGenerator/LitUp.cs
@@ -156,8 +156,8 @@ namespace DocGenerator
 				dir.Delete(true);
 
 			WaitForActualDelete(outputDir);
+			Console.WriteLine($"Swapping {tmpDir.FullName} to {outputDir.FullName}");
 			tmpDir.MoveTo(Program.OutputDirPath);
-			Console.WriteLine($"Swapped {tmpDir.FullName} to {outputDir.FullName}");
 
 			static void WaitForActualDelete(FileSystemInfo toDelete)
 			{

--- a/src/DocGenerator/LitUp.cs
+++ b/src/DocGenerator/LitUp.cs
@@ -65,7 +65,7 @@ namespace DocGenerator
 
 			workspace.WorkspaceFailed += (s, e) =>
 			{
-				Console.Error.WriteLine(e.Diagnostic.Message);
+				Console.Error.WriteLine($"Workplace failure: {e.Diagnostic.Message}");
 			};
 
 			// Buildalyzer, similar to MsBuildWorkspace with the new csproj file format, does
@@ -94,7 +94,7 @@ namespace DocGenerator
 
 		private static void DeleteExistingDocs()
 		{
-			var outputDir = new DirectoryInfo(Program.OutputDirPath);
+			var outputDir = new DirectoryInfo(Program.TmpOutputDirPath);
 
 			foreach (var file in outputDir.EnumerateFiles())
 				file.Delete();

--- a/src/DocGenerator/LitUp.cs
+++ b/src/DocGenerator/LitUp.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Threading;
 using System.Threading.Tasks;
 using Buildalyzer;
 using Buildalyzer.Workspaces;
@@ -15,10 +16,10 @@ namespace DocGenerator
 	{
 		private static readonly string[] SkipFolders = { "Debug", "Release" };
 
-		private static string GetProjectDir(string projectName) => Path.Combine(Program.InputDirPath, projectName);
+		private static string GetTestProjectDir(string projectName) => Path.Combine(Program.InputDirPath, "..", "tests", projectName);
 
 		public static IEnumerable<DocumentationFile> InputFiles(string path) =>
-			from f in Directory.GetFiles(GetProjectDir("Tests"), $"{path}", SearchOption.AllDirectories)
+			from f in Directory.GetFiles(GetTestProjectDir("Tests"), $"{path}", SearchOption.AllDirectories)
 			let dir = new DirectoryInfo(f)
 			where dir?.Parent != null && !SkipFolders.Contains(dir.Parent.Name)
 			select DocumentationFile.Load(new FileInfo(f));
@@ -49,7 +50,7 @@ namespace DocGenerator
 			"Elasticsearch.Net", "Nest", "Tests"
 		};
 
-		public static async Task GoAsync(string[] args)
+		public static async Task<int> GoAsync(string[] args)
 		{
 			//.NET core csprojects are not supported all that well.
 			// https://github.com/dotnet/roslyn/issues/21660 :sadpanda:
@@ -63,9 +64,11 @@ namespace DocGenerator
 
 			var workspace = analyzer.GetWorkspace();
 
+			var seenFailures = false;
 			workspace.WorkspaceFailed += (s, e) =>
 			{
 				Console.Error.WriteLine($"Workplace failure: {e.Diagnostic.Message}");
+				seenFailures = true;
 			};
 
 			// Buildalyzer, similar to MsBuildWorkspace with the new csproj file format, does
@@ -75,10 +78,31 @@ namespace DocGenerator
 			var projects = workspace.CurrentSolution.Projects
 				.ToDictionary(p => p.Name, StringComparer.OrdinalIgnoreCase);
 
-			DeleteExistingDocs();
+			if (seenFailures)
+			{
+				Console.ForegroundColor = ConsoleColor.Red;
+				Console.Error.WriteLine("Documentation failed to generate.");
+				Console.ResetColor();
+				return 2;
+			}
+
+			DeleteExistingTmpDocs();
 
 			foreach (var file in GetDocumentFiles(projects).SelectMany(s => s))
 				await file.SaveToDocumentationFolderAsync();
+
+			if (seenFailures)
+			{
+				Console.ForegroundColor = ConsoleColor.Red;
+				Console.Error.WriteLine("Documentation failed to generate.");
+				Console.ResetColor();
+				return 2;
+			}
+
+
+
+			CopyBreakingChangesDocs();
+			DeleteExistingDocsAndSwap();
 
 			Console.ForegroundColor = ConsoleColor.Green;
 			Console.WriteLine("Documentation generated.");
@@ -89,20 +113,62 @@ namespace DocGenerator
 				Console.WriteLine("Press any key to continue...");
 				Console.ReadKey();
 			}
+			return 0;
 		}
 
 
-		private static void DeleteExistingDocs()
+		private static void DeleteExistingTmpDocs()
 		{
 			var outputDir = new DirectoryInfo(Program.TmpOutputDirPath);
+			if (!outputDir.Exists) return;
+
+			foreach (var file in outputDir.EnumerateFiles())
+				file.Delete();
+
+		}
+		private static void CopyBreakingChangesDocs()
+		{
+			var outputDir = new DirectoryInfo(Program.OutputDirPath);
+			var tmpDir = new DirectoryInfo(Program.TmpOutputDirPath);
+			if (!outputDir.Exists) throw new Exception($"Docs folder should be present in repos but does not exist at: {Program.OutputDirPath}");
+			if (!tmpDir.Exists)
+				throw new Exception($"Temp docs folder should be present in repos after generation ran but does not exist at: {Program.TmpOutputDirPath}");
+
+			foreach (var dir in outputDir.EnumerateDirectories())
+			{
+				if (!dir.Name.EndsWith("breaking-changes")) continue;
+
+				var newLocation = Path.Combine(tmpDir.FullName, dir.Name);
+				Console.WriteLine($"Moving {dir.Name} to: {tmpDir.FullName}");
+				dir.MoveTo(newLocation);
+			}
+		}
+
+		private static void DeleteExistingDocsAndSwap()
+		{
+			var outputDir = new DirectoryInfo(Program.OutputDirPath);
+			var tmpDir = new DirectoryInfo(Program.TmpOutputDirPath);
 
 			foreach (var file in outputDir.EnumerateFiles())
 				file.Delete();
 
 			foreach (var dir in outputDir.EnumerateDirectories())
+				dir.Delete(true);
+
+			WaitForActualDelete(outputDir);
+			tmpDir.MoveTo(Program.OutputDirPath);
+			Console.WriteLine($"Swapped {tmpDir.FullName} to {outputDir.FullName}");
+
+			static void WaitForActualDelete(FileSystemInfo toDelete)
 			{
-				if (!dir.Name.EndsWith("breaking-changes"))
-					dir.Delete(true);
+				Console.WriteLine($"Attempting to delete {toDelete.FullName}");
+				toDelete.Delete();
+				var x = 0;
+				for (x = 0; toDelete.Exists && x < 100; x++)
+				{
+					Thread.Sleep(100);
+					x++;
+				}
 			}
 		}
 

--- a/src/DocGenerator/Program.cs
+++ b/src/DocGenerator/Program.cs
@@ -31,6 +31,7 @@ namespace DocGenerator
 			var globalJson = Path.Combine(r, "global.json");
 			InputDirPath = Path.Combine(r, "src");
 			OutputDirPath = Path.Combine(r, "docs");
+			TmpOutputDirPath = Path.Combine(r, "docs-temp");
 
 			var jObject = JObject.Parse(File.ReadAllText(globalJson));
 
@@ -58,6 +59,8 @@ namespace DocGenerator
 		public static string InputDirPath { get; }
 
 		public static string OutputDirPath { get; }
+
+		public static string TmpOutputDirPath { get; }
 
 		private static int Main(string[] args) =>
 			Parser.Default.ParseArguments<DocGeneratorOptions>(args)

--- a/src/DocGenerator/Program.cs
+++ b/src/DocGenerator/Program.cs
@@ -78,8 +78,7 @@ namespace DocGenerator
 							Console.WriteLine($"Using branch name {BranchName} in documentation");
 							Console.WriteLine($"Using doc reference version {DocVersion} in documentation");
 
-							LitUp.GoAsync(args).Wait();
-							return 0;
+							return LitUp.GoAsync(args).GetAwaiter().GetResult();
 						}
 						catch (AggregateException ae)
 						{


### PR DESCRIPTION
* Generate to temp location `docs-temp` first
* This folder is gitignored
* Only if generation is succesful swap `docs-temp` to `docs` this will
make `git status` a whole less noisy on generation failures.
* Make sure IncludeFiles references the new `tests/Tests` location
* `breaking-changes` folders are still preserved
* `Litup.Go` should return an exit code
* Call `build.sh documentation` to generate only the docs
* Improve [resilience of calling the documentation generator](https://github.com/elastic/elasticsearch-net/pull/4302#discussion_r362972586) from the command line
* Add azure devops job that fails if a PR has uncommitted documentation changes, which `master` has so [it currently fails on this PR](https://github.com/elastic/elasticsearch-net/pull/4302/checks?check_run_id=373092851). Will follow up with a new PR that solely updates the docs.

@codebrain @russcam tagging you as reviewers while you are out. Merging this in but please have a gander. 