### PR TITLE
Implement _source parameter on action and doc lines.

### DIFF
--- a/examples/Docs/BulkPage/8cd00a3aba7c3c158277bc032aac2830.asciidoc
+++ b/examples/Docs/BulkPage/8cd00a3aba7c3c158277bc032aac2830.asciidoc
@@ -1,0 +1,50 @@
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line405 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/BulkPage.cs#L47-L113.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+[source, csharp]
+----
+var bulkResponse = client.Bulk(b => b
+    .Update<object>(u => u
+        .Index("index1")
+        .Id("1")
+        .RetriesOnConflict(3)
+        .Doc(new { field = "value" })
+    )
+    .Update<object>(u => u
+        .Index("index1")
+        .Id("0")
+        .RetriesOnConflict(3)
+        .Script(s => s
+            .Source("ctx._source.counter += params.param1")
+            .Lang("painless")
+            .Params(d => d
+                .Add("param1", 1)
+            )
+        )
+        .Upsert(new { counter = 1 })
+    )
+    .Update<object>(u => u
+        .Index("index1")
+        .Id("2")
+        .RetriesOnConflict(3)
+        .Doc(new { field = "value" })
+        .DocAsUpsert(true)
+    )
+    .Update<object>(u => u
+        .Index("index1")
+        .Id("3")
+        .Source(true)
+        .Doc(new { field = "value" })
+    )
+    .Update<object>(u => u
+        .Index("index1")
+        .Id("4")
+        .Source(true)
+        .Doc(new { field = "value" })
+    )
+);
+----

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
@@ -52,7 +52,7 @@ namespace Nest
 		/// True or false to return the _source field or not, or a list of fields to return.
 		/// </summary>
 		[DataMember(Name = "_source")]
-		bool? Source { get; set; }
+		Union<bool, ISourceFilter> Source { get; set; }
 	}
 
 	[DataContract]
@@ -129,7 +129,7 @@ namespace Nest
 		/// <summary>
 		/// True or false to return the _source field or not, or a list of fields to return.
 		/// </summary>
-		public bool? Source { get; set; }
+		public Union<bool, ISourceFilter> Source { get; set; }
 
 		protected override Type ClrType => typeof(TDocument);
 
@@ -187,7 +187,7 @@ namespace Nest
 
 		long? IBulkUpdateOperation<TDocument, TPartialDocument>.IfPrimaryTerm { get; set; }
 
-		bool? IBulkUpdateOperation<TDocument, TPartialDocument>.Source { get; set; }
+		Union<bool, ISourceFilter> IBulkUpdateOperation<TDocument, TPartialDocument>.Source { get; set; }
 
 		protected override object GetBulkOperationBody() =>
 			new BulkUpdateBody<TDocument, TPartialDocument>
@@ -283,7 +283,7 @@ namespace Nest
 		/// <summary>
 		/// True or false to return the _source field or not, or a list of fields to return.
 		/// </summary>
-		public BulkUpdateDescriptor<TDocument, TPartialDocument> Source(bool? source = true) =>
+		public BulkUpdateDescriptor<TDocument, TPartialDocument> Source(Union<bool, ISourceFilter> source) =>
 			Assign(source, (a, v) => a.Source = v);
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdate.cs
@@ -47,6 +47,12 @@ namespace Nest
 		long? IfSequenceNumber { get; set; }
 
 		long? IfPrimaryTerm { get; set; }
+
+		/// <summary>
+		/// True or false to return the _source field or not, or a list of fields to return.
+		/// </summary>
+		[DataMember(Name = "_source")]
+		bool? Source { get; set; }
 	}
 
 	[DataContract]
@@ -120,6 +126,11 @@ namespace Nest
 
 		public long? IfPrimaryTerm { get; set; }
 
+		/// <summary>
+		/// True or false to return the _source field or not, or a list of fields to return.
+		/// </summary>
+		public bool? Source { get; set; }
+
 		protected override Type ClrType => typeof(TDocument);
 
 		protected override string Operation => "update";
@@ -150,7 +161,8 @@ namespace Nest
 				DocAsUpsert = DocAsUpsert,
 				ScriptedUpsert = ScriptedUpsert,
 				IfPrimaryTerm = IfPrimaryTerm,
