### PR TITLE
Reference an older Newtonsoft.Json package

### DIFF
--- a/src/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -16,6 +16,6 @@
     <PackageReference Include="ConfigureAwaitChecker.Analyzer" Version="4.0.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Reference an older Newtonsoft.Json package, because some clients depend on lower versions.