### PR TITLE
Additional UTF8Json overloads, consolidate how we tell it to write/serialize.

### DIFF
--- a/src/Elasticsearch.Net/Serialization/DiagnosticsSerializerProxy.cs
+++ b/src/Elasticsearch.Net/Serialization/DiagnosticsSerializerProxy.cs
@@ -54,8 +54,8 @@ namespace Elasticsearch.Net
 			}
 			else
 			{
-				_wrapsUtf8JsonSerializer = false;
 				_formatterResolver = null;
+				_wrapsUtf8JsonSerializer = false;
 			}
 		}
 

--- a/src/Elasticsearch.Net/Serialization/DiagnosticsSerializerProxy.cs
+++ b/src/Elasticsearch.Net/Serialization/DiagnosticsSerializerProxy.cs
@@ -32,13 +32,10 @@ namespace Elasticsearch.Net
 		public override string ToString() => _stringRepresentation;
 	}
 
-	//TODO this no longer needs to be IInternalSerializerWithFormatter
-	// Previous we checked that the serializer we are wrapping implements the interface and if so set the formatter
-	// However its totally fine for formatter to be null. `IJsonFormatter` solves this better.
 	/// <summary>
 	/// Wraps configured serializer so that we can emit diagnostics per configured serializer.
 	/// </summary>
-	internal class DiagnosticsSerializerProxy : IElasticsearchSerializer, IInternalSerializerWithFormatter, IInternalSerializer
+	internal class DiagnosticsSerializerProxy : IElasticsearchSerializer, IInternalSerializer
 	{
 		private readonly IElasticsearchSerializer _serializer;
 		private readonly bool _wrapsUtf8JsonSerializer;
@@ -50,9 +47,9 @@ namespace Elasticsearch.Net
 		{
 			_serializer = serializer;
 			_state = new SerializerRegistrationInformation(serializer.GetType(), purpose);
-			if (serializer is IInternalSerializerWithFormatter withFormatter)
+			if (serializer is IInternalSerializer s && s.TryGetJsonFormatter(out var formatterResolver))
 			{
-				_formatterResolver = withFormatter.FormatterResolver;
+				_formatterResolver = formatterResolver;
 				_wrapsUtf8JsonSerializer = true;
 			}
 			else
@@ -61,8 +58,6 @@ namespace Elasticsearch.Net
 				_formatterResolver = null;
 			}
 		}
-
-		public IJsonFormatterResolver FormatterResolver => _formatterResolver;
 
 		public bool TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver)
 		{

--- a/src/Elasticsearch.Net/Serialization/IInternalSerializerWithFormatter.cs
+++ b/src/Elasticsearch.Net/Serialization/IInternalSerializerWithFormatter.cs
@@ -7,8 +7,4 @@ namespace Elasticsearch.Net
 		bool TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver);
 	}
 
-	internal interface IInternalSerializerWithFormatter
-	{
-		IJsonFormatterResolver FormatterResolver { get; }
-	}
 }

--- a/src/Elasticsearch.Net/Serialization/IInternalSerializerWithFormatter.cs
+++ b/src/Elasticsearch.Net/Serialization/IInternalSerializerWithFormatter.cs
@@ -1,7 +1,12 @@
 using Elasticsearch.Net.Utf8Json;
 
-namespace Elasticsearch.Net 
+namespace Elasticsearch.Net
 {
+	internal interface IInternalSerializer
+	{
+		bool TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver);
+	}
+
 	internal interface IInternalSerializerWithFormatter
 	{
 		IJsonFormatterResolver FormatterResolver { get; }

--- a/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -7,10 +7,8 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Elasticsearch.Net
 {
-	public class LowLevelRequestResponseSerializer : IElasticsearchSerializer, IInternalSerializerWithFormatter
+	public class LowLevelRequestResponseSerializer : IElasticsearchSerializer, IInternalSerializer
 	{
-		IJsonFormatterResolver IInternalSerializerWithFormatter.FormatterResolver => null;
-
 		public static readonly LowLevelRequestResponseSerializer Instance = new LowLevelRequestResponseSerializer();
 
 		public object Deserialize(Type type, Stream stream) =>
@@ -32,5 +30,11 @@ namespace Elasticsearch.Net
 			CancellationToken cancellationToken = default
 		) =>
 			JsonSerializer.SerializeAsync(writableStream, data, ElasticsearchNetFormatterResolver.Instance);
+
+		bool IInternalSerializer.TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver)
+		{
+			formatterResolver = ElasticsearchNetFormatterResolver.Instance;
+			return true;
+		}
 	}
 }

