### PR TITLE
Support Enterprise license type

### DIFF
--- a/src/Nest/XPack/License/GetLicense/GetLicenseResponse.cs
+++ b/src/Nest/XPack/License/GetLicense/GetLicenseResponse.cs
@@ -36,6 +36,9 @@ namespace Nest
 		[DataMember(Name ="max_nodes")]
 		public long MaxNodes { get; internal set; }
 
+		[DataMember(Name = "max_resource_units")]
+		public int? MaxResourceUnits { get; internal set; }
+
 		[DataMember(Name ="status")]
 		public LicenseStatus Status { get; internal set; }
 

--- a/src/Nest/XPack/License/GetLicense/LicenseType.cs
+++ b/src/Nest/XPack/License/GetLicense/LicenseType.cs
@@ -29,6 +29,9 @@ namespace Nest
 		Gold,
 
 		[EnumMember(Value = "platinum")]
-		Platinum
+		Platinum,
+
+		[EnumMember(Value = "enterprise")]
+		Enterprise,
 	}
 }


### PR DESCRIPTION
Relates: #4341, elastic/elasticsearch#49223, elastic/elasticsearch#50735

This commit adds support for Enterprise LicenseType,
and adds max_resource_units to GetLicenseResponse.