### PR TITLE
DynamicValue can now dispatch into arrays

### DIFF
--- a/docs/client-concepts/low-level/low-level-response-types.asciidoc
+++ b/docs/client-concepts/low-level/low-level-response-types.asciidoc
@@ -17,30 +17,30 @@ please modify the original csharp file found at the link and submit the PR with 
 
 [source,csharp]
 ----
-return @"{
-""boolean"" : true,    
+return $@"{{
+""boolean"" : true,
 ""string"" : ""v"",
 ""number"" : 29,
 ""array"" : [1, 2, 3, 4],
-""object"" : {
+""object"" : {{
     ""first"" : ""value1"",
     ""second"" : ""value2"",
-    ""nested"" : { ""x"" : ""value3"" }
-},
+    ""nested"" : {{ ""x"" : ""value3"" }}
+}},
 ""array_of_objects"" : [
-    {
+    {{
         ""first"" : ""value11"",
         ""second"" : ""value12"",
-        ""nested"" : { ""x"" : ""value4"" }
-    },
-    {
+        ""nested"" : {{ ""x"" : ""value4"", ""z"" : [{{""id"": 1}}] }}
+    }},
+    {{
         ""first"" : ""value21"",
         ""second"" : ""value22"",
-        ""nested"" : { ""x"" : ""value5"" },
-        ""complex.nested"" : { ""x"" : ""value6"" }
-    }
+        ""nested"" : {{ ""x"" : ""value5"", ""z"" : [{{""id"": 3}}, {{""id"": 2}}] }},
+        ""complex.nested"" : {{ ""x"" : ""value6"" }}
+    }}
 ]
-        }";
+        }}";
 ----
 
 [float]
@@ -72,5 +72,26 @@ response.Get<string>("array_of_objects.1.second").Should()
 response.Get<string>("array_of_objects.1.complex\\.nested.x").Should()
     .NotBeEmpty()
     .And.Be("value6");
+----
+
+You can project into arrays using the dot notation
+
+[source,csharp]
+----
+response.Get<string[]>("array_of_objects.first").Should()
+    .NotBeEmpty()
+    .And.HaveCount(2)
+    .And.BeEquivalentTo(new [] {"value11", "value21"});
+----
+
+You can even peek into array of arrays
+
+[source,csharp]
+----
+var nestedZs = response.Get<int[][]>("array_of_objects.nested.z.id")
+    //.SelectMany(d=>d.Get<int[]>("id"))
+    .Should().NotBeEmpty()
+    .And.HaveCount(2)
+    .And.BeEquivalentTo(new [] { new [] {1}, new []{3,2}});
 ----
 

--- a/docs/client-concepts/low-level/low-level-response-types.asciidoc
+++ b/docs/client-concepts/low-level/low-level-response-types.asciidoc
@@ -17,30 +17,30 @@ please modify the original csharp file found at the link and submit the PR with 
 
 [source,csharp]
 ----
-return @"{{
-""boolean"" : true,
-""string"" : ""v"",
-""number"" : 29,
-""array"" : [1, 2, 3, 4],
-""object"" : {{
-    ""first"" : ""value1"",
-    ""second"" : ""value2"",
-    ""nested"" : {{ ""x"" : ""value3"" }}
-}},
-""array_of_objects"" : [
-    {{
-        ""first"" : ""value11"",
-        ""second"" : ""value12"",
-        ""nested"" : {{ ""x"" : ""value4"", ""z"" : [{{""id"": 1}}] }}
-    }},
-    {{
-        ""first"" : ""value21"",
-        ""second"" : ""value22"",
-        ""nested"" : {{ ""x"" : ""value5"", ""z"" : [{{""id"": 3}}, {{""id"": 2}}] }},
-        ""complex.nested"" : {{ ""x"" : ""value6"" }}
-    }}
-]
-        }}";
+return @"{
+    ""boolean"" : true,
+    ""string"" : ""v"",
+    ""number"" : 29,
+    ""array"" : [1, 2, 3, 4],
+    ""object"" : {
+        ""first"" : ""value1"",
+        ""second"" : ""value2"",
+        ""nested"" : { ""x"" : ""value3"" }
+    },
+    ""array_of_objects"" : [
+        {
+            ""first"" : ""value11"",
+            ""second"" : ""value12"",
+            ""nested"" : { ""x"" : ""value4"", ""z"" : [{""id"": 1}] }
+        },
+        {
+            ""first"" : ""value21"",
+            ""second"" : ""value22"",
+            ""nested"" : { ""x"" : ""value5"", ""z"" : [{""id"": 3}, {""id"": 2}] },
+            ""complex.nested"" : { ""x"" : ""value6"" }
+        }
+    ]
+}";
 ----
 
 [float]

--- a/docs/client-concepts/low-level/low-level-response-types.asciidoc
+++ b/docs/client-concepts/low-level/low-level-response-types.asciidoc
@@ -17,7 +17,7 @@ please modify the original csharp file found at the link and submit the PR with 
 
 [source,csharp]
 ----
-return $@"{{
+return @"{{
 ""boolean"" : true,
 ""string"" : ""v"",
 ""number"" : 29,

--- a/src/Elasticsearch.Net/Responses/Dynamic/DynamicValue.cs
+++ b/src/Elasticsearch.Net/Responses/Dynamic/DynamicValue.cs
@@ -552,7 +552,6 @@ namespace Elasticsearch.Net
 					var objectArray = ar
 						.Select(a => TryParse(defaultValue, t, a, out var o) ? o : null)
 						.Where(a => a != null)
