### PR TITLE
[7.x] Allow the code generator to generate only the low level client

### DIFF
--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -11,13 +11,46 @@ namespace ApiGenerator.Configuration
 		/// <summary> These APIs are not implemented yet in the low and high level client</summary>
 		public static string[] IgnoredApis { get; } =
 		{
-			// APIs is no longer useful and will be removed
+			// Upgrade API no longer relevant, might make a reapearance
 			"indices.upgrade.json",
 			"indices.get_upgrade.json",
 
 			// these APIs are not ready for primetime yet
 			"indices.reload_search_analyzers.json",
 			"rank_eval.json",
+
+			// Internal API,
+			"monitoring.bulk.json",
+
+			// Already gone in our client
+			"indices.exists_type.json",
+
+			// Never exposed and now deprecated
+			"data_frame_transform_deprecated.delete_transform.json",
+			"data_frame_transform_deprecated.get_transform.json",
+			"data_frame_transform_deprecated.get_transform_stats.json",
+			"data_frame_transform_deprecated.preview_transform.json",
+			"data_frame_transform_deprecated.put_transform.json",
+			"data_frame_transform_deprecated.start_transform.json",
+			"data_frame_transform_deprecated.stop_transform.json",
+			"data_frame_transform_deprecated.update_transform.json",
+		};
+
+		public static string[] IgnoredApisHighLevel { get; } = new []
+		{
+			"get_script_context.json",
+			"scripts_painless_context.json",
+			"security.get_builtin_privileges.json",
+
+			// these APIs are new and need to be mapped
+			"transform.delete_transform.json",
+			"transform.get_transform.json",
+			"transform.get_transform_stats.json",
+			"transform.preview_transform.json",
+			"transform.put_transform.json",
+			"transform.start_transform.json",
+			"transform.stop_transform.json",
+			"transform.update_transform.json",
 
 			"data_frame.delete_data_frame_transform.json",
 			"data_frame.get_data_frame_transform.json",
@@ -28,6 +61,9 @@ namespace ApiGenerator.Configuration
 			"data_frame.stop_data_frame_transform.json",
 			"data_frame.update_data_frame_transform.json",
 
+			"ml.estimate_memory_usage.json",
+			"ml.set_upgrade_mode.json",
+			"ml.find_file_structure.json",
 			"ml.evaluate_data_frame.json",
 			"ml.delete_data_frame_analytics.json",
 			"ml.get_data_frame_analytics.json",
@@ -35,33 +71,8 @@ namespace ApiGenerator.Configuration
 			"ml.put_data_frame_analytics.json",
 			"ml.start_data_frame_analytics.json",
 			"ml.stop_data_frame_analytics.json",
-
-			"scripts_painless_context.json",
-			"security.get_builtin_privileges.json",
-
-			// these APIs are new and need to be mapped
-			"ml.set_upgrade_mode.json",
-			"ml.find_file_structure.json",
-			"monitoring.bulk.json",
-			"ml.estimate_memory_usage.json",
-
-			"data_frame_transform_deprecated.delete_transform.json",
-			"data_frame_transform_deprecated.get_transform.json",
-			"data_frame_transform_deprecated.get_transform_stats.json",
-			"data_frame_transform_deprecated.preview_transform.json",
-			"data_frame_transform_deprecated.put_transform.json",
-			"data_frame_transform_deprecated.start_transform.json",
-			"data_frame_transform_deprecated.stop_transform.json",
-			"data_frame_transform_deprecated.update_transform.json",
-			"transform.delete_transform.json",
-			"transform.get_transform.json",
-			"transform.get_transform_stats.json",
-			"transform.preview_transform.json",
-			"transform.put_transform.json",
-			"transform.start_transform.json",
-			"transform.stop_transform.json",
-			"transform.update_transform.json",
 		};
+
 
 		/// <summary>
 		/// Scan all nest source code files for Requests and look for the [MapsApi(filename)] attribute.

--- a/src/ApiGenerator/Configuration/GeneratorLocations.cs
+++ b/src/ApiGenerator/Configuration/GeneratorLocations.cs
@@ -1,23 +1,23 @@
 using System.IO;
 using System.Reflection;
 
