### PR TITLE
Several improvements to PostData

### DIFF
--- a/docs/client-concepts/low-level/post-data.asciidoc
+++ b/docs/client-concepts/low-level/post-data.asciidoc
@@ -119,13 +119,20 @@ the bytes
 await Post(() => bytes, writes: bytes, writtenBytesIsSet: true, settings: settings);
 ----
 
-When passing a collection of `string`, the client assumes that it's a collection of valid serialized json,
-so joins each with newline feeds, ensuring there is a trailing linefeed. As with `string` and `byte[]`,
-the `WrittenBytes` property is assigned the UTF-8 bytes of the collection of strings
+On platforms that support `ReadOnlyMemory<byte>` you can use `PostData.ReadOnlyMemory` to pass this directly
 
 [source,csharp]
 ----
-await Post(() => PostData.MultiJson(collectionOfStrings), writes: utf8BytesOfListOfStrings, writtenBytesIsSet: true, settings: settings);
+await Post(() => PostData.ReadOnlyMemory(bytes.AsMemory()), writes: bytes, writtenBytesIsSet: false, settings: settings);
+----
+
+When passing a collection of `string`, the client assumes that it's a collection of valid serialized json,
+so joins each with newline feeds, ensuring there is a trailing linefeed. As with `string` and `byte[]`,
+the `WrittenBytes` property is assigned the UTF-8 bytes of the collection of strings if `DisableDirectStreaming` is set on `ConnectionConfiguration`
+
+[source,csharp]
+----
+await Post(() => PostData.MultiJson(collectionOfStrings), writes: utf8BytesOfListOfStrings, writtenBytesIsSet: false, settings: settings);
 ----
 
 When passing a collection of `object`, the client assumes that it's a collection of objects
@@ -144,6 +151,18 @@ In all other cases, Post data is serialized as is and `WrittenBytes` is not assi
 await Post(() => PostData.Serializable(@object), writes: utf8ObjectBytes, writtenBytesIsSet: false, settings: settings);
 ----
 
+If you want even more control over how your data is written to the stream consider `PostData.StreamHandler`
+which allows you to inject your own writer routines
+
+[source,csharp]
+----
+var streamHandler = PostData.StreamHandler(bytes,
+    (b, s) => s.Write(b.AsSpan()),
+    async (b, s, ctx) => await s.WriteAsync(b.AsMemory(), ctx)
+);
+await Post(() => streamHandler, writes: bytes, writtenBytesIsSet: false, settings: settings);
+----
+
 ==== Forcing WrittenBytes to be set
 
 If you want to maintain a copy of the request that went out, you can set `DisableDirectStreaming`  on `ConnectionConfiguration`.
@@ -154,6 +173,12 @@ In doing so, the serialized bytes are first written to a private `MemoryStream` 
 settings = new ConnectionConfiguration().DisableDirectStreaming();
 
 await Post(() => PostData.MultiJson(collectionOfObjects), writes: utf8BytesOfCollectionOfObjects, writtenBytesIsSet: true, settings: settings);
+
+await Post(() => PostData.MultiJson(collectionOfStrings), writes: utf8BytesOfListOfStrings, writtenBytesIsSet: true, settings: settings);
+
+await Post(() => PostData.ReadOnlyMemory(bytes.AsMemory()), writes: bytes, writtenBytesIsSet: true, settings: settings);
+
+await Post(() => streamHandler, writes: bytes, writtenBytesIsSet: true, settings: settings);
 ----
 
 This behavior can also be observed when serializing a simple object using `DisableDirectStreaming` enabled

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Elasticsearch.Net.Extensions;
@@ -11,15 +12,20 @@ namespace Elasticsearch.Net
 	public interface IPostData<out T>
 	{
 		void Write(Stream writableStream, IConnectionConfigurationValues settings);
+
 		Task WriteAsync(Stream writableStream, IConnectionConfigurationValues settings, CancellationToken token);
 	}
 
 	public enum PostType
 	{
 		ByteArray,
+#if NETSTANDARD2_1
+		ReadOnlyMemory,
+#endif
 		LiteralString,
 		EnumerableOfString,
 		EnumerableOfObject,
+		StreamHandler,
 		Serializable
 	}
 
@@ -52,20 +58,40 @@ namespace Elasticsearch.Net
 
 		public static PostData Bytes(byte[] bytes) => new PostData<object>(bytes);
 