--- a/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
+++ b/src/Elasticsearch.Net/Serialization/LowLevelRequestResponseSerializer.cs
@@ -7,8 +7,10 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Elasticsearch.Net
 {
-	public class LowLevelRequestResponseSerializer : IElasticsearchSerializer
+	public class LowLevelRequestResponseSerializer : IElasticsearchSerializer, IInternalSerializerWithFormatter
 	{
+		IJsonFormatterResolver IInternalSerializerWithFormatter.FormatterResolver => null;
+
 		public static readonly LowLevelRequestResponseSerializer Instance = new LowLevelRequestResponseSerializer();
 
 		public object Deserialize(Type type, Stream stream) =>

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -105,6 +105,8 @@ namespace Elasticsearch.Net
 
 	public class PostData<T> : PostData, IPostData<T>
 	{
+		private readonly Action<Stream> _syncWriter;
+		private readonly Func<Stream, CancellationToken, Task> _asyncWriter;
 		private readonly IEnumerable<object> _enumerableOfObject;
 		private readonly IEnumerable<string> _enumerableOfStrings;
 		private readonly string _literalString;
@@ -142,6 +144,25 @@ namespace Elasticsearch.Net
 		{
 			_enumerableOfObject = item;
 			Type = PostType.EnumerableOfObject;
+		}
+
+		protected internal PostData(Action<Stream> syncWriter, Func<Stream, CancellationToken, Task> asyncWriter)
+		{
+			const string message = "PostData.StreamHandler needs to handle both synchronous and async paths";
+			_syncWriter = syncWriter ?? throw new ArgumentNullException(nameof(syncWriter), message);
+			_asyncWriter = asyncWriter ?? throw new ArgumentNullException(nameof(asyncWriter), message);
+			if (_syncWriter == null || _asyncWriter == null)
+				throw new ArgumentNullException();
+		}
+
+		private static void BufferIfNeeded(IConnectionConfigurationValues settings, bool disableDirectStreaming, ref MemoryStream buffer,
+			ref Stream stream
+		)
+		{
+			if (!disableDirectStreaming) return;
+
+			buffer = settings.MemoryStreamFactory.Create();
+			stream = buffer;
 		}
 
 		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Text;
@@ -105,8 +105,6 @@ namespace Elasticsearch.Net
 
 	public class PostData<T> : PostData, IPostData<T>
 	{
-		private readonly Action<Stream> _syncWriter;
-		private readonly Func<Stream, CancellationToken, Task> _asyncWriter;
 		private readonly IEnumerable<object> _enumerableOfObject;
 		private readonly IEnumerable<string> _enumerableOfStrings;
 		private readonly string _literalString;
@@ -144,25 +142,6 @@ namespace Elasticsearch.Net
 		{
 			_enumerableOfObject = item;
 			Type = PostType.EnumerableOfObject;
-		}
-
-		protected internal PostData(Action<Stream> syncWriter, Func<Stream, CancellationToken, Task> asyncWriter)
-		{
-			const string message = "PostData.StreamHandler needs to handle both synchronous and async paths";
-			_syncWriter = syncWriter ?? throw new ArgumentNullException(nameof(syncWriter), message);
-			_asyncWriter = asyncWriter ?? throw new ArgumentNullException(nameof(asyncWriter), message);
-			if (_syncWriter == null || _asyncWriter == null)
-				throw new ArgumentNullException();
-		}
-
-		private static void BufferIfNeeded(IConnectionConfigurationValues settings, bool disableDirectStreaming, ref MemoryStream buffer,
-			ref Stream stream
-		)
-		{
-			if (!disableDirectStreaming) return;
-
-			buffer = settings.MemoryStreamFactory.Create();
-			stream = buffer;
 		}
 
 		public override void Write(Stream writableStream, IConnectionConfigurationValues settings)

--- a/src/Elasticsearch.Net/Transport/PostData.cs
+++ b/src/Elasticsearch.Net/Transport/PostData.cs
@@ -210,10 +210,13 @@ namespace Elasticsearch.Net
 					break;
 
 				case PostType.StreamHandler:
-					throw new Exception("PostData is not expected/capable to handle streamable data, use StreamableData instead");
-
+					var streamHandlerException = $"{nameof(PostData)} cannot handle {nameof(PostType.StreamHandler)} data. "
+						+ $"Use {typeof(StreamableData<>).FullName} through {nameof(PostData)}.{nameof(StreamHandler)}<T>() for streamable data";
+					throw new Exception(streamHandlerException);
 				case PostType.Serializable:
-					throw new Exception("PostData is not expected/capable to handle contain serializable, use SerializableData instead");
+					var serializableException = $"{nameof(PostData)} cannot handle {nameof(PostType.Serializable)} data. "
+						+ $"Use {typeof(SerializableData<>).FullName} through {nameof(PostData)}.{nameof(Serializable)}<T>() for serializable data";
+					throw new Exception(serializableException);
 
 				default:
 					throw new ArgumentOutOfRangeException();

--- a/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System;
+using System.Collections.Concurrent;
 using System.Reflection;
 
 namespace Elasticsearch.Net.Utf8Json

--- a/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/IJsonFormatterResolver.cs
@@ -60,11 +60,10 @@ namespace Elasticsearch.Net.Utf8Json
             return formatter;
         }
 
+		private static readonly MethodInfo _getFormatterMethod = typeof(IJsonFormatterResolver).GetRuntimeMethod("GetFormatter", Type.EmptyTypes);
         public static object GetFormatterDynamic(this IJsonFormatterResolver resolver, Type type)
         {
-            var methodInfo = typeof(IJsonFormatterResolver).GetRuntimeMethod("GetFormatter", Type.EmptyTypes);
-
-            var formatter = methodInfo.MakeGenericMethod(type).Invoke(resolver, null);
+            var formatter = _getFormatterMethod.MakeGenericMethod(type).Invoke(resolver, null);
             return formatter;
         }
     }

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
@@ -34,9 +34,10 @@ namespace Elasticsearch.Net.Utf8Json.Internal
     {
         public static readonly bool Is32Bit = (IntPtr.Size == 4);
 
-        public static void WriteRaw(ref JsonWriter writer, byte[] src)
+        public static void WriteRaw(ref JsonWriter writer, byte[] src) => WriteRaw(ref writer, src, src.Length);
+        public static void WriteRaw(ref JsonWriter writer, byte[] src, int length)
         {
-            switch (src.Length)
+            switch (length)
             {
                 case 0: break;
                 case 1: if (Is32Bit) { UnsafeMemory32.WriteRaw1(ref writer, src); } else { UnsafeMemory64.WriteRaw1(ref writer, src); } break;
@@ -76,15 +77,18 @@ namespace Elasticsearch.Net.Utf8Json.Internal
             }
         }
 
-        public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src)
+        public static void MemoryCopy(ref JsonWriter writer, byte[] src) => MemoryCopy(ref writer, src, src.Length);
+
+        public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src, int length)
         {
-            BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, src.Length);
+            BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, length);
+#if !NET45
             fixed (void* dstP = &writer.buffer[writer.offset])
             fixed (void* srcP = &src[0])
             {
-                Buffer.MemoryCopy(srcP, dstP, writer.buffer.Length - writer.offset, src.Length);
+                Buffer.MemoryCopy(srcP, dstP, writer.buffer.Length - writer.offset, length);
             }