-				IfSequenceNumber = IfSequenceNumber
+				IfSequenceNumber = IfSequenceNumber,
+				Source = Source
 			};
 	}
 
@@ -175,6 +187,8 @@ namespace Nest
 
 		long? IBulkUpdateOperation<TDocument, TPartialDocument>.IfPrimaryTerm { get; set; }
 
+		bool? IBulkUpdateOperation<TDocument, TPartialDocument>.Source { get; set; }
+
 		protected override object GetBulkOperationBody() =>
 			new BulkUpdateBody<TDocument, TPartialDocument>
 			{
@@ -184,7 +198,8 @@ namespace Nest
 				DocAsUpsert = Self.DocAsUpsert,
 				ScriptedUpsert = Self.ScriptedUpsert,
 				IfPrimaryTerm = Self.IfPrimaryTerm,
-				IfSequenceNumber = Self.IfSequenceNumber
+				IfSequenceNumber = Self.IfSequenceNumber,
+				Source = Self.Source
 			};
 
 		protected override Id GetIdForOperation(Inferrer inferrer) =>
@@ -264,5 +279,11 @@ namespace Nest
 		/// </summary>
 		public BulkUpdateDescriptor<TDocument, TPartialDocument> IfPrimaryTerm(long? primaryTerm) =>
 			Assign(primaryTerm, (a, v) => a.IfPrimaryTerm = v);
+
+		/// <summary>
+		/// True or false to return the _source field or not, or a list of fields to return.
+		/// </summary>
+		public BulkUpdateDescriptor<TDocument, TPartialDocument> Source(bool? source = true) =>
+			Assign(source, (a, v) => a.Source = v);
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
@@ -32,6 +32,6 @@ namespace Nest
 		internal long? IfPrimaryTerm { get; set; }
 
 		[DataMember(Name = "_source")]
-		internal bool? Source { get; set; }
+		internal Union<bool, ISourceFilter> Source { get; set; }
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkUpdateBody.cs
@@ -30,5 +30,8 @@ namespace Nest
 
 		[DataMember(Name = "if_primary_term")]
 		internal long? IfPrimaryTerm { get; set; }
+
+		[DataMember(Name = "_source")]
+		internal bool? Source { get; set; }
 	}
 }

--- a/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkResponseItem/BulkResponseItemBase.cs
@@ -34,6 +34,14 @@ namespace Nest
 		[DataMember(Name = "_primary_term")]
 		public long PrimaryTerm { get; internal set; }
 
+		[DataMember(Name = "get")]
+		internal LazyDocument Get { get; set; }
+
+		/// <summary>
+		/// Deserialize the <see cref="Get"/> property as a GetResponse<TDocument> type, where TDocument is the document type.
+		/// </summary>
+		public GetResponse<TDocument> GetResponse<TDocument>() where TDocument : class => Get?.AsUsingRequestResponseSerializer<GetResponse<TDocument>>();
+
 		/// <summary> The result of the bulk operation</summary>
 		[DataMember(Name = "result")]
 		public string Result { get; internal set; }

--- a/tests/Examples/Docs/BulkPage.cs
+++ b/tests/Examples/Docs/BulkPage.cs
@@ -1,6 +1,7 @@
 using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
+using Newtonsoft.Json.Linq;
 
 namespace Examples.Docs
 {
@@ -102,14 +103,11 @@ namespace Examples.Docs
 			{ ""doc"" : {""field"" : ""value""}, ""_source"": true}",
 				e =>
 				{
-					e.ApplyBodyLineChanges(lines =>
+					e.ApplyBulkBodyChanges(objects =>
 					{
-						lines[5] = @"{ ""doc_as_upsert"" : true, ""doc"" : {""field"" : ""value""} }";
-						lines[7] = @"{  ""_source"": true, ""doc"" : {""field"" : ""value""} }";
-						lines[8] = @"{ ""update"" : {""_id"" : ""4"", ""_index"" : ""index1"",  ""_source"": true } }";
-						lines[9] = @"{ ""_source"": true, ""doc"" : {""field"" : ""value""} }";
+						objects[7].Add("_source", true);
+						(objects[8]["update"] as JObject).Add("_source", true);
 					});
-
 					return e;
 				});
 		}