-namespace ApiGenerator.Configuration 
+namespace ApiGenerator.Configuration
 {
 	public static class GeneratorLocations
 	{
 		// @formatter:off — disable formatter after this line
-		public static string EsNetFolder { get; } = $@"{Root}../../../src/Elasticsearch.Net/";
+		public static string EsNetFolder { get; } = $@"{Root}../../src/Elasticsearch.Net/";
 		public static string LastDownloadedVersionFile { get; } = Path.Combine(Root, "last_downloaded_version.txt");
 
-		public static string NestFolder { get; } = $@"{Root}../../../src/Nest/";
+		public static string NestFolder { get; } = $@"{Root}../../src/Nest/";
 		public static string RestSpecificationFolder { get; } = $@"{Root}RestSpecification/";
 		// @formatter:on — enable formatter after this line
-		
+
 		public static string HighLevel(params string[] paths) => NestFolder + string.Join("/", paths);
 		public static string LowLevel(params string[] paths) => EsNetFolder + string.Join("/", paths);
 
 		public static readonly Assembly Assembly = typeof(Generator.ApiGenerator).Assembly;
-		
+
 		private static string _root;
 		public static string Root
 		{
@@ -27,12 +27,12 @@ namespace ApiGenerator.Configuration
 
 				var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
 
-				var runningAsDnx =
+				var dotnetRun =
 					directoryInfo.Name == "ApiGenerator" &&
 					directoryInfo.Parent != null &&
-					directoryInfo.Parent.Name == "CodeGeneration";
+					directoryInfo.Parent.Name == "src";
 
-				_root = runningAsDnx ? "" : @"../../../";
+				_root = dotnetRun ? "" : @"../../../";
 				return _root;
 			}
 		}

--- a/src/ApiGenerator/Domain/RestApiSpec.cs
+++ b/src/ApiGenerator/Domain/RestApiSpec.cs
@@ -2,6 +2,7 @@
 using System.Collections.Immutable;
 using System.Collections.ObjectModel;
 using System.Linq;
+using ApiGenerator.Configuration;
 using ApiGenerator.Domain.Specification;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
@@ -23,6 +24,12 @@ namespace ApiGenerator.Domain
 
 		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespace =>
 			Endpoints.Values.GroupBy(e=>e.CsharpNames.Namespace)
+				.ToImmutableSortedDictionary(kv => kv.Key, kv => kv.ToList().AsReadOnly());
+
+		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespaceHighLevel =>
+			Endpoints.Values
+				.Where(v => !CodeConfiguration.IgnoredApisHighLevel.Contains(v.Name))
+				.GroupBy(e => e.CsharpNames.Namespace)
 				.ToImmutableSortedDictionary(kv => kv.Key, kv => kv.ToList().AsReadOnly());
 
 		private IEnumerable<EnumDescription> _enumDescriptions;

--- a/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
+++ b/src/ApiGenerator/Domain/Specification/ApiEndpoint.cs
@@ -49,18 +49,19 @@ namespace ApiGenerator.Domain.Specification
 		{
 			CsharpNames = CsharpNames,
 			UrlParts = Url.Parts,
-			PartialParameters = Body == null ? Enumerable.Empty<QueryParameters>().ToList() : Url.Params.Values.Where(p=>p.RenderPartial && !p.Skip).ToList(),
-			OfficialDocumentationLink = OfficialDocumentationLink.Url
+			PartialParameters =
+				Body == null ? Enumerable.Empty<QueryParameters>().ToList() : Url.Params.Values.Where(p => p.RenderPartial && !p.Skip).ToList(),
+			OfficialDocumentationLink = OfficialDocumentationLink?.Url
 		};
 
 		public RequestPartialImplementation RequestPartialImplementation => new RequestPartialImplementation
 		{
 			CsharpNames = CsharpNames,
-			OfficialDocumentationLink = OfficialDocumentationLink.Url,
+			OfficialDocumentationLink = OfficialDocumentationLink?.Url,
 			Stability = Stability,
 			Paths = Url.Paths,
 			Parts = Url.Parts,
-			Params = Url.Params.Values.Where(p=>!p.Skip).ToList(),
+			Params = Url.Params.Values.Where(p => !p.Skip).ToList(),
 			Constructors = Constructor.RequestConstructors(CsharpNames, Url, inheritsFromPlainRequestBase: true).ToList(),
 			GenericConstructors = Constructor.RequestConstructors(CsharpNames, Url, inheritsFromPlainRequestBase: false).ToList(),
 			HasBody = Body != null,
@@ -69,19 +70,19 @@ namespace ApiGenerator.Domain.Specification
 		public DescriptorPartialImplementation DescriptorPartialImplementation => new DescriptorPartialImplementation
 		{
 			CsharpNames = CsharpNames,
-			OfficialDocumentationLink = OfficialDocumentationLink.Url,
+			OfficialDocumentationLink = OfficialDocumentationLink?.Url,
 			Constructors = Constructor.DescriptorConstructors(CsharpNames, Url).ToList(),
 			Paths = Url.Paths,
 			Parts = Url.Parts,
-			Params = Url.Params.Values.Where(p=>!p.Skip).ToList(),
+			Params = Url.Params.Values.Where(p => !p.Skip).ToList(),
 			HasBody = Body != null,
 		};
 
 		public RequestParameterImplementation RequestParameterImplementation => new RequestParameterImplementation
 		{
 			CsharpNames = CsharpNames,
-			OfficialDocumentationLink = OfficialDocumentationLink.Url,
-			Params = Url.Params.Values.Where(p=>!p.Skip).ToList(),
+			OfficialDocumentationLink = OfficialDocumentationLink?.Url,
+			Params = Url.Params.Values.Where(p => !p.Skip).ToList(),
 			HttpMethod = PreferredHttpMethod
 		};
 
@@ -92,32 +93,37 @@ namespace ApiGenerator.Domain.Specification
 				var first = HttpMethods.First();
 				if (HttpMethods.Count > 1 && first.ToUpperInvariant() == "GET")
 					return HttpMethods.Last();
+
 				return first;
 			}
 		}
 
