### PR TITLE
[Backport 6.x] Fix GetMany when no default index is set (#4463)

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/ElasticClient-DeleteMany.cs
+++ b/src/Nest/Document/Multiple/Bulk/ElasticClient-DeleteMany.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 namespace Nest
 {
 	/// <summary>
-	/// Provides GetMany extensions that make it easier to get many documents given a list of ids
+	/// Provides DeleteMany extensions that make it easier to get many documents given a list of ids
 	/// </summary>
 	public static class DeleteManyExtensions
 	{

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-GetMany.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,14 @@ namespace Nest
 	/// </summary>
 	public static class GetManyExtensions
 	{
+		private static Func<MultiGetOperationDescriptor<T>, string, IMultiGetOperation> Lookup<T>(IndexName index)
+			where T : class
+		{
+			if (index == null) return null;
+
+			return (d, id) => d.Index(index);
+		}
+
 		/// <summary>
 		/// Multi GET API allows to get multiple documents based on an index, type (optional) and id (and possibly routing).
 		/// The response includes a docs array with all the fetched documents, each element similar in structure to a document
@@ -29,10 +38,10 @@ namespace Nest
 			where T : class
 		{
 			var result = client.MultiGet(s => s
-				.RequestConfiguration(r => r.ThrowExceptions())
-				.GetMany<T>(ids)
 				.Index(index)
 				.Type(type)
+				.RequestConfiguration(r => r.ThrowExceptions())
+				.GetMany<T>(ids, Lookup<T>(index))
 			);
 			return result.GetMany<T>(ids);
 		}
@@ -73,10 +82,10 @@ namespace Nest
 			where T : class
 		{
 			var response = await client.MultiGetAsync(s => s
-						.RequestConfiguration(r => r.ThrowExceptions())
-						.GetMany<T>(ids)
 						.Index(index)
-						.Type(type),
+						.Type(type)
+						.RequestConfiguration(r => r.ThrowExceptions())
+						.GetMany<T>(ids, Lookup<T>(index)),
 					cancellationToken
 				)
 				.ConfigureAwait(false);

--- a/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
+++ b/src/Nest/Document/Multiple/MultiGet/ElasticClient-SourceMany.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Threading;
@@ -11,6 +12,15 @@ namespace Nest
 	/// </summary>
 	public static class SourceManyExtensions
 	{
+
+		private static Func<MultiGetOperationDescriptor<T>, string, IMultiGetOperation> Lookup<T>(IndexName index)
+			where T : class
+		{
+			if (index == null) return null;
+
+			return (d, id) => d.Index(index);
+		}
+
 		/// <summary>
 		/// SourceMany allows you to get a list of T documents out of elasticsearch, internally it calls into MultiGet()
 		/// <para>
@@ -33,7 +43,7 @@ namespace Nest
 				.Index(index)
 				.Type(type)
 				.RequestConfiguration(r => r.ThrowExceptions())
-				.GetMany<T>(ids)
+				.GetMany<T>(ids, Lookup<T>(index))
 			);
 			return result.SourceMany<T>(ids);
 		}
@@ -81,7 +91,7 @@ namespace Nest
 					.Index(index)
 					.Type(type)
 					.RequestConfiguration(r => r.ThrowExceptions())
-					.GetMany<T>(ids), cancellationToken)
+					.GetMany<T>(ids, Lookup<T>(index)), cancellationToken)
 				.ConfigureAwait(false);
 			return response.SourceMany<T>(ids);
 		}

--- a/src/Tests/Tests.Reproduce/GitHubIssue4462.cs
+++ b/src/Tests/Tests.Reproduce/GitHubIssue4462.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	/*
+	 * https://github.com/elastic/elasticsearch-net/pull/4353
+	 * Fixed an issue with the GetMany helpers that returned the cartesian product of all ids specified rather
+	 * then creating a distinct list if more then one index was targeted.
+	 *
+	 * This PR also updated the routine in the serializer to omit the index name from each item if the index is
+	 * already specified on the url in case of multiple indices
+	 *
+	 * This updated routine in the `7.6.0` could throw if you are calling:
+	 *
+	 * client.GetMany<T>(ids, "indexName");
+	 *
+	 * Without configuring `ConnectionSettings()` with either a default index for T or a global default index.
+	 */
+	public class GitHubIssue4462
+	{
+		[U] public void GetManyShouldNotThrowIfIndexIsProvided()
+		{
+			var json = "{}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes));
+			var client = new ElasticClient(connectionSettings);
+
+			var response = client.GetMany<Project>(new long[] {1, 2, 3}, "indexName");
+			response.Should().NotBeNull();
+		}
+
+		[U] public void SourceManyShouldNotThrowIfIndexIsProvided()
+		{
+			var json = "{}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes));
+			var client = new ElasticClient(connectionSettings);
+
+			var response = client.SourceMany<Project>(new long[] {1, 2, 3}, "indexName");
+			response.Should().NotBeNull();
+		}
+	}
+}


### PR DESCRIPTION
https://github.com/elastic/elasticsearch-net/pull/4353

Fixed an issue with the GetMany helpers that returned the cartesian product of all ids specified rather
then creating a distinct list if more then one index was targeted.

This PR also updated the routine in the serializer to omit the index name from each item if the index is
already specified on the url in case of multiple indices

This updated routine in the `7.6.0` could throw if you are calling:

    client.GetMany<T>(ids, "indexName");

Without configuring `ConnectionSettings()` with either a default index for T or a global default index.

(cherry picked from commit 87c8cdd05ba3ef3818e6cd3444bd71b5de84d443)