### PR TITLE
Update rest-spec runner to completion

### DIFF
--- a/.ci/jobs/elastic+elasticsearch-net+pull-request.yml
+++ b/.ci/jobs/elastic+elasticsearch-net+pull-request.yml
@@ -3,6 +3,7 @@
     name: elastic+elasticsearch-net+pull-request
     display-name: 'elastic / elasticsearch-net # pull-request'
     description: Testing of elasticsearch-net pull requests.
+    junit_results: "*-junit.xml"
     scm:
     - git:
         branches:

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -35,4 +35,4 @@ docker run \
   --volume ${repo}/build/output:/sln/build/output \
   --rm \
   elastic/elasticsearch-net \
-  ./build.sh rest-spec-tests -f count -e ${ELASTICSEARCH_URL} -o /sln/build/output/rest-spec-junit.xml
+  ./build.sh rest-spec-tests -e ${ELASTICSEARCH_URL} -o /sln/build/output/rest-spec-junit.xml

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -35,4 +35,4 @@ docker run \
   --volume ${repo}/build/output:/sln/build/output \
   --rm \
   elastic/elasticsearch-net \
-  ./build.sh rest-spec-tests -e ${ELASTICSEARCH_URL} -o /sln/build/output/rest-spec-junit.xml
+  ./build.sh rest-spec-tests $TEST_SUITE -e ${ELASTICSEARCH_URL} -o /sln/build/output/rest-spec-junit.xml

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -5,7 +5,7 @@ ELASTICSEARCH_VERSION:
 
 TEST_SUITE:
   - oss
-# - xpack
+  - xpack
 
 DOTNET_VERSION:
     - 3.0.100

--- a/src/Elasticsearch.Net/Responses/ServerException/Error.cs
+++ b/src/Elasticsearch.Net/Responses/ServerException/Error.cs
@@ -20,6 +20,10 @@ namespace Elasticsearch.Net
 
 		[DataMember(Name = "root_cause")]
 		public IReadOnlyCollection<ErrorCause> RootCause { get; set; }
+
+		public override string ToString() => CausedBy == null
+			? $"Type: {Type} Reason: \"{Reason}\""
+			: $"Type: {Type} Reason: \"{Reason}\" CausedBy: \"{CausedBy}\"";
 	}
 
 	internal class ErrorFormatter : ErrorCauseFormatter<Error>

--- a/tests/Tests.YamlRunner/Commands.fs
+++ b/tests/Tests.YamlRunner/Commands.fs
@@ -35,14 +35,14 @@ let ReadTests (tests:LocateResults list) =
     
     tests |> List.map (fun t -> { Folder= t.Folder; Files = readPaths t.Paths})
     
