### PR TITLE
Additional client examples

### DIFF
--- a/examples/Aggregations/Bucket/TermsAggregationPage/028f6d6ac2594e20b78b8a8f8cbad49d.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/028f6d6ac2594e20b78b8a8f8cbad49d.asciidoc
@@ -1,0 +1,34 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line470 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L300-L353.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("countries", t => t
+            .Field("artist.country")
+            .Order(o => o
+                .Descending("rock>playback_stats.avg")
+                .CountDescending()
+            )
+            .Aggregations(aa => aa
+                .Filter("rock", f => f
+                    .Filter(q => q
+                        .Term("genre", "rock")
+                    )
+                    .Aggregations(aaa => aaa
+                        .Stats("playback_stats", st => st
+                            .Field("play_count")
+                        )
+                    )
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/033778305d52746f5ce0a2a922c8e521.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/033778305d52746f5ce0a2a922c8e521.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line544 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L383-L413.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Script(sc => sc
+                .Source("doc['genre'].value")
+                .Lang("painless")
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/0afaf1cad692e6201aa574c8feb6e622.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/0afaf1cad692e6201aa574c8feb6e622.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line626 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L485-L513.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("tags", t => t
+            .Field("tags")
+            .Include(".*sport.*")
+            .Exclude("water_.*")
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/34efeade38445b2834749ced59782e25.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/34efeade38445b2834749ced59782e25.asciidoc
@@ -1,0 +1,26 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line397 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L200-L240.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+            .Order(o => o
+                .Descending("playback_stats.max")
+            )
+            .Aggregations(aa => aa
+                .Stats("playback_stats", m => m
+                    .Field("play_count")
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/35e8da9410b8432cf4095f2541ad7b1d.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/35e8da9410b8432cf4095f2541ad7b1d.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line264 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L60-L88.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("products", t => t
+            .Field("product")
+            .Size(5)
+            .ShowTermDocCountError()
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/4646764bf09911fee7d58630c72d3137.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/4646764bf09911fee7d58630c72d3137.asciidoc
@@ -1,0 +1,23 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line578 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L415-L449.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Script(sc => sc
+                .Id("my_script")
+                .Params(p => p
+                    .Add("field", "genre")
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/527324766814561b75aaee853ede49a7.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/527324766814561b75aaee853ede49a7.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line503 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L355-L381.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("tags", t => t
+            .Field("tags")
+            .MinimumDocumentCount(10)
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
@@ -1,0 +1,29 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line683 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L553-L608.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Size(0)
+    .Aggregations(a => a
+        .Terms("expired_sessions", t => t
+            .Field("account_id")
+            .Include(0, 20)
+            .Size(10000)
+            .Order(o => o
+                .Ascending("last_access")
+            )
+            .Aggregations(aa => aa
+                .Max("last_access", m => m
+                    .Field("access_date")
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/6a4679531e64c492fce16dc12de6dcb0.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/6a4679531e64c492fce16dc12de6dcb0.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line341 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L90-L122.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+            .Order(o => o
+                .CountAscending()
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/71b5b2ba9557d0f296ff2de91727d2f6.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/71b5b2ba9557d0f296ff2de91727d2f6.asciidoc
@@ -1,0 +1,26 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line377 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L158-L198.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+            .Order(o => o
+                .Descending("max_play_count")
+            )
+            .Aggregations(aa => aa
+                .Max("max_play_count", m => m
+                    .Field("play_count")
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/774d715155cd13713e6e327adf6ce328.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/774d715155cd13713e6e327adf6ce328.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line857 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L696-L722.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("tags", t => t
+            .Field("tags")
+            .ExecutionHint(TermsAggregationExecutionHint.Map)
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
@@ -1,0 +1,25 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line775 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L610-L650.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("actors", t => t
+            .Field("actors")
+            .Size(10)
+            .Aggregations(aa => aa
+                .Terms("costars", tt => tt
+                    .Field("actors")
+                    .Size(5)
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/93f1bdd72e79827dcf9a34efa02fd977.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/93f1bdd72e79827dcf9a34efa02fd977.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line358 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L124-L156.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+            .Order(o => o
+                .KeyAscending()
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/98b121bf47cebd85671a2cb519688d28.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/98b121bf47cebd85671a2cb519688d28.asciidoc
@@ -1,0 +1,23 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line654 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L515-L551.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("JapaneseCars", t => t
+            .Field("make")
+            .Include(new[] { "mazda", "honda" })
+        )
+        .Terms("ActiveCarManufacturers", t => t
+            .Field("make")
+            .Exclude(new[] { "rover", "jensen" })
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/9a8995fd31351045d99c78e40444c8ea.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/9a8995fd31351045d99c78e40444c8ea.asciidoc
@@ -1,0 +1,18 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line57 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L8-L30.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/a49169b4622918992411fab4ec48191b.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/a49169b4622918992411fab4ec48191b.asciidoc
@@ -1,0 +1,22 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line600 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L451-L483.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("genres", t => t
+            .Field("genre")
+            .Script(sc => sc
+                .Source("'Genre: ' +_value")
+                .Lang("painless")
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
@@ -1,0 +1,26 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line806 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L652-L694.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("actors", t => t
+            .Field("actors")
+            .Size(10)
+            .CollectMode(TermsAggregationCollectMode.BreadthFirst)
+            .Aggregations(aa => aa
+                .Terms("costars", tt => tt
+                    .Field("actors")
+                    .Size(5)
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/d50a3835bf5795ac73e58906a3413544.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/d50a3835bf5795ac73e58906a3413544.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line135 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L32-L58.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("products", t => t
+            .Field("product")
+            .Size(5)
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/dc15e2373e5ecbe09b4ea0858eb63d47.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/dc15e2373e5ecbe09b4ea0858eb63d47.asciidoc
@@ -1,0 +1,33 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line443 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L242-L298.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("countries", t => t
+            .Field("artist.country")
+            .Order(o => o
+                .Descending("rock>playback_stats.avg")
+            )
+            .Aggregations(aa => aa
+                .Filter("rock", f => f
+                    .Filter(q => q
+                        .Term("genre", "rock")
+                    )
+                    .Aggregations(aaa => aaa
+                        .Stats("playback_stats", st => st
+                            .Field("play_count")
+                        )
+                    )
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Aggregations/Bucket/TermsAggregationPage/f085fb032dae56a3b104ab874eaea2ad.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/f085fb032dae56a3b104ab874eaea2ad.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line882 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L724-L750.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Aggregations(a => a
+        .Terms("tags", t => t
+            .Field("tags")
+            .Missing("N/A")
+        )
+    )
+);
+----

--- a/examples/Docs/UpdateByQueryPage/4acf902c2598b2558f34f20c1744c433.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/4acf902c2598b2558f34f20c1744c433.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line561 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L264-L299.
+This file is generated from method Line561 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L264-L289.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////
@@ -12,11 +12,7 @@ var refreshResponse = client.Indices.Refresh();
 var searchResponse = client.Search<Tweet>(s => s
     .Index("twitter")
     .Size(0)
-    .Query(q => q
-        .QueryString(qs => qs
-            .Query("extra:test")
-        )
-    )
+    .QueryOnQueryString("extra:test")
     .FilterPath(new[] { "hits.total" }) //<1>
 );
 ----

--- a/examples/Indices/CreateIndexPage/1c23507edd7a3c18538b68223378e4ab.asciidoc
+++ b/examples/Indices/CreateIndexPage/1c23507edd7a3c18538b68223378e4ab.asciidoc
@@ -1,0 +1,11 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line10 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L9-L17.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("twitter");
+----

--- a/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
@@ -1,0 +1,15 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line195 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L162-L179.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("test", c => c
+    .Settings(s => s
+        .Setting("index.write.wait_for_active_shards", "2")
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line195 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L162-L179.
+This file is generated from method Line195 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L164-L181.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line148 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L127-L160.
+This file is generated from method Line148 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L129-L162.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line148 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L127-L160.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("test", c => c
+    .Aliases(a => a
+        .Alias("alias_1")
+        .Alias("alias_2", aa => aa
+            .Filter<object>(f => f
+                .Term("user", "kimchy")
+            )
+            .Routing("kimchy")
+        )
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/b9c5d7ca6ca9c6f747201f45337a4abf.asciidoc
+++ b/examples/Indices/CreateIndexPage/b9c5d7ca6ca9c6f747201f45337a4abf.asciidoc
@@ -1,0 +1,16 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line100 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L54-L85.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("twitter", c => c
+    .Settings(s => s
+        .NumberOfShards(3)
+        .NumberOfReplicas(2)
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
+++ b/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line124 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L87-L125.
+This file is generated from method Line124 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L87-L127.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
+++ b/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
@@ -1,0 +1,22 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line124 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L87-L125.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("test", c => c
+    .Settings(s => s
+        .NumberOfShards(1)
+    )
+    .Map(m => m
+        .Properties(p => p
+            .Text(t => t
+                .Name("field1")
+            )
+        )
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/e5d2172b524332196cac0f031c043659.asciidoc
+++ b/examples/Indices/CreateIndexPage/e5d2172b524332196cac0f031c043659.asciidoc
@@ -1,0 +1,16 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line82 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L19-L52.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("twitter", c => c
+    .Settings(s => s
+        .NumberOfShards(3)
+        .NumberOfReplicas(2)
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
+++ b/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
@@ -1,0 +1,15 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line208 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L181-L198.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("test", c => c
+    .Settings(s => s
+        .Setting("index.write.wait_for_active_shards", "2")
+    )
+);
+----

--- a/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
+++ b/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line208 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L181-L198.
+This file is generated from method Line208 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L183-L200.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/06afce2955f9094d96d27067ebca32e8.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/06afce2955f9094d96d27067ebca32e8.asciidoc
@@ -21,8 +21,8 @@ var searchResponse = client.Search<Account>(s => s
                 )
             )
             .Should(
-                _ => _.Term(p => p.Tags, "wow"),
-                _ => _.Term(p => p.Tags, "elasticsearch")
+                sh => sh.Term(p => p.Tags, "wow"),
+                sh => sh.Term(p => p.Tags, "elasticsearch")
             )
             .MinimumShouldMatch(1)
             .Boost(1.0)

--- a/examples/QueryDsl/BoolQueryPage/162b5b693b713f0bfab1209d59443c46.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/162b5b693b713f0bfab1209d59443c46.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line117 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L150-L178.
+This file is generated from method Line117 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L152-L180.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/f70a54cd9a9f4811bf962e469f2ca2ea.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/f70a54cd9a9f4811bf962e469f2ca2ea.asciidoc
@@ -7,7 +7,7 @@ and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////
 [source, csharp]
 ----
-var response0 = client.Search<Blog>(s => s
+var searchResponse = client.Search<Blog>(s => s
     .AllIndices()
     .Query(q => +q.Term(p => p.Status, PublishStatus.Active))
 );

--- a/examples/QueryDsl/BoolQueryPage/fa88f6f5a7d728ec4f1d05244228cb09.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/fa88f6f5a7d728ec4f1d05244228cb09.asciidoc
@@ -1,13 +1,13 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line94 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L116-L148.
+This file is generated from method Line94 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L116-L150.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////
 [source, csharp]
 ----
-var response0 = client.Search<Blog>(s => s
+var searchResponse = client.Search<Blog>(s => s
     .AllIndices()
     .Query(q =>
         +q.Term(p => p.Status, PublishStatus.Active)

--- a/examples/QueryDsl/MatchQueryPage/0ac9916f47a2483b89c1416684af322a.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/0ac9916f47a2483b89c1416684af322a.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line241 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L124-L153.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("to be or not to be")
+            .Operator(Operator.And)
+            .ZeroTermsQuery(ZeroTermsQuery.All)
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/5043b83a89091fa00edb341ddf7ba370.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/5043b83a89091fa00edb341ddf7ba370.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line219 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L95-L122.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("this is a testt")
+            .Fuzziness(Fuzziness.Auto)
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/6138d6919f3cbaaf61e1092f817d295c.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/6138d6919f3cbaaf61e1092f817d295c.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line175 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L66-L93.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("this is a test")
+            .Operator(Operator.And)
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line268 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L155-L182.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("ny city")
+            .AutoGenerateSynonymsPhraseQuery(false)
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/e0d6e02b998bdea99c9c08dcc3630c5e.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/e0d6e02b998bdea99c9c08dcc3630c5e.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line18 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L8-L33.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("this is a test")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/fa2fe60f570bd930d2891778c6efbfe6.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/fa2fe60f570bd930d2891778c6efbfe6.asciidoc
@@ -1,0 +1,19 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line150 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L35-L64.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Match(m => m
+            .Field("message")
+            .Query("this is a test")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/QueryStringQueryPage/ad6ea0c1e46712aa1fd6d3bfa0ec979e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/ad6ea0c1e46712aa1fd6d3bfa0ec979e.asciidoc
@@ -7,7 +7,7 @@ and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////
 [source, csharp]
 ----
-var response0 = client.Search<Blog>(s => s
+var searchResponse = client.Search<Blog>(s => s
     .AllIndices()
     .Query(q => q
         .QueryString(qs => qs

--- a/examples/QueryDsl/RangeQueryPage/4466d410e06712c63328de4db249e6da.asciidoc
+++ b/examples/QueryDsl/RangeQueryPage/4466d410e06712c63328de4db249e6da.asciidoc
@@ -1,0 +1,20 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line152 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/RangeQueryPage.cs#L40-L67.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .DateRange(r => r
+            .Field("timestamp")
+            .GreaterThanOrEquals("now-1d/d")
+            .LessThan("now/d")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/RangeQueryPage/5d13a71fa7fda73b15111803b1c7cfd3.asciidoc
+++ b/examples/QueryDsl/RangeQueryPage/5d13a71fa7fda73b15111803b1c7cfd3.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line214 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/RangeQueryPage.cs#L69-L98.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .DateRange(r => r
+            .Field("timestamp")
+            .TimeZone("+01:00")
+            .GreaterThanOrEquals("2015-01-01 00:00:00")
+            .LessThanOrEquals("now")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/RangeQueryPage/97bcd92ef148312d41e69f0d18284327.asciidoc
+++ b/examples/QueryDsl/RangeQueryPage/97bcd92ef148312d41e69f0d18284327.asciidoc
@@ -1,0 +1,21 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line16 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/RangeQueryPage.cs#L9-L38.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .LongRange(r => r
+            .Field("age")
+            .GreaterThanOrEquals(10)
+            .LessThanOrEquals(20)
+            .Boost(2)
+        )
+    )
+);
+----

--- a/examples/Root/MappingPage/609260ad1d5998be2ca09ff1fe237efa.asciidoc
+++ b/examples/Root/MappingPage/609260ad1d5998be2ca09ff1fe237efa.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line211 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L62-L70.
+This file is generated from method Line211 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L63-L71.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/71ba9033107882f61cdc3b32fc73568d.asciidoc
+++ b/examples/Root/MappingPage/71ba9033107882f61cdc3b32fc73568d.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line173 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L36-L60.
+This file is generated from method Line173 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L37-L61.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/99a52be903945b17e734a1d02a57e958.asciidoc
+++ b/examples/Root/MappingPage/99a52be903945b17e734a1d02a57e958.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line257 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L72-L83.
+This file is generated from method Line257 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L73-L84.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/d8b2a88b5eca99d3691ad3cd40266736.asciidoc
+++ b/examples/Root/MappingPage/d8b2a88b5eca99d3691ad3cd40266736.asciidoc
@@ -1,16 +1,16 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line144 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L9-L34.
+This file is generated from method Line144 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L10-L35.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////
 [source, csharp]
 ----
-var mapResponse = client.Indices.Create("my-index", c => c
+var createIndexResponse = client.Indices.Create("my-index", c => c
     .Map<Employee>(m => m
         .Properties(props => props
-            .Scalar(p => p.Age)
+            .Number(n => n.Name(p => p.Age).Type(NumberType.Integer))
             .Keyword(k => k.Name(p => p.Email))
             .Text(k => k.Name(p => p.Name))
         )

--- a/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
+++ b/examples/Root/SearchPage/014b788c879e4aaa1020672e45e25473.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line72 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L85-L102.
+This file is generated from method Line72 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L80-L97.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
+++ b/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line96 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L104-L131.
+This file is generated from method Line96 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L99-L126.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
+++ b/examples/Root/SearchPage/8acc1d67b152e7027e0f0e1a8b4b2431.asciidoc
@@ -1,7 +1,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line32 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L33-L83.
+This file is generated from method Line32 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L33-L78.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/src/ExamplesGenerator/ExampleLocation.cs
+++ b/src/ExamplesGenerator/ExampleLocation.cs
@@ -6,8 +6,8 @@ namespace ExamplesGenerator
 	{
 		private static string _root;
 
-		public static DirectoryInfo ExamplesAsciiDocDir { get; } = new DirectoryInfo($@"{Root}../../../examples");
-		public static DirectoryInfo ExamplesCSharpProject { get; } = new DirectoryInfo($@"{Root}../../../src/Examples/Examples");
+		public static DirectoryInfo ExamplesAsciiDocDir { get; } = new DirectoryInfo($@"{Root}../../examples");
+		public static DirectoryInfo ExamplesCSharpProject { get; } = new DirectoryInfo($@"{Root}../../tests/Examples");
 
 		private static string Root
 		{
@@ -20,7 +20,7 @@ namespace ExamplesGenerator
 				var runningAsNetCore =
 					directoryInfo.Name == "ExamplesGenerator" &&
 					directoryInfo.Parent != null &&
-					directoryInfo.Parent.Name == "Examples";
+					directoryInfo.Parent.Name == "src";
 
 				_root = runningAsNetCore ? "" : @"../../../";
 				return _root;

--- a/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
@@ -5,14 +5,21 @@ namespace Examples.Aggregations.Bucket
 {
 	public class TermsAggregationPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line57()
 		{
 			// tag::9a8995fd31351045d99c78e40444c8ea[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+					)
+				)
+			);
 			// end::9a8995fd31351045d99c78e40444c8ea[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -22,14 +29,22 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line135()
 		{
 			// tag::d50a3835bf5795ac73e58906a3413544[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("products", t => t
+						.Field("product")
+						.Size(5)
+					)
+				)
+			);
 			// end::d50a3835bf5795ac73e58906a3413544[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""products"" : {
@@ -42,14 +57,23 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line264()
 		{
 			// tag::35e8da9410b8432cf4095f2541ad7b1d[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("products", t => t
+						.Field("product")
+						.Size(5)
+						.ShowTermDocCountError()
+					)
+				)
+			);
 			// end::35e8da9410b8432cf4095f2541ad7b1d[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""products"" : {
@@ -63,14 +87,24 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line341()
 		{
 			// tag::6a4679531e64c492fce16dc12de6dcb0[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+						.Order(o => o
+							.CountAscending()
+						)
+					)
+				)
+			);
 			// end::6a4679531e64c492fce16dc12de6dcb0[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -80,17 +114,31 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line358()
 		{
 			// tag::93f1bdd72e79827dcf9a34efa02fd977[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+						.Order(o => o
+							.KeyAscending()
+						)
+					)
+				)
+			);
 			// end::93f1bdd72e79827dcf9a34efa02fd977[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -100,17 +148,36 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line377()
 		{
 			// tag::71b5b2ba9557d0f296ff2de91727d2f6[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+						.Order(o => o
+							.Descending("max_play_count")
+						)
+						.Aggregations(aa => aa
+							.Max("max_play_count", m => m
+								.Field("play_count")
+							)
+						)
+					)
+				)
+			);
 			// end::71b5b2ba9557d0f296ff2de91727d2f6[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -123,17 +190,36 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line397()
 		{
 			// tag::34efeade38445b2834749ced59782e25[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+						.Order(o => o
+							.Descending("playback_stats.max")
+						)
+						.Aggregations(aa => aa
+							.Stats("playback_stats", m => m
+								.Field("play_count")
+							)
+						)
+					)
+				)
+			);
 			// end::34efeade38445b2834749ced59782e25[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -146,17 +232,43 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line443()
 		{
 			// tag::dc15e2373e5ecbe09b4ea0858eb63d47[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("countries", t => t
+						.Field("artist.country")
+						.Order(o => o
+							.Descending("rock>playback_stats.avg")
+						)
+						.Aggregations(aa => aa
+							.Filter("rock", f => f
+								.Filter(q => q
+									.Term("genre", "rock")
+								)
+								.Aggregations(aaa => aaa
+									.Stats("playback_stats", st => st
+										.Field("play_count")
+									)
+								)
+							)
+						)
+					)
+				)
+			);
 			// end::dc15e2373e5ecbe09b4ea0858eb63d47[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""countries"" : {
@@ -174,17 +286,48 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b =>
+				{
+					b["aggs"]["countries"]["terms"]["order"].ToJArray();
+					b["aggs"]["countries"]["aggs"]["rock"]["filter"]["term"]["genre"].ToLongFormTermQuery();
+				});
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line470()
 		{
 			// tag::028f6d6ac2594e20b78b8a8f8cbad49d[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("countries", t => t
+						.Field("artist.country")
+						.Order(o => o
+							.Descending("rock>playback_stats.avg")
+							.CountDescending()
+						)
+						.Aggregations(aa => aa
+							.Filter("rock", f => f
+								.Filter(q => q
+									.Term("genre", "rock")
+								)
+								.Aggregations(aaa => aaa
+									.Stats("playback_stats", st => st
+										.Field("play_count")
+									)
+								)
+							)
+						)
+					)
+				)
+			);
 			// end::028f6d6ac2594e20b78b8a8f8cbad49d[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""countries"" : {
@@ -202,17 +345,29 @@ namespace Examples.Aggregations.Bucket
 			            }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["countries"]["aggs"]["rock"]["filter"]["term"]["genre"].ToLongFormTermQuery(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line503()
 		{
 			// tag::527324766814561b75aaee853ede49a7[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("tags", t => t
+						.Field("tags")
+						.MinimumDocumentCount(10)
+					)
+				)
+			);
 			// end::527324766814561b75aaee853ede49a7[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""tags"" : {
@@ -225,14 +380,24 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line544()
 		{
 			// tag::033778305d52746f5ce0a2a922c8e521[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Script(sc => sc
+							.Source("doc['genre'].value")
+							.Lang("painless")
+						)
+					)
+				)
+			);
 			// end::033778305d52746f5ce0a2a922c8e521[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -247,14 +412,26 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line578()
 		{
 			// tag::4646764bf09911fee7d58630c72d3137[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Script(sc => sc
+							.Id("my_script")
+							.Params(p => p
+								.Add("field", "genre")
+							)
+						)
+					)
+				)
+			);
 			// end::4646764bf09911fee7d58630c72d3137[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -271,14 +448,25 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line600()
 		{
 			// tag::a49169b4622918992411fab4ec48191b[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("genres", t => t
+						.Field("genre")
+						.Script(sc => sc
+							.Source("'Genre: ' +_value")
+							.Lang("painless")
+						)
+					)
+				)
+			);
 			// end::a49169b4622918992411fab4ec48191b[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""genres"" : {
@@ -294,14 +482,23 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line626()
 		{
 			// tag::0afaf1cad692e6201aa574c8feb6e622[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("tags", t => t
+						.Field("tags")
+						.Include(".*sport.*")
+						.Exclude("water_.*")
+					)
+				)
+			);
 			// end::0afaf1cad692e6201aa574c8feb6e622[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""tags"" : {
@@ -315,14 +512,26 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line654()
 		{
 			// tag::98b121bf47cebd85671a2cb519688d28[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("JapaneseCars", t => t
+						.Field("make")
+						.Include(new [] { "mazda", "honda" })
+					)
+					.Terms("ActiveCarManufacturers", t => t
+						.Field("make")
+						.Exclude(new [] { "rover", "jensen" })
+					)
+				)
+			);
 			// end::98b121bf47cebd85671a2cb519688d28[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""JapaneseCars"" : {
@@ -341,14 +550,32 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line683()
 		{
 			// tag::5d9d7b84e2fec7ecd832145cbb951cf1[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Size(0)
+				.Aggregations(a => a
+					.Terms("expired_sessions", t => t
+						.Field("account_id")
+						.Include(0, 20)
+						.Size(10000)
+						.Order(o => o
+							.Ascending("last_access")
+						)
+						.Aggregations(aa => aa
+							.Max("last_access", m => m
+								.Field("access_date")
+							)
+						)
+					)
+				)
+			);
 			// end::5d9d7b84e2fec7ecd832145cbb951cf1[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			   ""size"": 0,
 			   ""aggs"": {
@@ -373,17 +600,35 @@ namespace Examples.Aggregations.Bucket
 			         }
 			      }
 			   }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aggs"]["expired_sessions"]["terms"]["order"].ToJArray(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line775()
 		{
 			// tag::7f28f8ae8fcdbd807dadde0b5b007a6d[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("actors", t => t
+						.Field("actors")
+						.Size(10)
+						.Aggregations(aa => aa
+							.Terms("costars", tt => tt
+								.Field("actors")
+								.Size(5)
+							)
+						)
+					)
+				)
+			);
 			// end::7f28f8ae8fcdbd807dadde0b5b007a6d[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""actors"" : {
@@ -404,14 +649,29 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line806()
 		{
 			// tag::cd5bc5bf7cd58d7b1492c9c298b345f6[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("actors", t => t
+						.Field("actors")
+						.Size(10)
+						.CollectMode(TermsAggregationCollectMode.BreadthFirst)
+						.Aggregations(aa => aa
+							.Terms("costars", tt => tt
+								.Field("actors")
+								.Size(5)
+							)
+						)
+					)
+				)
+			);
 			// end::cd5bc5bf7cd58d7b1492c9c298b345f6[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""actors"" : {
@@ -433,14 +693,22 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line857()
 		{
 			// tag::774d715155cd13713e6e327adf6ce328[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("tags", t => t
+						.Field("tags")
+						.ExecutionHint(TermsAggregationExecutionHint.Map)
+					)
+				)
+			);
 			// end::774d715155cd13713e6e327adf6ce328[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""tags"" : {
@@ -453,14 +721,22 @@ namespace Examples.Aggregations.Bucket
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line882()
 		{
 			// tag::f085fb032dae56a3b104ab874eaea2ad[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Aggregations(a => a
+					.Terms("tags", t => t
+						.Field("tags")
+						.Missing("N/A")
+					)
+				)
+			);
 			// end::f085fb032dae56a3b104ab874eaea2ad[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""aggs"" : {
 			        ""tags"" : {

--- a/tests/Examples/Indices/CreateIndexPage.cs
+++ b/tests/Examples/Indices/CreateIndexPage.cs
@@ -1,28 +1,34 @@
 using Elastic.Xunit.XunitPlumbing;
 using Nest;
+using Newtonsoft.Json.Linq;
 
 namespace Examples.Indices
 {
 	public class CreateIndexPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line10()
 		{
 			// tag::1c23507edd7a3c18538b68223378e4ab[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("twitter");
 			// end::1c23507edd7a3c18538b68223378e4ab[]
 
-			response0.MatchesExample(@"PUT /twitter");
+			createIndexResponse.MatchesExample(@"PUT /twitter");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line82()
 		{
 			// tag::e5d2172b524332196cac0f031c043659[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("twitter", c => c
+				.Settings(s => s
+					.NumberOfShards(3)
+					.NumberOfReplicas(2)
+				)
+			);
 			// end::e5d2172b524332196cac0f031c043659[]
 
-			response0.MatchesExample(@"PUT /twitter
+			createIndexResponse.MatchesExample(@"PUT /twitter
 			{
 			    ""settings"" : {
 			        ""index"" : {
@@ -30,33 +36,73 @@ namespace Examples.Indices
 			            ""number_of_replicas"" : 2 <2>
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b =>
+				{
+					b["settings"] = new JObject
+					{
+						{ "index.number_of_shards", 3 },
+						{ "index.number_of_replicas", 2 }
+					};
+				});
+
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line100()
 		{
 			// tag::b9c5d7ca6ca9c6f747201f45337a4abf[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("twitter", c => c
+				.Settings(s => s
+					.NumberOfShards(3)
+					.NumberOfReplicas(2)
+				)
+			);
 			// end::b9c5d7ca6ca9c6f747201f45337a4abf[]
 
-			response0.MatchesExample(@"PUT /twitter
+			createIndexResponse.MatchesExample(@"PUT /twitter
 			{
 			    ""settings"" : {
 			        ""number_of_shards"" : 3,
 			        ""number_of_replicas"" : 2
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b =>
+				{
+					b["settings"] = new JObject
+					{
+						{ "index.write.number_of_shards", 3 },
+						{ "index.write.number_of_replicas", 2 },
+					};
+				});
+
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line124()
 		{
 			// tag::dfef545b1e2c247bafd1347e8e807ac1[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("test", c => c
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Map(m => m
+					.Properties(p => p
+						.Text(t => t
+							.Name("field1")
+						)
+					)
+				)
+			);
 			// end::dfef545b1e2c247bafd1347e8e807ac1[]
 
-			response0.MatchesExample(@"PUT /test
+			createIndexResponse.MatchesExample(@"PUT /test
 			{
 			    ""settings"" : {
 			        ""number_of_shards"" : 1
@@ -66,17 +112,36 @@ namespace Examples.Indices
 			            ""field1"" : { ""type"" : ""text"" }
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b =>
+				{
+					b["settings"]["number_of_shards"].Remove();
+					b["settings"]["index.number_of_shards"] = 1;
+				});
+
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line148()
 		{
 			// tag::4d56b179242fed59e3d6476f817b6055[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("test", c => c
+				.Aliases(a => a
+					.Alias("alias_1")
+					.Alias("alias_2", aa => aa
+						.Filter<object>(f => f
+							.Term("user", "kimchy")
+						)
+						.Routing("kimchy")
+					)
+				)
+			);
 			// end::4d56b179242fed59e3d6476f817b6055[]
 
-			response0.MatchesExample(@"PUT /test
+			createIndexResponse.MatchesExample(@"PUT /test
 			{
 			    ""aliases"" : {
 			        ""alias_1"" : {},
@@ -87,17 +152,25 @@ namespace Examples.Indices
 			            ""routing"" : ""kimchy""
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["aliases"]["alias_2"]["filter"]["term"]["user"].ToLongFormTermQuery(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line195()
 		{
 			// tag::4d46dbb96125b27f46299547de9d8709[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("test", c => c
+				.Settings(s => s
+					.Setting("index.write.wait_for_active_shards", "2")
+				)
+			);
 			// end::4d46dbb96125b27f46299547de9d8709[]
 
-			response0.MatchesExample(@"PUT /test
+			createIndexResponse.MatchesExample(@"PUT /test
 			{
 			    ""settings"": {
 			        ""index.write.wait_for_active_shards"": ""2""
@@ -105,14 +178,23 @@ namespace Examples.Indices
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line208()
 		{
 			// tag::fabe14480624a99e8ee42c7338672058[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("test", c => c
+				.Settings(s => s
+					.Setting("index.write.wait_for_active_shards", "2")
+				)
+			);
 			// end::fabe14480624a99e8ee42c7338672058[]
 
-			response0.MatchesExample(@"PUT /test?wait_for_active_shards=2");
+			createIndexResponse.MatchesExample(@"PUT /test?wait_for_active_shards=2", e =>
+			{
+				e.Uri.Query = null;
+				e.ApplyBodyChanges(b => { b["settings"] = new JObject { { "index.write.wait_for_active_shards", "2" } }; });
+				return e;
+			});
 		}
 	}
 }

--- a/tests/Examples/Indices/CreateIndexPage.cs
+++ b/tests/Examples/Indices/CreateIndexPage.cs
@@ -75,8 +75,8 @@ namespace Examples.Indices
 				{
 					b["settings"] = new JObject
 					{
-						{ "index.write.number_of_shards", 3 },
-						{ "index.write.number_of_replicas", 2 },
+						{ "index.number_of_shards", 3 },
+						{ "index.number_of_replicas", 2 },
 					};
 				});
 
@@ -116,8 +116,10 @@ namespace Examples.Indices
 			{
 				e.ApplyBodyChanges(b =>
 				{
-					b["settings"]["number_of_shards"].Remove();
-					b["settings"]["index.number_of_shards"] = 1;
+					b["settings"] = new JObject
+					{
+						{ "index.number_of_shards", 1 },
+					};
 				});
 
 				return e;

--- a/tests/Examples/QueryDsl/MatchQueryPage.cs
+++ b/tests/Examples/QueryDsl/MatchQueryPage.cs
@@ -5,14 +5,22 @@ namespace Examples.QueryDsl
 {
 	public class MatchQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line18()
 		{
 			// tag::e0d6e02b998bdea99c9c08dcc3630c5e[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("this is a test")
+					)
+				)
+			);
 			// end::e0d6e02b998bdea99c9c08dcc3630c5e[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match"" : {
@@ -24,31 +32,54 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line150()
 		{
 			// tag::fa2fe60f570bd930d2891778c6efbfe6[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("this is a test")
+					)
+				)
+			);
 			// end::fa2fe60f570bd930d2891778c6efbfe6[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match"" : {
 			            ""message"" : ""this is a test""
 			        }
 			    }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => {
+					b["query"]["match"]["message"].ToLongFormQuery();
+				});
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line175()
 		{
 			// tag::6138d6919f3cbaaf61e1092f817d295c[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("this is a test")
+						.Operator(Operator.And)
+					)
+				)
+			);
 			// end::6138d6919f3cbaaf61e1092f817d295c[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match"" : {
@@ -61,14 +92,23 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line219()
 		{
 			// tag::5043b83a89091fa00edb341ddf7ba370[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("this is a testt")
+						.Fuzziness(Fuzziness.Auto)
+					)
+				)
+			);
 			// end::5043b83a89091fa00edb341ddf7ba370[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match"" : {
@@ -81,14 +121,24 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line241()
 		{
 			// tag::0ac9916f47a2483b89c1416684af322a[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("to be or not to be")
+						.Operator(Operator.And)
+						.ZeroTermsQuery(ZeroTermsQuery.All)
+					)
+				)
+			);
 			// end::0ac9916f47a2483b89c1416684af322a[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match"" : {
@@ -102,14 +152,23 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line268()
 		{
 			// tag::7f56755fb6c42f7e6203339a6d0cb6e6[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Match(m => m
+						.Field("message")
+						.Query("ny city")
+						.AutoGenerateSynonymsPhraseQuery(false)
+					)
+				)
+			);
 			// end::7f56755fb6c42f7e6203339a6d0cb6e6[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			   ""query"": {
 			       ""match"" : {

--- a/tests/Examples/QueryDsl/RangeQueryPage.cs
+++ b/tests/Examples/QueryDsl/RangeQueryPage.cs
@@ -1,3 +1,4 @@
+using System;
 using Elastic.Xunit.XunitPlumbing;
 using Nest;
 
@@ -5,14 +6,24 @@ namespace Examples.QueryDsl
 {
 	public class RangeQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line16()
 		{
 			// tag::97bcd92ef148312d41e69f0d18284327[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.LongRange(r => r
+						.Field("age")
+						.GreaterThanOrEquals(10)
+						.LessThanOrEquals(20)
+						.Boost(2)
+					)
+				)
+			);
 			// end::97bcd92ef148312d41e69f0d18284327[]
 
-			response0.MatchesExample(@"GET _search
+			searchResponse.MatchesExample(@"GET _search
 			{
 			    ""query"": {
 			        ""range"" : {
@@ -26,14 +37,23 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line152()
 		{
 			// tag::4466d410e06712c63328de4db249e6da[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.DateRange(r => r
+						.Field("timestamp")
+						.GreaterThanOrEquals("now-1d/d")
+						.LessThan("now/d")
+					)
+				)
+			);
 			// end::4466d410e06712c63328de4db249e6da[]
 
-			response0.MatchesExample(@"GET _search
+			searchResponse.MatchesExample(@"GET _search
 			{
 			    ""query"": {
 			        ""range"" : {
@@ -46,14 +66,24 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line214()
 		{
 			// tag::5d13a71fa7fda73b15111803b1c7cfd3[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.DateRange(r => r
+						.Field("timestamp")
+						.TimeZone("+01:00")
+						.GreaterThanOrEquals("2015-01-01 00:00:00")
+						.LessThanOrEquals("now")
+					)
+				)
+			);
 			// end::5d13a71fa7fda73b15111803b1c7cfd3[]
 
-			response0.MatchesExample(@"GET _search
+			searchResponse.MatchesExample(@"GET _search
 			{
 			    ""query"": {
 			        ""range"" : {


### PR DESCRIPTION
Relates: elastic/clients-team#96

This commit adds client examples for the following pages:

1. https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-match-query.html
2. https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-create-index.html
3. https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-index_.html
4. https://www.elastic.co/guide/en/elasticsearch/reference/master/search-aggregations-bucket-terms-aggregation.html
5. https://www.elastic.co/guide/en/elasticsearch/reference/master/query-dsl-range-query.html