-            writer.offset += src.Length;
+            writer.offset += length;
         }
     }
 

--- a/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/UnsafeMemory.Low.cs
@@ -82,7 +82,6 @@ namespace Elasticsearch.Net.Utf8Json.Internal
         public static unsafe void MemoryCopy(ref JsonWriter writer, byte[] src, int length)
         {
             BinaryUtil.EnsureCapacity(ref writer.buffer, writer.offset, length);
-#if !NET45
             fixed (void* dstP = &writer.buffer[writer.offset])
             fixed (void* srcP = &src[0])
             {

--- a/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
@@ -134,15 +134,10 @@ namespace Elasticsearch.Net.Utf8Json
         {
             UnsafeMemory.WriteRaw(ref this, rawValue, length);
         }
-        public void WriteRaw(MemoryStream ms)
+
+		public void WriteRaw(MemoryStream ms)
 		{
-			if (ms.TryGetBuffer(out var b) && !(b.Array is null) && b.Offset == 0)
-				WriteRaw(b.Array, b.Count);
-			else
-			{
-				var bytes = ms.ToArray();
-				this.WriteRaw(bytes);
-			}
+			UnsafeMemory.WriteRaw(ref this, ms);
 		}
 
 		public void WriteSerialized<T>(T value, IElasticsearchSerializer serializer, IConnectionConfigurationValues settings, SerializationFormatting formatting = SerializationFormatting.None)

--- a/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonWriter.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System;
+using System.IO;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Elasticsearch.Net.Extensions;
@@ -129,6 +130,27 @@ namespace Elasticsearch.Net.Utf8Json
         {
             UnsafeMemory.WriteRaw(ref this, rawValue);
         }
+        public void WriteRaw(byte[] rawValue, int length)
+        {
+            UnsafeMemory.WriteRaw(ref this, rawValue, length);
+        }
+        public void WriteRaw(MemoryStream ms)
+		{
+			if (ms.TryGetBuffer(out var b) && !(b.Array is null) && b.Offset == 0)
+				WriteRaw(b.Array, b.Count);
+			else
+			{
+				var bytes = ms.ToArray();
+				this.WriteRaw(bytes);
+			}
+		}
+
+		public void WriteSerialized<T>(T value, IElasticsearchSerializer serializer, IConnectionConfigurationValues settings, SerializationFormatting formatting = SerializationFormatting.None)
+		{
+			using var ms = settings.MemoryStreamFactory.Create();
+			serializer.Serialize(value, ms, formatting);
+			WriteRaw(ms);
+		}
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void WriteRawUnsafe(byte rawValue)
@@ -423,5 +445,6 @@ namespace Elasticsearch.Net.Utf8Json
 			buffer[offset++] = (byte)CharUtils.HexDigit((c >> 4) & '\x000f');
 			buffer[offset++] = (byte)CharUtils.HexDigit(c & '\x000f');
 		}
+
 	}
 }