--- a/tests/Examples/Docs/BulkPage.cs
+++ b/tests/Examples/Docs/BulkPage.cs
@@ -102,18 +102,15 @@ namespace Examples.Docs
 			{ ""doc"" : {""field"" : ""value""}, ""_source"": true}",
 				e =>
 				{
-					// This is quite ugly, but seems reasonable given the patching that would need to occur.
-					return Example.Create(@"POST _bulk
-			{ ""update"" : {""_id"" : ""1"", ""_index"" : ""index1"", ""retry_on_conflict"" : 3} }
-			{ ""doc"" : {""field"" : ""value""} }
-			{ ""update"" : { ""_id"" : ""0"", ""_index"" : ""index1"", ""retry_on_conflict"" : 3} }
-			{ ""script"" : { ""source"": ""ctx._source.counter += params.param1"", ""lang"" : ""painless"", ""params"" : {""param1"" : 1}}, ""upsert"" : {""counter"" : 1}}
-			{ ""update"" : {""_id"" : ""2"", ""_index"" : ""index1"", ""retry_on_conflict"" : 3} }
-			{ ""doc_as_upsert"" : true, ""doc"" : {""field"" : ""value""} }
-			{ ""update"" : {""_id"" : ""3"", ""_index"" : ""index1"", ""_source"" : true } }
-			{  ""_source"": true, ""doc"" : {""field"" : ""value""} }
-			{ ""update"" : {""_id"" : ""4"", ""_index"" : ""index1"",  ""_source"": true } }
-			{ ""_source"": true, ""doc"" : {""field"" : ""value""} }");
+					e.ApplyBodyLineChanges(lines =>
+					{
+						lines[5] = @"{ ""doc_as_upsert"" : true, ""doc"" : {""field"" : ""value""} }";
+						lines[7] = @"{  ""_source"": true, ""doc"" : {""field"" : ""value""} }";
+						lines[8] = @"{ ""update"" : {""_id"" : ""4"", ""_index"" : ""index1"",  ""_source"": true } }";
+						lines[9] = @"{ ""_source"": true, ""doc"" : {""field"" : ""value""} }";
+					});
+
+					return e;
 				});
 		}
 	}

--- a/tests/Examples/Docs/BulkPage.cs
+++ b/tests/Examples/Docs/BulkPage.cs
@@ -42,7 +42,7 @@ namespace Examples.Docs
 			{ ""doc"" : {""field2"" : ""value2""} }");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line405()
 		{
 			// tag::8cd00a3aba7c3c158277bc032aac2830[]
@@ -76,15 +76,13 @@ namespace Examples.Docs
 				.Update<object>(u => u
 					.Index("index1")
 					.Id("3")
-					// TODO: missing
-					//.Source(true)
+					.Source(true)
 					.Doc(new { field = "value" })
 				)
 				.Update<object>(u => u
 					.Index("index1")
 					.Id("4")
-					// TODO: missing
-					//.Source(true)
+					.Source(true)
 					.Doc(new { field = "value" })
 				)
 			);

--- a/tests/Examples/Example.cs
+++ b/tests/Examples/Example.cs
@@ -26,15 +26,6 @@ namespace Examples
 
 		public UriBuilder Uri { get; set; }
 