-						//.Select(a => Convert.ChangeType(a, t))
 						.ToArray();
 
 					var arr = Array.CreateInstance(t, objectArray.Length);

--- a/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
@@ -28,30 +28,30 @@ namespace Tests.ClientConcepts.LowLevel
 
 		public static string Response()
 		{
-			return @"{
-			""boolean"" : true,	
+			return $@"{{
+			""boolean"" : true,
 			""string"" : ""v"",
 			""number"" : 29,
 			""array"" : [1, 2, 3, 4],
-			""object"" : {
+			""object"" : {{
 				""first"" : ""value1"",
 				""second"" : ""value2"",
-				""nested"" : { ""x"" : ""value3"" }
-			},
+				""nested"" : {{ ""x"" : ""value3"" }}
+			}},
 			""array_of_objects"" : [
-				{
+				{{
 					""first"" : ""value11"",
 					""second"" : ""value12"",
-					""nested"" : { ""x"" : ""value4"" }
-				},
-				{
+					""nested"" : {{ ""x"" : ""value4"", ""z"" : [{{""id"": 1}}] }}
+				}},
+				{{
 					""first"" : ""value21"",
 					""second"" : ""value22"",
-					""nested"" : { ""x"" : ""value5"" },
-					""complex.nested"" : { ""x"" : ""value6"" }
-				}
+					""nested"" : {{ ""x"" : ""value5"", ""z"" : [{{""id"": 3}}, {{""id"": 2}}] }},
+					""complex.nested"" : {{ ""x"" : ""value6"" }}
+				}}
 			]
-		}";
+		}}";
 		}
 
 		public LowLevelResponseTypes()
@@ -94,6 +94,24 @@ namespace Tests.ClientConcepts.LowLevel
 			response.Get<string>("array_of_objects.1.complex\\.nested.x").Should()
 				.NotBeEmpty()
 				.And.Be("value6");
+
+			/**
+			 * You can project into arrays using the dot notation
+			 */
+			response.Get<string[]>("array_of_objects.first").Should()
+				.NotBeEmpty()
+				.And.HaveCount(2)
+				.And.BeEquivalentTo(new [] {"value11", "value21"});
+
+			/**
+			 * You can even peek into array of arrays
+			 */
+			var nestedZs = response.Get<int[][]>("array_of_objects.nested.z.id")
+				//.SelectMany(d=>d.Get<int[]>("id"))
+				.Should().NotBeEmpty()
+				.And.HaveCount(2)
+				.And.BeEquivalentTo(new [] { new [] {1}, new []{3,2}});
+
 
 		}
 

--- a/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
@@ -28,7 +28,7 @@ namespace Tests.ClientConcepts.LowLevel
 
 		public static string Response()
 		{
-			return $@"{{
+			return @"{{
 			""boolean"" : true,
 			""string"" : ""v"",
 			""number"" : 29,

--- a/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
+++ b/tests/Tests/ClientConcepts/LowLevel/LowLevelResponseTypes.doc.cs
@@ -28,30 +28,30 @@ namespace Tests.ClientConcepts.LowLevel
 
 		public static string Response()
 		{
-			return @"{{
-			""boolean"" : true,
-			""string"" : ""v"",
-			""number"" : 29,
-			""array"" : [1, 2, 3, 4],
-			""object"" : {{
-				""first"" : ""value1"",
-				""second"" : ""value2"",
-				""nested"" : {{ ""x"" : ""value3"" }}
-			}},
-			""array_of_objects"" : [
-				{{
-					""first"" : ""value11"",
-					""second"" : ""value12"",
-					""nested"" : {{ ""x"" : ""value4"", ""z"" : [{{""id"": 1}}] }}
-				}},
-				{{
-					""first"" : ""value21"",
-					""second"" : ""value22"",
-					""nested"" : {{ ""x"" : ""value5"", ""z"" : [{{""id"": 3}}, {{""id"": 2}}] }},
-					""complex.nested"" : {{ ""x"" : ""value6"" }}
-				}}
-			]
-		}}";
+			return @"{
+				""boolean"" : true,
+				""string"" : ""v"",
+				""number"" : 29,
+				""array"" : [1, 2, 3, 4],
+				""object"" : {
+					""first"" : ""value1"",
+					""second"" : ""value2"",
+					""nested"" : { ""x"" : ""value3"" }
+				},
+				""array_of_objects"" : [
+					{
+						""first"" : ""value11"",
+						""second"" : ""value12"",
+						""nested"" : { ""x"" : ""value4"", ""z"" : [{""id"": 1}] }
+					},
+					{
+						""first"" : ""value21"",
+						""second"" : ""value22"",
+						""nested"" : { ""x"" : ""value5"", ""z"" : [{""id"": 3}, {""id"": 2}] },
+						""complex.nested"" : { ""x"" : ""value6"" }
+					}
+				]
+			}";
 		}
 
 		public LowLevelResponseTypes()


### PR DESCRIPTION
e.g `.Get<string[]>("dataframes.id")` will work even if `dataframes` is a an array of objects. This makes picking values dynamically a ton easier.

(cherry picked from commit 1218888e47afe2147ec787d87fea4a2600c80da4)

Isolated from #4336