### PR TITLE
Read numeric aggs keys as long or double

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
@@ -158,11 +158,11 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
                 case JsonToken.Number:
 					var numberSegment = reader.ReadNumberSegment();
 					// conditional operator here would cast both to double, so don't use.
-					if (numberSegment.IsDouble())
-						return NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
+					if (numberSegment.IsLong())
+						return NumberConverter.ReadInt64(numberSegment.Array, numberSegment.Offset, out _);
 
-					// potential overflow if larger than int64
-					return NumberConverter.ReadInt64(numberSegment.Array, numberSegment.Offset, out _);
+
+					return NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
 				case JsonToken.String:
                     return reader.ReadString();
                 case JsonToken.True:

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -770,12 +770,23 @@ namespace Nest
 			if (token == JsonToken.String)
 				key = reader.ReadString();
 			else
-				key = reader.ReadDouble();
+			{
+				var numberSegment = reader.ReadNumberSegment();
+				if (numberSegment.IsDouble())
+					key = NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
+				else
+					key = NumberConverter.ReadInt64(numberSegment.Array, numberSegment.Offset, out _);
+			}
 
 			reader.ReadNext(); // ,
 			var propertyName = reader.ReadPropertyName();
 			if (propertyName == Parser.From || propertyName == Parser.To)
-				return GetRangeBucket(ref reader, formatterResolver, (string)key, propertyName);
+			{
+				var rangeKey = key is double d
+					? d.ToString("#.#")
+					: key.ToString();
+				return GetRangeBucket(ref reader, formatterResolver, rangeKey, propertyName);
+			}
 
 			string keyAsString = null;
 			if (propertyName == Parser.KeyAsString)

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -760,6 +760,8 @@ namespace Nest
 			return dateHistogram;
 		}
 
+
+
 		private IBucket GetKeyedBucket(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var token = reader.GetCurrentJsonToken();
@@ -772,10 +774,10 @@ namespace Nest
 			else
 			{
 				var numberSegment = reader.ReadNumberSegment();
-				if (numberSegment.IsDouble())
-					key = NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
-				else
+				if (numberSegment.IsLong())
 					key = NumberConverter.ReadInt64(numberSegment.Array, numberSegment.Offset, out _);
+				else
+					key = NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
 			}
 
 			reader.ReadNext(); // ,

--- a/tests/Tests.Reproduce/GitHubIssue4285.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4285.cs
@@ -1,0 +1,60 @@
+using System;
+using System.Linq;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce {
+	public class GitHubIssue4285
+	{
+		[U]
+		public void CanReadAggBucketWithLongKey()
+		{
+			var json = @"{
+				""took"" : 2612,
+				""timed_out"" : false,
+				""_shards"" : {
+					""total"" : 3,
+					""successful"" : 3,
+					""skipped"" : 0,
+					""failed"" : 0
+				},
+				""hits"" : {
+					""total"" : {
+						""value"" : 10000,
+						""relation"" : ""gte""
+					},
+					""max_score"" : null,
+					""hits"" : [ ]
+				},
+				""aggregations"" : {
+					""terms#top_tags"" : {
+						""buckets"" : [
+						{
+							""key"" : 3515753798950990007,
+							""doc_count"" : 3
+						}
+						]
+					}
+				}
+			}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes)).DefaultIndex("default_index");
+			var client = new ElasticClient(connectionSettings);
+
+			var response = client.Search<object>(s => s);
+
+			var longTerms = response.Aggregations.Terms<long>("top_tags");
+			longTerms.Buckets.Should().HaveCount(1);
+			longTerms.Buckets.First().Key.Should().Be(3515753798950990007);
+
+			var stringTerms = response.Aggregations.Terms("top_tags");
+			stringTerms.Buckets.Should().HaveCount(1);
+			stringTerms.Buckets.First().Key.Should().Be("3515753798950990007");
+		}
+	}
+}


### PR DESCRIPTION
This commit updates the reading of numeric aggregation keys to read as double only when the byte representation of the value contains a decimal point, and to read it as a long otherwise. This makes the assumption that whole numbers returned are smaller than long.MaxValue. This same assumption is made in PrimitiveObjectFormatter.

Closes #4285