--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/CompositeResolver.cs
@@ -157,7 +157,7 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
     {
 		private static readonly string ModuleName =  $"{ResolverConfig.Namespace}.DynamicCompositeResolver";
 
-        static readonly DynamicAssembly assembly;
+		static readonly DynamicAssembly assembly;
 
         static DynamicCompositeResolver()
         {

--- a/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
+++ b/src/Nest/CommonAbstractions/Extensions/TypeExtensions.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using System.Text;
+using Elasticsearch.Net.CrossPlatform;
 
 namespace Nest
 {
@@ -150,5 +151,9 @@ namespace Nest
 		}
 
 		internal delegate T ObjectActivator<out T>(params object[] args);
+
+		private static readonly Assembly NestAssembly = typeof(TypeExtensions).Assembly();
+
+		public static bool IsNestType(this Type type) => type.Assembly() == NestAssembly;
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/DefaultHighLevelSerializer.cs
@@ -8,11 +8,17 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	/// <summary>The built in internal serializer that the high level client NEST uses.</summary>
-	internal class DefaultHighLevelSerializer : IElasticsearchSerializer, IInternalSerializerWithFormatter
+	internal class DefaultHighLevelSerializer : IElasticsearchSerializer, IInternalSerializer
 	{
 		public DefaultHighLevelSerializer(IJsonFormatterResolver formatterResolver) => FormatterResolver = formatterResolver;
 
-		public IJsonFormatterResolver FormatterResolver { get; }
+		private IJsonFormatterResolver FormatterResolver { get; }
+
+		bool IInternalSerializer.TryGetJsonFormatter(out IJsonFormatterResolver formatterResolver)
+		{
+			formatterResolver = FormatterResolver;
+			return true;
+		}
 
 		public T Deserialize<T>(Stream stream) =>
 			JsonSerializer.Deserialize<T>(stream, FormatterResolver);
@@ -32,5 +38,6 @@ namespace Nest
 		public Task SerializeAsync<T>(T data, Stream stream, SerializationFormatting formatting = SerializationFormatting.None,
 			CancellationToken cancellationToken = default
 		) => JsonSerializer.SerializeAsync(stream, data, FormatterResolver);
+
 	}
 }

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/ProxyRequestFormatterBase.cs
@@ -37,8 +37,7 @@ namespace Nest
 			using (var ms = settings.MemoryStreamFactory.Create())
 			{
 				untypedDocumentRequest.WriteJson(serializer, ms, SerializationFormatting.None);
-				var v = ms.ToArray();
-				writer.WriteRaw(v);
+				writer.WriteRaw(ms);
 			}
 		}
 	}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -30,8 +30,13 @@ namespace Nest
 			var settings = formatterResolver.GetConnectionSettings();
 
 			// avoid serialization to bytes when not using custom source serializer
