### PR TITLE
Get highest AssemblyFileVersionAttribute version (#4387)

### DIFF
--- a/src/Elasticsearch.Net/Domain/RuntimeInformation.cs
+++ b/src/Elasticsearch.Net/Domain/RuntimeInformation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 #if NET461
 using System.Reflection;
 
@@ -16,7 +17,11 @@ namespace Elasticsearch.Net
 				if (_frameworkDescription == null)
 				{
 					var assemblyFileVersionAttribute =
-						(AssemblyFileVersionAttribute)typeof(object).GetTypeInfo().Assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute));
+						((AssemblyFileVersionAttribute[])Attribute.GetCustomAttributes(
+							typeof(object).GetTypeInfo().Assembly,
+							typeof(AssemblyFileVersionAttribute)))
+						.OrderByDescending(a => a.Version)
+						.First();
 					_frameworkDescription = $".NET Framework {assemblyFileVersionAttribute.Version}";
 				}
 				return _frameworkDescription;

--- a/src/Nest/CrossPlatform/RuntimeInformation.cs
+++ b/src/Nest/CrossPlatform/RuntimeInformation.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 #if NET461
 using System.Reflection;
 
@@ -16,7 +17,11 @@ namespace Nest
 				if (_frameworkDescription == null)
 				{
 					var assemblyFileVersionAttribute =
-						(AssemblyFileVersionAttribute)typeof(object).GetTypeInfo().Assembly.GetCustomAttribute(typeof(AssemblyFileVersionAttribute));
+						((AssemblyFileVersionAttribute[])Attribute.GetCustomAttributes(
+							typeof(object).GetTypeInfo().Assembly,
+							typeof(AssemblyFileVersionAttribute)))
+						.OrderByDescending(a => a.Version)
+						.First();
 					_frameworkDescription = $".NET Framework {assemblyFileVersionAttribute.Version}";
 				}
 				return _frameworkDescription;


### PR DESCRIPTION
This commit updates the FrameworkDescription logic used to determine
the .NET framework version from the AssemblyFileVersionAttribute on the
assembly containing the base object type to

1. Get all AssemblyFileVersionAttribute attributes
2. order by versioning descending
3. get the first version

This is to workaround an edge case in using this technique to get the
.NET Framework version that appears to affect running an application
under full framework in IIS.

Fixes #4387.