+#if NETSTANDARD2_1
+		public static PostData ReadOnlyMemory(ReadOnlyMemory<byte> bytes) => new PostData<object>(bytes);
+#endif
+
 		public static PostData String(string serializedString) => new PostData<object>(serializedString);
+
+		public static PostData StreamHandler(Action<Stream> syncWriter, Func<Stream, CancellationToken, Task> asyncWriter) =>
+			new PostData<object>(syncWriter, asyncWriter);
 	}
 
 	public class PostData<T> : PostData, IPostData<T>
 	{
+		private readonly Action<Stream> _syncWriter;
+		private readonly Func<Stream, CancellationToken, Task> _asyncWriter;
 		private readonly IEnumerable<object> _enumerableOfObject;
 		private readonly IEnumerable<string> _enumerableOfStrings;
 		private readonly string _literalString;
+#if NETSTANDARD2_1
+		private readonly ReadOnlyMemory<byte> _memoryOfBytes;
+#endif
 
 		protected internal PostData(byte[] item)
 		{
 			WrittenBytes = item;
 			Type = PostType.ByteArray;
 		}
+
+#if NETSTANDARD2_1
+		protected internal PostData(ReadOnlyMemory<byte> item)
+		{
+			_memoryOfBytes = item;
+			Type = PostType.ReadOnlyMemory;
+		}
+#endif
 
 		protected internal PostData(string item)
 		{
@@ -85,76 +111,164 @@ namespace Elasticsearch.Net
 			Type = PostType.EnumerableOfObject;
 		}
 
+		protected internal PostData(Action<Stream> syncWriter, Func<Stream, CancellationToken, Task> asyncWriter)
+		{
+			const string message = "PostData.StreamHandler needs to handle both synchronous and async paths";
+			_syncWriter = syncWriter ?? throw new ArgumentNullException(nameof(syncWriter), message);
+			_asyncWriter = asyncWriter ?? throw new ArgumentNullException(nameof(asyncWriter), message);
+			if (_syncWriter == null || _asyncWriter == null)
+				throw new ArgumentNullException();
+		}
+
+		private static void BufferIfNeeded(IConnectionConfigurationValues settings, bool disableDirectStreaming, ref MemoryStream buffer,
+			ref Stream stream
+		)
+		{
+			if (!disableDirectStreaming) return;
+
+			buffer = settings.MemoryStreamFactory.Create();
+			stream = buffer;
+		}
+
 		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)
 		{
-			MemoryStream ms = null;
+			MemoryStream buffer = null;
+			var stream = writableStream;
+			var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+
 			switch (Type)
 			{
 				case PostType.ByteArray:
-					ms = settings.MemoryStreamFactory.Create(WrittenBytes);
+					if (WrittenBytes == null) return;
+
+					if (!disableDirectStreaming)
+						stream.Write(WrittenBytes, 0, WrittenBytes.Length);
+					else
+						buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 					break;
+
+#if NETSTANDARD2_1
+				case PostType.ReadOnlyMemory:
+					if (_memoryOfBytes.IsEmpty) return;
+
+					if (!disableDirectStreaming)
+						stream.Write(_memoryOfBytes.Span);
+					else
+					{
+						WrittenBytes ??= _memoryOfBytes.Span.ToArray();
+						buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
+					}
+					break;
+#endif
+
 				case PostType.LiteralString:
-					ms = !string.IsNullOrEmpty(_literalString) ? settings.MemoryStreamFactory.Create(_literalString?.Utf8Bytes()) : null;
+					if (string.IsNullOrEmpty(_literalString)) return;
+
+					var stringBytes = WrittenBytes ?? _literalString.Utf8Bytes();
+					WrittenBytes ??= stringBytes;
+					if (!disableDirectStreaming)
+						stream.Write(stringBytes, 0, stringBytes.Length);
+					else
+						buffer = settings.MemoryStreamFactory.Create(stringBytes);
 					break;
+
 				case PostType.EnumerableOfString:
-					ms = _enumerableOfStrings.HasAny()
-						? settings.MemoryStreamFactory.Create((string.Join(NewLineString, _enumerableOfStrings) + NewLineString).Utf8Bytes())
-						: null;
+					if (!_enumerableOfStrings.HasAny()) return;
+
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
+					foreach (var s in _enumerableOfStrings)
+					{
+						var bytes = s.Utf8Bytes();
+						stream.Write(bytes, 0, bytes.Length);
+						stream.Write(NewLineByteArray, 0, 1);
+					}
 					break;
+
 				case PostType.EnumerableOfObject:
 					if (!_enumerableOfObject.HasAny()) return;
 
-					Stream stream;
-					if (DisableDirectStreaming ?? settings.DisableDirectStreaming)
-					{
-						ms = settings.MemoryStreamFactory.Create();
-						stream = ms;
-					}
-					else stream = writableStream;
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
 					foreach (var o in _enumerableOfObject)
 					{
 						settings.RequestResponseSerializer.Serialize(o, stream, SerializationFormatting.None);
 						stream.Write(NewLineByteArray, 0, 1);
 					}
 					break;
+
+				case PostType.StreamHandler:
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
+					_syncWriter(stream);
+					break;
+
 				case PostType.Serializable:
 					throw new Exception("PostData is not expected/capable to handle contain serializable, use SerializableData instead");
+
+				default:
+					throw new ArgumentOutOfRangeException();
 			}
-			if (ms != null)
-			{
-				ms.Position = 0;
-				ms.CopyTo(writableStream, BufferSize);
-			}
-			if (Type != 0)
-				WrittenBytes = ms?.ToArray();
+			if (buffer == null || !disableDirectStreaming) return;
+
+			buffer.Position = 0;
+			buffer.CopyTo(writableStream, BufferSize);
+			WrittenBytes ??= buffer.ToArray();
 		}
 
 		public override async Task WriteAsync(Stream writableStream, IConnectionConfigurationValues settings, CancellationToken cancellationToken)
 		{
-			MemoryStream ms = null;
+			MemoryStream buffer = null;
+			var stream = writableStream;
+			var disableDirectStreaming = DisableDirectStreaming ?? settings.DisableDirectStreaming;
+
 			switch (Type)
 			{
 				case PostType.ByteArray:
-					ms = settings.MemoryStreamFactory.Create(WrittenBytes);
+					if (!disableDirectStreaming)
+						await stream.WriteAsync(WrittenBytes, 0, WrittenBytes.Length, cancellationToken).ConfigureAwait(false);
+					else
+						buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
 					break;
+
+#if NETSTANDARD2_1
+				case PostType.ReadOnlyMemory:
+					if (_memoryOfBytes.IsEmpty) return;
+
+					if (!disableDirectStreaming)
+						stream.Write(_memoryOfBytes.Span);
+					else
+					{
+						WrittenBytes ??= _memoryOfBytes.Span.ToArray();
+						buffer = settings.MemoryStreamFactory.Create(WrittenBytes);
+					}
+					break;
+#endif
+
 				case PostType.LiteralString:
-					ms = !string.IsNullOrEmpty(_literalString) ? settings.MemoryStreamFactory.Create(_literalString.Utf8Bytes()) : null;
+					if (string.IsNullOrEmpty(_literalString)) return;
+
+					var stringBytes = WrittenBytes ?? _literalString.Utf8Bytes();
+					WrittenBytes ??= stringBytes;
+					if (!disableDirectStreaming)
+						await stream.WriteAsync(stringBytes, 0, stringBytes.Length, cancellationToken).ConfigureAwait(false);
+					else
+						buffer = settings.MemoryStreamFactory.Create(stringBytes);
 					break;
+
 				case PostType.EnumerableOfString:
-					ms = _enumerableOfStrings.HasAny()
-						? settings.MemoryStreamFactory.Create((string.Join(NewLineString, _enumerableOfStrings) + NewLineString).Utf8Bytes())
-						: null;
+					if (!_enumerableOfStrings.HasAny()) return;
+
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
+					foreach (var s in _enumerableOfStrings)
+					{
+						var bytes = s.Utf8Bytes();
+						await stream.WriteAsync(bytes, 0, bytes.Length, cancellationToken).ConfigureAwait(false);
+						await stream.WriteAsync(NewLineByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
+					}
 					break;
+
 				case PostType.EnumerableOfObject:
 					if (!_enumerableOfObject.HasAny()) return;
 
-					Stream stream;
-					if (DisableDirectStreaming ?? settings.DisableDirectStreaming)
-					{
-						ms = settings.MemoryStreamFactory.Create();
-						stream = ms;
-					}
-					else stream = writableStream;
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
 					foreach (var o in _enumerableOfObject)
 					{
 						await settings.RequestResponseSerializer.SerializeAsync(o, stream, SerializationFormatting.None, cancellationToken)
@@ -162,16 +276,24 @@ namespace Elasticsearch.Net
 						await stream.WriteAsync(NewLineByteArray, 0, 1, cancellationToken).ConfigureAwait(false);
 					}
 					break;
+
+				case PostType.StreamHandler:
+					BufferIfNeeded(settings, disableDirectStreaming, ref buffer, ref stream);
+					await _asyncWriter(stream, cancellationToken).ConfigureAwait(false);
+					break;
+
 				case PostType.Serializable:
 					throw new Exception("PostData is not expected/capable to handle contain serializable, use SerializableData instead");
+
+				default:
+					throw new ArgumentOutOfRangeException();
 			}
-			if (ms != null)
-			{
-				ms.Position = 0;
-				await ms.CopyToAsync(writableStream, BufferSize, cancellationToken).ConfigureAwait(false);
-			}
-			if (Type != 0)
-				WrittenBytes = ms?.ToArray();
+
+			if (buffer == null || !disableDirectStreaming) return;
+
+			buffer.Position = 0;
+			await buffer.CopyToAsync(writableStream, BufferSize, cancellationToken).ConfigureAwait(false);
+			WrittenBytes ??= buffer.ToArray();
 		}
 	}
 }

