### PR TITLE
Add support for multiple versions in restspec runner

### DIFF
--- a/src/Elasticsearch.Net/Serialization/Formatters/DynamicDictionaryFormatter.cs
+++ b/src/Elasticsearch.Net/Serialization/Formatters/DynamicDictionaryFormatter.cs
@@ -9,6 +9,7 @@ namespace Elasticsearch.Net
 	{
 		protected static readonly DictionaryFormatter<string, object> DictionaryFormatter =
 			new DictionaryFormatter<string, object>();
+
 		protected static readonly ArrayFormatter<object> ArrayFormatter = new ArrayFormatter<object>();
 
 		public void Serialize(ref JsonWriter writer, DynamicDictionary value, IJsonFormatterResolver formatterResolver)

--- a/tests/Tests.YamlRunner/Models.fs
+++ b/tests/Tests.YamlRunner/Models.fs
@@ -144,7 +144,7 @@ let (|ToFeature|) (s:string) =
     | "arbitrary_key" -> ArbitraryKey
     | s -> Unsupported s
 
-type Skip = { Version:SemVer.Range option; Reason:string option; Features: Feature list option }
+type Skip = { Version:SemVer.Range list option; Reason:string option; Features: Feature list option }
     with member this.Log = sprintf "Version %A Features:%A Reason: %A" this.Version this.Features this.Reason
 
 type NumericAssert = 

--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -15,6 +15,14 @@ let SkipList = dict<SkipFile,SkipSection> [
         "Test put and get privileges"
     ]
     
+    // 7.x only
+    // We skip the generation of this API till one of the later minors
+    SkipFile "indices.upgrade/10_basic.yml", All
+    // Sets a dictionary to null, we need to see if we can backport this from master
+    SkipFile "search.aggregation/240_max_buckets.yml", All
+    SkipFile "search.aggregation/180_percentiles_tdigest_metric.yml", Section "Invalid params test"
+    SkipFile "search.aggregation/190_percentiles_hdr_metric.yml", Section "Invalid params test"
+
     // - Failed: Assert operation NumericAssert Length invalidated_api_keys "Long" Reason: Expected 2.000000 = 3.000000        
     SkipFile "api_key/11_invalidation.yml", Section "Test invalidate api key by realm name"
 
@@ -32,7 +40,7 @@ let SkipList = dict<SkipFile,SkipSection> [
         "Test reopen job resets the finished time"
         "Test put job after closing state index"
     ])
-
+    
     SkipFile "rollup/put_job.yml", Section "Test put job with templates"
     
     SkipFile "change_password/11_token.yml", Section "Test user changing their password authenticating with token not allowed"

--- a/tests/Tests.YamlRunner/TestsReader.fs
+++ b/tests/Tests.YamlRunner/TestsReader.fs
@@ -61,12 +61,18 @@ let private mapSkip (operation:YamlMap) =
     let versionRange =
         match version with
         | Some "all"
-        | Some "All" -> Some <| SemVer.Range("0.0.0 - 100.0.0")
-        | Some v ->
-            let range =
+        | Some "All" -> Some <| [SemVer.Range("0.0.0 - 100.0.0")]
+        | Some version ->
+            let range v =
                 let range = Regex.Replace(v, @"^\s*?-", "0.0.0 -")
                 Regex.Replace(range, @"-\s*?$", "- 100.0.0")
-            Some <| SemVer.Range(range)
+            let versions =
+                version.Split(',')
+                |> Array.map (fun v -> v.Trim())
+                |> Array.map range
+                |> Array.map SemVer.Range
+                |> Array.toList
+            Some <| versions
         | None -> None
         
     Skip { Version=versionRange; Reason=reason; Features=features }


### PR DESCRIPTION
(cherry picked from commit cc2682b9067216f2a7a0197c285243530b54878b)

Forward port of part of the backport of #4352 to `7.x`