### PR TITLE
Function is optional for rank_feature query

### DIFF
--- a/src/Nest/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/RankFeature/RankFeatureQuery.cs
@@ -25,7 +25,7 @@ namespace Nest
 	{
 		protected override bool Conditionless => IsConditionless(this);
 
-		internal static bool IsConditionless(IRankFeatureQuery q) => q.Field.IsConditionless() || q.Function == null;
+		internal static bool IsConditionless(IRankFeatureQuery q) => q.Field.IsConditionless();
 
 		internal override void InternalWrapInContainer(IQueryContainer container) => container.RankFeature = this;
 
@@ -189,18 +189,22 @@ namespace Nest
 			writer.WritePropertyName("field");
 			var fieldFormatter = formatterResolver.GetFormatter<Field>();
 			fieldFormatter.Serialize(ref writer, value.Field, formatterResolver);
-			writer.WriteValueSeparator();
-			switch (value.Function)
+
+			if (value.Function != null)
 			{
-				case IRankFeatureSigmoidFunction sigmoid:
-					SerializeScoreFunction(ref writer, "sigmoid", sigmoid, formatterResolver);
-					break;
-				case IRankFeatureSaturationFunction saturation:
-					SerializeScoreFunction(ref writer, "saturation", saturation, formatterResolver);
-					break;
-				case IRankFeatureLogarithmFunction log:
-					SerializeScoreFunction(ref writer, "log", log, formatterResolver);
-					break;
+				writer.WriteValueSeparator();
+				switch (value.Function)
+				{
+					case IRankFeatureSigmoidFunction sigmoid:
+						SerializeScoreFunction(ref writer, "sigmoid", sigmoid, formatterResolver);
+						break;
+					case IRankFeatureSaturationFunction saturation:
+						SerializeScoreFunction(ref writer, "saturation", saturation, formatterResolver);
+						break;
+					case IRankFeatureLogarithmFunction log:
+						SerializeScoreFunction(ref writer, "log", log, formatterResolver);
+						break;
+				}
 			}
 
 			writer.WriteEndObject();

--- a/tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Specialized/RankFeature/RankFeatureQueryUsageTests.cs
@@ -24,14 +24,13 @@ namespace Tests.QueryDsl.Specialized.RankFeature
 			q =>
 			{
 				q.Field = null;
-				q.Function = null;
 			}
 		};
 
 		protected override QueryContainer QueryInitializer => new RankFeatureQuery()
 		{
 			Name = "named_query",
-			Boost = 1.1, 
+			Boost = 1.1,
 			Field = Infer.Field<Project>(f => f.Rank),
 			Function = new RankFeatureSaturationFunction()
 		};
@@ -45,6 +44,27 @@ namespace Tests.QueryDsl.Specialized.RankFeature
 				.Boost(1.1)
 				.Field(f => f.Rank)
 				.Saturation()
+			);
+	}
+
+	public class RankFeatureQueryNoFunctionUsageTests : QueryDslUsageTestsBase
+	{
+		public RankFeatureQueryNoFunctionUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+		protected override QueryContainer QueryInitializer => new RankFeatureQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = Infer.Field<Project>(f => f.Rank),
+		};
+
+		protected override object QueryJson =>
+			new { rank_feature = new { _name = "named_query", boost = 1.1, field = "rank" } };
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.RankFeature(rf => rf
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(f => f.Rank)
 			);
 	}
 }


### PR DESCRIPTION
This commit updates the rank_feature query to make function an optional field,
and to omit the JSON value separator when not set

Fixes #4392