### PR TITLE
Use correct IJsonFormatter<T> in attributes

### DIFF
--- a/src/Nest/Ingest/Processors/ScriptProcessor.cs
+++ b/src/Nest/Ingest/Processors/ScriptProcessor.cs
@@ -27,7 +27,7 @@ namespace Nest
 		/// Parameters for the script
 		/// </summary>
 		[DataMember(Name ="params")]
-		[JsonFormatter(typeof(VerbatimDictionaryInterfaceKeysFormatter<string, object>))]
+		[JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<string, object>))]
 		Dictionary<string, object> Params { get; set; }
 
 		/// <summary>

--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryResponse.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/VerifyRepository/VerifyRepositoryResponse.cs
@@ -12,7 +12,7 @@ namespace Nest
 		///  A dictionary of nodeId => nodeinfo of nodes that verified the repository
 		/// </summary>
 		[DataMember(Name = "nodes")]
-		[JsonFormatter(typeof(VerbatimDictionaryInterfaceKeysFormatter<string, CompactNodeInfo>))]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, CompactNodeInfo>))]
 		public IReadOnlyDictionary<string, CompactNodeInfo> Nodes { get; internal set; } = EmptyReadOnly<string, CompactNodeInfo>.Dictionary;
 	}
 }

--- a/src/Nest/XPack/MachineLearning/UpdateJob/UpdateJobRequest.cs
+++ b/src/Nest/XPack/MachineLearning/UpdateJob/UpdateJobRequest.cs
@@ -30,7 +30,7 @@ namespace Nest
 		/// Contains custom meta data about the job.
 		/// </summary>
 		[DataMember(Name ="custom_settings")]
-		[JsonFormatter(typeof(VerbatimDictionaryInterfaceKeysFormatter<string, object>))]
+		[JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<string, object>))]
 		Dictionary<string, object> CustomSettings { get; set; }
 
 		/// <summary>

--- a/src/Nest/XPack/Watcher/Action/Actions.cs
+++ b/src/Nest/XPack/Watcher/Action/Actions.cs
@@ -5,7 +5,7 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
-	[JsonFormatter(typeof(ActionsFormatter))]
+	[JsonFormatter(typeof(ActionsInterfaceFormatter))]
 	public interface IActions : IIsADictionary<string, IAction> { }
 
 	[JsonFormatter(typeof(ActionsFormatter))]

--- a/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
+++ b/src/Nest/XPack/Watcher/Transform/ScriptTransformBase.cs
@@ -15,7 +15,7 @@ namespace Nest
 		string Lang { get; set; }
 
 		[DataMember(Name = "params")]
-		[JsonFormatter(typeof(VerbatimDictionaryInterfaceKeysFormatter<string, object>))]
+		[JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<string, object>))]
 		Dictionary<string, object> Params { get; set; }
 	}
 

--- a/tests/Tests.Reproduce/GitHubIssue4382.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4382.cs
@@ -1,0 +1,27 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4382
+	{
+		[U]
+		public void CanDeserializeVerifyRepositoryResponse()
+		{
+			var json = @"{""nodes"":{""1cWG9trDRi--6I-46lOlBw"":{""name"":""DESKTOP-5L01F6I""}}}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes)).DefaultIndex("default_index");
+			var client = new ElasticClient(connectionSettings);
+
+			var response = client.Snapshot.VerifyRepository("repository");
+			response.Nodes.Should().NotBeNullOrEmpty();
+			response.Nodes["1cWG9trDRi--6I-46lOlBw"].Name.Should().Be("DESKTOP-5L01F6I");
+		}
+	}
+}

--- a/tests/Tests/CodeStandards/Serialization/Formatters.doc.cs
+++ b/tests/Tests/CodeStandards/Serialization/Formatters.doc.cs
@@ -5,6 +5,7 @@ using FluentAssertions;
 using Nest;
 using Tests.Framework;
 using System.Collections.Generic;
+using System.Reflection;
 using Elastic.Xunit.XunitPlumbing;
 using Elasticsearch.Net.Utf8Json;
 
@@ -15,7 +16,6 @@ namespace Tests.CodeStandards.Serialization
 		[U]
 		public void CustomFormattersShouldBeInternal()
 		{
-			// TODO: Make internals visible to IL generated modules
 			var formatters = typeof(IElasticClient).Assembly.GetTypes()
 				.Concat(typeof(IElasticLowLevelClient).Assembly.GetTypes())
 				.Where(t => t.GetInterfaces().Any(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IJsonFormatter<>)))
@@ -27,6 +27,64 @@ namespace Tests.CodeStandards.Serialization
 					visible.Add(formatter.Name);
 			}
 			visible.Should().BeEmpty();
+		}
+
+		[U]
+		public void TypesAndPropertiesShouldBeAttributedWithCorrectlyTypedJsonFormatter()
+		{
+			Type GetFormatterTargetType(Type t)
+			{
+				var attribute = t.GetCustomAttribute<JsonFormatterAttribute>();
+
+				if (attribute == null)
+					return null;
+
+				var formatterType = attribute.FormatterType;
+
+				if (formatterType.IsGenericType && !formatterType.IsConstructedGenericType)
+					return null;
+
+				return formatterType.GetInterfaces()
+					.Where(i => i.IsGenericType && i.GetGenericTypeDefinition() == typeof(IJsonFormatter<>))
+					.Select(i => i.GetGenericArguments()[0])
+					.Single();
+			}
+
+			var typesAndProperties =
+				from t in typeof(IElasticClient).Assembly.GetTypes().Concat(typeof(IElasticLowLevelClient).Assembly.GetTypes())
+				let p = t.GetProperties()
+				let typeHasFormatter = t.GetCustomAttribute<JsonFormatterAttribute>(false) != null
+				let propertiesHaveFormatter = p.Any(pp => pp.GetCustomAttribute<JsonFormatterAttribute>(false) != null)
+				where typeHasFormatter || propertiesHaveFormatter
+				select new { Type = t, TypeHasFormatter = typeHasFormatter, Properties = p, PropertiesHaveFormatter = propertiesHaveFormatter };
+
+			var invalid = new List<string>();
+
+			foreach (var typeAndProperties in typesAndProperties)
+			{
+				if (typeAndProperties.TypeHasFormatter)
+				{
+					var t = typeAndProperties.Type;
+					var f = GetFormatterTargetType(t);
+
+					if (f != null && t != f)
+						invalid.Add($"{t.FullName} has IJsonFormatter<{f.FullName}>");
+				}
+
+				if (typeAndProperties.PropertiesHaveFormatter)
+				{
+					foreach (var property in typeAndProperties.Properties)
+					{
+						var t = property.PropertyType;
+						var f = GetFormatterTargetType(t);
+
+						if (f != null && t != f)
+							invalid.Add($"property {property.Name} on {typeAndProperties.Type.FullName} has IJsonFormatter<{f.FullName}>");
+					}
+				}
+			}
+
+			invalid.Should().BeEmpty();
 		}
 	}
 }


### PR DESCRIPTION
This commit fixes a bug where VerifyRepositoryResponse was attributed
with the wrong formatter type in JsonFormatterAttribute applied at the type level.
Utf8Json's formatters are strongly typed for speed at the cost of less flexibility.

Fix other cases where the incorrect formatter type is used, and introduce a
convention test to assert that types and their properties attributed with
JsonFormatterAttribute use the correct formatter type.

Fixes #4382