-			if (ReferenceEquals(settings.SourceSerializer, settings.RequestResponseSerializer)
-				|| settings.SourceSerializer is IInternalSerializerWithFormatter s && s.FormatterResolver != null)
+			// This used to check for reference of the source serializer and the request response serializer
+			// However each now gets wrapped in a new `DiagnosticsSerializerProxy` so this check no longer works
+			// therefor we now check if the SourceSerializer is internal with a formatter.
+			// DiagnosticsSerializerProxy implements this interface, it simply proxies to whatever it wraps so
+			// we need to assert the resolver is not actually null here since it can wrap something that is not
+			// `IInternalSerializerWithFormatter`
+			if (settings.SourceSerializer is IInternalSerializerWithFormatter s && s.FormatterResolver != null)
 			{
 				formatterResolver.GetFormatter<T>().Serialize(ref writer, value, formatterResolver);
 				return;

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -12,45 +12,42 @@ namespace Nest
 	{
 		public virtual SerializationFormatting? ForceFormatting { get; } = null;
 
+		/// <summary>
+		/// If SourceSerializer exposes a formatter we can use it directly
+		/// </summary>
+		private static bool AttemptFastPath(IElasticsearchSerializer serializer, out IJsonFormatterResolver formatter)
+		{
+			formatter = null;
+			return serializer is IInternalSerializer s && s.TryGetJsonFormatter(out formatter);
+		}
+
+
 		public T Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var settings = formatterResolver.GetConnectionSettings();
 
-			// avoid deserialization through stream when not using custom source serializer
-			if (AttemptFastPath(settings.SourceSerializer))
-				return formatterResolver.GetFormatter<T>().Deserialize(ref reader, formatterResolver);
+			var sourceSerializer = settings.SourceSerializer;
+			if (AttemptFastPath(sourceSerializer, out var formatter))
+				return formatter.GetFormatter<T>().Deserialize(ref reader, formatter);
 
 			var arraySegment = reader.ReadNextBlockSegment();
 			using (var ms = settings.MemoryStreamFactory.Create(arraySegment.Array, arraySegment.Offset, arraySegment.Count))
-				return settings.SourceSerializer.Deserialize<T>(ms);
+				return sourceSerializer.Deserialize<T>(ms);
 		}
-
-		/// <summary>
-		/// Avoid serialization to bytes when not using a custom source serializer.
-		/// This used to check for reference of the source serializer and the request response serializer
-		/// However each now gets wrapped in a new `DiagnosticsSerializerProxy` so this check no longer works
-		/// therefor we now check if the SourceSerializer is internal with a formatter.
-		/// DiagnosticsSerializerProxy implements this interface, it simply proxies to whatever it wraps so
-		/// we need to assert the resolver is not actually null here since it can wrap something that is not
-		/// `IInternalSerializerWithFormatter`
-		/// </summary>
-		private static bool AttemptFastPath(IElasticsearchSerializer serializer) =>
-			serializer is IInternalSerializer s && s.TryGetJsonFormatter(out var _);
 
 
 		public virtual void Serialize(ref JsonWriter writer, T value, IJsonFormatterResolver formatterResolver)
 		{
 			var settings = formatterResolver.GetConnectionSettings();
 
-			if (AttemptFastPath(settings.SourceSerializer))
+			var sourceSerializer = settings.SourceSerializer;
+			if (AttemptFastPath(sourceSerializer, out var formatter))
 			{
-				formatterResolver.GetFormatter<T>().Serialize(ref writer, value, formatterResolver);
+				formatter.GetFormatter<T>().Serialize(ref writer, value, formatter);
 				return;
 			}
 
-			var sourceSerializer = settings.SourceSerializer;
 			var f = ForceFormatting ?? SerializationFormatting.None;
-
 			writer.WriteSerialized(value, sourceSerializer, settings, f);
 		}
 	}

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/SourceFormatter.cs
@@ -35,7 +35,7 @@ namespace Nest
 		/// `IInternalSerializerWithFormatter`
 		/// </summary>
 		private static bool AttemptFastPath(IElasticsearchSerializer serializer) =>
