### PR TITLE
Fix yaml tests not deleting newly defined hidden indices

### DIFF
--- a/tests/Tests.YamlRunner/Commands.fs
+++ b/tests/Tests.YamlRunner/Commands.fs
@@ -5,7 +5,6 @@ open ShellProgressBar
 open Tests.YamlRunner.AsyncExtensions
 open Tests.YamlRunner.TestsLocator
 open Tests.YamlRunner.TestsReader
-open Elasticsearch.Net
 open Tests.YamlRunner
 
 let private barOptions = 

--- a/tests/Tests.YamlRunner/TestSuiteBootstrap.fs
+++ b/tests/Tests.YamlRunner/TestSuiteBootstrap.fs
@@ -1,0 +1,159 @@
+module Tests.YamlRunner.TestSuiteBootstrap
+
+open System
+open System.Linq
+
+open Elasticsearch.Net
+open Elasticsearch.Net.Specification.CatApi
+open Elasticsearch.Net.Specification.ClusterApi
+open Tests.YamlRunner.Models
+
+let DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
+    let firstFailure (responses:DynamicResponse seq) =
+            responses
+            |> Seq.filter (fun r -> not r.Success && r.HttpStatusCode <> Nullable.op_Implicit 404)
+            |> Seq.tryHead
+    
+    match suite with
+    | Oss ->
+        let deleteAll = client.Indices.Delete<DynamicResponse>("*")
+        let templates =
+            client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
+                .Body.Split("\n")
+                |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
+                //TODO template does not accept comma separated list but is documented as such
+                |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
+                |> Seq.toList
+        firstFailure <| [deleteAll] @ templates
+        
+    | XPack ->
+        firstFailure <| seq {
+            //delete all templates
+            let templates =
+                client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
+                    .Body.Split("\n")
+                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
+                    //TODO template does not accept comma separated list but is documented as such
+                    |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
+            
+            yield! templates
+            
+            yield client.Watcher.Delete<DynamicResponse>("my_watch")
+            
+            let deleteNonReserved (setup:_ -> DynamicResponse) (delete:(_ -> DynamicResponse)) = 
+                setup().Dictionary.GetKeyValues()
+                |> Seq.map (fun kv ->
+                    match kv.Value.Get<bool> "metadata._reserved" with
+                    | false -> Some <| delete(kv.Key)
+                    | _ -> None
+                )
+                |> Seq.choose id
+                |> Seq.toList
+            
+            yield! //roles
+                deleteNonReserved
+                   (fun _ -> client.Security.GetRole<DynamicResponse>())
+                   (fun role -> client.Security.DeleteRole<DynamicResponse> role)
+                   
+            yield! //users
+                deleteNonReserved
+                   (fun _ -> client.Security.GetUser<DynamicResponse>())
+                   (fun user -> client.Security.DeleteUser<DynamicResponse> user)
+            
+            yield! //privileges
+                deleteNonReserved
+                   (fun _ -> client.Security.GetPrivileges<DynamicResponse>())
+                   (fun priv -> client.Security.DeletePrivileges<DynamicResponse>(priv, "_all"))
+                
+            // deleting feeds before jobs is important
+            let mlDataFeeds = 
+                let stopFeeds = client.MachineLearning.StopDatafeed<DynamicResponse>("_all")
+                let getFeeds = client.MachineLearning.GetDatafeeds<DynamicResponse> ()
+                let deleteFeeds =
+                    getFeeds.Get<string[]> "datafeeds.datafeed_id"
+                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteDatafeed<DynamicResponse>(jobId))
+                    |> Seq.toList
+                [stopFeeds; getFeeds] @ deleteFeeds
+            yield! mlDataFeeds
+                
+            yield client.IndexLifecycleManagement.RemovePolicy<DynamicResponse>("_all")
+            
+            let mlJobs = 
+                let closeJobs = client.MachineLearning.CloseJob<DynamicResponse>("_all", PostData.Empty)
+                let getJobs = client.MachineLearning.GetJobs<DynamicResponse> "_all"
+                let deleteJobs =
+                    getJobs.Get<string[]> "jobs.job_id"
+                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteJob<DynamicResponse>(jobId))
+                    |> Seq.toList
+                [closeJobs; getJobs] @ deleteJobs
+            yield! mlJobs
+                
+            let rollupJobs = 
+                let getJobs = client.Rollup.GetJob<DynamicResponse> "_all"
+                let deleteJobs =
+                    getJobs.Get<string[]> "jobs.config.id"
+                    |> Seq.collect (fun jobId -> [
+                         client.Rollup.StopJob<DynamicResponse>(jobId)
+                         client.Rollup.DeleteJob<DynamicResponse>(jobId)
+                    ])
+                    |> Seq.toList
+                [getJobs] @ deleteJobs
+            yield! rollupJobs
+                
+            let tasks =
+                let getJobs = client.Tasks.List<DynamicResponse> ()
+                let cancelJobs = 
+                    let dict = getJobs.Get<DynamicDictionary> "nodes"
+                    dict.GetKeyValues()
+                    |> Seq.collect(fun kv ->
+                        let dict = kv.Value.Get<DynamicDictionary> "tasks"
+                        dict.GetKeyValues()
+                    )
+                    |> Seq.map (fun kv ->
+                        match kv.Value.Get<bool> "cancellable" with
+                        | true -> Some <| client.Tasks.Cancel<DynamicResponse>(kv.Key)
+                        | _ -> None
+                    )
+                    |> Seq.choose id
+                    |> Seq.toList
+                
+                [getJobs] @ cancelJobs
+            yield! tasks
+            
+            let transforms =
+                let transforms = client.Transform.Get<DynamicResponse> "_all"
+                let stopTransforms =
+                    transforms.Get<string[]> "transforms.id"
+                    |> Seq.collect (fun id -> [
+                         client.Transform.Stop<DynamicResponse> id
+                         client.Transform.Delete<DynamicResponse> id
+                    ])
+                    |> Seq.toList
+                [transforms] @ stopTransforms
+            yield! transforms
+                
+            let yellowStatus = Nullable.op_Implicit WaitForStatus.Yellow
+            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
+            
+            //make sure we don't delete system indices
+            let indices =
+                client.Cat.Indices<StringResponse>("*", CatIndicesRequestParameters(Headers=["index"].ToArray()))
+                    .Body.Split("\n")
+                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)))
+                    //|> Seq.filter(fun f -> not(f.StartsWith(".")) && )
+                    |> String.concat ","
+                    |> function
+                       | s when String.IsNullOrEmpty(s) -> None
+                       | s -> Some <| client.Indices.Delete<DynamicResponse>(s)
+            
+            match indices with Some r -> yield r | None -> ignore() 
+            
+            let data = PostData.String @"{""password"":""x-pack-test-password"", ""roles"":[""superuser""]}"
+            yield client.Security.PutUser<DynamicResponse>("x_pack_rest_user", data)
+            
+            yield client.Indices.Refresh<DynamicResponse> "_all"
+            
+            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
+        }
+)]
+