-		public string HighLevelMethodXmlDocDescription => $"<c>{PreferredHttpMethod}</c> request to the <c>{Name}</c> API, read more about this API online:";
+		public string HighLevelMethodXmlDocDescription =>
+			$"<c>{PreferredHttpMethod}</c> request to the <c>{Name}</c> API, read more about this API online:";
 
 		public HighLevelModel HighLevelModel => new HighLevelModel
 		{
 			CsharpNames = CsharpNames,
 			Fluent = new FluentMethod(CsharpNames, Url.Parts,
 				selectorIsOptional: Body == null || !Body.Required || HttpMethods.Contains("GET"),
-				link: OfficialDocumentationLink.Url,
+				link: OfficialDocumentationLink?.Url,
 				summary: HighLevelMethodXmlDocDescription
 			),
-			FluentBound = !CsharpNames.DescriptorBindsOverMultipleDocuments ? null : new BoundFluentMethod(CsharpNames, Url.Parts,
-				selectorIsOptional: Body == null || !Body.Required || HttpMethods.Contains("GET"),
-				link: OfficialDocumentationLink.Url,
-				summary: HighLevelMethodXmlDocDescription
-			),
+			FluentBound = !CsharpNames.DescriptorBindsOverMultipleDocuments
+				? null
+				: new BoundFluentMethod(CsharpNames, Url.Parts,
+					selectorIsOptional: Body == null || !Body.Required || HttpMethods.Contains("GET"),
+					link: OfficialDocumentationLink?.Url,
+					summary: HighLevelMethodXmlDocDescription
+				),
 			Initializer = new InitializerMethod(CsharpNames,
-				link: OfficialDocumentationLink.Url,
+				link: OfficialDocumentationLink?.Url,
 				summary: HighLevelMethodXmlDocDescription
 			)
 		};
 
 		private List<LowLevelClientMethod> _lowLevelClientMethods;
+
 		public IReadOnlyCollection<LowLevelClientMethod> LowLevelClientMethods
 		{
 			get
@@ -126,6 +132,9 @@ namespace ApiGenerator.Domain.Specification
 
 				// enumerate once and cache
 				_lowLevelClientMethods = new List<LowLevelClientMethod>();
+
+				if (OfficialDocumentationLink == null)
+					Generator.ApiGenerator.Warnings.Add($"API '{Name}' has no documentation");
 
 				var httpMethod = PreferredHttpMethod;
 				foreach (var path in Url.PathsWithDeprecations)
@@ -156,7 +165,7 @@ namespace ApiGenerator.Domain.Specification
 						CsharpNames = CsharpNames,
 						PerPathMethodName = methodName,
 						HttpMethod = httpMethod,
-						OfficialDocumentationLink = OfficialDocumentationLink.Url,
+						OfficialDocumentationLink = OfficialDocumentationLink?.Url,
 						Stability = Stability,
 						DeprecatedPath = path.Deprecation,
 						Path = path.Path,
@@ -169,6 +178,5 @@ namespace ApiGenerator.Domain.Specification
 				return _lowLevelClientMethods;
 			}
 		}