-			serializer is IInternalSerializerWithFormatter s && s.FormatterResolver != null;
+			serializer is IInternalSerializer s && s.TryGetJsonFormatter(out var _);
 
 
 		public virtual void Serialize(ref JsonWriter writer, T value, IJsonFormatterResolver formatterResolver)

--- a/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/SourceValueWriteConverter.cs
@@ -1,4 +1,3 @@
-using Elasticsearch.Net.CrossPlatform;
 using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
@@ -13,8 +12,7 @@ namespace Nest
 				return;
 			}
 
-			var nestType = value.GetType().Assembly() == typeof(SourceWriteFormatter<>).Assembly();
-			if (nestType)
+			if (value.GetType().IsNestType())
 				formatterResolver.GetFormatter<T>().Serialize(ref writer, value, formatterResolver);
 			else
 				base.Serialize(ref writer, value, formatterResolver);

--- a/src/Nest/CommonAbstractions/SerializationBehavior/StatefulSerializerExtensions.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/StatefulSerializerExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Elasticsearch.Net;
 using Elasticsearch.Net.Utf8Json;
 
@@ -7,7 +8,9 @@ namespace Nest
 	{
 		public static DefaultHighLevelSerializer CreateStateful<T>(this IElasticsearchSerializer serializer, IJsonFormatter<T> formatter)
 		{
-			var currentFormatterResolver = ((IInternalSerializerWithFormatter)serializer).FormatterResolver;
+			if (!(serializer is IInternalSerializer s) || !s.TryGetJsonFormatter(out var currentFormatterResolver))
+				throw new Exception($"Can not create a stateful serializer because {serializer.GetType()} does not yield a json formatter");
+
 			var formatterResolver = new StatefulFormatterResolver<T>(formatter, currentFormatterResolver);
 			return new DefaultHighLevelSerializer(formatterResolver);
 		}

--- a/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
@@ -45,10 +45,9 @@ namespace Nest
 				{
 					var requestResponseSerializer = settings.RequestResponseSerializer;
 					requestResponseSerializer.SerializeUsingWriter(ref writer, body, settings, SerializationFormatting.None);
-					return;
 				}
-
-				SourceWriter.Serialize(ref writer, body, formatterResolver);
+				else
+					SourceWriter.Serialize(ref writer, body, formatterResolver);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequestFormatter.cs
@@ -41,6 +41,13 @@ namespace Nest
 				if (body == null)
 					continue;
 
+				if (op.Operation == "update" || body is ILazyDocument)
+				{
+					var requestResponseSerializer = settings.RequestResponseSerializer;
+					requestResponseSerializer.SerializeUsingWriter(ref writer, body, settings, SerializationFormatting.None);
+					return;
+				}
+
 				SourceWriter.Serialize(ref writer, body, formatterResolver);
 				writer.WriteRaw(Newline);
 			}