-let RunTests (tests:YamlTestFolder list) client = async {
+let RunTests (tests:YamlTestFolder list) client version namedSuite = async {
     do! Async.SwitchToNewThread()
-    
     
     let f = tests.Length
     let l = tests |> List.sumBy (fun t -> t.Files.Length)
     use progress = new ProgressBar(l, sprintf "Folders [0/%i]" l, barOptions)
-    let runner = TestRunner(client, progress, subBarOptions)
+    let runner = TestRunner(client, version, namedSuite, progress, subBarOptions)
+    runner.GlobalSetup() 
     let a (i, v) = async {
         let mainMessage = sprintf "[%i/%i] Folders : %s | " (i+1) f v.Folder
         let! op = runner.RunTestsInFolder mainMessage v

--- a/tests/Tests.YamlRunner/Models.fs
+++ b/tests/Tests.YamlRunner/Models.fs
@@ -9,7 +9,7 @@ open Microsoft.FSharp.Reflection
 
 let private getName a = match FSharpValue.GetUnionFields(a, a.GetType()) with | (case, _) -> case.Name   
 
-type TestSuite = OpenSource | XPack
+type TestSuite = Oss | XPack
 
 type YamlMap = Dictionary<Object,Object>
 type YamlValue = YamlDictionary of YamlMap | YamlString of string

--- a/tests/Tests.YamlRunner/Models.fs
+++ b/tests/Tests.YamlRunner/Models.fs
@@ -1,5 +1,6 @@
 module Tests.YamlRunner.Models
 
+open Elasticsearch.Net
 open System
 open System.Collections.Generic
 open System.Text.RegularExpressions
@@ -180,6 +181,7 @@ type Assert =
 
 type Operation =
     | Unknown of string
+    | Actions of string * (IElasticLowLevelClient -> unit)
     | Skip of Skip
     | Do of Do
     | Set of Set
@@ -192,6 +194,7 @@ type Operation =
             | Assert s -> sprintf "%s operation %s" this.Name (s.Log())
             | Do s -> sprintf "%s operation %s" "Do" (s.Log())
             | Unknown s -> sprintf "%s operation %s" this.Name s
+            | Actions (s, _) -> sprintf "%s custom %s actions" this.Name s
             | Skip s -> sprintf "%s operation %s" this.Name s.Log
             | Set s ->
                 sprintf "%s operation %s" this.Name (s |> Seq.map (fun k -> sprintf "%A %A" k.Key k.Value) |> String.concat " ")

--- a/tests/Tests.YamlRunner/OperationExecutor.fs
+++ b/tests/Tests.YamlRunner/OperationExecutor.fs
@@ -1,6 +1,7 @@
 module Tests.YamlRunner.OperationExecutor
 
 open System
+open System.Linq
 open System.IO
 open Microsoft.FSharp.Reflection
 open Tests.YamlRunner.DoMapper
@@ -11,8 +12,10 @@ open Elasticsearch.Net
 open Newtonsoft.Json
 open Newtonsoft.Json.Linq
 open System.Collections.Generic
+open System.Runtime.ExceptionServices
 
 type ExecutionContext = {
+    Version: string
     Suite: TestSuite
     Folder: DirectoryInfo
     File: FileInfo
@@ -25,25 +28,28 @@ type ExecutionContext = {
     with member __.Throw message = failwithf "%s" message
 
 type Fail =
-    | SeenException of ExecutionContext * Exception
+    | SeenException of ExecutionContext * Exception 
     | ValidationFailure of ExecutionContext * string
     with
         member this.Context = match this with | SeenException (c, _) -> c | ValidationFailure (c, _) -> c
         member this.Log () =
             match this with
-            | SeenException (_, e) -> sprintf "Exception: %O" e 
+            | SeenException (_, e) -> sprintf "Exception: %s" e.Message 
             | ValidationFailure (_, r) -> sprintf "Reason: %s" r 
         static member private FormatFailure op fmt = ValidationFailure (op, sprintf "%s" fmt)
         static member Create op fmt = Printf.kprintf (fun x -> Fail.FormatFailure op x) fmt
-
+        
 type ExecutionResult =
     | Succeeded of ExecutionContext
-    | Skipped of ExecutionContext 
+    | Skipped of ExecutionContext * string
+    | NotSkipped of ExecutionContext
     | Failed of Fail
     with
         member this.Name = match FSharpValue.GetUnionFields(this, this.GetType()) with | (case, _) -> case.Name
-        member this.Context = match this with | Succeeded c -> c | Skipped c -> c | Failed f -> f.Context
-
+        member this.Context =
+            match this with | Succeeded c -> c | NotSkipped c -> c | Skipped (c, _) -> c | Failed f -> f.Context
+            
+type JTokenOrFailure = Token of JToken | Fail of Fail
 
 type OperationExecutor(client:IElasticLowLevelClient) =
 
@@ -66,11 +72,11 @@ type OperationExecutor(client:IElasticLowLevelClient) =
 
     static member Do op d (lookup:YamlMap -> FastApiInvoke) progress = async {
         let stashes = op.Stashes
-        let (_, data) = d.ApiCall
+        let (api, data) = d.ApiCall
         try
             let invoke = lookup data
             let resolvedData = stashes.Resolve progress data
-            let! r = Async.AwaitTask <| invoke.Invoke resolvedData
+            let! r = Async.AwaitTask <| invoke.Invoke resolvedData d.Headers
             
             let responseMimeType = r.ApiCall.ResponseMimeType
             match responseMimeType with
@@ -80,8 +86,39 @@ type OperationExecutor(client:IElasticLowLevelClient) =
             
             op.Stashes.ResponseOption <- Some r
             
+            let result =
+                let autoFailed = d.AutoFail && not r.Success
+                let statusCode = if r.HttpStatusCode.HasValue then Some r.HttpStatusCode.Value else None
+                match (autoFailed, d.Catch, statusCode) with
+                | true, _, _ -> Failed <| Fail.Create op "AutoFail triggered on api: %s" api
+                | false, None, _  -> Succeeded op
+                | _, Some catch, statusCode ->
+                    match (catch, statusCode) with
+                    | BadRequest, Some s when s <> 400 ->
+                        Failed <| Fail.Create op "Catch %A: expected 400 received %i" catch s
+                    | Unauthorized, Some s when s <> 401 ->
+                        Failed <| Fail.Create op "Catch %A: expected 401 received %i" catch s
+                    | Forbidden, Some s when s <> 403 ->
+                        Failed <| Fail.Create op "Catch %A: expected 403 received %i" catch s
+                    | Missing, Some s when s <> 404 ->
+                        Failed <| Fail.Create op "Catch %A: expected 403 received %i" catch s
+                    | RequestTimeout, Some s when s <> 408 ->
+                        Failed <| Fail.Create op "Catch %A: expected 408 received %i" catch s
+                    | Conflict, Some s when s <> 409 ->
+                        Failed <| Fail.Create op "Catch %A: expected 409 received %i" catch s
+                    | Unavailable, Some s when s <> 503 ->
+                        Failed <| Fail.Create op "Catch %A: expected 503 received %i" catch s
+                    | OtherBadResponse, Some s when s < 400 || s >= 600 ->
+                        Failed <| Fail.Create op "Catch %A: expected 4xx-5xx received %i" catch s
+                    | (CatchRegex regexp), _ -> 
+                        let body = System.Text.Encoding.UTF8.GetString(r.ApiCall.ResponseBodyInBytes)
+                        match System.Text.RegularExpressions.Regex.IsMatch(body, regexp) with
+                        | true -> Succeeded op
+                        | false -> Failed <| Fail.Create op "Catching error failed: %O on server error" d.Catch 
+                    | _ -> Succeeded op
+            
             //progress.WriteLine <| sprintf "%s %s" (r.ApiCall.HttpMethod.ToString()) (r.Uri.PathAndQuery)
-            return Succeeded op
+            return result
         with
         | ParamException e ->
             match d.Catch with
@@ -115,27 +152,28 @@ type OperationExecutor(client:IElasticLowLevelClient) =
     static member IsFalse op (t:AssertOn) progress =
         let isTrue = OperationExecutor.IsTrue op t progress
         match isTrue with
-        | Skipped op -> Skipped op
+        | Skipped (op, r) -> Skipped (op, r)
+        | NotSkipped c -> NotSkipped c
         | Failed f -> Succeeded f.Context
         | Succeeded op ->
             Failed <| Fail.Create op "Expected is_false but got is_true behavior"
-        
-    static member IsMatch op (matchOp:Match) progress =
-        let stashes = op.Stashes
-        let isMatch expected actual =
-            let toJtoken (t:Object) =
-                match t with
-                | null -> new JValue(t) :> JToken
-                // yaml test framework often compares ints with doubles, does not validate
-                // actual numeric types returned
-                | :? int 
-                | :? int64 -> new JValue(Convert.ToDouble(t)) :> JToken
-                | :? Dictionary<Object, Object> as d -> JObject.FromObject(d) :> JToken
-                | :? IDictionary<String, Object> as d -> JObject.FromObject(d) :> JToken
-                | _ -> JToken.FromObject t
-                
-            let expected = toJtoken expected
-            let actual = toJtoken actual
+    
+    
+    static member ToJToken (t:Object) =
+        match t with
+        | null -> new JValue(t) :> JToken
+        | :? JToken as j -> j 
+        // yaml test framework often compares ints with doubles, does not validate
+        // actual numeric types returned
+        | :? int 
+        | :? int64 -> new JValue(Convert.ToDouble(t)) :> JToken
+        | :? Dictionary<Object, Object> as d -> JObject.FromObject(d) :> JToken
+        | :? IDictionary<String, Object> as d -> JObject.FromObject(d) :> JToken
+        | _ -> JToken.FromObject t
+    
+    static member JTokenDeepEquals op expected actual =
+            let expected = OperationExecutor.ToJToken expected
+            let actual = OperationExecutor.ToJToken actual
             match JToken.DeepEquals (expected, actual) with
             | false ->
                 let a = actual.ToString(Formatting.None)
@@ -143,6 +181,67 @@ type OperationExecutor(client:IElasticLowLevelClient) =
                 Failed <| Fail.Create op "expected: %s actual: %s" e a
             | _ -> Succeeded op
         
+    static member IsNumericMatch op (assertion:NumericAssert) (m:NumericMatch) progress =
+        let stashes = op.Stashes
+        let doMatch assertOn assertValue = 
+            match assertOn with
+            | WholeResponse ->
+                Failed <| Fail.Create op "Can not do numeric asserts on whole responses" 
+            | ResponsePath path ->
+                let expected =
+                    match assertValue with
+                    | Long l -> Token(JValue(Convert.ToDouble(l)))
+                    | Double d -> Token(JValue(d))
+                    | NumericId id ->
+                        let found, expected = stashes.TryGetValue id
+                        match found with
+                        | true -> Token(OperationExecutor.ToJToken expected)
+                        | false -> Fail(Fail.Create op "%A not stashed at this point" id)
+                        
+                let expectedValue (value:JToken) =
+                    match value with
+                    | :? JValue as v -> Some(Convert.ChangeType(v.Value, typeof<double>) :?> double)
+                    | :? JArray as a -> Some <| Convert.ToDouble(a.Count)
+                    | :? JObject as o -> Some <| Convert.ToDouble(o.Properties().Count())
+                    | _ -> None
+                        
+                let actual =
+                    match path with 
+                    | "$body" ->
+                        let dictOrArray = stashes.Response().Dictionary.Count
+                        Some <| Convert.ToDouble(dictOrArray)
+                    | _ -> 
+                        let a = OperationExecutor.ToJToken <| (stashes.GetResponseValue progress path :> Object)
+                        expectedValue a
+                
+                let numMatch a e s c = 
+                    let e = expectedValue e
+                    match e with
+                    | None -> Failed <| Fail.Create op "Can not get numeric value from expected %O" e
+                    | Some e when c a e  -> Succeeded op 
+                    | Some e -> Failed <| Fail.Create op "Expected %f %s %f " e s a
+                
+                match (assertion, actual, expected) with
+                | (_, _, Fail f) -> Failed <| f
+                | (_, None, _) -> Failed <| Fail.Create op "Can not get numeric value from actual %O" actual
+                | (Equal, Some a, Token e) -> OperationExecutor.JTokenDeepEquals op e a 
+                | (Length, Some a, Token e) -> numMatch a e "=" <| (fun a e -> a = e)
+                | (LowerThan, Some a, Token e) -> numMatch a e "<" <| (fun a e -> a < e)
+                | (GreaterThan, Some a, Token e)  -> numMatch a e ">" <| (fun a e -> a > e)
+                | (GreaterThanOrEqual, Some a, Token e) -> numMatch a e ">=" <| (fun a e -> a >= e)
+                | (LowerThanOrEqual, Some a, Token e)  -> numMatch a e "<=" <| (fun a e -> a <= e)
+    
+        let asserts =
+            m
+            |> Map.toList
+            |> Seq.map (fun (k, v) -> doMatch k v)
+            |> Seq.sortBy (fun ex -> match ex with | Succeeded o -> 4 | Skipped (o, s) -> 3 | NotSkipped s -> 2 | Failed o -> 1)
+            |> Seq.toList
+            
+        asserts |> Seq.head
+        
+    static member IsMatch op (matchOp:Match) progress =
+        let stashes = op.Stashes
         let doMatch assertOn assertValue = 
             let value =
                 match (assertOn, assertValue) with
@@ -151,11 +250,11 @@ type OperationExecutor(client:IElasticLowLevelClient) =
                 | (WholeResponse, _) -> stashes.Response().Dictionary.ToDictionary() :> Object
             
             match assertValue with
-            | Value o -> isMatch o value
+            | Value o -> OperationExecutor.JTokenDeepEquals op o value
             | Id id ->
                 let found, expected = stashes.TryGetValue id
                 match found with
-                | true -> isMatch expected value
+                | true -> OperationExecutor.JTokenDeepEquals op expected value
                 | false -> Failed <| Fail.Create op "%A not stashed at this point" id 
             | RegexAssertion re ->
                 match assertOn with
@@ -172,20 +271,54 @@ type OperationExecutor(client:IElasticLowLevelClient) =
             matchOp
             |> Map.toList
             |> Seq.map (fun (k, v) -> doMatch k v)
-            |> Seq.sortBy (fun ex -> match ex with | Succeeded o -> 3 | Skipped o -> 2 | Failed o -> 1)
+            |> Seq.sortBy (fun ex -> match ex with | Succeeded o -> 4 | Skipped (o, s) -> 3 | NotSkipped s -> 2 | Failed o -> 1)
             |> Seq.toList
             
         asserts |> Seq.head
 
     member this.Execute (op:ExecutionContext) (progress:IProgressBar) = async {
         match op.Operation with
-        | Unknown u -> return Skipped op
+        | Unknown u -> return Skipped (op, sprintf "Unknown operation: %s" u)
         | Actions (s, a) ->
-            // TODO try with
-            a client
-            return Succeeded op
+            match a (client, op.Suite) with
+            | None -> return Succeeded op
+            | r ->
+                op.Stashes.ResponseOption <- r
+                return Failed <| Fail.Create op "%s" op.Section
+        | Skip s ->
+            let skip reason = Skipped (op, s.Reason |> Option.defaultValue reason)
+            let versionRangeCheck (v:SemVer.Range) =
+                let anchoredVersion =
+                    let x = SemVer.Version(op.Version)
+                    sprintf "%i.%i.%i" x.Major x.Minor x.Patch
+                match v.IsSatisfied(op.Version) || v.IsSatisfied(anchoredVersion) with
+                | true -> skip (sprintf "version:%s in range:%O" op.Version v)
+                | false -> NotSkipped op
+            let featureCheck (features:Feature list) =
+                let unsupportedFeatures =
+                    features
+                    |> Seq.filter (fun feature -> not (SupportedFeatures |> List.contains feature))
+                    |> Seq.toList
+                
+                match unsupportedFeatures with
+                | [] -> NotSkipped op
+                | _ -> skip (sprintf "feature %O not support" features)
             
-        | Skip s -> return Skipped op
+            let result =
+                match (s.Version, s.Features) with
+                | (Some v, Some features) ->
+                    match (versionRangeCheck v) with
+                    | Skipped (op, r) -> Skipped (op, r)
+                    | _ ->
+                        featureCheck features
+                | (Some v, None) -> 
+                    versionRangeCheck v
+                | (None, Some features) ->
+                    featureCheck features
+                | _  ->
+                    NotSkipped op
+    
+            return result
         | Do d ->
             let (name, _) = d.ApiCall
             let found, lookup = this.OpMap.TryGetValue name
@@ -194,13 +327,13 @@ type OperationExecutor(client:IElasticLowLevelClient) =
             else 
                 return Failed <| Fail.Create op "Api: %s not found on client" name 
         | Set s -> return OperationExecutor.Set op s progress
-        | TransformAndSet ts -> return Skipped op
+        | TransformAndSet ts -> return Skipped (op, "TODO transform_and_set")
         | Assert a ->
             return
                 match a with
                 | IsTrue t -> OperationExecutor.IsTrue op t progress
                 | IsFalse t -> OperationExecutor.IsFalse op t progress
                 | Match m -> OperationExecutor.IsMatch op m progress
-                | NumericAssert (a, m) -> Skipped op
+                | NumericAssert (a, m) -> OperationExecutor.IsNumericMatch op a m progress
               
     }

--- a/tests/Tests.YamlRunner/Program.fs
+++ b/tests/Tests.YamlRunner/Program.fs
@@ -1,10 +1,14 @@
 ﻿module Tests.YamlRunner.Main
 
 open System
+open System.Linq
 open System.Diagnostics
 open Argu
 open Tests.YamlRunner
 open Tests.YamlRunner.Models
+open Elasticsearch.Net
+open Elasticsearch.Net
+open Elasticsearch.Net
 open Elasticsearch.Net
 
 type Arguments =
@@ -29,21 +33,56 @@ type Arguments =
 
 let private runningMitmProxy = Process.GetProcessesByName("mitmproxy").Length > 0
 let private runningProxy = runningMitmProxy || Process.GetProcessesByName("fiddler").Length > 0
-let private defaultEndpoint = 
-    let defaultHost = if runningProxy then "ipv4.fiddler" else "localhost";
-    sprintf "http://%s:9200" defaultHost;
+let private defaultEndpoint namedSuite = 
+    let host = 
+        match (runningProxy, namedSuite) with
+        | (true, OpenSource) -> "ipv.fiddler"
+        | _ -> "localhost"
+    let https = match namedSuite with | XPack -> "s" | _ -> ""
+    sprintf "http%s://%s:9200" https host;
 
-let private createClient endpoint = 
-    let uri = new Uri(endpoint)
+let private createClient endpoint namedSuite = 
+    let uri, userInfo = 
+        let e = Uri(endpoint)
+        let sanitized = UriBuilder(e)
+        sanitized.UserName <- null
+        sanitized.Password <- null
+        let uri = sanitized.Uri
+        let tokens = e.UserInfo.Split(':') |> Seq.toList
+        match (tokens, namedSuite) with 
+        | ([username; password], _) -> uri, Some (username, password)
+        | (_, XPack) -> uri, Some ("elastic", "changeme")
+        | _ -> uri, None
     let settings = new ConnectionConfiguration(uri)
-    let settings =
-        match runningMitmProxy with
-        | true -> settings.Proxy(Uri("http://ipv4.fiddler:8080"), String(null), String(null))
+    // proxy 
+    let proxySettings =
+        match (runningMitmProxy, namedSuite) with
+        | (true, OpenSource) -> settings.Proxy(Uri("http://ipv4.fiddler:8080"), String(null), String(null))
         | _ -> settings
-    new ElasticLowLevelClient(settings)
+    // auth
+    let authSettings =
+        match userInfo with
+        | Some(username, password) -> proxySettings.BasicAuthentication(username, password)
+        | _ -> proxySettings
+    // certs
+    let authSettings =
+        match namedSuite with
+        | XPack -> 
+            proxySettings.ServerCertificateValidationCallback(fun _ _ _ _ -> true)
+        | _ -> proxySettings
+    new ElasticLowLevelClient(authSettings)
     
-let validateRevisionParams endpoint passedRevision =    
-    let client = createClient endpoint
+let validateRevisionParams endpoint passedRevision namedSuite =    
+    let client = createClient endpoint namedSuite
+    
+    let node = client.Settings.ConnectionPool.Nodes.First()
+    let auth =     
+        match client.Settings.BasicAuthenticationCredentials with 
+        | null -> ""
+        | s -> sprintf "%s:%s" s.Username (s.Password.CreateString())
+        
+    printfn "Running elasticsearch %O %s" (node.Uri) auth
+    
     let r =
         let config = new RequestConfiguration(DisableDirectStreaming=Nullable(true))
         let p = new RootNodeInfoRequestParameters(RequestConfiguration = config)
@@ -68,14 +107,14 @@ let runMain (parsed:ParseResults<Arguments>) = async {
     let namedSuite = parsed.TryGetResult NamedSuite |> Option.defaultValue OpenSource
     let directory = parsed.TryGetResult Folder //|> Option.defaultValue "indices.create" |> Some
     let file = parsed.TryGetResult TestFile //|> Option.defaultValue "10_basic.yml" |> Some
-    let endpoint = parsed.TryGetResult Endpoint |> Option.defaultValue defaultEndpoint
+    let endpoint = parsed.TryGetResult Endpoint |> Option.defaultValue (defaultEndpoint namedSuite)
     let profile = parsed.TryGetResult Profile |> Option.defaultValue false
     let passedRevision = parsed.TryGetResult Revision
     let outputFile =
         parsed.TryGetResult JUnitOutputFile
         |> Option.defaultValue (System.IO.Path.GetTempFileName())
-    
-    let (client, revision, version) = validateRevisionParams endpoint passedRevision
+        
+    let (client, revision, version) = validateRevisionParams endpoint passedRevision namedSuite
     
     printfn "Found version %s downloading specs from: %s" version revision
     
@@ -85,7 +124,7 @@ let runMain (parsed:ParseResults<Arguments>) = async {
         printf "Waiting for profiler to attach to pid: %O" <| Process.GetCurrentProcess().Id
         Console.ReadKey() |> ignore
         
-    let! runResults = Commands.RunTests readResults client
+    let! runResults = Commands.RunTests readResults client version namedSuite
     let summary = Commands.ExportTests runResults outputFile
     
     Commands.PrettyPrintResults outputFile

--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -10,16 +10,13 @@ let SkipList = dict<SkipFile,SkipSection> [
     SkipFile "ml/explain_data_frame_analytics.yml", Section "Test neither job id nor body"
     
     // funny looking dispatch /_security/privilege/app?name
-    SkipFile "privileges/10_basic.yml ", Sections [
+    SkipFile "privileges/10_basic.yml", Sections [
         "Test put and delete privileges"
         "Test put and get privileges"
     ]
     
     // - Failed: Assert operation NumericAssert Length invalidated_api_keys "Long" Reason: Expected 2.000000 = 3.000000        
     SkipFile "api_key/11_invalidation.yml", Section "Test invalidate api key by realm name"
-
-    // tries to change current users password, not something we keep track of with later tests
-    SkipFile "change_password/10_basic.yml", Section "Test user changing their own password"
 
     // Test looks for "testnode.crt", but "ca.crt" is returned first
     SkipFile "ssl/10_basic.yml", Section "Test get SSL certificates"
@@ -37,6 +34,9 @@ let SkipList = dict<SkipFile,SkipSection> [
     ])
 
     SkipFile "rollup/put_job.yml", Section "Test put job with templates"
+    
+    SkipFile "change_password/11_token.yml", Section "Test user changing their password authenticating with token not allowed"
+
     SkipFile "change_password/10_basic.yml", Sections [
         // Changing password locks out tests
         "Test user changing their own password"
@@ -53,7 +53,6 @@ let SkipList = dict<SkipFile,SkipSection> [
         "Verify start transform reuses destination index"
         "Test get multiple transform stats"
     ]
-    SkipFile "privileges/10_basic.yml", Section "Test put and delete privileges"
     
     SkipFile "transform/transforms_stats.yml", Sections [
         "Test get multiple transform stats"

--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -1,0 +1,136 @@
+module Tests.YamlRunner.Skips
+
+type SkipSection = All | Section of string | Sections of string list
+
+type SkipFile = SkipFile of string 
+
+let SkipList = dict<SkipFile,SkipSection> [
+    // These send empty strings for required parameters
+    // TODO i THINK this is now supported
+    SkipFile "ml/explain_data_frame_analytics.yml", Section "Test neither job id nor body"
+    
+    // funny looking dispatch /_security/privilege/app?name
+    SkipFile "privileges/10_basic.yml ", Sections [
+        "Test put and delete privileges"
+        "Test put and get privileges"
+    ]
+    
+    // - Failed: Assert operation NumericAssert Length invalidated_api_keys "Long" Reason: Expected 2.000000 = 3.000000        
+    SkipFile "api_key/11_invalidation.yml", Section "Test invalidate api key by realm name"
+
+    // tries to change current users password, not something we keep track of with later tests
+    SkipFile "change_password/10_basic.yml", Section "Test user changing their own password"
+
+    // Test looks for "testnode.crt", but "ca.crt" is returned first
+    SkipFile "ssl/10_basic.yml", Section "Test get SSL certificates"
+    
+    // Uses variables in strings e.g Bearer ${token} we can not due variable substitution in string yet
+    SkipFile "token/10_basic.yml", All
+    
+    // We don't expose the overload with just id, warrants investigation in the code generator
+    SkipFile "ml/delete_forecast.yml", Section "Test delete all where no forecast_id is set"
+
+    // Leaves .ml-state index closed after running
+    (SkipFile "ml/jobs_crud.yml", Sections [
+        "Test reopen job resets the finished time"
+        "Test put job after closing state index"
+    ])
+
+    SkipFile "rollup/put_job.yml", Section "Test put job with templates"
+    SkipFile "change_password/10_basic.yml", Sections [
+        // Changing password locks out tests
+        "Test user changing their own password"
+        // Uses variables in strings e.g Bearer ${token} we can not due variable substitution in string yet
+        "Test user changing their password authenticating with token not allowed"
+    ] 
+    
+    // Missing refreshes in the test
+    SkipFile "data_frame/transforms_start_stop.yml", All
+    SkipFile "ml/index_layout.yml", All
+    
+    // Todo investigate
+    SkipFile "transform/transforms_start_stop.yml", Sections [
+        "Verify start transform reuses destination index"
+        "Test get multiple transform stats"
+    ]
+    SkipFile "privileges/10_basic.yml", Section "Test put and delete privileges"
+    
+    SkipFile "transform/transforms_stats.yml", Sections [
+        "Test get multiple transform stats"
+        "Test get multiple transform stats where one does not have a task"
+    ]
+    // More QA tests than API tests
+    SkipFile "data_frame/transforms_stats.yml", Sections [
+        "Test get multiple transform stats"
+        "Test get transform stats on missing transform"
+        "Test get multiple transform stats where one does not have a task"
+    ]
+           
+    SkipFile "ml/jobs_crud.yml", Section "Test reopen job resets the finished time"
+    // Invalid license makes subsequent tests fail
+    SkipFile "license/20_put_license.yml", All
+    // Test tries to match on map from body, but Go keys are not sorted
+    SkipFile "ml/jobs_crud.yml", Sections [
+        "Test job with rules"
+        "Test put job with model_memory_limit as number"
+        "Test put job with model_memory_limit as string and lazy open"
+    ]
+    // Test gets stuck every time
+    SkipFile "ml/jobs_get_stats.yml", All
+    // status_exception, Cannot process data because job [post-data-job] does not have a corresponding autodetect process
+    // resource_already_exists_exception, task with id {job-post-data-job} already exist
+    // status_exception, Cannot open job [start-stop-datafeed-job-foo-1] because it has already been opened
+    SkipFile "ml/post_data.yml", Sections [
+        "Test flush with skip_time"
+        "Test POST data job api, flush, close and verify DataCounts doc"
+        "Test flush and close job WITHOUT sending any data"
+    ]
+    SkipFile "ml/start_stop_datafeed.yml", Section "Test stop given expression"
+    SkipFile "transform/transforms_start_stop.yml", Sections [
+        "Test start transform"  
+        "Verify start transform reuses destination index"
+    ]
+    // Possible bad test setup, Cannot open job [start-stop-datafeed-job] because it has already been opened
+    // resource_already_exists_exception, task with id {job-start-stop-datafeed-job-foo-2} already exist
+    SkipFile "ml/start_stop_datafeed.yml",
+        Section "Test start datafeed when persistent task allocation disabled"
+    // Indexing step doesn't appear to work (getting total.hits=0)
+    SkipFile "monitoring/bulk/10_basic.yml",
+        Section "Bulk indexing of monitoring data on closed indices should throw an export exception"
+        
+    // Indexing step doesn't appear to work (getting total.hits=0)
+    SkipFile "monitoring/bulk/20_privileges.yml", Section "Monitoring Bulk API"
+    // Test tries to match on whole body, but map keys are unstable in Go
+    SkipFile "rollup/security_tests.yml", All
+    // Test tries to match on map key, but map keys are unstable in Go
+    SkipFile "ml/data_frame_analytics_crud.yml", Sections [
+        "Test put with description"
+        "Test put valid config with custom outlier detection"
+    ]
+    // TEMPORARY: Missing 'body: { indices: "test_index" }' payload, TODO: PR
+    SkipFile "snapshot/10_basic.yml", Section "Create a source only snapshot and then restore it"
+    // illegal_argument_exception: Provided password hash uses [NOOP] but the configured hashing algorithm is [BCRYPT]
+    SkipFile "users/10_basic.yml", Section "Test put user with password hash"
+    // Slash in index name is not escaped (BUG)
+    SkipFile "security/authz/13_index_datemath.yml", Section "Test indexing documents with datemath, when permitted"
+    // Possibly a cluster health color mismatch...
+    SkipFile "security/authz/14_cat_indices.yml", All
+    // Test looks for "testnode.crt", but "ca.crt" is returned first
+    SkipFile "ssl/10_basic.yml", Section "Test get SSL certificates"
+    // class org.elasticsearch.xpack.vectors.query.VectorScriptDocValues$DenseVectorScriptDocValues cannot be cast to
+    // class org.elasticsearch.xpack.vectors.query.VectorScriptDocValues$SparseVectorScriptDocValues ...
+    SkipFile "vectors/30_sparse_vector_basic.yml", Section "Dot Product"
+    // java.lang.IllegalArgumentException: No field found for [my_dense_vector] in mapping
+    SkipFile "vectors/40_sparse_vector_special_cases.yml", Sections [
+        "Vectors of different dimensions and data types"
+        "Dimensions can be sorted differently"
+        "Distance functions for documents missing vector field should return 0"
+    ]
+    // Cannot connect to Docker IP
+    SkipFile "watcher/execute_watch/60_http_input.yml", All
+    // Test tries to match on "tagline", which requires "human=false", which doesn't work in the Go API.
+    // Also test does too much within a single test, so has to be disabled as whole, unfortunately.
+    SkipFile "xpack/15_basic.yml", All
+]
+
+

--- a/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
+++ b/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
@@ -13,6 +13,8 @@
     <ProjectReference Include="$(SolutionRoot)\src\Elasticsearch.Net\Elasticsearch.Net.csproj" />
     
     <Compile Include="AsyncExtensions.fs" />
+    
+    <Compile Include="SkipList.fs" />
     <Compile Include="Models.fs" />
     <Compile Include="Stashes.fs" />
     <Compile Include="DoMapper.fs" />
@@ -32,6 +34,7 @@
     <PackageReference Include="Argu" Version="5.5.0" />
     <PackageReference Include="FSharp.Data" Version="3.1.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="SemanticVersioning" Version="1.2.2" />
     <PackageReference Include="SharpYaml" Version="1.6.5" />
     <PackageReference Include="ShellProgressBar" Version="4.3.0" />
   </ItemGroup>

--- a/tests/Tests.YamlRunner/TestsDownloader.fs
+++ b/tests/Tests.YamlRunner/TestsDownloader.fs
@@ -13,7 +13,7 @@ let private openSourceResourcePath = "rest-api-spec/src/main/resources"
 let private xpackResourcesPath = "x-pack/plugin/src/test/resources"
 
 let private path namedSuite revision =
-    let path = match namedSuite with | OpenSource -> openSourceResourcePath | XPack -> xpackResourcesPath
+    let path = match namedSuite with | Oss -> openSourceResourcePath | XPack -> xpackResourcesPath
     sprintf "%s/%s/rest-api-spec/test" revision  path
     
 let TestGithubRootUrl namedSuite revision = sprintf "%s/tree/%s" rootListingUrl <| path namedSuite revision

--- a/tests/Tests.YamlRunner/TestsExporter.fs
+++ b/tests/Tests.YamlRunner/TestsExporter.fs
@@ -17,7 +17,8 @@ let XAttribute(name, value) = new XAttribute(XName.Get name, value)
 
 let mapExecutionResult result =
     match result with
-    | ExecutionResult.Succeeded f -> None
+    | ExecutionResult.NotSkipped c 
+    | ExecutionResult.Succeeded c -> None
     | ExecutionResult.Failed f ->
         let c = f.Context
         let message =
@@ -34,17 +35,19 @@ let mapExecutionResult result =
             | Some r -> failure.Value <- r.DebugInformation
             | None -> failure.Value <- "Could not access response!"
             Some failure
-    | ExecutionResult.Skipped s ->
-        Some <| XElement("skipped", [])
+    | ExecutionResult.Skipped (c, reason) ->
+        Some <| XElement("skipped", [XAttribute("message", reason)])
         
 let private timeOf result =
     match result with
-    | ExecutionResult.Succeeded f -> !f.Elapsed
+    | ExecutionResult.Succeeded c -> !c.Elapsed
+    | ExecutionResult.NotSkipped c -> !c.Elapsed
     | ExecutionResult.Failed f -> !f.Context.Elapsed
-    | ExecutionResult.Skipped s -> !s.Elapsed
+    | ExecutionResult.Skipped (c, reason) -> !c.Elapsed
 
 let testCasesSection document (results: FileResults) =
     results
+    |> List.filter (fun (section, _) -> section <> "TEARDOWN")
     |> List.map (fun (section, results) ->
        let name = sprintf "%s - %s" document.FileInfo.Name section
        let time =
@@ -73,7 +76,7 @@ let countTests (xElement:XElement) =
     let xp = xElement.XPathSelectElements 
     let x s = xp s |> Seq.length
     let testCases = x "//testcase" 
-    let errors = x "//testcase[errors]"
+    let errors = x "//testcase[error]"
     let failed = x "//testcase[failure]"
     let skipped = x "//testcase[skipped]"
     let time =

--- a/tests/Tests.YamlRunner/TestsLocator.fs
+++ b/tests/Tests.YamlRunner/TestsLocator.fs
@@ -37,7 +37,6 @@ let ListFolderFiles namedSuite revision folder fileFilter = async {
         |> List.map(fun a -> a.InnerText())
         |> List.filter(fun f -> f.EndsWith(".yml"))
         |> List.filter (fun f -> match fileFilter with | Some s -> f.StartsWith(s, StringComparison.OrdinalIgnoreCase) | None -> true)
-        //|> List.filter(fun f -> f = "51_refresh_with_types.yml")
         |> List.map fileUrl
     return yamlFiles
 }

--- a/tests/Tests.YamlRunner/TestsReader.fs
+++ b/tests/Tests.YamlRunner/TestsReader.fs
@@ -5,8 +5,14 @@ open System.Collections.Generic
 open System.Text.RegularExpressions
 open System.Linq
 
+open System.Collections.Specialized
 open Elasticsearch.Net
+open Elasticsearch.Net
+open Elasticsearch.Net.Specification.CatApi
+open Elasticsearch.Net.Specification.ClusterApi
+open Elasticsearch.Net.Specification.MachineLearningApi
 open System.IO
+open Tests.YamlRunner
 open Tests.YamlRunner.Models
 open Tests.YamlRunner.Models
 open Tests.YamlRunner.TestsLocator
@@ -52,9 +58,18 @@ let private mapSkip (operation:YamlMap) =
             | :? List<Object> -> tryPickList<string, Feature> operation "features" parseFeature
             | :? String as feature -> Some [parseFeature feature]
             | _ -> None
+    let versionRange =
+        match version with
+        | Some "all"
+        | Some "All" -> Some <| SemVer.Range("0.0.0 - 100.0.0")
+        | Some v ->
+            let range =
+                let range = Regex.Replace(v, @"^\s*?-", "0.0.0 -")
+                Regex.Replace(range, @"-\s*?$", "- 100.0.0")
+            Some <| SemVer.Range(range)
+        | None -> None
         
-        
-    Skip { Version=version; Reason=reason; Features=features }
+    Skip { Version=versionRange; Reason=reason; Features=features }
     
 let private mapNumericAssert (operation:YamlMap) =
     operation
@@ -102,13 +117,7 @@ let private mapNodeSelector (operation:YamlMap) =
     | _ -> None
             
     
-let private mapDo (operation:YamlMap) =
-    
-    let last = operation.Last()
-    //Todo should be map.First after picking the others
-    let lastKey = last.Key :?> string
-    let lastValue =
-        last.Value :?> YamlMap
+let private mapDo section (operation:YamlMap) =
     
     let catch =
         match tryPick<string> operation "catch" with
@@ -116,16 +125,39 @@ let private mapDo (operation:YamlMap) =
             match s with | IsDoCatch s -> Some s | _ -> None
         | _ -> None
         
+    let headers =
+        match tryPick<YamlMap> operation "headers" with
+        | Some map ->
+            Some <| (map
+                |> Seq.map (fun (kv) -> kv.Key :?> string, kv.Value :?> string)
+                |> Map.ofSeq
+                |> Map.fold
+                  (fun (nv:NameValueCollection) k v ->
+                    (nv.[k] <- v)
+                    nv
+                  )
+                  (NameValueCollection())
+           )
+        | None -> None
+    
     let warnings = tryPickList<string, string> operation "warnings" id
     let nodeSelector = mapNodeSelector operation
+    
+    let last = operation.Last()
+    let lastKey = last.Key :?> string
+    let lastValue =
+        last.Value :?> YamlMap
+    
     Do {
         ApiCall = (lastKey, lastValue)
         Catch = catch
         Warnings = warnings
         NodeSelector = nodeSelector
+        Headers = headers
+        AutoFail = match section with | "setup" | "teardown" -> false | _ -> false
     }
     
-let private mapOperation (operation:YamlMap) =
+let private mapOperation section (operation:YamlMap) =
     let kv = operation.First();
     let key = kv.Key :?> string
     let yamlValue : YamlValue =
@@ -140,7 +172,7 @@ let private mapOperation (operation:YamlMap) =
         | ("skip", YamlDictionary map) -> mapSkip map
         | ("set", YamlDictionary map) -> Set <| mapSet map
         | ("transform_and_set", YamlDictionary map) -> TransformAndSet <| mapTransformAndSet map
-        | ("do", YamlDictionary map) -> mapDo map
+        | ("do", YamlDictionary map) -> mapDo section map
         | ("match", YamlDictionary map) ->  Assert <| Match (mapMatch map)
         | ("is_false", YamlDictionary map) -> Assert <| IsFalse (firstValueAsPath map)
         | ("is_true", YamlDictionary map) -> Assert <| IsTrue (firstValueAsPath map)
@@ -150,8 +182,8 @@ let private mapOperation (operation:YamlMap) =
         | (k, v) -> failwithf "%s does not support %s" k (v.GetType().Name)
     | unknownOperation -> Unknown unknownOperation
     
-let private mapOperations (operations:YamlMap list) =
-    operations |> List.map mapOperation
+let private mapOperations section (operations:YamlMap list) =
+    operations |> List.map (mapOperation section)
     
 let private mapDocument (document:Dictionary<string, Object>) =
     
@@ -159,10 +191,10 @@ let private mapDocument (document:Dictionary<string, Object>) =
     let key = kv.Key
     let values = kv.Value :?> List<Object>
     
-    let operations = values |> Enumerable.Cast<YamlMap> |> Seq.toList |> mapOperations
+    let operations = values |> Enumerable.Cast<YamlMap> |> Seq.toList |> mapOperations key
     
     match key with
-    | "setup" -> Setup operations
+    | "setup" -> Setup operations 
     | "teardown" -> Teardown operations
     | name -> YamlTest { Name=name; Operations=operations }
 
@@ -173,10 +205,149 @@ type YamlTestDocument = {
     Tests: YamlTest list
 }
 
-let private DefaultSetup : Operation list = [Actions("Setup", fun client ->
-    let x = client.Indices.Delete<VoidResponse>("*") 
-    let x = client.Indices.DeleteTemplateForAll<VoidResponse>("*")
-    ignore()
+let private DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
+    let firstFailure (responses:DynamicResponse seq) =
+            responses
+            |> Seq.filter (fun r -> not r.Success && r.HttpStatusCode <> Nullable.op_Implicit 404)
+            |> Seq.tryHead
+    
+    match suite with
+    | OpenSource ->
+        let deleteAll = client.Indices.Delete<DynamicResponse>("*")
+        let templates =
+            client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
+                .Body.Split("\n")
+                |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
+                //TODO template does not accept comma separated list but is documented as such
+                |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
+                |> Seq.toList
+        firstFailure <| [deleteAll] @ templates
+        
+    | XPack ->
+        firstFailure <| seq {
+            //delete all templates
+            let templates =
+                client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
+                    .Body.Split("\n")
+                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
+                    //TODO template does not accept comma separated list but is documented as such
+                    |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
+            
+            yield! templates
+            
+            yield client.Watcher.Delete<DynamicResponse>("my_watch")
+            
+            let deleteNonReserved (setup:_ -> DynamicResponse) (delete:(_ -> DynamicResponse)) = 
+                setup().Dictionary
+                |> Seq.map (fun kv ->
+                    match kv.Value.Get<bool> "metadata._reserved" with
+                    | false -> Some <| delete(kv.Key)
+                    | _ -> None
+                )
+                |> Seq.choose id
+                |> Seq.toList
+            
+            yield! //roles
+                deleteNonReserved
+                   (fun _ -> client.Security.GetRole<DynamicResponse>())
+                   (fun role -> client.Security.DeleteRole<DynamicResponse> role)
+                   
+            yield! //users
+                deleteNonReserved
+                   (fun _ -> client.Security.GetUser<DynamicResponse>())
+                   (fun user -> client.Security.DeleteUser<DynamicResponse> user)
+            
+            yield! //privileges
+                deleteNonReserved
+                   (fun _ -> client.Security.GetPrivileges<DynamicResponse>())
+                   (fun priv -> client.Security.DeletePrivileges<DynamicResponse>(priv, "_all"))
+                
+            // deleting feeds before jobs is important
+            let mlDataFeeds = 
+                let stopFeeds = client.MachineLearning.StopDatafeed<DynamicResponse>("_all")
+                let getFeeds = client.MachineLearning.GetDatafeeds<DynamicResponse> ()
+                let deleteFeeds =
+                    getFeeds.Get<string[]> "datafeeds.datafeed_id"
+                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteDatafeed<DynamicResponse>(jobId))
+                    |> Seq.toList
+                [stopFeeds; getFeeds] @ deleteFeeds
+            yield! mlDataFeeds
+                
+            yield client.IndexLifecycleManagement.RemovePolicy<DynamicResponse>("_all")
+            
+            let mlJobs = 
+                let closeJobs = client.MachineLearning.CloseJob<DynamicResponse>("_all", PostData.Empty)
+                let getJobs = client.MachineLearning.GetJobs<DynamicResponse> "_all"
+                let deleteJobs =
+                    getJobs.Get<string[]> "jobs.job_id"
+                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteJob<DynamicResponse>(jobId))
+                    |> Seq.toList
+                [closeJobs; getJobs] @ deleteJobs
+            yield! mlJobs
+                
+            let rollupJobs = 
+                let getJobs = client.Rollup.GetJob<DynamicResponse> "_all"
+                let deleteJobs =
+                    getJobs.Get<string[]> "jobs.config.id"
+                    |> Seq.collect (fun jobId -> [
+                         client.Rollup.StopJob<DynamicResponse>(jobId)
+                         client.Rollup.DeleteJob<DynamicResponse>(jobId)
+                    ])
+                    |> Seq.toList
+                [getJobs] @ deleteJobs
+            yield! rollupJobs
+                
+            let tasks =
+                let getJobs = client.Tasks.List<DynamicResponse> ()
+                let cancelJobs = 
+                    getJobs.Get<DynamicDictionary> "nodes"
+                    |> Seq.collect(fun kv -> kv.Value.Get<DynamicDictionary> "tasks")
+                    |> Seq.map (fun kv ->
+                        match kv.Value.Get<bool> "cancellable" with
+                        | true -> Some <| client.Tasks.Cancel<DynamicResponse>(kv.Key)
+                        | _ -> None
+                    )
+                    |> Seq.choose id
+                    |> Seq.toList
+                
+                [getJobs] @ cancelJobs
+            yield! tasks
+            
+            let transforms =
+                let transforms = client.Transform.Get<DynamicResponse> "_all"
+                let stopTransforms =
+                    transforms.Get<string[]> "transforms.id"
+                    |> Seq.collect (fun id -> [
+                         client.Transform.Stop<DynamicResponse> id
+                         client.Transform.Delete<DynamicResponse> id
+                    ])
+                    |> Seq.toList
+                [transforms] @ stopTransforms
+            yield! transforms
+                
+            let yellowStatus = Nullable.op_Implicit WaitForStatus.Yellow
+            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
+            
+            //make sure we don't delete system indices
+            let indices =
+                client.Cat.Indices<StringResponse>("*", CatIndicesRequestParameters(Headers=["index"].ToArray()))
+                    .Body.Split("\n")
+                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)))
+                    |> Seq.filter(fun f -> not(f.StartsWith(".")) || f.StartsWith(".ml-"))
+                    |> String.concat ","
+                    |> function
+                       | s when String.IsNullOrEmpty(s) -> None
+                       | s -> Some <| client.Indices.Delete<DynamicResponse>(s)
+            
+            match indices with Some r -> yield r | None -> ignore() 
+            
+            let data = PostData.String @"{""password"":""x-pack-test-password"", ""roles"":[""superuser""]}"
+            yield client.Security.PutUser<DynamicResponse>("x_pack_rest_user", data)
+            
+            yield client.Indices.Refresh<DynamicResponse> "_all"
+            
+            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
+        }
 )]
 
 let private toDocument (yamlInfo:YamlFileInfo) (sections:YamlTestSection list) =
@@ -194,7 +365,7 @@ let ReadYamlFile (yamlInfo:YamlFileInfo) =
 
     let serializer = SharpYaml.Serialization.Serializer()
     let sections =
-        let r e message = raise <| new Exception(message, e)
+        let r e message = raise <| Exception(message, e)
         Regex.Split(yamlInfo.Yaml, @"---\s*?\r?\n")
         |> Seq.filter (fun s -> not <| String.IsNullOrWhiteSpace s)
         |> Seq.map (fun sectionString ->

--- a/tests/Tests.YamlRunner/TestsReader.fs
+++ b/tests/Tests.YamlRunner/TestsReader.fs
@@ -212,7 +212,7 @@ let private DefaultSetup : Operation list = [Actions("Setup", fun (client, suite
             |> Seq.tryHead
     
     match suite with
-    | OpenSource ->
+    | Oss ->
         let deleteAll = client.Indices.Delete<DynamicResponse>("*")
         let templates =
             client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))

--- a/tests/Tests.YamlRunner/TestsRunner.fs
+++ b/tests/Tests.YamlRunner/TestsRunner.fs
@@ -133,7 +133,7 @@ type TestRunner(client:IElasticLowLevelClient, version: string, suite: TestSuite
     
     member this.GlobalSetup () =
         match suite with
-        | OpenSource -> ignore()
+        | Oss -> ignore()
         | XPack ->
             let data = PostData.String @"{""password"":""x-pack-test-password"", ""roles"":[""superuser""]}"
             let r = client.Security.PutUser<DynamicResponse>("x_pack_rest_user", data)


### PR DESCRIPTION
Can now run the `opensource` and `xpack` test suites fully.

- Support catching of do's
- Support stashes in the form of ${var}
- Support feature `headers`
- Support proper skip version ranges
- Test/Teardown now run between test sections
- Per test suite setup
- Support `warnings`
- Introduce `NotSkipped` Execution result to indicate `skip` should continue
- Better proxy detection (only works for for oss on linux)
- TestExported now skips setup/teardown sections
- Summary reports on errors properly
- Support `ignore` parameters
- Make sure export has both DebugInformation and StackTrace info.

------

Originally opened under #4336 but that PR is too big. Split out unrelated commits into their own PR's. However this PR is depending on the features they introduce. Opening this as a draft to `master` and rebasing once `master` has the required features merged in.

Please review and merge the following PR's in order.

- [x] https://github.com/elastic/elasticsearch-net/pull/4347
- [x] https://github.com/elastic/elasticsearch-net/pull/4346
- [x] https://github.com/elastic/elasticsearch-net/pull/4348
- [x] https://github.com/elastic/elasticsearch-net/pull/4349
- [x] https://github.com/elastic/elasticsearch-net/pull/4350
- [x] https://github.com/elastic/elasticsearch-net/pull/4351