-		public void ApplyBodyLineChanges(Action<List<string>> lines)
-		{
-			var body = Body == null
-				? new List<string>()
-				: Body.Split(new [] { Environment.NewLine, "\r", "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
-			lines(body);
-			Body = string.Join(Environment.NewLine, body);
-		}
-
 		public void ApplyBulkBodyChanges(Action<List<JObject>> action)
 		{
 			var body = Body == null

--- a/tests/Examples/Example.cs
+++ b/tests/Examples/Example.cs
@@ -35,6 +35,15 @@ namespace Examples
 			Body = string.Join(Environment.NewLine, body);
 		}
 
+		public void ApplyBulkBodyChanges(Action<List<JObject>> action)
+		{
+			var body = Body == null
+				? new List<JObject>()
+				: ResponseExtensions.ParseJObjects(Body);
+			action(body);
+			Body = string.Join(Environment.NewLine, body.Select(b => b.ToString()).ToArray());
+		}
+
 		public void ApplyBodyChanges(Action<JObject> action)
 		{
 			var body = Body == null

--- a/tests/Examples/Example.cs
+++ b/tests/Examples/Example.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.RegularExpressions;
 using Elasticsearch.Net;
 using Newtonsoft.Json.Linq;
@@ -23,6 +25,15 @@ namespace Examples
 		public HttpMethod Method { get; set; }
 
 		public UriBuilder Uri { get; set; }
+
+		public void ApplyBodyLineChanges(Action<List<string>> lines)
+		{
+			var body = Body == null
+				? new List<string>()
+				: Body.Split(new [] { Environment.NewLine, "\r", "\r\n", "\n" }, StringSplitOptions.RemoveEmptyEntries).ToList();
+			lines(body);
+			Body = string.Join(Environment.NewLine, body);
+		}
 
 		public void ApplyBodyChanges(Action<JObject> action)
 		{

--- a/tests/Examples/ResponseExtensions.cs
+++ b/tests/Examples/ResponseExtensions.cs
@@ -106,7 +106,7 @@ namespace Examples
 		/// Parses a collection of JObjects from the JSON input. Provides support
 		/// for both regular JSON and newline delimited JSON
 		/// </summary>
-		private static List<JObject> ParseJObjects(string json)
+		public static List<JObject> ParseJObjects(string json)
 		{
 			var jObjects = new List<JObject>();
 			using (var stringReader = new StringReader(json))

--- a/tests/Tests/Document/Multiple/Bulk/BulkSourceDeserialize.cs
+++ b/tests/Tests/Document/Multiple/Bulk/BulkSourceDeserialize.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+
+namespace Tests.Document.Multiple.Bulk
+{
+	public class BulkSourceDeserialize
+	{
+		[U]
+		public void CanDeserialize()
+		{
+			var json = @"{
+							""took"": 61,
+							""errors"": false,
+							""items"": [{
+								""update"": {
+									""_index"": ""test"",
+									""_type"": ""_doc"",
+									""_id"": ""1"",
+									""_version"": 2,
+									""result"": ""updated"",
+									""_shards"": {
+										""total"": 2,
+										""successful"": 1,
+										""failed"": 0
+									},
+									""_seq_no"": 3,
+									""_primary_term"": 1,
+									""get"": {
+										""_seq_no"": 3,
+										""_primary_term"": 1,
+										""found"": true,
+										""_source"": {
+											""field1"": ""value1"",
+											""field2"": ""value2""
+										}
+									},
+									""status"": 200
+								}
+							}]
+						}";
+
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+
+			var connection = new InMemoryConnection(Encoding.UTF8.GetBytes(json));
+			var settings = new ConnectionSettings(pool, connection);
+			var client = new ElasticClient(settings);
+
+			var bulkResponse = client.Bulk(r => r);
+
+			bulkResponse.ShouldBeValid();
+
+			var simpleObject = bulkResponse.Items[0].GetResponse<SimpleObject>();
+
+			simpleObject.Found.Should().BeTrue();
+			simpleObject.Source.field1.Should().Be("value1");
+			simpleObject.Source.field2.Should().Be("value2");
+		}
+
+		private class SimpleObject
+		{
+			public string field1 { get; set; }
+			public string field2 { get; set; }
+		}
+	}
+}


### PR DESCRIPTION
The documentation (https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html) indicates that `_source` is valid on both the action and the doc lines (see the JSON example at the bottom of the page).

```
{ "update" : {"_id" : "3", "_index" : "index1", "_source" : true} }
{ "doc" : {"field" : "value"} }
{ "update" : {"_id" : "4", "_index" : "index1"} }
{ "doc" : {"field" : "value"}, "_source": true}
```

This PR is in draft whilst it is ratified if there is any precendence in parameters being set, or if the parameters are preferred on the action line or doc line.