--- a/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
+++ b/src/Nest/Search/MultiSearch/MultiSearchFormatter.cs
@@ -44,11 +44,9 @@ namespace Nest
 					ignore_unavailable = GetString("ignore_unavailable")
 				};
 
-				var headerBytes = serializer.SerializeToBytes(header, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(headerBytes);
+				writer.WriteSerialized(header, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
-				var bodyBytes = serializer.SerializeToBytes(operation, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyBytes);
+				writer.WriteSerialized(operation, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
+++ b/src/Nest/Search/MultiSearchTemplate/MultiSearchTemplateJsonConverter.cs
@@ -44,11 +44,9 @@ namespace Nest
 					ignore_unavailable = GetString("ignore_unavailable")
 				};
 
-				var headerBytes = serializer.SerializeToBytes(header, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(headerBytes);
+				writer.WriteSerialized(header, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
-				var bodyBytes = serializer.SerializeToBytes(operation, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyBytes);
+				writer.WriteSerialized(operation, serializer, settings, SerializationFormatting.None);
 				writer.WriteRaw(Newline);
 			}
 		}

--- a/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
+++ b/src/Nest/XPack/MachineLearning/PostJobData/PostJobDataRequest.cs
@@ -63,14 +63,9 @@ namespace Nest
 
 			var settings = formatterResolver.GetConnectionSettings();
 			var sourceSerializer = settings.SourceSerializer;
-			var memoryStreamFactory = settings.MemoryStreamFactory;
 
 			foreach (var data in value.Data)
-			{
-				var bodyJson = sourceSerializer.SerializeToBytes(data, memoryStreamFactory, SerializationFormatting.None);
-				writer.WriteRaw(bodyJson);
-				writer.WriteRaw(Newline);
-			}
+				writer.WriteSerialized(data, sourceSerializer, settings, SerializationFormatting.None);
 		}
 	}
 }

--- a/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
@@ -31,6 +31,13 @@ namespace Tests.Benchmarking
 		[GlobalSetup]
 		public void Setup() { }
 
+		[Benchmark(Description = "NEST")]
+		public BulkResponse HighLevel()
+		{
+			var lowLevel = Client.Bulk(b=>b.IndexMany(Projects));
+			return lowLevel;
+		}
+
 		[Benchmark(Description = "ListOfObjects")]
 		public BulkResponse ListOfObjects()
 		{

--- a/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkLowLevelTests.cs
@@ -28,9 +28,6 @@ namespace Tests.Benchmarking
 
 		private static readonly IElasticLowLevelClient ClientLowLevel = Client.LowLevel;
 
-		[GlobalSetup]
-		public void Setup() { }
-
 		[Benchmark(Description = "NEST")]
 		public BulkResponse HighLevel()
 		{
@@ -123,13 +120,6 @@ namespace Tests.Benchmarking
 				(bytes, s) => s.Write(bytes.AsSpan()),
 				async (bytes, s, ctx) => await s.WriteAsync(bytes.AsMemory(), ctx)));
 			return lowLevel;
-		}
-
-		[GlobalCleanup]
-		private static void X()
-		{
-			var bytes = Encoding.UTF8.GetByteCount(StaticString);
-			Console.WriteLine($"=====> {((bytes/1024f)/1024f)}");
 		}
 
 		private static object BulkItemResponse(Project project) => new