-
 	}
 }

--- a/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/DescriptorsGenerator.cs
@@ -18,7 +18,7 @@ namespace ApiGenerator.Generator.Razor
 
 			var dependantView = ViewLocations.HighLevel("Descriptors", "Descriptors.cshtml");
 			string Target(string id) => GeneratorLocations.HighLevel($"Descriptors.{id}.cs");
-			var namespaced = spec.EndpointsPerNamespace.ToList();
+			var namespaced = spec.EndpointsPerNamespaceHighLevel.ToList();
 			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
 		}
 	}

--- a/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/HighLevelClientImplementationGenerator.cs
@@ -19,7 +19,7 @@ namespace ApiGenerator.Generator.Razor
 
 			string Target(string id) => GeneratorLocations.HighLevel($"ElasticClient.{id}.cs");
 
-			var namespaced = spec.EndpointsPerNamespace.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
+			var namespaced = spec.EndpointsPerNamespaceHighLevel.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
 			var dependantView = ViewLocations.HighLevel("Client", "Implementation", "ElasticClient.Namespace.cshtml");
 			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
 

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
@@ -17,7 +17,7 @@ namespace ApiGenerator.Generator.Razor
 			var target = GeneratorLocations.LowLevel($"ElasticLowLevelClient.{CsharpNames.RootNamespace}.cs");
 			await DoRazor(spec, view, target);
 
-			var namespaced = spec.EndpointsPerNamespace.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
+			var namespaced = spec.EndpointsPerNamespaceHighLevel.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
 			var namespacedView = ViewLocations.LowLevel("Client", "Implementation", "ElasticLowLevelClient.Namespace.cshtml");
 			await DoRazorDependantFiles(progressBar, namespaced, namespacedView, kv => kv.Key,
 				id => GeneratorLocations.LowLevel($"ElasticLowLevelClient.{id}.cs"));

--- a/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
@@ -15,7 +15,7 @@ namespace ApiGenerator.Generator.Razor
 			var view = ViewLocations.LowLevel("RequestParameters", "RequestParameters.cshtml");
 			string Target(string id) => GeneratorLocations.LowLevel("Api", "RequestParameters", $"RequestParameters.{id}.cs");
 
-			var namespaced = spec.EndpointsPerNamespace.ToList();
+			var namespaced = spec.EndpointsPerNamespaceHighLevel.ToList();
 			await DoRazorDependantFiles(progressBar, namespaced, view, kv => kv.Key, id => Target(id));
 		}
 	}

--- a/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestsGenerator.cs
@@ -18,7 +18,7 @@ namespace ApiGenerator.Generator.Razor
 
 			var dependantView = ViewLocations.HighLevel("Requests", "Requests.cshtml");
 			string Target(string id) => GeneratorLocations.HighLevel($"Requests.{id}.cs");
-			var namespaced = spec.EndpointsPerNamespace.ToList();
+			var namespaced = spec.EndpointsPerNamespaceHighLevel.ToList();
 			await DoRazorDependantFiles(progressBar, namespaced, dependantView, kv => kv.Key, id => Target(id));
 		}
 	}