--- a/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
+++ b/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
@@ -21,6 +21,7 @@
     <Compile Include="TestsDownloader.fs" />
     <Compile Include="TestsLocator.fs" />
     <Compile Include="OperationExecutor.fs" />
+    <Compile Include="TestSuiteBootstrap.fs" />
     <Compile Include="TestsReader.fs" />
     <Compile Include="TestsRunner.fs" />
     <Compile Include="TestsExporter.fs" />

--- a/tests/Tests.YamlRunner/TestsReader.fs
+++ b/tests/Tests.YamlRunner/TestsReader.fs
@@ -6,17 +6,9 @@ open System.Text.RegularExpressions
 open System.Linq
 
 open System.Collections.Specialized
-open Elasticsearch.Net
-open Elasticsearch.Net
-open Elasticsearch.Net.Specification.CatApi
-open Elasticsearch.Net.Specification.ClusterApi
-open Elasticsearch.Net.Specification.MachineLearningApi
 open System.IO
-open Tests.YamlRunner
-open Tests.YamlRunner.Models
 open Tests.YamlRunner.Models
 open Tests.YamlRunner.TestsLocator
-
 
 let private tryPick<'a> (map:YamlMap) key =
     let found, value =  map.TryGetValue key
@@ -211,160 +203,11 @@ type YamlTestDocument = {
     Tests: YamlTest list
 }
 