--- a/src/Elasticsearch.Net/Transport/SerializableData.cs
+++ b/src/Elasticsearch.Net/Transport/SerializableData.cs
@@ -1,6 +1,7 @@
 ﻿using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
+using static Elasticsearch.Net.SerializationFormatting;
 
 namespace Elasticsearch.Net
 {
@@ -14,46 +15,31 @@ namespace Elasticsearch.Net
 			_serializable = item;
 		}
 
+		public static implicit operator SerializableData<T>(T serializableData) => new SerializableData<T>(serializableData);
+
 		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)
 		{
-			var indent = settings.PrettyJson ? SerializationFormatting.Indented : SerializationFormatting.None;
+			MemoryStream buffer = null;
 			var stream = writableStream;
-			MemoryStream ms = null;
-			if (DisableDirectStreaming ?? settings.DisableDirectStreaming)
-			{
-				ms = settings.MemoryStreamFactory.Create();
-				stream = ms;
-			}
-			settings.RequestResponseSerializer.Serialize(_serializable, stream, indent);
-			if (ms != null)
-			{
-				ms.Position = 0;
-				ms.CopyTo(writableStream, BufferSize);
-			}
-			if (Type != 0)
-				WrittenBytes = ms?.ToArray();
-		}
+			BufferIfNeeded(settings, ref buffer, ref stream);
 
