### PR TITLE
Fix typo in code that cause the docs stale check to trigger (#4343)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -23,6 +23,7 @@
     <PackageProjectUrl>https://github.com/elastic/elasticsearch-net</PackageProjectUrl>
     <PackageIconUrl>https://raw.githubusercontent.com/elastic/elasticsearch-net/master/build/nuget-icon.png</PackageIconUrl>
   </PropertyGroup>
+
   <PropertyGroup>
     <LangVersion>latest</LangVersion>
     <!-- Default Version numbers -->

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(IsPackable) == True">
 
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <NoWarn>1591,1572,1571,1573,1587,1570,NU5048,</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
     <DebugSymbols>true</DebugSymbols>

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -29,7 +29,9 @@ module ReposTooling =
         //TODO allow branch name to be passed for CI
         let folder = Path.getDirectory (Paths.ProjFile "ApiGenerator")
         let timeout = TimeSpan.FromMinutes(120.)
-        Tooling.DotNet.ExecInWithTimeout folder ["run"; ] timeout  |> ignore
+        // Building to make sure XML docs files are there, faster then relying on the ApiGenerator to emit these
+        // from a compilation unit
+        Tooling.DotNet.ExecInWithTimeout folder ["run"; "-c"; " Release"; ] timeout  |> ignore
         
     let RestSpecTests args =
         let folder = Path.getDirectory (Paths.TestProjFile "Tests.YamlRunner")

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -34,6 +34,10 @@ Api Key to send with all requests to Elasticsearch
 
 Api Key to send with all requests to Elasticsearch
 
+`ApiKeyAuthentication`::
+
+Api Key to send with all requests to Elasticsearch
+
 `BasicAuthentication`::
 
 Basic Authentication credentials to send with all requests to Elasticsearch

--- a/src/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
+++ b/src/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
@@ -232,10 +232,10 @@ namespace DocGenerator.AsciiDoc
 			string XmlFile(string project)
 			{
 				if (configuration == null)
-					return Path.Combine(Program.InputDirPath, project, "netstandard2.0", $"{project}.XML");
+					return Path.Combine(Program.InputDirPath, project, "netstandard2.0", $"{project}.xml");
 
 				return Path.Combine(Program.InputDirPath, project, "bin", configuration, "netstandard2.0",
-					$"{project}.XML");
+					$"{project}.xml");
 			}
 
 			var value = attributeEntry.Value;
@@ -272,6 +272,7 @@ namespace DocGenerator.AsciiDoc
 			// build xml documentation file on the fly if it doesn't exist
 			if (!File.Exists(xmlDocsFile))
 			{
+				Console.WriteLine($"Can not find {xmlDocsFile} attempting to build");
 				var project = _projects[assemblyName];
 
 				var compilation = project.GetCompilationAsync().Result;
@@ -288,7 +289,7 @@ namespace DocGenerator.AsciiDoc
 							diagnostic.Severity == DiagnosticSeverity.Error);
 
 						var builder = new StringBuilder($"Unable to emit compilation for: {assemblyName}");
-						foreach (var diagnostic in failures) builder.AppendLine($"{diagnostic.Id}: {diagnostic.GetMessage()}");
+						foreach (var diagnostic in failures.Take(50)) builder.AppendLine($"{diagnostic.Id}: {diagnostic.GetMessage()}");
 
 						builder.AppendLine(new string('-', 30));
 

--- a/src/Elasticsearch.Net.VirtualizedCluster/Elasticsearch.Net.VirtualizedCluster.csproj
+++ b/src/Elasticsearch.Net.VirtualizedCluster/Elasticsearch.Net.VirtualizedCluster.csproj
@@ -7,8 +7,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="Elasticsearch.Net" Version="$(TestPackageVersion)"/>

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -11,8 +11,9 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     
     <CheckForOverflowUnderflow>true</CheckForOverflowUnderflow>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/src/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
+++ b/src/Nest.JsonNetSerializer/Nest.JsonNetSerializer.csproj
@@ -8,8 +8,9 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\src\Nest\Nest.csproj" />

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -11,8 +11,9 @@
   </PropertyGroup>
   
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <IsPackable>true</IsPackable>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />

--- a/tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
+++ b/tests/Tests/ClientConcepts/HighLevel/GettingStarted.doc.cs
@@ -105,7 +105,7 @@ namespace Tests.ClientConcepts.HighLevel
 				LastName = "Laarman"
 			};
 
-			var ndexResponse = client.IndexDocument(person); //<1> synchronous method that returns an `IndexResponse`
+			var indexResponse = client.IndexDocument(person); //<1> synchronous method that returns an `IndexResponse`
 
 			var asyncIndexResponse = await client.IndexDocumentAsync(person); //<2> asynchronous method that returns a `Task<IndexResponse>` that can be awaited
 		}


### PR DESCRIPTION
* Fix typo in code that cause the docs stale check to trigger

* GenerateDocumentationFile evaluated and read before

build.targets evaluates we there for need to manually set it on the
projects with intend to publish.

Make sure the doc generator reads this file rather then always forcing
its own xmldocs emit.

(cherry picked from commit 0e739bc119375604d69f72ef573421543c1f1c5a)