### PR TITLE
Use XPackCluster for PutPipeline API tests

### DIFF
--- a/tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Elastic.Managed.Ephemeral;
+using Elastic.Stack.Artifacts.Products;
 using Elastic.Xunit;
 using Elasticsearch.Net;
 using Nest;
@@ -15,7 +16,7 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 	{
 		public XPackClusterConfiguration() : this(ClusterFeatures.SSL | ClusterFeatures.Security) { }
 
-		public XPackClusterConfiguration(ClusterFeatures features) : base(ClusterFeatures.XPack | features)
+		public XPackClusterConfiguration(ClusterFeatures features) : base(ClusterFeatures.XPack | features, 1, ElasticsearchPlugin.IngestAttachment)
 		{
 			// Get license file path from environment variable
 			var licenseFilePath = Environment.GetEnvironmentVariable("ES_LICENSE_FILE");

--- a/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
+++ b/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
@@ -12,11 +12,11 @@ using Tests.Framework.EndpointTests.TestState;
 namespace Tests.Ingest.PutPipeline
 {
 	public class PutPipelineApiTests
-		: ApiIntegrationTestBase<WritableCluster, PutPipelineResponse, IPutPipelineRequest, PutPipelineDescriptor, PutPipelineRequest>
+		: ApiIntegrationTestBase<XPackCluster, PutPipelineResponse, IPutPipelineRequest, PutPipelineDescriptor, PutPipelineRequest>
 	{
 		private static readonly string _id = "pipeline-1";
 
-		public PutPipelineApiTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+		public PutPipelineApiTests(XPackCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override bool ExpectIsValid => true;
 


### PR DESCRIPTION
This commit changes the PutPipelineApiTests to use
an X-Pack cluster with security enabled. As part of this change,
the ingest attachment plugin must also be installed. This is deemed a
better compromise than specifying a new cluster type for this test only.

This change also fixes a NPE thrown by set_security_user processor, which
appears to happen when security is disabled. See elastic/elasticsearch#52474

Closes #4385