### PR TITLE
Return distinct items from GetMany and SourceMany

### DIFF
--- a/src/Nest/Document/Multiple/MultiGet/Request/MultiGetRequestFormatter.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Request/MultiGetRequestFormatter.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using Elasticsearch.Net.Utf8Json;
 
@@ -20,12 +21,28 @@ namespace Nest
 				return;
 			}
 
-			var docs = value.Documents.Select(d =>
-				{
-					if (value.Index != null) d.Index = null;
-					return d;
-				})
-				.ToList();
+			List<IMultiGetOperation> docs;
+
+			// if an index is specified at the request level and all documents have the same index, remove the index
+			if (value.Index != null)
+			{
+				var settings = formatterResolver.GetConnectionSettings();
+				var resolvedIndex = value.Index.GetString(settings);
+				docs = value.Documents.Select(d =>
+					{
+						if (d.Index == null)
+							return d;
+
+						// TODO: not nice to resolve index for each doc here for comparison, only for it to be resolved later in serialization.
+						// Might be better to simply remove the flattening logic.
+						var docIndex = d.Index.GetString(settings);
+						if (string.Equals(resolvedIndex, docIndex)) d.Index = null;
+						return d;
+					})
+					.ToList();
+			}
+			else
+				docs = value.Documents.ToList();
 
 			var flatten = docs.All(p => p.CanBeFlattened);
 

--- a/src/Nest/Document/Multiple/MultiGet/Request/MultiGetRequestJsonConverter.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Request/MultiGetRequestJsonConverter.cs
@@ -41,11 +41,11 @@ namespace Nest
 				if (index > 0)
 					writer.WriteValueSeparator();
 
-				var id = docs[index];
+				var doc = docs[index];
 				if (flatten)
-					IdFormatter.Serialize(ref writer, id.Id, formatterResolver);
+					IdFormatter.Serialize(ref writer, doc.Id, formatterResolver);
 				else
-					formatter.Serialize(ref writer, id, formatterResolver);
+					formatter.Serialize(ref writer, doc, formatterResolver);
 			}
 			writer.WriteEndArray();
 			writer.WriteEndObject();

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHitJsonConverter.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetHitJsonConverter.cs
@@ -36,6 +36,9 @@ namespace Nest
 						responses.Add(reader.ReadNextBlockSegment());
 					break;
 				}
+
+				// skip any other properties that are not "docs"
+				reader.ReadNextBlock();
 			}
 
 			if (responses.Count == 0)

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
@@ -63,28 +63,15 @@ namespace Nest
 		public T Source<T>(long id) where T : class => Source<T>(id.ToString(CultureInfo.InvariantCulture));
 
 		/// <summary>
-		/// Retrieves the source for each distinct id.
+		/// Retrieves the source, if available, for each distinct id.
 		/// </summary>
 		/// <param name="ids">The ids to retrieve source for</param>
 		/// <typeparam name="T">The document type for the hits to return</typeparam>
 		/// <returns>An IEnumerable{T} of sources</returns>
-		public IEnumerable<T> SourceMany<T>(IEnumerable<string> ids) where T : class
-		{
-			HashSet<string> seenIndices = null;
-			foreach (var id in ids.Distinct())
-			{
-				if (seenIndices == null)
-					seenIndices = new HashSet<string>();
-				else
-					seenIndices.Clear();
-
-				foreach (var doc in Hits.OfType<IMultiGetHit<T>>())
-				{
-					if (string.Equals(doc.Id, id) && doc.Found && seenIndices.Add(doc.Index))
-						yield return doc.Source;
-				}
-			}
-		}
+		public IEnumerable<T> SourceMany<T>(IEnumerable<string> ids) where T : class =>
+			from hit in GetMany<T>(ids)
+			where hit.Found
+			select hit.Source;
 
 		public IEnumerable<T> SourceMany<T>(IEnumerable<long> ids) where T : class =>
 			SourceMany<T>(ids.Select(i => i.ToString(CultureInfo.InvariantCulture)));

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
@@ -27,15 +27,23 @@ namespace Nest
 			return multiHit?.Fields ?? FieldValues.Empty;
 		}
 
