### PR TITLE
Wait for .security index to be green

### DIFF
--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -53,7 +53,7 @@ module Tests =
         let commandWithAdditionalOptions =
             wantsCoverage |> List.append wantsTrx |> List.append command
             
-        Tooling.DotNet.ExecInWithTimeout "." commandWithAdditionalOptions (TimeSpan.FromMinutes 30.)
+        Tooling.DotNet.ExecInWithTimeout "." commandWithAdditionalOptions (TimeSpan.FromMinutes 60.)
 
     let RunReleaseUnitTests version args =
         //xUnit always does its own build, this env var is picked up by Tests.csproj

--- a/tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/Clusters/XPackCluster.cs
@@ -49,8 +49,10 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 		protected sealed override void SeedCluster()
 		{
 			Client.Cluster.Health(new ClusterHealthRequest { WaitForStatus = WaitForStatus.Green });
+			Client.Cluster.Health(new ClusterHealthRequest(".security-7") { WaitForStatus = WaitForStatus.Green });
 			SeedNode();
 			Client.Cluster.Health(new ClusterHealthRequest { WaitForStatus = WaitForStatus.Green });
+			Client.Cluster.Health(new ClusterHealthRequest(".security-7") { WaitForStatus = WaitForStatus.Green });
 		}
 
 		protected virtual void SeedNode() => new DefaultSeeder(Client).SeedNode();


### PR DESCRIPTION
Extend integration test run timeout to 60 minutes. They take longer than 30 minutes on my machine, ~35 minutes.