-		public static implicit operator SerializableData<T>(T serializableData) => new SerializableData<T>(serializableData);
+			var indent = settings.PrettyJson ? Indented : None;
+			settings.RequestResponseSerializer.Serialize(_serializable, stream, indent);
+
+			FinishStream(writableStream, buffer, settings);
+		}
 
 		public override async Task WriteAsync(Stream writableStream, IConnectionConfigurationValues settings, CancellationToken cancellationToken)
 		{
-			var indent = settings.PrettyJson ? SerializationFormatting.Indented : SerializationFormatting.None;
-			var stream = writableStream;
-			MemoryStream ms = null;
-			if (DisableDirectStreaming ?? settings.DisableDirectStreaming)
-			{
-				ms = settings.MemoryStreamFactory.Create();
-				stream = ms;
-			}
-			await settings.RequestResponseSerializer.SerializeAsync(_serializable, stream, indent, cancellationToken).ConfigureAwait(false);
-			if (ms != null)
-			{
-				ms.Position = 0;
-				await ms.CopyToAsync(writableStream, BufferSize, cancellationToken).ConfigureAwait(false);
-			}
-			if (Type != 0)
-				WrittenBytes = ms?.ToArray();
+			MemoryStream buffer = null;
+            var stream = writableStream;
+            BufferIfNeeded(settings, ref buffer, ref stream);
+
+            var indent = settings.PrettyJson ? Indented : None;
+			await settings.RequestResponseSerializer.SerializeAsync(_serializable, stream, indent, cancellationToken)
+				.ConfigureAwait(false);
+
+			await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
 		}
 	}
 }

