### PR TITLE
Deprecate index soft delete enabled setting

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
@@ -123,7 +123,9 @@ namespace Nest
 				Set(RoutingPartitionSize, indexSettings.RoutingPartitionSize);
 				if (indexSettings.SoftDeletes != null)
 				{
+#pragma warning disable 618
 					Set(SoftDeletesEnabled, indexSettings.SoftDeletes.Enabled);
+#pragma warning restore 618
 					Set(SoftDeletesRetentionOperations, indexSettings.SoftDeletes.Retention?.Operations);
 				}
 
@@ -259,7 +261,9 @@ namespace Nest
 			Set<bool?>(s, settings, QueriesCacheEnabled, v => queriesCache.Enabled = v, formatterResolver);
 
 			var softDeletes = s.SoftDeletes = new SoftDeleteSettings();
+#pragma warning disable 618
 			Set<bool?>(s, settings, SoftDeletesEnabled, v => softDeletes.Enabled = v, formatterResolver);
+#pragma warning restore 618
 			var softDeletesRetention = s.SoftDeletes.Retention = new SoftDeleteRetentionSettings();
 			Set<long?>(s, settings, SoftDeletesEnabled, v => softDeletesRetention.Operations = v, formatterResolver);
 

--- a/src/Nest/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/SoftDeletes/ISoftDeleteSettings.cs
@@ -4,6 +4,7 @@ namespace Nest
 {
 	public interface ISoftDeleteSettings
 	{
+		[Obsolete("Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. Do not set a value of 'false'")]
 		/// <summary> Enables soft deletes on the index</summary>
 		bool? Enabled { get; set; }
 		/// <summary> Configure the retention of soft deletes on the index</summary>
@@ -15,6 +16,7 @@ namespace Nest
 		/// <inheritdoc see cref="ISoftDeleteSettings.Retention"/>
 		public ISoftDeleteRetentionSettings Retention { get; set; }
 
+		[Obsolete("Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. Do not set a value of 'false'")]
 		/// <inheritdoc see cref="ISoftDeleteSettings.Enabled"/>
 		public bool? Enabled { get; set; }
 	}
@@ -28,6 +30,7 @@ namespace Nest
 		public SoftDeleteSettingsDescriptor Retention(Func<SoftDeleteRetentionSettingsDescriptor, ISoftDeleteRetentionSettings> selector) =>
 			Assign(selector.Invoke(new SoftDeleteRetentionSettingsDescriptor()), (a, v) => a.Retention = v);
 
+		[Obsolete("Creating indices with soft-deletes disabled is deprecated and will be removed in future Elasticsearch versions. Do not set a value of 'false'")]
 		/// <inheritdoc see cref="ISoftDeleteSettings.Enabled"/>
 		public SoftDeleteSettingsDescriptor Enabled(bool? enabled = true) => Assign(enabled, (a, v) => a.Enabled = v);
 	}

--- a/tests/Tests/XPack/CrossClusterReplication/CrossClusterReplicationFollowTests.cs
+++ b/tests/Tests/XPack/CrossClusterReplication/CrossClusterReplicationFollowTests.cs
@@ -54,7 +54,6 @@ namespace Tests.XPack.CrossClusterReplication
 							NumberOfReplicas = 0,
 							SoftDeletes = new SoftDeleteSettings
 							{
-								Enabled = true,
 								Retention = new SoftDeleteRetentionSettings { Operations = 1024 }
 							}
 						}
@@ -63,7 +62,6 @@ namespace Tests.XPack.CrossClusterReplication
 						.NumberOfShards(1)
 						.NumberOfReplicas(0)
 						.SoftDeletes(sd => sd
-							.Enabled()
 							.Retention(r => r.Operations(1024))
 						)
 					),


### PR DESCRIPTION
Relates: #4341, elastic/elasticsearch#50502

This commit marks the enabled setting on soft delete index settings
as obsolete, as setting enabled to false is deprecated.