### PR TITLE
Add Estonian language analyzer

### DIFF
--- a/src/Nest/Analysis/Languages/Language.cs
+++ b/src/Nest/Analysis/Languages/Language.cs
@@ -21,6 +21,8 @@ namespace Nest
 		Danish,
 		Dutch,
 		English,
+		/// <summary>Available in Elasticsearch 7.6.0+</summary>
+		Estonian,
 		Finnish,
 		French,
 		Galician,


### PR DESCRIPTION
Relates: #4341

This commit adds support for the Estonian language in the
LanguageAnalyzer.