--- a/src/Elasticsearch.Net/Transport/StreamableData.cs
+++ b/src/Elasticsearch.Net/Transport/StreamableData.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Represents an instance of <see cref="PostData"/> that can handle <see cref="PostType.StreamHandler"/>.
+	/// Allows users full control over how they want to write data to the stream to Elasticsearch
+	/// </summary>
+	/// <typeparam name="T">The data or a state object used during writing, passed to the handlers to avoid boxing</typeparam>
+	public class StreamableData<T> : PostData, IPostData<T>
+	{
+		private readonly T _state;
+		private readonly Action<T, Stream> _syncWriter;
+		private readonly Func<T, Stream, CancellationToken, Task> _asyncWriter;
+
+		public StreamableData(T state, Action<T, Stream> syncWriter, Func<T, Stream, CancellationToken, Task> asyncWriter)
+		{
+			_state = state;
+			const string message = "PostData.StreamHandler needs to handle both synchronous and async paths";
+			_syncWriter = syncWriter ?? throw new ArgumentNullException(nameof(syncWriter), message);
+			_asyncWriter = asyncWriter ?? throw new ArgumentNullException(nameof(asyncWriter), message);
+			if (_syncWriter == null || _asyncWriter == null)
+				throw new ArgumentNullException();
+			Type = PostType.StreamHandler;
+		}
+
+		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)
+		{
+			MemoryStream buffer = null;
+			var stream = writableStream;
+			BufferIfNeeded(settings, ref buffer, ref stream);
+			_syncWriter(_state, stream);
+			FinishStream(writableStream, buffer, settings);
+		}
+
+		public override async Task WriteAsync(Stream writableStream, IConnectionConfigurationValues settings, CancellationToken cancellationToken)
+		{
+			MemoryStream buffer = null;
+			var stream = writableStream;
+			BufferIfNeeded(settings, ref buffer, ref stream);
+			await _asyncWriter(_state, stream, cancellationToken).ConfigureAwait(false);
+			await FinishStreamAsync(writableStream, buffer, settings, cancellationToken).ConfigureAwait(false);
+		}
+	}
+}

