### PR TITLE
Add index.final_pipeline index setting

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/DynamicIndexSettings.cs
@@ -113,11 +113,19 @@ namespace Nest
 		string DefaultPipeline { get; set; }
 
 		/// <summary>
-		/// The required ingest node pipeline for this index. Index requests will fail if the required pipeline is set and the pipeline
+		/// The required ingest pipeline for this index. Index requests will fail if the required pipeline is set and the pipeline
 		/// does not exist. The required pipeline can not be overridden with the pipeline parameter. A default pipeline and a required pipeline
 		/// can not both be set. The special pipeline name _none indicates no ingest pipeline will run.
 		/// </summary>
+		[Obsolete("Use FinalPipeline")]
 		string RequiredPipeline { get; set; }
+
+		/// <summary>
+		/// The final ingest pipeline for this index. Index requests will fail if the final pipeline is set and the pipeline does not exist.
+		/// The final pipeline always runs after the request pipeline (if specified) and the default pipeline (if it exists). The special pipeline
+		/// name `_none` indicates no ingest pipeline will run.
+		/// </summary>
+		string FinalPipeline { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -195,7 +203,11 @@ namespace Nest
 		public string DefaultPipeline { get; set; }
 
 		/// <inheritdoc cref="IDynamicIndexSettings.RequiredPipeline" />
+		[Obsolete("Use FinalPipeline")]
 		public string RequiredPipeline { get; set; }
+
+		/// <inheritdoc cref="IDynamicIndexSettings.FinalPipeline" />
+		public string FinalPipeline { get; set; }
 
 		/// <summary> Add any setting to the index </summary>
 		public void Add(string setting, object value) => BackingDictionary[setting] = value;
@@ -232,7 +244,11 @@ namespace Nest
 		public TDescriptor DefaultPipeline(string defaultPipeline) => Assign(defaultPipeline, (a, v) => a.DefaultPipeline = v);
 
 		/// <inheritdoc cref="IDynamicIndexSettings.RequiredPipeline" />
+		[Obsolete("Use FinalPipeline")]
 		public TDescriptor RequiredPipeline(string requiredPipeline) => Assign(requiredPipeline, (a, v) => a.RequiredPipeline = v);
+
+		/// <inheritdoc cref="IDynamicIndexSettings.RequiredPipeline" />
+		public TDescriptor FinalPipeline(string finalPipeline) => Assign(finalPipeline, (a, v) => a.FinalPipeline = v);
 
 		/// <inheritdoc cref="IDynamicIndexSettings.BlocksMetadata" />
 		public TDescriptor BlocksMetadata(bool? blocksMetadata = true) => Assign(blocksMetadata, (a, v) => a.BlocksMetadata = v);

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
@@ -51,7 +51,10 @@ namespace Nest
 			Set(NumberOfReplicas, value.NumberOfReplicas);
 			Set(RefreshInterval, value.RefreshInterval);
 			Set(DefaultPipeline, value.DefaultPipeline);
+#pragma warning disable 618
 			Set(RequiredPipeline, value.RequiredPipeline);
+#pragma warning restore 618
+			Set(FinalPipeline, value.FinalPipeline);
 			Set(BlocksReadOnly, value.BlocksReadOnly);
 			Set(BlocksRead, value.BlocksRead);
 			Set(BlocksWrite, value.BlocksWrite);
@@ -182,7 +185,10 @@ namespace Nest
 			Set<bool?>(s, settings, BlocksReadOnlyAllowDelete, v => s.BlocksReadOnlyAllowDelete = v, formatterResolver);
 			Set<int?>(s, settings, Priority, v => s.Priority = v, formatterResolver);
 			Set<string>(s, settings, DefaultPipeline, v => s.DefaultPipeline = v, formatterResolver);
+#pragma warning disable 618
 			Set<string>(s, settings, RequiredPipeline, v => s.RequiredPipeline = v, formatterResolver);
+#pragma warning restore 618
+			Set<string>(s, settings, FinalPipeline, v => s.FinalPipeline = v, formatterResolver);
 
 			Set<Union<int, RecoveryInitialShards>>(s, settings, UpdatableIndexSettings.RecoveryInitialShards,
 				v => s.RecoveryInitialShards = v, formatterResolver);

--- a/src/Nest/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/UpdatableIndexSettings.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Nest
 {
 	/// <summary>
@@ -60,7 +62,9 @@ namespace Nest
 		public const string RefreshInterval = "index.refresh_interval";
 
 		public const string DefaultPipeline = "index.default_pipeline";
+		[Obsolete("Use FinalPipeline")]
 		public const string RequiredPipeline = "index.required_pipeline";
+		public const string FinalPipeline = "index.final_pipeline";
 
 		public const string RequestsCacheEnable = "index.requests.cache.enable";
 		public const string RoutingAllocationDisableAllocation = "index.routing.allocation.disable_allocation";

--- a/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
+++ b/tests/Tests/IndexModules/IndexSettings/Settings/TypedIndexSettings.cs
@@ -20,7 +20,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 				{ "index.number_of_replicas", 2 },
 				{ "index.auto_expand_replicas", "1-3" },
 				{ "index.default_pipeline", "a-default-pipeline" },
-				{ "index.required_pipeline", "a-required-pipeline" },
+				{ "index.final_pipeline", "a-final-pipeline" },
 				{ "index.refresh_interval", -1 },
 				{ "index.blocks.read_only", true },
 				{ "index.blocks.read", true },
@@ -48,7 +48,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 				.NumberOfShards(1)
 				.NumberOfReplicas(2)
 				.DefaultPipeline("a-default-pipeline")
-				.RequiredPipeline("a-required-pipeline")
+				.FinalPipeline("a-final-pipeline")
 				.AutoExpandReplicas("1-3")
 				.BlocksMetadata()
 				.BlocksRead()
@@ -78,7 +78,7 @@ namespace Tests.IndexModules.IndexSettings.Settings
 					NumberOfShards = 1,
 					NumberOfReplicas = 2,
 					DefaultPipeline = "a-default-pipeline",
-					RequiredPipeline = "a-required-pipeline",
+					FinalPipeline = "a-final-pipeline",
 					AutoExpandReplicas = "1-3",
 					BlocksMetadata = true,
 					BlocksRead = true,


### PR DESCRIPTION
Relates: #4341, elastic/elasticsearch#49470

This commit adds final pipeline to index settings and deprecates
required pipeline.