-let private DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
-    let firstFailure (responses:DynamicResponse seq) =
-            responses
-            |> Seq.filter (fun r -> not r.Success && r.HttpStatusCode <> Nullable.op_Implicit 404)
-            |> Seq.tryHead
-    
-    match suite with
-    | Oss ->
-        let deleteAll = client.Indices.Delete<DynamicResponse>("*")
-        let templates =
-            client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
-                .Body.Split("\n")
-                |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
-                //TODO template does not accept comma separated list but is documented as such
-                |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
-                |> Seq.toList
-        firstFailure <| [deleteAll] @ templates
-        
-    | XPack ->
-        firstFailure <| seq {
-            //delete all templates
-            let templates =
-                client.Cat.Templates<StringResponse>("*", CatTemplatesRequestParameters(Headers=["name"].ToArray()))
-                    .Body.Split("\n")
-                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)) && not(f.StartsWith(".")) && f <> "security-audit-log")
-                    //TODO template does not accept comma separated list but is documented as such
-                    |> Seq.map(fun template -> client.Indices.DeleteTemplateForAll<DynamicResponse>(template))
-            
-            yield! templates
-            
-            yield client.Watcher.Delete<DynamicResponse>("my_watch")
-            
-            let deleteNonReserved (setup:_ -> DynamicResponse) (delete:(_ -> DynamicResponse)) = 
-                setup().Dictionary.GetKeyValues()
-                |> Seq.map (fun kv ->
-                    match kv.Value.Get<bool> "metadata._reserved" with
-                    | false -> Some <| delete(kv.Key)
-                    | _ -> None
-                )
-                |> Seq.choose id
-                |> Seq.toList
-            
-            yield! //roles
-                deleteNonReserved
-                   (fun _ -> client.Security.GetRole<DynamicResponse>())
-                   (fun role -> client.Security.DeleteRole<DynamicResponse> role)
-                   
-            yield! //users
-                deleteNonReserved
-                   (fun _ -> client.Security.GetUser<DynamicResponse>())
-                   (fun user -> client.Security.DeleteUser<DynamicResponse> user)
-            
-            yield! //privileges
-                deleteNonReserved
-                   (fun _ -> client.Security.GetPrivileges<DynamicResponse>())
-                   (fun priv -> client.Security.DeletePrivileges<DynamicResponse>(priv, "_all"))
-                
-            // deleting feeds before jobs is important
-            let mlDataFeeds = 
-                let stopFeeds = client.MachineLearning.StopDatafeed<DynamicResponse>("_all")
-                let getFeeds = client.MachineLearning.GetDatafeeds<DynamicResponse> ()
-                let deleteFeeds =
-                    getFeeds.Get<string[]> "datafeeds.datafeed_id"
-                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteDatafeed<DynamicResponse>(jobId))
-                    |> Seq.toList
-                [stopFeeds; getFeeds] @ deleteFeeds
-            yield! mlDataFeeds
-                
-            yield client.IndexLifecycleManagement.RemovePolicy<DynamicResponse>("_all")
-            
-            let mlJobs = 
-                let closeJobs = client.MachineLearning.CloseJob<DynamicResponse>("_all", PostData.Empty)
-                let getJobs = client.MachineLearning.GetJobs<DynamicResponse> "_all"
-                let deleteJobs =
-                    getJobs.Get<string[]> "jobs.job_id"
-                    |> Seq.map (fun jobId -> client.MachineLearning.DeleteJob<DynamicResponse>(jobId))
-                    |> Seq.toList
-                [closeJobs; getJobs] @ deleteJobs
-            yield! mlJobs
-                
-            let rollupJobs = 
-                let getJobs = client.Rollup.GetJob<DynamicResponse> "_all"
-                let deleteJobs =
-                    getJobs.Get<string[]> "jobs.config.id"
-                    |> Seq.collect (fun jobId -> [
-                         client.Rollup.StopJob<DynamicResponse>(jobId)
-                         client.Rollup.DeleteJob<DynamicResponse>(jobId)
-                    ])
-                    |> Seq.toList
-                [getJobs] @ deleteJobs
-            yield! rollupJobs
-                
-            let tasks =
-                let getJobs = client.Tasks.List<DynamicResponse> ()
-                let cancelJobs = 
-                    let dict = getJobs.Get<DynamicDictionary> "nodes"
-                    dict.GetKeyValues()
-                    |> Seq.collect(fun kv ->
-                        let dict = kv.Value.Get<DynamicDictionary> "tasks"
-                        dict.GetKeyValues()
-                    )
-                    |> Seq.map (fun kv ->
-                        match kv.Value.Get<bool> "cancellable" with
-                        | true -> Some <| client.Tasks.Cancel<DynamicResponse>(kv.Key)
-                        | _ -> None
-                    )
-                    |> Seq.choose id
-                    |> Seq.toList
-                
-                [getJobs] @ cancelJobs
-            yield! tasks
-            
-            let transforms =
-                let transforms = client.Transform.Get<DynamicResponse> "_all"
-                let stopTransforms =
-                    transforms.Get<string[]> "transforms.id"
-                    |> Seq.collect (fun id -> [
-                         client.Transform.Stop<DynamicResponse> id
-                         client.Transform.Delete<DynamicResponse> id
-                    ])
-                    |> Seq.toList
-                [transforms] @ stopTransforms
-            yield! transforms
-                
-            let yellowStatus = Nullable.op_Implicit WaitForStatus.Yellow
-            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
-            
-            //make sure we don't delete system indices
-            let indices =
-                client.Cat.Indices<StringResponse>("*", CatIndicesRequestParameters(Headers=["index"].ToArray()))
-                    .Body.Split("\n")
-                    |> Seq.filter(fun f -> not(String.IsNullOrWhiteSpace(f)))
-                    |> Seq.filter(fun f -> not(f.StartsWith(".")) || f.StartsWith(".ml-"))
-                    |> String.concat ","
-                    |> function
-                       | s when String.IsNullOrEmpty(s) -> None
-                       | s -> Some <| client.Indices.Delete<DynamicResponse>(s)
-            
-            match indices with Some r -> yield r | None -> ignore() 
-            
-            let data = PostData.String @"{""password"":""x-pack-test-password"", ""roles"":[""superuser""]}"
-            yield client.Security.PutUser<DynamicResponse>("x_pack_rest_user", data)
-            
-            yield client.Indices.Refresh<DynamicResponse> "_all"
-            
-            yield client.Cluster.Health<DynamicResponse>(ClusterHealthRequestParameters(WaitForStatus=yellowStatus))
-        }
-)]
-
 let private toDocument (yamlInfo:YamlFileInfo) (sections:YamlTestSection list) =
     let setups = (sections |> List.tryPick (fun s -> match s with | Setup s -> Some s | _ -> None)) 
     {
         FileInfo = FileInfo yamlInfo.File
-        Setup = Some <| (DefaultSetup @ (setups |> Option.defaultValue []))
+        Setup = Some <| (TestSuiteBootstrap.DefaultSetup @ (setups |> Option.defaultValue []))
         Teardown = sections |> List.tryPick (fun s -> match s with | Teardown s -> Some s | _ -> None)
         Tests = sections |> List.map (fun s -> match s with | YamlTest s -> Some s | _ -> None) |> List.choose id
     }


### PR DESCRIPTION
Before we were not deleting system indices only `.ml-*`

However this started to become an issue because it left closed indices
around. This might be related to .ml indices now being hidden.

Warrants more investigation as the new solution deleting all indices all
the time is definitely a bit slower