### PR TITLE
Use MachineLearningDateTimeFormatter

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/Attributes/MachineLearningDateTimeAttribute.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/Attributes/MachineLearningDateTimeAttribute.cs
@@ -11,7 +11,7 @@ namespace Nest
 	}
 
 	/// <summary>
-	/// Signals that this date time property is used in Machine learning API's some of which will always return the date as
+	/// Signals that this date time property is used in Machine learning APIs some of which will always return the date as
 	/// epoch.
 	/// </summary>
 	[AttributeUsage(AttributeTargets.Property)]
@@ -50,6 +50,8 @@ namespace Nest
 
 	internal class MachineLearningDateTimeFormatter : IJsonFormatter<DateTime>
 	{
+		public static readonly MachineLearningDateTimeFormatter Instance = new MachineLearningDateTimeFormatter();
+
 		public DateTime Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
 		{
 			var token = reader.GetCurrentJsonToken();

--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/NestFormatterResolver.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/NestFormatterResolver.cs
@@ -116,6 +116,8 @@ namespace Nest
 							break;
 					}
 				}
+				else if (member.GetCustomAttribute<MachineLearningDateTimeAttribute>() != null)
+					property.JsonFormatter = MachineLearningDateTimeFormatter.Instance;
 
 				return property;
 			}


### PR DESCRIPTION
This commit uses the MachineLearningDateTimeFormatter when
a model property is attributed with MachineLearningDateTimeAttribute.

Without the application of the formatter, an attempt is made to deserialize
a returned timestamp numeric value as a string in PreviewDataFeedApiTests