+		/// <summary>
+		/// Retrieves the hits for each distinct id.
+		/// </summary>
+		/// <param name="ids">The ids to retrieve source for</param>
+		/// <typeparam name="T">The document type for the hits to return</typeparam>
+		/// <returns>An IEnumerable{T} of hits</returns>
 		public IEnumerable<IMultiGetHit<T>> GetMany<T>(IEnumerable<string> ids) where T : class
 		{
-			var docs = Hits.OfType<IMultiGetHit<T>>();
-			var seenIndices = new HashSet<string>();
-
-			foreach (var id in ids)
+			HashSet<string> seenIndices = null;
+			foreach (var id in ids.Distinct())
 			{
-				seenIndices.Clear();
-				foreach (var doc in docs)
+				if (seenIndices == null)
+					seenIndices = new HashSet<string>();
+				else
+					seenIndices.Clear();
+
+				foreach (var doc in Hits.OfType<IMultiGetHit<T>>())
 				{
 					if (string.Equals(doc.Id, id) && seenIndices.Add(doc.Index))
 						yield return doc;
@@ -54,15 +62,23 @@ namespace Nest
 
 		public T Source<T>(long id) where T : class => Source<T>(id.ToString(CultureInfo.InvariantCulture));
 
+		/// <summary>
+		/// Retrieves the source for each distinct id.
+		/// </summary>
+		/// <param name="ids">The ids to retrieve source for</param>
+		/// <typeparam name="T">The document type for the hits to return</typeparam>
+		/// <returns>An IEnumerable{T} of sources</returns>
 		public IEnumerable<T> SourceMany<T>(IEnumerable<string> ids) where T : class
 		{
-			var docs = Hits.OfType<IMultiGetHit<T>>();
-			var seenIndices = new HashSet<string>();
-
-			foreach (var id in ids)
+			HashSet<string> seenIndices = null;
+			foreach (var id in ids.Distinct())
 			{
-				seenIndices.Clear();
-				foreach (var doc in docs)
+				if (seenIndices == null)
+					seenIndices = new HashSet<string>();
+				else
+					seenIndices.Clear();
+
+				foreach (var doc in Hits.OfType<IMultiGetHit<T>>())
 				{
 					if (string.Equals(doc.Id, id) && doc.Found && seenIndices.Add(doc.Index))
 						yield return doc.Source;

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
@@ -30,16 +30,15 @@ namespace Nest
 		public IEnumerable<IMultiGetHit<T>> GetMany<T>(IEnumerable<string> ids) where T : class
 		{
 			var docs = Hits.OfType<IMultiGetHit<T>>();
+			var seenIndices = new HashSet<string>();
 
 			foreach (var id in ids)
 			{
+				seenIndices.Clear();
 				foreach (var doc in docs)
 				{
-					if (string.Equals(doc.Id, id))
-					{
+					if (string.Equals(doc.Id, id) && seenIndices.Add(doc.Index))
 						yield return doc;
-						break;
-					}
 				}
 			}
 		}
@@ -58,16 +57,15 @@ namespace Nest
 		public IEnumerable<T> SourceMany<T>(IEnumerable<string> ids) where T : class
 		{
 			var docs = Hits.OfType<IMultiGetHit<T>>();
+			var seenIndices = new HashSet<string>();
 
 			foreach (var id in ids)
 			{
+				seenIndices.Clear();
 				foreach (var doc in docs)
 				{
-					if (string.Equals(doc.Id, id) && doc.Found)
-					{
+					if (string.Equals(doc.Id, id) && doc.Found && seenIndices.Add(doc.Index))
 						yield return doc.Source;
-						break;
-					}
 				}
 			}
 		}

--- a/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
+++ b/src/Nest/Document/Multiple/MultiGet/Response/MultiGetResponse.cs
@@ -30,9 +30,18 @@ namespace Nest
 		public IEnumerable<IMultiGetHit<T>> GetMany<T>(IEnumerable<string> ids) where T : class
 		{
 			var docs = Hits.OfType<IMultiGetHit<T>>();
-			return from d in docs
-				join id in ids on d.Id equals id
-				select d;
+
+			foreach (var id in ids)
+			{
+				foreach (var doc in docs)
+				{
+					if (string.Equals(doc.Id, id))
+					{
+						yield return doc;
+						break;
+					}
+				}
+			}
 		}
 
 		public IEnumerable<IMultiGetHit<T>> GetMany<T>(IEnumerable<long> ids) where T : class =>
@@ -49,10 +58,18 @@ namespace Nest
 		public IEnumerable<T> SourceMany<T>(IEnumerable<string> ids) where T : class
 		{
 			var docs = Hits.OfType<IMultiGetHit<T>>();
-			return from d in docs
-				join id in ids on d.Id equals id
-				where d.Found
-				select d.Source;
+
+			foreach (var id in ids)
+			{
+				foreach (var doc in docs)
+				{
+					if (string.Equals(doc.Id, id) && doc.Found)
+					{
+						yield return doc.Source;
+						break;
+					}
+				}
+			}
 		}
 
 		public IEnumerable<T> SourceMany<T>(IEnumerable<long> ids) where T : class =>

--- a/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
@@ -44,12 +44,12 @@ namespace Tests.Document.Multiple.MultiGet
 			}
 		}
 
-		[I] public async Task ReturnsDocsMatchingIds()
+		[I] public async Task ReturnsDocMatchingDistinctIds()
 		{
 			var id = _ids.First();
 
 			var response = await _client.GetManyAsync<Developer>(new[] { id, id, id });
-			response.Count().Should().Be(3);
+			response.Count().Should().Be(1);
 			foreach (var hit in response)
 			{
 				hit.Index.Should().NotBeNullOrWhiteSpace();
@@ -58,7 +58,7 @@ namespace Tests.Document.Multiple.MultiGet
 			}
 		}
 
-		[I] public void ReturnsDocsMatchingIdsFromDifferentIndices()
+		[I] public void ReturnsDocsMatchingDistinctIdsFromDifferentIndices()
 		{
 			var developerIndex = Nest.Indices.Index<Developer>();
 			var indexName = developerIndex.GetString(_client.ConnectionSettings);
@@ -94,7 +94,7 @@ namespace Tests.Document.Multiple.MultiGet
 
 			var response = multiGetResponse.GetMany<Developer>(new [] { id, id });
 
-			response.Count().Should().Be(4);
+			response.Count().Should().Be(2);
 			foreach (var hit in response)
 			{
 				hit.Index.Should().NotBeNullOrWhiteSpace();
@@ -103,12 +103,12 @@ namespace Tests.Document.Multiple.MultiGet
 			}
 		}
 
-		[I] public async Task ReturnsSourceMatchingIds()
+		[I] public async Task ReturnsSourceMatchingDistinctIds()
 		{
 			var id = _ids.First();
 
 			var sources = await _client.SourceManyAsync<Developer>(new[] { id, id, id });
-			sources.Count().Should().Be(3);
+			sources.Count().Should().Be(1);
 			foreach (var hit in sources)
 			{
 				hit.Id.Should().Be(id);

--- a/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
+++ b/tests/Tests/Document/Multiple/MultiGet/GetManyApiTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Elastic.Xunit.XunitPlumbing;
@@ -40,6 +41,32 @@ namespace Tests.Document.Multiple.MultiGet
 				hit.Index.Should().NotBeNullOrWhiteSpace();
 				hit.Id.Should().NotBeNullOrWhiteSpace();
 				hit.Found.Should().BeTrue();
+			}
+		}
+
+		[I] public async Task ReturnsDocsMatchingIds()
+		{
+			var id = _ids.First();
+
+			var response = await _client.GetManyAsync<Developer>(new[] { id, id, id });
+			response.Count().Should().Be(3);
+			foreach (var hit in response)
+			{
+				hit.Index.Should().NotBeNullOrWhiteSpace();
+				hit.Id.Should().Be(id.ToString(CultureInfo.InvariantCulture));
+				hit.Found.Should().BeTrue();
+			}
+		}
+
+		[I] public async Task ReturnsSourceMatchingIds()
+		{
+			var id = _ids.First();
+
+			var sources = await _client.SourceManyAsync<Developer>(new[] { id, id, id });
+			sources.Count().Should().Be(3);
+			foreach (var hit in sources)
+			{
+				hit.Id.Should().Be(id);
 			}
 		}
 


### PR DESCRIPTION
This commit fixes a bug where a GetMany or SourceMany API call
with a repeated id would return a cartesian product of id and documents.

Take for example the same id repeated 3 times; Elasticsearch will return
3 documents in the response, where each JSON object is a representation
of the same underlying document. Since all 3 documents have the same id,
GetMany and SourceMany would return all 3 documents as a match for the first id,
all 3 as a match for the second id, and so on.

With this fix, For each id, only the first matching document is returned.
One _could_ argue that only a single document should be returned for the same
repeated id. This fix however tries to reflect what is in the
Elasticsearch response.

Fixes #4342