### PR TITLE
Remove edgengram tokenizer spelling

### DIFF
--- a/src/Nest/Analysis/Tokenizers/TokenizerFormatter.cs
+++ b/src/Nest/Analysis/Tokenizers/TokenizerFormatter.cs
@@ -14,7 +14,6 @@ namespace Nest
 		private static readonly AutomataDictionary TokenizerTypes = new AutomataDictionary
 		{
 			{ "char_group", 0 },
-			{ "edgengram", 1 },
 			{ "edge_ngram", 1 },
 			{ "ngram", 2 },
 			{ "path_hierarchy", 3 },


### PR DESCRIPTION
This commit removes the edgengram tokenizer type name, as it is
no longer a valid option:

https://github.com/elastic/elasticsearch/blob/b65e29337d0370ec1c51060c338238eea5a04d80/modules/analysis-common/src/main/java/org/elasticsearch/analysis/common/CommonAnalysisPlugin.java#L246-L252

Closes #4354