--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -12,18 +12,10 @@ namespace ApiGenerator
 		// ReSharper disable once UnusedParameter.Local
 		private static async Task Main(string[] args)
 		{
-			var redownloadCoreSpecification = false;
-			var generateCode = false;
+
+			var redownloadCoreSpecification = Ask("Download online rest specifications?", false);
+
 			var downloadBranch = DownloadBranch;
-
-			var answer = "invalid";
-			while (answer != "y" && answer != "n" && answer != "")
-			{
-				Console.Write("Download online rest specifications? [y/N] (default N): ");
-				answer = Console.ReadLine()?.Trim().ToLowerInvariant();
-				redownloadCoreSpecification = answer == "y";
-			}
-
 			if (redownloadCoreSpecification)
 			{
 				Console.Write($"Branch to download specification from (default {downloadBranch}): ");
@@ -40,18 +32,29 @@ namespace ApiGenerator
 			if (string.IsNullOrEmpty(downloadBranch))
 				downloadBranch = DownloadBranch;
 
+			var generateCode = Ask("Generate code from the specification files on disk?", true);
+			var lowLevelOnly = generateCode && Ask("Generate low level client only?", false);
+
 			if (redownloadCoreSpecification)
 				RestSpecDownloader.Download(downloadBranch);
 
-			answer = "invalid";
+			if (generateCode)
+				await Generator.ApiGenerator.Generate(downloadBranch, lowLevelOnly, "Core", "XPack");
+		}
+
+		private static bool Ask(string question, bool defaultAnswer = true)
+		{
+			var answer = "invalid";
+			var defaultResponse = defaultAnswer ? "y" : "n";
+
 			while (answer != "y" && answer != "n" && answer != "")
 			{
-				Console.Write("Generate code from the specification files on disk? [Y/n] (default Y): ");
+				Console.Write($"{question}[y/N] (default {defaultResponse}): ");
 				answer = Console.ReadLine()?.Trim().ToLowerInvariant();
-				generateCode = answer == "y" || answer == "";
+				if (string.IsNullOrWhiteSpace(answer)) answer = defaultResponse;
+				defaultAnswer = answer == "y";
 			}
-			if (generateCode)
-				await Generator.ApiGenerator.Generate(downloadBranch, "Core", "XPack");
+			return defaultAnswer;
 		}
 	}
 }

--- a/src/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Implementation/ElasticClient.cshtml
@@ -20,7 +20,7 @@ using Nest;
 
 @{
 	RestApiSpec model = Model;
-	var namespaces = model.EndpointsPerNamespace.Keys.Where(k => k != CsharpNames.RootNamespace);
+	var namespaces = model.EndpointsPerNamespaceHighLevel.Keys.Where(k => k != CsharpNames.RootNamespace);
 <text>
 // ReSharper disable RedundantTypeArgumentsOfMethod
 namespace Nest
@@ -51,7 +51,7 @@ namespace Nest
 </text>
 	
 
-	foreach (var kv in model.EndpointsPerNamespace)
+	foreach (var kv in model.EndpointsPerNamespaceHighLevel)
 	{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{

--- a/src/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Interface/IElasticClient.cshtml
@@ -21,7 +21,7 @@ namespace Nest
 	///</summary>
 	public partial interface IElasticClient 
 	{
-		@foreach(var kv in Model.EndpointsPerNamespace)
+		@foreach(var kv in Model.EndpointsPerNamespaceHighLevel)
 		{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{

--- a/src/ApiGenerator/Views/HighLevel/Client/Usings.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Client/Usings.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@foreach(var kv in Model.EndpointsPerNamespace)
+@foreach(var kv in Model.EndpointsPerNamespaceHighLevel)
 {
 	if (kv.Key != CsharpNames.RootNamespace)
 	{

--- a/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
@@ -5,6 +5,7 @@
 @using System.Net.Cache
 @using ApiGenerator.Domain
 @using ApiGenerator
+@using ApiGenerator.Configuration
 @using CsQuery.ExtensionMethods.Internal
 @using Microsoft.CodeAnalysis.CSharp
 @inherits CodeTemplatePage<RestApiSpec>
@@ -18,6 +19,10 @@ namespace Nest
 	{
 @foreach (var endpoint in m.Endpoints.Values)
 {
+	if (CodeConfiguration.IgnoredApisHighLevel.Contains(endpoint.Name))
+	{
+		continue;
+	}
 	var propertyName = $"{endpoint.CsharpNames.Namespace}{endpoint.CsharpNames.MethodName}";
 	var paths = endpoint.RequestPartialImplementation.Paths;
 	<text>


### PR DESCRIPTION
(cherry picked from commit fa60a8ec3b95ebd186ca182eba5d6ce6c0592b7d)
(cherry picked from commit 402c0023fd3bc34cb013f00d003173ec8cdcebef)

backport of https://github.com/elastic/elasticsearch-net/pull/4346