--- a/tests/Tests.Benchmarking/BenchmarkProgram.cs
+++ b/tests/Tests.Benchmarking/BenchmarkProgram.cs
@@ -64,10 +64,8 @@ namespace Tests.Benchmarking
 		{
 			var jobs = new List<Job>
 			{
-				Job.MediumRun.With(CoreRuntime.Core30).With(Jit.RyuJit),
+				Job.Default.With(CoreRuntime.Core30).With(Jit.RyuJit),
 			};
-			if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-				jobs.Add(Job.MediumRun.With(ClrRuntime.Net472).With(Jit.LegacyJit));
 
 			var config = DefaultConfig.Instance
 				.With(jobs.ToArray())

--- a/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
@@ -1,0 +1,164 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using BenchmarkDotNet.Attributes;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Benchmarking.Framework;
+using Tests.Core.Client;
+using Tests.Domain;
+
+namespace Tests.Benchmarking
+{
+	[BenchmarkConfig(5)]
+	public class BulkBenchmarkLowLevelTests
+	{
+		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
+
+		private static readonly byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+
+		private static readonly IElasticClient Client =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+			);
+
+		private static readonly IElasticLowLevelClient ClientLowLevel = Client.LowLevel;
+
+		[GlobalSetup]
+		public void Setup() { }
+
+		[Benchmark(Description = "ListOfObjects")]
+		public BulkResponse ListOfObjects()
+		{
+			var postData = Projects.SelectMany(p => new object[] { new { index = new { } }, p });
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.MultiJson(postData));
+			return lowLevel;
+		}
+
+		private static readonly object[] StaticArrayOfObjects =
+			Projects.SelectMany(p => new object[] { new { index = new { } }, p }).ToArray();
+
+		[Benchmark(Description = "StaticListOfObjects")]
+		public BulkResponse StaticListOfObjects()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.MultiJson(StaticArrayOfObjects));
+			return lowLevel;
+		}
+
+		private static readonly PostData StaticPostData = PostData.MultiJson(StaticArrayOfObjects);
+		[Benchmark(Description = "PrecomputedPostDataOfObjects")]
+		public BulkResponse PrecomputedPostDataOfObjects()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(StaticPostData);
+			return lowLevel;
+		}
+
+		private static readonly string _header = @"{""index"":{}}";
+		private static readonly string[] StaticListString =
+			Projects.SelectMany(p => new string[] { _header, Client.SourceSerializer.SerializeToString(p) }).ToArray();
+		private static readonly PostData StaticPostDataListString = PostData.MultiJson(StaticListString);
+
+		[Benchmark(Description = "StaticListOfStrings")]
+		public BulkResponse StaticListOfStrings()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.MultiJson(StaticListString));
+			return lowLevel;
+		}
+
+		[Benchmark(Description = "PrecomputedPostDataOfStrings")]
+		public BulkResponse PrecomputedPostDataOfStrings()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(StaticPostDataListString);
+			return lowLevel;
+		}
+
+		private static readonly string StaticString = string.Join("\n", StaticListString);
+		[Benchmark(Description = "PostDataString")]
+		public BulkResponse PostDataString()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.String(StaticString));
+			return lowLevel;
+		}
+
+		private static readonly PostData PrecomputedStaticString = PostData.String(StaticString);
+		[Benchmark(Description = "PrecomputedPostDataString")]
+		public BulkResponse PrecomputedPostDataString()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PrecomputedStaticString);
+			return lowLevel;
+		}
+
+		private static readonly byte[] StaticBytes = Encoding.UTF8.GetBytes(StaticString);
+		[Benchmark(Description = "PostDataByteArray")]
+		public BulkResponse PostDataByteArray()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.Bytes(StaticBytes));
+			return lowLevel;
+		}
+
+		private static readonly ReadOnlyMemory<byte> StaticMemory = StaticBytes.AsMemory();
+
+		[Benchmark(Description = "PostDataReadOnlyMemory")]
+		public BulkResponse PostDataReadOnlyMemory()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.ReadOnlyMemory(StaticMemory));
+			return lowLevel;
+		}
+
+		[Benchmark(Description = "PostDataStreamHandler")]
+		public BulkResponse PostDataStreamHandler()
+		{
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.StreamHandler(
+				s =>
+				{
+					var span = StaticBytes.AsSpan();
+					s.Write(span);
+				},
+				async (s, ctx) =>
+				{
+					var span = StaticBytes.AsMemory();
+					await s.WriteAsync(span, ctx);
+				}
+				));
+			return lowLevel;
+		}
+
+		[GlobalCleanup]
+		private static void X()
+		{
+			var bytes = Encoding.UTF8.GetByteCount(StaticString);
+			Console.WriteLine($"=====> {((bytes/1024f)/1024f)}");
+		}
+
+		private static object BulkItemResponse(Project project) => new
+		{
+			index = new
+			{
+				_index = "nest-52cfd7aa",
+				_id = project.Name,
+				_version = 1,
+				_shards = new
+				{
+					total = 2,
+					successful = 1,
+					failed = 0
+				},
+				created = true,
+				status = 201
+			}
+		};
+
+		private static object ReturnBulkResponse(IList<Project> projects) => new
+		{
+			took = 276,
+			errors = false,
+			items = projects
+				.Select(p => BulkItemResponse(p))
+				.ToArray()
+		};
+	}
+}

--- a/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
@@ -112,18 +112,9 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "PostDataStreamHandler")]
 		public BulkResponse PostDataStreamHandler()
 		{
-			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.StreamHandler(
-				s =>
-				{
-					var span = StaticBytes.AsSpan();
-					s.Write(span);
-				},
-				async (s, ctx) =>
-				{
-					var span = StaticBytes.AsMemory();
-					await s.WriteAsync(span, ctx);
-				}
-				));
+			var lowLevel = ClientLowLevel.Bulk<BulkResponse>(PostData.StreamHandler(StaticBytes,
+				(bytes, s) => s.Write(bytes.AsSpan()),
+				async (bytes, s, ctx) => await s.WriteAsync(bytes.AsMemory(), ctx)));
 			return lowLevel;
 		}
 

--- a/tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -21,13 +21,12 @@ namespace Tests.Benchmarking
 				.EnableHttpCompression(false)
 			);
 
-		//TODO can uncomment when https://github.com/elastic/elasticsearch-net/pull/4202 lands
-//		private static readonly IElasticClient ClientNoRecyclableMemory =
-//			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
-//				.DefaultIndex("index")
-//				.EnableHttpCompression(false)
-//				.MemoryStreamFactory(MemoryStreamFactory.Default)
-//			);
+		private static readonly IElasticClient ClientNoRecyclableMemory =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+				.MemoryStreamFactory(MemoryStreamFactory.Default)
+			);
 
 		private static readonly Nest8.IElasticClient ClientV8 =
 			new Nest8.ElasticClient(new Nest8.ConnectionSettings(
@@ -42,8 +41,8 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "PR")]
 		public BulkResponse NestUpdatedBulk() => Client.Bulk(b => b.IndexMany(Projects));
 
