### PR TITLE
Deprecate sort on ReindexOnServer

### DIFF
--- a/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/ReindexSource.cs
@@ -50,6 +50,7 @@ namespace Nest
 		/// in conjunction with <see cref="Size" />
 		/// </summary>
 		[DataMember(Name ="sort")]
+		[Obsolete("Deprecated in 7.6.0. Instead consider using query filtering to find the desired subset of data.")]
 		IList<ISort> Sort { get; set; }
 
 		/// <summary>
@@ -78,6 +79,7 @@ namespace Nest
 		public ISlicedScroll Slice { get; set; }
 
 		/// <inheritdoc />
+		[Obsolete("Deprecated in 7.6.0. Instead consider using query filtering to find the desired subset of data.")]
 		public IList<ISort> Sort { get; set; }
 
 		/// <inheritdoc />
@@ -100,6 +102,7 @@ namespace Nest
 			Assign(querySelector, (a, v) => a.Query = v?.Invoke(new QueryContainerDescriptor<T>()));
 
 		/// <inheritdoc cref="IReindexSource.Sort" />
+		[Obsolete("Deprecated in 7.6.0. Instead consider using query filtering to find the desired subset of data.")]
 		public ReindexSourceDescriptor Sort<T>(Func<SortDescriptor<T>, IPromise<IList<ISort>>> selector) where T : class =>
 			Assign(selector, (a, v) => a.Sort = v?.Invoke(new SortDescriptor<T>())?.Value);
 

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerApiTests.cs
@@ -46,6 +46,8 @@ namespace Tests.Document.Multiple.ReindexOnServer
 
 		protected override int ExpectStatusCode => 200;
 
+		// Sort is deprecated
+#pragma warning disable 618
 		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
 			.Source(s => s
 				.Index(CallIsolatedValue)
@@ -56,6 +58,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 						.Query("bar")
 					)
 				)
+
 				.Sort<Test>(sort => sort
 					.Ascending("id")
 				)
@@ -69,6 +72,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			.Script(ss => ss.Source(PainlessScript))
 			.Conflicts(Conflicts.Proceed)
 			.Refresh();
+#pragma warning restore 618
 
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
 
@@ -78,7 +82,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			{
 				Index = CallIsolatedValue,
 				Query = new MatchQuery { Field = Field<Test>(p => p.Flag), Query = "bar" },
+#pragma warning disable 618
 				Sort = new List<ISort> { new FieldSort { Field = "id", Order = SortOrder.Ascending } },
+#pragma warning restore 618
 				Size = 100
 			},
 			Destination = new ReindexDestination

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerSliceApiTests.cs
@@ -45,6 +45,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 
 		protected override int ExpectStatusCode => 200;
 
+#pragma warning disable 618
 		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
 			.Source(s => s
 				.Index(CallIsolatedValue)
@@ -69,6 +70,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			)
 			.Conflicts(Conflicts.Proceed)
 			.Refresh();
+#pragma warning restore 618
 
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
 
@@ -78,7 +80,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 			{
 				Index = CallIsolatedValue,
 				Query = new MatchAllQuery(),
+#pragma warning disable 618
 				Sort = new List<ISort> { new FieldSort { Field = "id", Order = SortOrder.Ascending } },
+#pragma warning restore 618
 				Size = 100,
 				Slice = new SlicedScroll { Field = "id", Id = 0, Max = 2 }
 			},


### PR DESCRIPTION
Relates: #4341

Deprecate sorting in reindex elastic/elasticsearch#49458 (issue: elastic/elasticsearch#47567)

Closes #4356