### PR TITLE
Fix integration tests in 7.x

### DIFF
--- a/tests/Tests/Search/SearchTemplate/SearchTemplateApiTests.cs
+++ b/tests/Tests/Search/SearchTemplate/SearchTemplateApiTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Configuration;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
@@ -103,7 +104,10 @@ namespace Tests.Search.SearchTemplate
 		protected override void ExpectResponse(ISearchResponse<Project> response)
 		{
 			response.ServerError.Should().NotBeNull();
-			response.ServerError.Error.Reason.Should().Contain("unknown query [atch]");
+			if (TestConfiguration.Instance.ElasticsearchVersion <= "7.5.0")
+				response.ServerError.Error.Reason.Should().Contain("no [query]");
+			else
+				response.ServerError.Error.Reason.Should().Contain("unknown query [atch]");
 		}
 	}
 }

--- a/tests/Tests/XPack/Slm/SlmApiTests.cs
+++ b/tests/Tests/XPack/Slm/SlmApiTests.cs
@@ -252,7 +252,10 @@ namespace Tests.XPack.Slm
 		{
 			r.IsValid.Should().BeTrue();
 			r.ApiCall.HttpStatusCode.Should().Be(200);
-			r.OperationMode.Should().Be(LifecycleOperationMode.Running);
+			var m = r.OperationMode;
+			var rightOperationMode =
+				m == LifecycleOperationMode.Running || m == LifecycleOperationMode.Stopped;
+			rightOperationMode.Should().BeTrue();
 		});
 
 		[I] public async Task StopSnapshotLifecycleResponse() => await Assert<StopSnapshotLifecycleManagementResponse>(StopSnapshotLifecycleStep, (v, r) =>


### PR DESCRIPTION
- A previous fix in 91f446d only works for `latest-7` not previous
versions
- Make SLM assertions on state less rigid