-//		[Benchmark(Description = "PR no recyclable")]
-//		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
+		[Benchmark(Description = "PR no recyclable")]
+		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
 
 		[Benchmark(Description = "8.x")]
 		public Nest8.BulkResponse NestCurrentBulk() => ClientV8.Bulk(b => b.IndexMany(Projects));

--- a/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.0;net472</TargetFrameworks>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>


### PR DESCRIPTION
New types

* `ReadOnlyMemory`, only available in `netstandard2.1` allows you to
post `ReadOnlyMemory<byte>`
* `StreamHandler` allows you to inject a stream handler and write to the
request streams the best way you see fit yourself

Performance

* `PostData.String` now reuses bytes
* `PostData.MultiJson(string[])` uses way less allocations


Benchmarks current PR posting `10.000` objects (many megabytes overal in size) in various ways.


|                       Method |      Mean |    Error |    StdDev |    Median |      Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------------------- |----------:|---------:|----------:|----------:|-----------:|------:|------:|----------:|
|                ListOfObjects | 449.20 ms | 8.854 ms | 13.785 ms | 447.42 ms | 11000.0000 |     - |     - |  74.89 MB |
|          StaticListOfObjects | 437.08 ms | 8.321 ms |  7.784 ms | 437.84 ms | 11000.0000 |     - |     - |  74.58 MB |
| PrecomputedPostDataOfObjects | 435.43 ms | 8.643 ms | 17.061 ms | 437.11 ms | 11000.0000 |     - |     - |  74.57 MB |
|          StaticListOfStrings |  48.20 ms | 1.066 ms |  3.042 ms |  47.25 ms |  4000.0000 |     - |     - |  32.64 MB |
| PrecomputedPostDataOfStrings |  47.48 ms | 1.084 ms |  3.076 ms |  46.58 ms |  4000.0000 |     - |     - |  32.64 MB |
|               PostDataString |  48.30 ms | 2.238 ms |  6.598 ms |  49.59 ms |          - |     - |     - |  31.97 MB |
|    PrecomputedPostDataString |  29.05 ms | 0.579 ms |  1.546 ms |  28.98 ms |          - |     - |     - |   7.95 MB |
|            PostDataByteArray |  28.50 ms | 0.566 ms |  1.521 ms |  28.30 ms |          - |     - |     - |   7.95 MB |
|       PostDataReadOnlyMemory |  28.43 ms | 0.562 ms |  1.070 ms |  28.29 ms |          - |     - |     - |   7.95 MB |
|        PostDataStreamHandler |  28.89 ms | 0.576 ms |  1.240 ms |  28.77 ms |          - |     - |     - |   7.95 MB |


Compare with current master:

|                       Method |      Mean |     Error |    StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|----------------------------- |----------:|----------:|----------:|-----------:|----------:|------:|----------:|
|                ListOfObjects | 577.61 ms | 22.658 ms | 33.212 ms | 11000.0000 |         - |     - |   74.9 MB |
|          StaticListOfObjects | 564.67 ms | 16.437 ms | 24.093 ms | 11000.0000 |         - |     - |  73.78 MB |
| PrecomputedPostDataOfObjects | 486.68 ms | 30.829 ms | 46.143 ms | 11000.0000 |         - |     - |  73.86 MB |
|          StaticListOfStrings | 184.01 ms |  5.788 ms |  8.483 ms |  8000.0000 | 3000.0000 |     - | 201.65 MB |
| PrecomputedPostDataOfStrings | 182.36 ms |  4.817 ms |  7.061 ms |  8000.0000 | 3000.0000 |     - | 201.88 MB |
|               PostDataString |  59.34 ms |  5.446 ms |  8.152 ms |          - |         - |     - |  56.01 MB |
|    PrecomputedPostDataString |  60.56 ms |  5.526 ms |  8.271 ms |          - |         - |     - |  56.12 MB |
|            PostDataByteArray |  33.31 ms |  1.265 ms |  1.894 ms |          - |         - |     - |   7.95 MB |


