### PR TITLE
Create exception formatters for different exceptions

### DIFF
--- a/tests/Tests.Reproduce/GitHubIssue4294.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4294.cs
@@ -1,0 +1,28 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4294
+	{
+		[U] public void CanSerializeNullReferenceException()
+		{
+			var settings = new ConnectionConfiguration();
+
+			var dic = new Dictionary<string, object>()
+			{
+				["Exception"] = new NullReferenceException(),
+			};
+
+			var data = PostData.Serializable(dic);
+			using var ms = new MemoryStream();
+			Action write = () => data.Write(ms, settings);
+
+			write.Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
This commit changes the ExceptionFormatterResolver to return a new instance
of the now generic ExceptionFormatter<TException> for the type of exception.
This fixes a bug where an ExceptionFormatter of type IJsonFormatter<Exception>
is returned for derived exception types, resulting in an InvalidCastException
at runtime.

Formatter instances created are cached in ElasticsearchNetFormatterResolver
for the type T, so will be reused once created.

Fixes #4294