### PR TITLE
Add index setting method for index.blocks.read_only_allow_delete

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -43,6 +43,11 @@ namespace Nest
 		bool? BlocksWrite { get; set; }
 
 		/// <summary>
+		/// Set to true to disable read operations, but allow delete operations, against the index.
+		/// </summary>
+		bool? BlocksReadOnlyAllowDelete { get; set; }
+
+		/// <summary>
 		/// All of the settings exposed in the merge module are expert only and may be obsoleted in the future at any time!
 		/// </summary>
 		IMergeSettings Merge { get; set; }
@@ -142,6 +147,9 @@ namespace Nest
 		/// <inheritdoc cref="IDynamicIndexSettings.BlocksWrite" />
 		public bool? BlocksWrite { get; set; }
 
+		/// <inheritdoc cref="IDynamicIndexSettings.BlocksReadOnlyAllowDelete" />
+		public bool? BlocksReadOnlyAllowDelete { get; set; }
+
 		/// <inheritdoc cref="IDynamicIndexSettings.Merge" />
 		public IMergeSettings Merge { get; set; }
 
@@ -237,6 +245,9 @@ namespace Nest
 
 		/// <inheritdoc cref="IDynamicIndexSettings.BlocksWrite" />
 		public TDescriptor BlocksWrite(bool? blocksWrite = true) => Assign(blocksWrite, (a, v) => a.BlocksWrite = v);
+
+		/// <inheritdoc cref="IDynamicIndexSettings.BlocksReadOnlyAllowDelete" />
+		public TDescriptor BlocksReadOnlyAllowDelete(bool? blocksReadOnlyAllowDelete = true) => Assign(blocksReadOnlyAllowDelete, (a, v) => a.BlocksReadOnlyAllowDelete = v);
 
 		/// <inheritdoc cref="IDynamicIndexSettings.Priority" />
 		public TDescriptor Priority(int? priority) => Assign(priority, (a, v) => a.Priority = v);

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
@@ -56,6 +56,7 @@ namespace Nest
 			Set(BlocksRead, value.BlocksRead);
 			Set(BlocksWrite, value.BlocksWrite);
 			Set(BlocksMetadata, value.BlocksMetadata);
+			Set(BlocksReadOnlyAllowDelete, value.BlocksReadOnlyAllowDelete);
 			Set(Priority, value.Priority);
 			Set(UpdatableIndexSettings.AutoExpandReplicas, value.AutoExpandReplicas);
 			Set(UpdatableIndexSettings.RecoveryInitialShards, value.RecoveryInitialShards);
@@ -178,6 +179,7 @@ namespace Nest
 			Set<bool?>(s, settings, BlocksRead, v => s.BlocksRead = v, formatterResolver);
 			Set<bool?>(s, settings, BlocksWrite, v => s.BlocksWrite = v, formatterResolver);
 			Set<bool?>(s, settings, BlocksMetadata, v => s.BlocksMetadata = v, formatterResolver);
+			Set<bool?>(s, settings, BlocksReadOnlyAllowDelete, v => s.BlocksReadOnlyAllowDelete = v, formatterResolver);
 			Set<int?>(s, settings, Priority, v => s.Priority = v, formatterResolver);
 			Set<string>(s, settings, DefaultPipeline, v => s.DefaultPipeline = v, formatterResolver);
 			Set<string>(s, settings, RequiredPipeline, v => s.RequiredPipeline = v, formatterResolver);

--- a/src/Nest/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
@@ -9,13 +9,14 @@ namespace Nest
 		public const string AnalyzeMaxTokenCount = "index.analyze.max_token_count";
 		public const string AutoExpandReplicas = "index.auto_expand_replicas";
 		public const string BlocksMetadata = "index.blocks.metadata";
+		public const string BlocksReadOnlyAllowDelete = "index.blocks.read_only_allow_delete";
 		public const string BlocksRead = "index.blocks.read";
 		public const string BlocksReadOnly = "index.blocks.read_only";
 		public const string BlocksWrite = "index.blocks.write";
 
 		public const string CompoundFormat = "index.compound_format";
 		public const string CompoundOnFlush = "index.compound_on_flush";
-    
+
 		/// <summary>limits the number of unique nested types per index.</summary>
 		public const string MappingNestedFieldsLimit = "index.mapping.nested_fields.limit";
 		/// <summary>

--- a/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
@@ -25,6 +25,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 				{ "index.blocks.read_only", true },
 				{ "index.blocks.read", true },
 				{ "index.blocks.write", true },
+				{ "index.blocks.read_only_allow_delete", true },
 				{ "index.blocks.metadata", true },
 				{ "index.priority", 11 },
 				{ "index.recovery.initial_shards", "full-1" },
@@ -53,6 +54,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 				.BlocksRead()
 				.BlocksReadOnly()
 				.BlocksWrite()
+				.BlocksReadOnlyAllowDelete()
 				.Priority(11)
 				.RecoveryInitialShards(RecoveryInitialShards.FullMinusOne)
 				.RequestsCacheEnabled()
@@ -82,6 +84,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 					BlocksRead = true,
 					BlocksReadOnly = true,
 					BlocksWrite = true,
+					BlocksReadOnlyAllowDelete = true,
 					Priority = 11,
 					RecoveryInitialShards = RecoveryInitialShards.FullMinusOne,
 					RequestsCacheEnabled = true,


### PR DESCRIPTION
Relates: https://stackoverflow.com/questions/59882293/how-to-set-settings-in-elastic-search-nest-7-x/59889463#59889463

This PR adds a property/method on DynamicIndexSettings and the
respective descriptor to be able to set the index.blocks.read_only_allow_delete
setting.