--- a/tests/Tests.Core/Serialization/SerializationTester.cs
+++ b/tests/Tests.Core/Serialization/SerializationTester.cs
@@ -215,7 +215,15 @@ namespace Tests.Core.Serialization
 
 		private static bool MatchJson<T>(JToken expectedJson, string actualJson, RoundTripResult<T> result, string message)
 		{
-			var actualJsonToken = JToken.Parse(actualJson);
+			JToken actualJsonToken = null;
+			try
+			{
+				actualJsonToken = JToken.Parse(actualJson);
+			}
+			catch (Exception e)
+			{
+				throw new Exception($"Invalid json: {actualJson}", e);
+			}
 			var matches = JToken.DeepEquals(expectedJson, actualJsonToken);
 			if (matches) return true;
 


### PR DESCRIPTION
Continuation of https://github.com/elastic/elasticsearch-net/pull/4312

Pulling in the bits initially opened here: https://github.com/elastic/elasticsearch-net/pull/4209

Either memory stream or to serialize on the writer.

This consolidates and funnels places that need to write bytes/streams/objects directly.

Isolated from #4172 and #4191 which both grew to be too big to review

Prior:

|                       Method |      Mean |     Error |    StdDev |    Median |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|----------------------------- |----------:|----------:|----------:|----------:|-----------:|----------:|------:|----------:|
|                         NEST | 530.15 ms | 10.534 ms | 13.323 ms | 527.06 ms | 17000.0000 | 4000.0000 |     - | 197.13 MB |
|                ListOfObjects | 417.04 ms |  8.318 ms | 20.089 ms | 410.26 ms | 11000.0000 |         - |     - |  75.67 MB |
|          StaticListOfObjects | 386.24 ms |  4.305 ms |  4.027 ms | 385.53 ms | 11000.0000 |         - |     - |  74.47 MB |
| PrecomputedPostDataOfObjects | 396.67 ms |  4.197 ms |  3.720 ms | 396.63 ms | 11000.0000 |         - |     - |  73.82 MB |
|          StaticListOfStrings |  45.40 ms |  1.077 ms |  3.073 ms |  44.50 ms |  4000.0000 |         - |     - |  32.51 MB |
| PrecomputedPostDataOfStrings |  46.32 ms |  0.922 ms |  2.507 ms |  45.65 ms |  4000.0000 |         - |     - |  32.48 MB |
|               PostDataString |  45.91 ms |  2.028 ms |  5.949 ms |  46.76 ms |          - |         - |     - |  32.15 MB |
|    PrecomputedPostDataString |  29.56 ms |  0.583 ms |  1.066 ms |  29.47 ms |          - |         - |     - |   7.95 MB |
|            PostDataByteArray |  29.18 ms |  0.578 ms |  1.601 ms |  29.08 ms |          - |         - |     - |   7.95 MB |
|       PostDataReadOnlyMemory |  28.03 ms |  0.559 ms |  1.372 ms |  27.80 ms |          - |         - |     - |   7.95 MB |
|        PostDataStreamHandler |  28.09 ms |  0.552 ms |  1.090 ms |  28.03 ms |          - |         - |     - |   7.95 MB |


After:


|                       Method |      Mean |    Error |   StdDev |      Gen 0 |     Gen 1 | Gen 2 | Allocated |
|----------------------------- |----------:|---------:|---------:|-----------:|----------:|------:|----------:|
|                         NEST | 329.47 ms | 4.382 ms | 3.885 ms |  8000.0000 | 2000.0000 |     - | 145.15 MB |
|                ListOfObjects | 300.87 ms | 4.014 ms | 3.755 ms | 11000.0000 |         - |     - |     75 MB |
|          StaticListOfObjects | 292.50 ms | 6.562 ms | 6.138 ms | 11000.0000 |         - |     - |  73.76 MB |
| PrecomputedPostDataOfObjects | 293.36 ms | 3.864 ms | 3.614 ms | 11000.0000 |         - |     - |   74.5 MB |
|          StaticListOfStrings |  29.14 ms | 0.582 ms | 1.092 ms |  4000.0000 |         - |     - |  32.65 MB |
| PrecomputedPostDataOfStrings |  28.86 ms | 0.556 ms | 0.546 ms |  4000.0000 |         - |     - |   32.5 MB |
|               PostDataString |  29.76 ms | 1.149 ms | 3.369 ms |          - |         - |     - |  32.17 MB |
|    PrecomputedPostDataString |  18.10 ms | 0.357 ms | 0.587 ms |          - |         - |     - |   7.95 MB |
|            PostDataByteArray |  17.57 ms | 0.346 ms | 0.355 ms |          - |         - |     - |   7.95 MB |
|       PostDataReadOnlyMemory |  17.42 ms | 0.232 ms | 0.193 ms |          - |         - |     - |   7.95 MB |
|        PostDataStreamHandler |  17.66 ms | 0.337 ms | 0.426 ms |          - |         - |     - |   7.95 MB |