### PR TITLE
Implement client examples (2020-02-27 to 2020-04-01)

### DIFF
--- a/src/ExamplesGenerator/Program.cs
+++ b/src/ExamplesGenerator/Program.cs
@@ -74,7 +74,7 @@ namespace ExamplesGenerator
 	[Verb("csharp", HelpText = "Generate C# Examples classes from the asciidoc master reference")]
 	public class CSharpOptions
 	{
-		[Option('p', "path", Required = true, HelpText = "Path to the master reference file")]
+		[Option('p', "path", Required = true, HelpText = "Path to the master reference file, for example: https://raw.githubusercontent.com/elastic/built-docs/master/raw/en/elasticsearch/reference/master/alternatives_report.json")]
 		public string Path { get; set; }
 	}
 }

--- a/src/Nest/Document/Multiple/ReindexOnServer/RemoteSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/RemoteSource.cs
@@ -13,6 +13,12 @@ namespace Nest
 
 		[DataMember(Name ="username")]
 		string Username { get; set; }
+
+		[DataMember(Name ="socket_timeout")]
+		Time SocketTimeout { get; set; }
+
+		[DataMember(Name ="connect_timeout")]
+		Time ConnectTimeout { get; set; }
 	}
 
 	public class RemoteSource : IRemoteSource
@@ -22,6 +28,10 @@ namespace Nest
 		public string Password { get; set; }
 
 		public string Username { get; set; }
+
+		public Time SocketTimeout { get; set; }
+
+		public Time ConnectTimeout { get; set; }
 	}
 
 	public class RemoteSourceDescriptor : DescriptorBase<RemoteSourceDescriptor, IRemoteSource>, IRemoteSource
@@ -30,10 +40,18 @@ namespace Nest
 		string IRemoteSource.Password { get; set; }
 		string IRemoteSource.Username { get; set; }
 
+		Time IRemoteSource.SocketTimeout { get; set; }
+
+		Time IRemoteSource.ConnectTimeout { get; set; }
+
 		public RemoteSourceDescriptor Host(Uri host) => Assign(host, (a, v) => a.Host = v);
 
 		public RemoteSourceDescriptor Username(string username) => Assign(username, (a, v) => a.Username = v);
 
 		public RemoteSourceDescriptor Password(string password) => Assign(password, (a, v) => a.Password = v);
+
+		public RemoteSourceDescriptor SocketTimeout(Time socketTimeout) => Assign(socketTimeout, (a, v) => a.SocketTimeout = v);
+
+		public RemoteSourceDescriptor ConnectTimeout(Time connectTimeout) => Assign(connectTimeout, (a, v) => a.ConnectTimeout = v);
 	}
 }

--- a/tests/Examples/Aggregations/Bucket/CompositeAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/CompositeAggregationPage.cs
@@ -6,14 +6,15 @@ namespace Examples.Aggregations.Bucket
 	public class CompositeAggregationPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line116()
+		public void Line117()
 		{
-			// tag::118c81b8561fd9a9ead388d7971fccd9[]
+			// tag::b0d7068cff901f2b91f8387628e3c2c0[]
 			var response0 = new SearchResponse<object>();
-			// end::118c81b8561fd9a9ead388d7971fccd9[]
+			// end::b0d7068cff901f2b91f8387628e3c2c0[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -27,14 +28,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line134()
+		public void Line136()
 		{
-			// tag::d4d4cb1e761f72aa7cd408655dbcbeac[]
+			// tag::47f1e01d131fd50304dd35f1c459d222[]
 			var response0 = new SearchResponse<object>();
-			// end::d4d4cb1e761f72aa7cd408655dbcbeac[]
+			// end::47f1e01d131fd50304dd35f1c459d222[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -57,14 +59,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line168()
+		public void Line172()
 		{
-			// tag::59d377892d4d912b216defa48e7befce[]
+			// tag::426eb07a1fc499df8ea30d8593a0d989[]
 			var response0 = new SearchResponse<object>();
-			// end::59d377892d4d912b216defa48e7befce[]
+			// end::426eb07a1fc499df8ea30d8593a0d989[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -78,14 +81,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line186()
+		public void Line191()
 		{
-			// tag::a7ad889b26defd508889b288e076f05f[]
+			// tag::d4c5e4123e53daa39775def537365376[]
 			var response0 = new SearchResponse<object>();
-			// end::a7ad889b26defd508889b288e076f05f[]
+			// end::d4c5e4123e53daa39775def537365376[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -109,14 +113,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line218()
+		public void Line224()
 		{
-			// tag::9361db99de15d1f18233a555777c2e1f[]
+			// tag::4997db4f41283835e5a6250c454bec92[]
 			var response0 = new SearchResponse<object>();
-			// end::9361db99de15d1f18233a555777c2e1f[]
+			// end::4997db4f41283835e5a6250c454bec92[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -130,14 +135,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line247()
+		public void Line254()
 		{
-			// tag::2fb60a596d3d996c1329fb4c50955b89[]
+			// tag::1c42bc684745178a587494809ab6ae57[]
 			var response0 = new SearchResponse<object>();
-			// end::2fb60a596d3d996c1329fb4c50955b89[]
+			// end::1c42bc684745178a587494809ab6ae57[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -147,7 +153,7 @@ namespace Examples.Aggregations.Bucket
 			                            ""date_histogram"" : {
 			                                ""field"": ""timestamp"",
 			                                ""calendar_interval"": ""1d"",
-			                                ""format"": ""yyyy-MM-dd"" \<1>
+			                                ""format"": ""yyyy-MM-dd"" <1>
 			                            }
 			                        }
 			                    }
@@ -159,14 +165,59 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line289()
+		public void Line295()
 		{
-			// tag::5d9aef8cd8d324049e34bf96e38814ee[]
+			// tag::038bef10c90916a9addab866fc73dcca[]
 			var response0 = new SearchResponse<object>();
-			// end::5d9aef8cd8d324049e34bf96e38814ee[]
+
+			var response1 = new SearchResponse<object>();
+
+			var response2 = new SearchResponse<object>();
+			// end::038bef10c90916a9addab866fc73dcca[]
+
+			response0.MatchesExample(@"PUT my_index/_doc/1?refresh
+			{
+			  ""date"": ""2015-10-01T05:30:00Z""
+			}");
+
+			response1.MatchesExample(@"PUT my_index/_doc/2?refresh
+			{
+			  ""date"": ""2015-10-01T06:30:00Z""
+			}");
+
+			response2.MatchesExample(@"GET my_index/_search?size=0
+			{
+			  ""aggs"": {
+			    ""my_buckets"": {
+			      ""composite"" : {
+			        ""sources"" : [
+			          {
+			            ""date"": {
+			              ""date_histogram"" : {
+			                ""field"": ""date"",
+			                ""calendar_interval"": ""day"",
+			                ""offset"": ""+6h"",
+			                ""format"": ""iso8601""
+			              }
+			            }
+			          }
+			        ]
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line363()
+		{
+			// tag::7df600a962ddb9e75462cab1017ab710[]
+			var response0 = new SearchResponse<object>();
+			// end::7df600a962ddb9e75462cab1017ab710[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -181,14 +232,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line311()
+		public void Line386()
 		{
-			// tag::ce182c31ce9ffb336dd26ee9899da3e7[]
+			// tag::1559d896ef715c8997e773e8f26ded49[]
 			var response0 = new SearchResponse<object>();
-			// end::ce182c31ce9ffb336dd26ee9899da3e7[]
+			// end::1559d896ef715c8997e773e8f26ded49[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -204,14 +256,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line340()
+		public void Line416()
 		{
-			// tag::9837cab0afe4bae8d11e42411cb812ad[]
+			// tag::1111d70f0ae3044b0a86c82b2ded5f74[]
 			var response0 = new SearchResponse<object>();
-			// end::9837cab0afe4bae8d11e42411cb812ad[]
+			// end::1111d70f0ae3044b0a86c82b2ded5f74[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -226,14 +279,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line366()
+		public void Line443()
 		{
-			// tag::af056fa2f099bbf339d07b6d11a46210[]
+			// tag::441e1052c59a3d9182fd608c08e11169[]
 			var response0 = new SearchResponse<object>();
-			// end::af056fa2f099bbf339d07b6d11a46210[]
+			// end::441e1052c59a3d9182fd608c08e11169[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -247,14 +301,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line405()
+		public void Line483()
 		{
-			// tag::b29c0503d688299dd1eb87ff0fe69415[]
+			// tag::a84493b3b31741c9e1f998b59b40db82[]
 			var response0 = new SearchResponse<object>();
-			// end::b29c0503d688299dd1eb87ff0fe69415[]
+			// end::a84493b3b31741c9e1f998b59b40db82[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -270,14 +325,15 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line470()
+		public void Line541()
 		{
-			// tag::b6dc7bb2713d7fe2eb6e480dee2e458d[]
+			// tag::eac8d98e2bd0eb75e8428212e9f4e4a7[]
 			var response0 = new SearchResponse<object>();
-			// end::b6dc7bb2713d7fe2eb6e480dee2e458d[]
+			// end::eac8d98e2bd0eb75e8428212e9f4e4a7[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {
@@ -286,7 +342,7 @@ namespace Examples.Aggregations.Bucket
 			                    { ""date"": { ""date_histogram"": { ""field"": ""timestamp"", ""calendar_interval"": ""1d"", ""order"": ""desc"" } } },
 			                    { ""product"": { ""terms"": {""field"": ""product"", ""order"": ""asc"" } } }
 			                ],
-			                ""after"": { ""date"": 1494288000000, ""product"": ""mad max"" } \<1>
+			                ""after"": { ""date"": 1494288000000, ""product"": ""mad max"" } <1>
 			            }
 			        }
 			    }
@@ -294,14 +350,113 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line499()
+		public void Line573()
 		{
-			// tag::e4979ca30ac53864edb4871a23ad73b3[]
+			// tag::1d1186dc28cb5b11c19a8341ec1c0558[]
 			var response0 = new SearchResponse<object>();
-			// end::e4979ca30ac53864edb4871a23ad73b3[]
+			// end::1d1186dc28cb5b11c19a8341ec1c0558[]
+
+			response0.MatchesExample(@"PUT twitter
+			{
+			    ""settings"" : {
+			        ""index"" : {
+			            ""sort.field"" : [""username"", ""timestamp""],   <1>
+			            ""sort.order"" : [""asc"", ""desc""]              <2>
+			        }
+			    },
+			    ""mappings"": {
+			        ""properties"": {
+			            ""username"": {
+			                ""type"": ""keyword"",
+			                ""doc_values"": true
+			            },
+			            ""timestamp"": {
+			                ""type"": ""date""
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line602()
+		{
+			// tag::ca3c86d8bb26a8a9422b4b628de03dc4[]
+			var response0 = new SearchResponse<object>();
+			// end::ca3c86d8bb26a8a9422b4b628de03dc4[]
 
 			response0.MatchesExample(@"GET /_search
 			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""my_buckets"": {
+			            ""composite"" : {
+			                ""sources"" : [
+			                    { ""user_name"": { ""terms"" : { ""field"": ""user_name"" } } }     <1>
+			                ]
+			            }
+			        }
+			     }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line621()
+		{
+			// tag::c98edce2074791ebad716b9a5b03215f[]
+			var response0 = new SearchResponse<object>();
+			// end::c98edce2074791ebad716b9a5b03215f[]
+
+			response0.MatchesExample(@"GET /_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""my_buckets"": {
+			            ""composite"" : {
+			                ""sources"" : [
+			                    { ""user_name"": { ""terms"" : { ""field"": ""user_name"" } } }, <1>
+			                    { ""date"": { ""date_histogram"": { ""field"": ""timestamp"", ""calendar_interval"": ""1d"", ""order"": ""desc"" } } } <2>
+			                ]
+			            }
+			        }
+			     }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line646()
+		{
+			// tag::b2d0d2f519a37b93b93889be7979ee5d[]
+			var response0 = new SearchResponse<object>();
+			// end::b2d0d2f519a37b93b93889be7979ee5d[]
+
+			response0.MatchesExample(@"GET /_search
+			{
+			    ""size"": 0,
+			    ""track_total_hits"": false,
+			    ""aggs"" : {
+			        ""my_buckets"": {
+			            ""composite"" : {
+			                ""sources"" : [
+			                    { ""user_name"": { ""terms"" : { ""field"": ""user_name"" } } },
+			                    { ""date"": { ""date_histogram"": { ""field"": ""timestamp"", ""calendar_interval"": ""1d"", ""order"": ""desc"" } } }
+			                ]
+			            }
+			        }
+			     }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line685()
+		{
+			// tag::4a37d7d228d9cba63ebe7b9870dce531[]
+			var response0 = new SearchResponse<object>();
+			// end::4a37d7d228d9cba63ebe7b9870dce531[]
+
+			response0.MatchesExample(@"GET /_search
+			{
+			    ""size"": 0,
 			    ""aggs"" : {
 			        ""my_buckets"": {
 			            ""composite"" : {

--- a/tests/Examples/Aggregations/Bucket/DatehistogramAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/DatehistogramAggregationPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Aggregations.Bucket
 	public class DatehistogramAggregationPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line107()
+		public void Line110()
 		{
 			// tag::b789292f9cf63ce912e058c46d90ce20[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line126()
+		public void Line129()
 		{
 			// tag::73e5c88ad1488b213fb278ee1cb42289[]
 			var response0 = new SearchResponse<object>();
@@ -46,7 +46,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line201()
+		public void Line206()
 		{
 			// tag::09ecba5814d71e4c44468575eada9878[]
 			var response0 = new SearchResponse<object>();
@@ -66,7 +66,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line219()
+		public void Line224()
 		{
 			// tag::2bb2339ac055337abf753bddb7771659[]
 			var response0 = new SearchResponse<object>();
@@ -86,7 +86,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line290()
+		public void Line295()
 		{
 			// tag::8a355eb25d2a01ba62dc1a22dd46f46f[]
 			var response0 = new SearchResponse<object>();
@@ -107,7 +107,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line352()
+		public void Line357()
 		{
 			// tag::70f0aa5853697e265ef3b1df72940951[]
 			var response0 = new SearchResponse<object>();
@@ -141,7 +141,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line403()
+		public void Line408()
 		{
 			// tag::8de3206f80e18185a5ad6481f4c2ee07[]
 			var response0 = new SearchResponse<object>();
@@ -162,7 +162,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line471()
+		public void Line479()
 		{
 			// tag::aa6bfe54e2436eb668091fe31c2fbf4d[]
 			var response0 = new SearchResponse<object>();
@@ -197,7 +197,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line532()
+		public void Line544()
 		{
 			// tag::9524a9b7373fa4eb2905183b0e806962[]
 			var response0 = new SearchResponse<object>();
@@ -219,7 +219,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line601()
+		public void Line613()
 		{
 			// tag::39a6a038c4b551022afe83de0523634e[]
 			var response0 = new SearchResponse<object>();
@@ -240,7 +240,7 @@ namespace Examples.Aggregations.Bucket
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line634()
+		public void Line646()
 		{
 			// tag::6faf10a73f7d5fffbcb037bdb2cbaff8[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Aggregations/Bucket/GeohashgridAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/GeohashgridAggregationPage.cs
@@ -117,5 +117,29 @@ namespace Examples.Aggregations.Bucket
 			    }
 			}");
 		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line206()
+		{
+			// tag::850c30e63e2237776a7ed299f0262316[]
+			var response0 = new SearchResponse<object>();
+			// end::850c30e63e2237776a7ed299f0262316[]
+
+			response0.MatchesExample(@"POST /museums/_search?size=0
+			{
+			    ""aggregations"" : {
+			        ""tiles-in-bounds"" : {
+			            ""geohash_grid"" : {
+			                ""field"" : ""location"",
+			                ""precision"" : 8,
+			                ""bounds"": {
+			                  ""top_left"" : ""53.4375, 4.21875"",
+			                  ""bottom_right"" : ""52.03125, 5.625""
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
 	}
 }

--- a/tests/Examples/Aggregations/Bucket/GeotilegridAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/GeotilegridAggregationPage.cs
@@ -85,5 +85,29 @@ namespace Examples.Aggregations.Bucket
 			    }
 			}");
 		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line177()
+		{
+			// tag::473bc08acc95689e256c7160fec07c0c[]
+			var response0 = new SearchResponse<object>();
+			// end::473bc08acc95689e256c7160fec07c0c[]
+
+			response0.MatchesExample(@"POST /museums/_search?size=0
+			{
+			    ""aggregations"" : {
+			        ""tiles-in-bounds"" : {
+			            ""geotile_grid"" : {
+			                ""field"" : ""location"",
+			                ""precision"" : 22,
+			                ""bounds"": {
+			                  ""top_left"" : ""52.4, 4.9"",
+			                  ""bottom_right"" : ""52.3, 5.0""
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
 	}
 }

--- a/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
@@ -521,11 +521,11 @@ namespace Examples.Aggregations.Bucket
 				.Aggregations(a => a
 					.Terms("JapaneseCars", t => t
 						.Field("make")
-						.Include(new [] { "mazda", "honda" })
+						.Include(new[] { "mazda", "honda" })
 					)
 					.Terms("ActiveCarManufacturers", t => t
 						.Field("make")
-						.Exclude(new [] { "rover", "jensen" })
+						.Exclude(new[] { "rover", "jensen" })
 					)
 				)
 			);

--- a/tests/Examples/Aggregations/Metrics/BoxplotAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/BoxplotAggregationPage.cs
@@ -1,0 +1,121 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Aggregations.Metrics
+{
+	public class BoxplotAggregationPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line30()
+		{
+			// tag::2203588f4793e0e99ccd9240b5afdff7[]
+			var response0 = new SearchResponse<object>();
+			// end::2203588f4793e0e99ccd9240b5afdff7[]
+
+			response0.MatchesExample(@"GET latency/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""load_time_boxplot"" : {
+			            ""boxplot"" : {
+			                ""field"" : ""load_time"" <1>
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line73()
+		{
+			// tag::c2d1756ceca8fdc40a2b97ea275de676[]
+			var response0 = new SearchResponse<object>();
+			// end::c2d1756ceca8fdc40a2b97ea275de676[]
+
+			response0.MatchesExample(@"GET latency/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""load_time_boxplot"" : {
+			            ""boxplot"" : {
+			                ""script"" : {
+			                    ""lang"": ""painless"",
+			                    ""source"": ""doc['load_time'].value / params.timeUnit"", <1>
+			                    ""params"" : {
+			                        ""timeUnit"" : 1000   <2>
+			                    }
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line102()
+		{
+			// tag::ae2331b7e35af4bbc4df7b98f2527c7f[]
+			var response0 = new SearchResponse<object>();
+			// end::ae2331b7e35af4bbc4df7b98f2527c7f[]
+
+			response0.MatchesExample(@"GET latency/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""load_time_boxplot"" : {
+			            ""boxplot"" : {
+			                ""script"" : {
+			                    ""id"": ""my_script"",
+			                    ""params"": {
+			                        ""field"": ""load_time""
+			                    }
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line143()
+		{
+			// tag::195af3fda6cb2811d40e22fc54cd3286[]
+			var response0 = new SearchResponse<object>();
+			// end::195af3fda6cb2811d40e22fc54cd3286[]
+
+			response0.MatchesExample(@"GET latency/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""load_time_boxplot"" : {
+			            ""boxplot"" : {
+			                ""field"" : ""load_time"",
+			                ""compression"" : 200 <1>
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line170()
+		{
+			// tag::71387a61dd965479b767c8dcea1478a9[]
+			var response0 = new SearchResponse<object>();
+			// end::71387a61dd965479b767c8dcea1478a9[]
+
+			response0.MatchesExample(@"GET latency/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""grade_boxplot"" : {
+			            ""boxplot"" : {
+			                ""field"" : ""grade"",
+			                ""missing"": 10 <1>
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Aggregations/Metrics/PercentileAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/PercentileAggregationPage.cs
@@ -119,7 +119,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line261()
+		public void Line268()
 		{
 			// tag::829d345e5e15e371aeb820f4d62a1b2a[]
 			var response0 = new SearchResponse<object>();
@@ -142,7 +142,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line311()
+		public void Line320()
 		{
 			// tag::db17a10cf64c84bd2fc4ebb073e59cec[]
 			var response0 = new SearchResponse<object>();
@@ -166,7 +166,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line343()
+		public void Line352()
 		{
 			// tag::e557ce02e192939944ebc6bae87e98a6[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Aggregations/Metrics/PercentileRankAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/PercentileRankAggregationPage.cs
@@ -27,7 +27,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line71()
+		public void Line73()
 		{
 			// tag::156dd311073c8c825e608becf63ae7fe[]
 			var response0 = new SearchResponse<object>();
@@ -49,7 +49,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line121()
+		public void Line125()
 		{
 			// tag::c9ea558335446fc64006724cb72684e1[]
 			var response0 = new SearchResponse<object>();
@@ -76,7 +76,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line150()
+		public void Line154()
 		{
 			// tag::59bcc5d1ed0aac1aa949f84d80a4fa1d[]
 			var response0 = new SearchResponse<object>();
@@ -102,7 +102,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line185()
+		public void Line189()
 		{
 			// tag::214d704d18485ab75ef53aa9c0524590[]
 			var response0 = new SearchResponse<object>();
@@ -126,7 +126,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line217()
+		public void Line221()
 		{
 			// tag::77f575b0cc37dd7a2415cbf6417d3148[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Aggregations/Metrics/StringStatsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/StringStatsAggregationPage.cs
@@ -1,0 +1,135 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Aggregations.Metrics
+{
+	public class StringStatsAggregationPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line22()
+		{
+			// tag::5507b01f713674781996a07718785444[]
+			var response0 = new SearchResponse<object>();
+			// end::5507b01f713674781996a07718785444[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : { ""string_stats"" : { ""field"" : ""message.keyword"" } }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line63()
+		{
+			// tag::a1d02ab1549dbd3f1874f6a2fd48ec48[]
+			var response0 = new SearchResponse<object>();
+			// end::a1d02ab1549dbd3f1874f6a2fd48ec48[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : {
+			            ""string_stats"" : {
+			                ""field"" : ""message.keyword"",
+			                ""show_distribution"": true  <1>
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line130()
+		{
+			// tag::24b22f8b83e9b199964036a170e4299e[]
+			var response0 = new SearchResponse<object>();
+			// end::24b22f8b83e9b199964036a170e4299e[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : {
+			             ""string_stats"" : {
+			                 ""script"" : {
+			                     ""lang"": ""painless"",
+			                     ""source"": ""doc['message.keyword'].value""
+			                 }
+			             }
+			         }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line151()
+		{
+			// tag::a89a22d4f41ee3538bbfec8ac9e7ac74[]
+			var response0 = new SearchResponse<object>();
+			// end::a89a22d4f41ee3538bbfec8ac9e7ac74[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : {
+			            ""string_stats"" : {
+			                ""script"" : {
+			                    ""id"": ""my_script"",
+			                    ""params"" : {
+			                        ""field"" : ""message.keyword""
+			                    }
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line175()
+		{
+			// tag::46078bde3789b5e7e83ab458857bc9c9[]
+			var response0 = new SearchResponse<object>();
+			// end::46078bde3789b5e7e83ab458857bc9c9[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : {
+			            ""string_stats"" : {
+			                ""field"" : ""message.keyword"",
+			                ""script"" : {
+			                    ""lang"": ""painless"",
+			                    ""source"": ""params.prefix + _value"",
+			                    ""params"" : {
+			                        ""prefix"" : ""Message: ""
+			                    }
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line202()
+		{
+			// tag::437f4009a93d46b6b76e7db366b34ce6[]
+			var response0 = new SearchResponse<object>();
+			// end::437f4009a93d46b6b76e7db366b34ce6[]
+
+			response0.MatchesExample(@"POST /twitter/_search?size=0
+			{
+			    ""aggs"" : {
+			        ""message_stats"" : {
+			            ""string_stats"" : {
+			                ""field"" : ""message.keyword"",
+			                ""missing"": ""[empty message]"" <1>
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
@@ -1,0 +1,209 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Aggregations.Metrics
+{
+	public class TopMetricsAggregationPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line12()
+		{
+			// tag::8fa80d369028e9ac0432f5c2d64ac574[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::8fa80d369028e9ac0432f5c2d64ac574[]
+
+			response0.MatchesExample(@"POST /test/_bulk?refresh
+			{""index"": {}}
+			{""s"": 1, ""v"": 3.1415}
+			{""index"": {}}
+			{""s"": 2, ""v"": 1.0}
+			{""index"": {}}
+			{""s"": 3, ""v"": 2.71828}");
+
+			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""tm"": {
+			      ""top_metrics"": {
+			        ""metric"": {""field"": ""v""},
+			        ""sort"": {""s"": ""desc""}
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line82()
+		{
+			// tag::2c45781caccfc50c0656802fb613a6ea[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::2c45781caccfc50c0656802fb613a6ea[]
+
+			response0.MatchesExample(@"POST /test/_bulk?refresh
+			{""index"": {}}
+			{""s"": 1, ""v"": 3.1415}
+			{""index"": {}}
+			{""s"": 2, ""v"": 1.0}
+			{""index"": {}}
+			{""s"": 3, ""v"": 2.71828}");
+
+			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""tm"": {
+			      ""top_metrics"": {
+			        ""metric"": {""field"": ""v""},
+			        ""sort"": {""s"": ""desc""},
+			        ""size"": 2
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line130()
+		{
+			// tag::b63ce79ce4fa1bb9b99a789f4dcfef4e[]
+			var response0 = new SearchResponse<object>();
+			// end::b63ce79ce4fa1bb9b99a789f4dcfef4e[]
+
+			response0.MatchesExample(@"PUT /test/_settings
+			{
+			  ""top_metrics_max_size"": 100
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line150()
+		{
+			// tag::a4f89e46f108ddab069bd4b3f798f2c6[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+
+			var response2 = new SearchResponse<object>();
+			// end::a4f89e46f108ddab069bd4b3f798f2c6[]
+
+			response0.MatchesExample(@"PUT /node
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""ip"": {""type"": ""ip""},
+			      ""date"": {""type"": ""date""}
+			    }
+			  }
+			}");
+
+			response1.MatchesExample(@"POST /node/_bulk?refresh
+			{""index"": {}}
+			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T01:01:01"", ""v"": 1}
+			{""index"": {}}
+			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T02:01:01"", ""v"": 2}
+			{""index"": {}}
+			{""ip"": ""192.168.0.2"", ""date"": ""2020-01-01T02:01:01"", ""v"": 3}");
+
+			response2.MatchesExample(@"POST /node/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""ip"": {
+			      ""terms"": {
+			        ""field"": ""ip""
+			      },
+			      ""aggs"": {
+			        ""tm"": {
+			          ""top_metrics"": {
+			            ""metric"": {""field"": ""v""},
+			            ""sort"": {""date"": ""desc""}
+			          }
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line221()
+		{
+			// tag::1ba79a9bfab9275c2095e720f5664fab[]
+			var response0 = new SearchResponse<object>();
+			// end::1ba79a9bfab9275c2095e720f5664fab[]
+
+			response0.MatchesExample(@"POST /node/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""ip"": {
+			      ""terms"": {
+			        ""field"": ""ip"",
+			        ""order"": {""tm.v"": ""desc""}
+			      },
+			      ""aggs"": {
+			        ""tm"": {
+			          ""top_metrics"": {
+			            ""metric"": {""field"": ""v""},
+			            ""sort"": {""date"": ""desc""}
+			          }
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line282()
+		{
+			// tag::b160996a6ab06abeed6899e63c2d192b[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::b160996a6ab06abeed6899e63c2d192b[]
+
+			response0.MatchesExample(@"POST /test/_bulk?refresh
+			{""index"": {""_index"": ""test1""}}
+			{""s"": 1, ""v"": 3.1415}
+			{""index"": {""_index"": ""test1""}}
+			{""s"": 2, ""v"": 1}
+			{""index"": {""_index"": ""test2""}}
+			{""s"": 3.1, ""v"": 2.71828}");
+
+			response1.MatchesExample(@"POST /test*/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""tm"": {
+			      ""top_metrics"": {
+			        ""metric"": {""field"": ""v""},
+			        ""sort"": {""s"": ""asc""}
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line322()
+		{
+			// tag::efc492b00b90206ae795f9afda4a1307[]
+			var response0 = new SearchResponse<object>();
+			// end::efc492b00b90206ae795f9afda4a1307[]
+
+			response0.MatchesExample(@"POST /test*/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""tm"": {
+			      ""top_metrics"": {
+			        ""metric"": {""field"": ""v""},
+			        ""sort"": {""s"": {""order"": ""asc"", ""numeric_type"": ""double""}}
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Analyzers/LangAnalyzerPage.cs
+++ b/tests/Examples/Analysis/Analyzers/LangAnalyzerPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Analyzers
 	public class LangAnalyzerPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line80()
+		public void Line81()
 		{
 			// tag::137c62a4443bdd7d5b95a15022a9dc30[]
 			var response0 = new SearchResponse<object>();
@@ -49,7 +49,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line130()
+		public void Line131()
 		{
 			// tag::f7dc2fed08e57abda2c3e8a14f8eb098[]
 			var response0 = new SearchResponse<object>();
@@ -90,7 +90,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line178()
+		public void Line179()
 		{
 			// tag::01f50acf7998b24969f451e922d145eb[]
 			var response0 = new SearchResponse<object>();
@@ -131,7 +131,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line226()
+		public void Line227()
 		{
 			// tag::496d35c89dc991a1509f7e8fb93ade45[]
 			var response0 = new SearchResponse<object>();
@@ -175,7 +175,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line277()
+		public void Line278()
 		{
 			// tag::13670d1534125831c2059eebd86d840c[]
 			var response0 = new SearchResponse<object>();
@@ -216,7 +216,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line325()
+		public void Line326()
 		{
 			// tag::d0378fe5e3aad05a2fd2e6e81213374f[]
 			var response0 = new SearchResponse<object>();
@@ -257,11 +257,11 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line373()
+		public void Line374()
 		{
-			// tag::d5f3be3b9edf0119fa19e5693cfac05a[]
+			// tag::7ab968a61bb0783f563dd6d29b253901[]
 			var response0 = new SearchResponse<object>();
-			// end::d5f3be3b9edf0119fa19e5693cfac05a[]
+			// end::7ab968a61bb0783f563dd6d29b253901[]
 
 			response0.MatchesExample(@"PUT /catalan_example
 			{
@@ -275,11 +275,11 @@ namespace Examples.Analysis.Analyzers
 			        },
 			        ""catalan_stop"": {
 			          ""type"":       ""stop"",
-			          ""stopwords"":  ""_catalan_"" \<1>
+			          ""stopwords"":  ""_catalan_"" <1>
 			        },
 			        ""catalan_keywords"": {
 			          ""type"":       ""keyword_marker"",
-			          ""keywords"":   [""exemple""] \<2>
+			          ""keywords"":   [""example""] <2>
 			        },
 			        ""catalan_stemmer"": {
 			          ""type"":       ""stemmer"",
@@ -304,7 +304,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line430()
+		public void Line431()
 		{
 			// tag::d305110a8cabfbebd1e38d85559d1023[]
 			var response0 = new SearchResponse<object>();
@@ -343,7 +343,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line476()
+		public void Line477()
 		{
 			// tag::a28111cdd9b5aaea96c779cbfbf38780[]
 			var response0 = new SearchResponse<object>();
@@ -384,7 +384,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line524()
+		public void Line525()
 		{
 			// tag::ed85ed833bec7286a0dfbe64077c5715[]
 			var response0 = new SearchResponse<object>();
@@ -425,7 +425,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line572()
+		public void Line573()
 		{
 			// tag::10d8b17e73d31dcd907de67327ed78a2[]
 			var response0 = new SearchResponse<object>();
@@ -476,7 +476,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line630()
+		public void Line631()
 		{
 			// tag::81c7a392efd505b686eed978fb7d9d17[]
 			var response0 = new SearchResponse<object>();
@@ -522,7 +522,48 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line683()
+		public void Line684()
+		{
+			// tag::2f4e28c81db47547ad39d0926babab12[]
+			var response0 = new SearchResponse<object>();
+			// end::2f4e28c81db47547ad39d0926babab12[]
+
+			response0.MatchesExample(@"PUT /estonian_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""filter"": {
+			        ""estonian_stop"": {
+			          ""type"":       ""stop"",
+			          ""stopwords"":  ""_estonian_"" <1>
+			        },
+			        ""estonian_keywords"": {
+			          ""type"":       ""keyword_marker"",
+			          ""keywords"":   [""näide""] <2>
+			        },
+			        ""estonian_stemmer"": {
+			          ""type"":       ""stemmer"",
+			          ""language"":   ""estonian""
+			        }
+			      },
+			      ""analyzer"": {
+			        ""rebuilt_estonian"": {
+			          ""tokenizer"":  ""standard"",
+			          ""filter"": [
+			            ""lowercase"",
+			            ""estonian_stop"",
+			            ""estonian_keywords"",
+			            ""estonian_stemmer""
+			          ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line732()
 		{
 			// tag::85f0e5e8ab91ceab63c21dbedd9f4037[]
 			var response0 = new SearchResponse<object>();
@@ -563,11 +604,11 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line731()
+		public void Line780()
 		{
-			// tag::e5498c139ce9053805c8931334ee324e[]
+			// tag::f545bb95214769aca993c1632a71ad2c[]
 			var response0 = new SearchResponse<object>();
-			// end::e5498c139ce9053805c8931334ee324e[]
+			// end::f545bb95214769aca993c1632a71ad2c[]
 
 			response0.MatchesExample(@"PUT /french_example
 			{
@@ -585,11 +626,11 @@ namespace Examples.Analysis.Analyzers
 			        },
 			        ""french_stop"": {
 			          ""type"":       ""stop"",
-			          ""stopwords"":  ""_french_"" \<1>
+			          ""stopwords"":  ""_french_"" <1>
 			        },
 			        ""french_keywords"": {
 			          ""type"":       ""keyword_marker"",
-			          ""keywords"":   [""Exemple""] \<2>
+			          ""keywords"":   [""Example""] <2>
 			        },
 			        ""french_stemmer"": {
 			          ""type"":       ""stemmer"",
@@ -614,7 +655,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line789()
+		public void Line838()
 		{
 			// tag::9606c271921cb800d5ea395b16d6ceaf[]
 			var response0 = new SearchResponse<object>();
@@ -655,7 +696,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line837()
+		public void Line886()
 		{
 			// tag::187e8786e0a90f1f6278cf89b670de0a[]
 			var response0 = new SearchResponse<object>();
@@ -697,7 +738,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line886()
+		public void Line935()
 		{
 			// tag::1f00e73c144603e97f6c14ab15fa1913[]
 			var response0 = new SearchResponse<object>();
@@ -742,7 +783,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line938()
+		public void Line987()
 		{
 			// tag::af00a58d9171d32f6efe52d94e51e526[]
 			var response0 = new SearchResponse<object>();
@@ -786,7 +827,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line989()
+		public void Line1038()
 		{
 			// tag::84108653e9e03b4edacd878ec870df77[]
 			var response0 = new SearchResponse<object>();
@@ -827,7 +868,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1038()
+		public void Line1087()
 		{
 			// tag::eb5987b58dae90c3a8a1609410be0570[]
 			var response0 = new SearchResponse<object>();
@@ -868,7 +909,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1086()
+		public void Line1135()
 		{
 			// tag::160f39a50847bad0be4be1529a95e4ce[]
 			var response0 = new SearchResponse<object>();
@@ -925,7 +966,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1150()
+		public void Line1199()
 		{
 			// tag::00e0c964c79fcc1876ab957da2ffce82[]
 			var response0 = new SearchResponse<object>();
@@ -977,7 +1018,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1209()
+		public void Line1258()
 		{
 			// tag::d983c1ea730eeabac9e914656d7c9be2[]
 			var response0 = new SearchResponse<object>();
@@ -1018,7 +1059,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1257()
+		public void Line1306()
 		{
 			// tag::bb067c049331cc850a77b18bdfff81b5[]
 			var response0 = new SearchResponse<object>();
@@ -1059,7 +1100,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1305()
+		public void Line1354()
 		{
 			// tag::2731a8577ad734a732d784c5dcb1225d[]
 			var response0 = new SearchResponse<object>();
@@ -1100,7 +1141,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1353()
+		public void Line1402()
 		{
 			// tag::d1a285aa244ec461d68f13e7078a33c0[]
 			var response0 = new SearchResponse<object>();
@@ -1141,7 +1182,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1399()
+		public void Line1448()
 		{
 			// tag::584f502cf840134f2db5f39e2483ced1[]
 			var response0 = new SearchResponse<object>();
@@ -1182,7 +1223,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1447()
+		public void Line1496()
 		{
 			// tag::1ba7afe23a26fe9ac7856d8c5bc1059d[]
 			var response0 = new SearchResponse<object>();
@@ -1223,7 +1264,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1496()
+		public void Line1545()
 		{
 			// tag::d260225cf97e068ead2a8a6bb5aefd90[]
 			var response0 = new SearchResponse<object>();
@@ -1264,7 +1305,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1544()
+		public void Line1593()
 		{
 			// tag::320645d771e952af2a67bb7445c3688d[]
 			var response0 = new SearchResponse<object>();
@@ -1307,7 +1348,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1594()
+		public void Line1643()
 		{
 			// tag::327466380bcd55361973b4a96c6dccb2[]
 			var response0 = new SearchResponse<object>();
@@ -1348,7 +1389,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1642()
+		public void Line1691()
 		{
 			// tag::f097c02541056f3c0fc855e7bbeef8a8[]
 			var response0 = new SearchResponse<object>();
@@ -1389,7 +1430,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1690()
+		public void Line1739()
 		{
 			// tag::103296e16b4233926ad1f07360385606[]
 			var response0 = new SearchResponse<object>();
@@ -1435,7 +1476,7 @@ namespace Examples.Analysis.Analyzers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1743()
+		public void Line1792()
 		{
 			// tag::346f28d82acb5427c304aa574fea0008[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/SpecifyAnalyzerPage.cs
+++ b/tests/Examples/Analysis/SpecifyAnalyzerPage.cs
@@ -1,0 +1,114 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis
+{
+	public class SpecifyAnalyzerPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line50()
+		{
+			// tag::311c6e60a020df4e301c6db9bcaf9e0a[]
+			var response0 = new SearchResponse<object>();
+			// end::311c6e60a020df4e301c6db9bcaf9e0a[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""title"": {
+			        ""type"": ""text"",
+			        ""analyzer"": ""whitespace""
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line74()
+		{
+			// tag::7b2c75b4f6150485593c49f96f05fb2f[]
+			var response0 = new SearchResponse<object>();
+			// end::7b2c75b4f6150485593c49f96f05fb2f[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""default"": {
+			          ""type"": ""simple""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line130()
+		{
+			// tag::040e4b4d0119e4cc94eafb9db91baae5[]
+			var response0 = new SearchResponse<object>();
+			// end::040e4b4d0119e4cc94eafb9db91baae5[]
+
+			response0.MatchesExample(@"GET my_index/_search
+			{
+			  ""query"": {
+			    ""match"": {
+			      ""message"": {
+			        ""query"": ""Quick foxes"",
+			        ""analyzer"": ""stop""
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line158()
+		{
+			// tag::8870b188fd9471b853f03cbc2a312261[]
+			var response0 = new SearchResponse<object>();
+			// end::8870b188fd9471b853f03cbc2a312261[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""title"": {
+			        ""type"": ""text"",
+			        ""analyzer"": ""whitespace"",
+			        ""search_analyzer"": ""simple""
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line186()
+		{
+			// tag::77c1e9a95f91229bc3f4ede13af97d34[]
+			var response0 = new SearchResponse<object>();
+			// end::77c1e9a95f91229bc3f4ede13af97d34[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""default"": {
+			          ""type"": ""simple""
+			        },
+			        ""default_search"": {
+			          ""type"": ""whitespace""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/TestingPage.cs
+++ b/tests/Examples/Analysis/TestingPage.cs
@@ -8,19 +8,25 @@ namespace Examples.Analysis
 		[U(Skip = "Example not implemented")]
 		public void Line9()
 		{
-			// tag::f0d3b58abf6f2b499a38237a0e6d3498[]
+			// tag::035a7a919eb6513b4769a3727b7d6447[]
 			var response0 = new SearchResponse<object>();
-
-			var response1 = new SearchResponse<object>();
-			// end::f0d3b58abf6f2b499a38237a0e6d3498[]
+			// end::035a7a919eb6513b4769a3727b7d6447[]
 
 			response0.MatchesExample(@"POST _analyze
 			{
 			  ""analyzer"": ""whitespace"",
 			  ""text"":     ""The quick brown fox.""
 			}");
+		}
 
-			response1.MatchesExample(@"POST _analyze
+		[U(Skip = "Example not implemented")]
+		public void Line62()
+		{
+			// tag::f7ec9062b3a7578fed55f119d7c22b74[]
+			var response0 = new SearchResponse<object>();
+			// end::f7ec9062b3a7578fed55f119d7c22b74[]
+
+			response0.MatchesExample(@"POST _analyze
 			{
 			  ""tokenizer"": ""standard"",
 			  ""filter"":  [ ""lowercase"", ""asciifolding"" ],
@@ -29,7 +35,7 @@ namespace Examples.Analysis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line42()
+		public void Line125()
 		{
 			// tag::acebf0b821acfbd6089f71e0359a56d3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/AsciifoldingTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/AsciifoldingTokenfilterPage.cs
@@ -6,18 +6,33 @@ namespace Examples.Analysis.Tokenfilters
 	public class AsciifoldingTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line10()
+		public void Line21()
 		{
-			// tag::0d4cb64eca426ac03110fdfd01367ee9[]
+			// tag::00d65f7b9daa1c6b18eedd8ace206bae[]
 			var response0 = new SearchResponse<object>();
-			// end::0d4cb64eca426ac03110fdfd01367ee9[]
+			// end::00d65f7b9daa1c6b18eedd8ace206bae[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""asciifolding""],
+			  ""text"" : ""açaí à la carte""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line83()
+		{
+			// tag::a976bdf566730e35c5277740c1e3a7f2[]
+			var response0 = new SearchResponse<object>();
+			// end::a976bdf566730e35c5277740c1e3a7f2[]
 
 			response0.MatchesExample(@"PUT /asciifold_example
 			{
 			    ""settings"" : {
 			        ""analysis"" : {
 			            ""analyzer"" : {
-			                ""default"" : {
+			                ""standard_asciifolding"" : {
 			                    ""tokenizer"" : ""standard"",
 			                    ""filter"" : [""asciifolding""]
 			                }
@@ -28,18 +43,18 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line31()
+		public void Line118()
 		{
-			// tag::f0609100be8e9eb4af6cbc75d0c40ebe[]
+			// tag::c5a0248213307f8e036a26e3294ad611[]
 			var response0 = new SearchResponse<object>();
-			// end::f0609100be8e9eb4af6cbc75d0c40ebe[]
+			// end::c5a0248213307f8e036a26e3294ad611[]
 
 			response0.MatchesExample(@"PUT /asciifold_example
 			{
 			    ""settings"" : {
 			        ""analysis"" : {
 			            ""analyzer"" : {
-			                ""default"" : {
+			                ""standard_asciifolding"" : {
 			                    ""tokenizer"" : ""standard"",
 			                    ""filter"" : [""my_ascii_folding""]
 			                }

--- a/tests/Examples/Analysis/Tokenfilters/CjkBigramTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/CjkBigramTokenfilterPage.cs
@@ -6,11 +6,48 @@ namespace Examples.Analysis.Tokenfilters
 	public class CjkBigramTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line18()
+		public void Line22()
 		{
-			// tag::4a40ccf6b1a0090da8d8033b435b5b7d[]
+			// tag::b8c03bbd917d0cf5474a3e46ebdd7aad[]
 			var response0 = new SearchResponse<object>();
-			// end::4a40ccf6b1a0090da8d8033b435b5b7d[]
+			// end::b8c03bbd917d0cf5474a3e46ebdd7aad[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""cjk_bigram""],
+			  ""text"" : ""東京都は、日本の首都であり""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line126()
+		{
+			// tag::7230edf3a8cdb5e4091fad668b4049dc[]
+			var response0 = new SearchResponse<object>();
+			// end::7230edf3a8cdb5e4091fad668b4049dc[]
+
+			response0.MatchesExample(@"PUT /cjk_bigram_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""standard_cjk_bigram"" : {
+			                    ""tokenizer"" : ""standard"",
+			                    ""filter"" : [""cjk_bigram""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line176()
+		{
+			// tag::6b328ac5a63ac7f26b011a6905083934[]
+			var response0 = new SearchResponse<object>();
+			// end::6b328ac5a63ac7f26b011a6905083934[]
 
 			response0.MatchesExample(@"PUT /cjk_bigram_example
 			{
@@ -26,9 +63,9 @@ namespace Examples.Analysis.Tokenfilters
 			                ""han_bigrams_filter"" : {
 			                    ""type"" : ""cjk_bigram"",
 			                    ""ignored_scripts"": [
+			                        ""hangul"",
 			                        ""hiragana"",
-			                        ""katakana"",
-			                        ""hangul""
+			                        ""katakana""
 			                    ],
 			                    ""output_unigrams"" : true
 			                }

--- a/tests/Examples/Analysis/Tokenfilters/CjkWidthTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/CjkWidthTokenfilterPage.cs
@@ -1,0 +1,45 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class CjkWidthTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line28()
+		{
+			// tag::76b279835936ee4b546a171c671c3cd7[]
+			var response0 = new SearchResponse<object>();
+			// end::76b279835936ee4b546a171c671c3cd7[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""cjk_width""],
+			  ""text"" : ""ｼｰｻｲﾄﾞﾗｲﾅｰ""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line69()
+		{
+			// tag::3df1aa197f7498a534b0536f49aea28b[]
+			var response0 = new SearchResponse<object>();
+			// end::3df1aa197f7498a534b0536f49aea28b[]
+
+			response0.MatchesExample(@"PUT /cjk_width_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""standard_cjk_width"" : {
+			                    ""tokenizer"" : ""standard"",
+			                    ""filter"" : [""cjk_width""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/ClassicTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/ClassicTokenfilterPage.cs
@@ -1,0 +1,45 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class ClassicTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line21()
+		{
+			// tag::c8bbf362f06a0d8dab33ec0d99743343[]
+			var response0 = new SearchResponse<object>();
+			// end::c8bbf362f06a0d8dab33ec0d99743343[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""classic"",
+			  ""filter"" : [""classic""],
+			  ""text"" : ""The 2 Q.U.I.C.K. Brown-Foxes jumped over the lazy dog's bone.""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line132()
+		{
+			// tag::50952b8040f875ce3719c71ca1c3bc8f[]
+			var response0 = new SearchResponse<object>();
+			// end::50952b8040f875ce3719c71ca1c3bc8f[]
+
+			response0.MatchesExample(@"PUT /classic_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""classic_analyzer"" : {
+			                    ""tokenizer"" : ""classic"",
+			                    ""filter"" : [""classic""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/CommonGramsTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/CommonGramsTokenfilterPage.cs
@@ -6,36 +6,47 @@ namespace Examples.Analysis.Tokenfilters
 	public class CommonGramsTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line43()
+		public void Line28()
 		{
-			// tag::dc0d7dd6fb47db03df4cb11bdb00b125[]
+			// tag::2fd0b3c132b46aa34cc9d92dd2d4bc85[]
 			var response0 = new SearchResponse<object>();
-			// end::dc0d7dd6fb47db03df4cb11bdb00b125[]
+			// end::2fd0b3c132b46aa34cc9d92dd2d4bc85[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""whitespace"",
+			  ""filter"" : [
+			    {
+			      ""type"": ""common_grams"",
+			      ""common_words"": [""is"", ""the""]
+			    }
+			  ],
+			  ""text"" : ""the quick fox is brown""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line126()
+		{
+			// tag::63de16d533d65708cf794eb50da02fbd[]
+			var response0 = new SearchResponse<object>();
+			// end::63de16d533d65708cf794eb50da02fbd[]
 
 			response0.MatchesExample(@"PUT /common_grams_example
 			{
 			    ""settings"": {
 			        ""analysis"": {
 			            ""analyzer"": {
-			                ""index_grams"": {
-			                    ""tokenizer"": ""whitespace"",
-			                    ""filter"": [""common_grams""]
-			                },
-			                ""search_grams"": {
-			                    ""tokenizer"": ""whitespace"",
-			                    ""filter"": [""common_grams_query""]
-			                }
+			              ""index_grams"": {
+			                  ""tokenizer"": ""whitespace"",
+			                  ""filter"": [""common_grams""]
+			              }
 			            },
 			            ""filter"": {
-			                ""common_grams"": {
-			                    ""type"": ""common_grams"",
-			                    ""common_words"": [""the"", ""is"", ""a""]
-			                },
-			                ""common_grams_query"": {
-			                    ""type"": ""common_grams"",
-			                    ""query_mode"": true,
-			                    ""common_words"": [""the"", ""is"", ""a""]
-			                }
+			              ""common_grams"": {
+			                  ""type"": ""common_grams"",
+			                  ""common_words"": [""a"", ""is"", ""the""]
+			              }
 			            }
 			        }
 			    }
@@ -43,16 +54,32 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line77()
+		public void Line206()
 		{
-			// tag::817be849e2c568a21766d6ce2ffafadd[]
+			// tag::d2d5a5fa4ab40787db87c85e1dd2bd06[]
 			var response0 = new SearchResponse<object>();
-			// end::817be849e2c568a21766d6ce2ffafadd[]
+			// end::d2d5a5fa4ab40787db87c85e1dd2bd06[]
 
-			response0.MatchesExample(@"POST /common_grams_example/_analyze
+			response0.MatchesExample(@"PUT /common_grams_example
 			{
-			  ""analyzer"" : ""index_grams"",
-			  ""text"" : ""the quick brown is a fox""
+			    ""settings"": {
+			        ""analysis"": {
+			            ""analyzer"": {
+			              ""index_grams"": {
+			                  ""tokenizer"": ""whitespace"",
+			                  ""filter"": [""common_grams_query""]
+			              }
+			            },
+			            ""filter"": {
+			              ""common_grams_query"": {
+			                  ""type"": ""common_grams"",
+			                  ""common_words"": [""a"", ""is"", ""the""],
+			                  ""ignore_case"": true,
+			                  ""query_mode"": true
+			              }
+			            }
+			        }
+			    }
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/ConditionTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/ConditionTokenfilterPage.cs
@@ -8,45 +8,54 @@ namespace Examples.Analysis.Tokenfilters
 		[U(Skip = "Example not implemented")]
 		public void Line22()
 		{
-			// tag::59fd7082698a6b12d028105456016a66[]
+			// tag::09944369863fd8666d5301d717317276[]
 			var response0 = new SearchResponse<object>();
-			// end::59fd7082698a6b12d028105456016a66[]
+			// end::09944369863fd8666d5301d717317276[]
 
-			response0.MatchesExample(@"PUT /condition_example
+			response0.MatchesExample(@"GET /_analyze
 			{
-			    ""settings"" : {
-			        ""analysis"" : {
-			            ""analyzer"" : {
-			                ""my_analyzer"" : {
-			                    ""tokenizer"" : ""standard"",
-			                    ""filter"" : [ ""my_condition"" ]
-			                }
-			            },
-			            ""filter"" : {
-			                ""my_condition"" : {
-			                    ""type"" : ""condition"",
-			                    ""filter"" : [ ""lowercase"" ],
-			                    ""script"" : {
-			                        ""source"" : ""token.getTerm().length() < 5""  \<1>
-			                    }
-			                }
-			            }
-			        }
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""condition"",
+			      ""filter"": [ ""lowercase"" ],
+			      ""script"": {
+			        ""source"": ""token.getTerm().length() < 5""
+			      }
 			    }
+			  ],
+			  ""text"": ""THE QUICK BROWN FOX""
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line53()
+		public void Line125()
 		{
-			// tag::e20493a20d3992a97238b87c6930f08d[]
+			// tag::a197076e0e74951ea88f20309ec257e2[]
 			var response0 = new SearchResponse<object>();
-			// end::e20493a20d3992a97238b87c6930f08d[]
+			// end::a197076e0e74951ea88f20309ec257e2[]
 
-			response0.MatchesExample(@"POST /condition_example/_analyze
+			response0.MatchesExample(@"PUT /palindrome_list
 			{
-			  ""analyzer"" : ""my_analyzer"",
-			  ""text"" : ""What Flapdoodle""
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_reverse_first_token"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""reverse_first_token"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""reverse_first_token"": {
+			          ""type"": ""condition"",
+			          ""filter"": [ ""reverse"" ],
+			          ""script"": {
+			            ""source"": ""token.getPosition() === 0""
+			          }
+			        }
+			      }
+			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/DecimalDigitTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/DecimalDigitTokenfilterPage.cs
@@ -1,0 +1,45 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class DecimalDigitTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line20()
+		{
+			// tag::a21319c9eff1ac47d7fe7490f1ef2efa[]
+			var response0 = new SearchResponse<object>();
+			// end::a21319c9eff1ac47d7fe7490f1ef2efa[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"" : ""whitespace"",
+			  ""filter"" : [""decimal_digit""],
+			  ""text"" : ""१-one two-२ ३""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line75()
+		{
+			// tag::121b8bc28620095dfa570a989bcdb04e[]
+			var response0 = new SearchResponse<object>();
+			// end::121b8bc28620095dfa570a989bcdb04e[]
+
+			response0.MatchesExample(@"PUT /decimal_digit_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""whitespace_decimal_digit"" : {
+			                    ""tokenizer"" : ""whitespace"",
+			                    ""filter"" : [""decimal_digit""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/DelimitedPayloadTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/DelimitedPayloadTokenfilterPage.cs
@@ -1,0 +1,132 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class DelimitedPayloadTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line47()
+		{
+			// tag::7dc82f7d36686fd57a47e34cbda39a4e[]
+			var response0 = new SearchResponse<object>();
+			// end::7dc82f7d36686fd57a47e34cbda39a4e[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [""delimited_payload""],
+			  ""text"": ""the|0 brown|10 fox|5 is|0 quick|10""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line120()
+		{
+			// tag::d443db2755fde3b49ca3a9d296c4a96f[]
+			var response0 = new SearchResponse<object>();
+			// end::d443db2755fde3b49ca3a9d296c4a96f[]
+
+			response0.MatchesExample(@"PUT delimited_payload
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_delimited_payload"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""delimited_payload"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line173()
+		{
+			// tag::27f9f604e7a48799fa30529cbc0ff619[]
+			var response0 = new SearchResponse<object>();
+			// end::27f9f604e7a48799fa30529cbc0ff619[]
+
+			response0.MatchesExample(@"PUT delimited_payload_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_plus_delimited"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""plus_delimited"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""plus_delimited"": {
+			          ""type"": ""delimited_payload"",
+			          ""delimiter"": ""+"",
+			          ""encoding"": ""int""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line206()
+		{
+			// tag::50c2cea2adbe9523458c2686ab11df54[]
+			var response0 = new SearchResponse<object>();
+			// end::50c2cea2adbe9523458c2686ab11df54[]
+
+			response0.MatchesExample(@"PUT text_payloads
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""text"": {
+			        ""type"": ""text"",
+			        ""term_vector"": ""with_positions_payloads"",
+			        ""analyzer"": ""payload_delimiter""
+			      }
+			    }
+			  },
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""payload_delimiter"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""delimited_payload"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line234()
+		{
+			// tag::d2f6fb271e97fde8685d7744e6718cc7[]
+			var response0 = new SearchResponse<object>();
+			// end::d2f6fb271e97fde8685d7744e6718cc7[]
+
+			response0.MatchesExample(@"POST text_payloads/_doc/1
+			{
+			  ""text"": ""the|0 brown|3 fox|4 is|0 quick|10""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line246()
+		{
+			// tag::b24a374c0ad264abbcacb5686f5ed61c[]
+			var response0 = new SearchResponse<object>();
+			// end::b24a374c0ad264abbcacb5686f5ed61c[]
+
+			response0.MatchesExample(@"GET text_payloads/_termvectors/1
+			{
+			  ""fields"": [ ""text"" ],
+			  ""payloads"": true
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/DictionaryDecompounderTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/DictionaryDecompounderTokenfilterPage.cs
@@ -1,0 +1,57 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class DictionaryDecompounderTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line32()
+		{
+			// tag::3fecd5c6d0c172566da4a54320e1cff3[]
+			var response0 = new SearchResponse<object>();
+			// end::3fecd5c6d0c172566da4a54320e1cff3[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""dictionary_decompounder"",
+			      ""word_list"": [""Donau"", ""dampf"", ""meer"", ""schiff""]
+			    }
+			  ],
+			  ""text"": ""Donaudampfschiff""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line152()
+		{
+			// tag::a5a5fb129de2f492e8fd33043a73439c[]
+			var response0 = new SearchResponse<object>();
+			// end::a5a5fb129de2f492e8fd33043a73439c[]
+
+			response0.MatchesExample(@"PUT dictionary_decompound_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_dictionary_decompound"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""22_char_dictionary_decompound"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""22_char_dictionary_decompound"": {
+			          ""type"": ""dictionary_decompounder"",
+			          ""word_list_path"": ""analysis/example_word_list.txt"",
+			          ""max_subword_size"": 22
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/EdgengramTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/EdgengramTokenfilterPage.cs
@@ -1,0 +1,79 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class EdgengramTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line34()
+		{
+			// tag::6dbfe5565a95508e65d304131847f9fc[]
+			var response0 = new SearchResponse<object>();
+			// end::6dbfe5565a95508e65d304131847f9fc[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    { ""type"": ""edge_ngram"",
+			      ""min_gram"": 1,
+			      ""max_gram"": 2
+			    }
+			  ],
+			  ""text"": ""the quick brown fox jumps""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line143()
+		{
+			// tag::16351d99d0608789d04a0bb11a537098[]
+			var response0 = new SearchResponse<object>();
+			// end::16351d99d0608789d04a0bb11a537098[]
+
+			response0.MatchesExample(@"PUT edge_ngram_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_edge_ngram"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""edge_ngram"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line199()
+		{
+			// tag::6f07152055e99416deb10e95b428b847[]
+			var response0 = new SearchResponse<object>();
+			// end::6f07152055e99416deb10e95b428b847[]
+
+			response0.MatchesExample(@"PUT edge_ngram_custom_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""default"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""3_5_edgegrams"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""3_5_edgegrams"": {
+			          ""type"": ""edge_ngram"",
+			          ""min_gram"": 3,
+			          ""max_gram"": 5
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/ElisionTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/ElisionTokenfilterPage.cs
@@ -6,27 +6,64 @@ namespace Examples.Analysis.Tokenfilters
 	public class ElisionTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line15()
+		public void Line34()
 		{
-			// tag::c0fa4f18231d7495c39b62bb4e56fe50[]
+			// tag::446e8fc8ccfb13bb5ec64e32a5676d18[]
 			var response0 = new SearchResponse<object>();
-			// end::c0fa4f18231d7495c39b62bb4e56fe50[]
+			// end::446e8fc8ccfb13bb5ec64e32a5676d18[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""elision""],
+			  ""text"" : ""j’examine près du wharf""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line96()
+		{
+			// tag::26d49d11bb37c3f4ef8179010e34b50e[]
+			var response0 = new SearchResponse<object>();
+			// end::26d49d11bb37c3f4ef8179010e34b50e[]
 
 			response0.MatchesExample(@"PUT /elision_example
 			{
 			    ""settings"" : {
 			        ""analysis"" : {
 			            ""analyzer"" : {
-			                ""default"" : {
-			                    ""tokenizer"" : ""standard"",
+			                ""whitespace_elision"" : {
+			                    ""tokenizer"" : ""whitespace"",
 			                    ""filter"" : [""elision""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line165()
+		{
+			// tag::fc575e08d0bc8f4cb03a54e5d57fff7b[]
+			var response0 = new SearchResponse<object>();
+			// end::fc575e08d0bc8f4cb03a54e5d57fff7b[]
+
+			response0.MatchesExample(@"PUT /elision_case_sensitive_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""default"" : {
+			                    ""tokenizer"" : ""whitespace"",
+			                    ""filter"" : [""elision_case_sensitive""]
 			                }
 			            },
 			            ""filter"" : {
-			                ""elision"" : {
+			                ""elision_case_sensitive"" : {
 			                    ""type"" : ""elision"",
-			                    ""articles_case"": true,
-			                    ""articles"" : [""l"", ""m"", ""t"", ""qu"", ""n"", ""s"", ""j""]
+			                    ""articles"" : [""l"", ""m"", ""t"", ""qu"", ""n"", ""s"", ""j""],
+			                    ""articles_case"": true
 			                }
 			            }
 			        }

--- a/tests/Examples/Analysis/Tokenfilters/FingerprintTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/FingerprintTokenfilterPage.cs
@@ -1,0 +1,74 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class FingerprintTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line35()
+		{
+			// tag::df82a9cb21a7557f3ddba2509f76f608[]
+			var response0 = new SearchResponse<object>();
+			// end::df82a9cb21a7557f3ddba2509f76f608[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""whitespace"",
+			  ""filter"" : [""fingerprint""],
+			  ""text"" : ""zebra jumps over resting resting dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line76()
+		{
+			// tag::8e09caccab0c7c0f82f06cea45424396[]
+			var response0 = new SearchResponse<object>();
+			// end::8e09caccab0c7c0f82f06cea45424396[]
+
+			response0.MatchesExample(@"PUT fingerprint_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_fingerprint"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""elision"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line117()
+		{
+			// tag::1b0f40959a7a4d124372f2bd3f7eac85[]
+			var response0 = new SearchResponse<object>();
+			// end::1b0f40959a7a4d124372f2bd3f7eac85[]
+
+			response0.MatchesExample(@"PUT custom_fingerprint_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""fingerprint_plus_concat"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""fingerprint_plus_concat"": {
+			          ""type"": ""fingerprint"",
+			          ""max_output_size"": 100,
+			          ""separator"": ""+""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/HunspellTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/HunspellTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class HunspellTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line44()
+		public void Line47()
 		{
 			// tag::0af002734dd884f9385da6c3a4ca87a1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/HyphenationDecompounderTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/HyphenationDecompounderTokenfilterPage.cs
@@ -1,0 +1,59 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class HyphenationDecompounderTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line25()
+		{
+			// tag::f34c02351662481dd61a5c2a3e206c60[]
+			var response0 = new SearchResponse<object>();
+			// end::f34c02351662481dd61a5c2a3e206c60[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""hyphenation_decompounder"",
+			      ""hyphenation_patterns_path"": ""analysis/hyphenation_patterns.xml"",
+			      ""word_list"": [""Kaffee"", ""zucker"", ""tasse""]
+			    }
+			  ],
+			  ""text"": ""Kaffeetasse""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line132()
+		{
+			// tag::5f8acd1e367b048b5542dbc6079bcc88[]
+			var response0 = new SearchResponse<object>();
+			// end::5f8acd1e367b048b5542dbc6079bcc88[]
+
+			response0.MatchesExample(@"PUT hyphenation_decompound_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_hyphenation_decompound"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""22_char_hyphenation_decompound"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""22_char_hyphenation_decompound"": {
+			          ""type"": ""hyphenation_decompounder"",
+			          ""word_list_path"": ""analysis/example_word_list.txt"",
+			          ""hyphenation_patterns_path"": ""analysis/hyphenation_patterns.xml"",
+			          ""max_subword_size"": 22
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/KeepTypesTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeepTypesTokenfilterPage.cs
@@ -6,87 +6,71 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeepTypesTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line21()
+		public void Line38()
 		{
-			// tag::928923befcb84cdcace229b027fd281f[]
+			// tag::83cd4eb89818b4c32f654d370eafa920[]
 			var response0 = new SearchResponse<object>();
-			// end::928923befcb84cdcace229b027fd281f[]
+			// end::83cd4eb89818b4c32f654d370eafa920[]
 
-			response0.MatchesExample(@"PUT /keep_types_example
+			response0.MatchesExample(@"GET _analyze
 			{
-			    ""settings"" : {
-			        ""analysis"" : {
-			            ""analyzer"" : {
-			                ""my_analyzer"" : {
-			                    ""tokenizer"" : ""standard"",
-			                    ""filter"" : [""lowercase"", ""extract_numbers""]
-			                }
-			            },
-			            ""filter"" : {
-			                ""extract_numbers"" : {
-			                    ""type"" : ""keep_types"",
-			                    ""types"" : [ ""<NUM>"" ]
-			                }
-			            }
-			        }
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""keep_types"",
+			      ""types"": [ ""<NUM>"" ]
 			    }
+			  ],
+			  ""text"": ""1 quick fox 2 lazy dogs""
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line46()
+		public void Line91()
 		{
-			// tag::b425b2194294437ac21df0b5606fb3d2[]
+			// tag::d94f666616dea141dcb7aaf08a35bc10[]
 			var response0 = new SearchResponse<object>();
-			// end::b425b2194294437ac21df0b5606fb3d2[]
+			// end::d94f666616dea141dcb7aaf08a35bc10[]
 
-			response0.MatchesExample(@"POST /keep_types_example/_analyze
+			response0.MatchesExample(@"GET _analyze
 			{
-			  ""analyzer"" : ""my_analyzer"",
-			  ""text"" : ""this is just 1 a test""
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line80()
-		{
-			// tag::1658d704f26a06e8f37c6430361c3f26[]
-			var response0 = new SearchResponse<object>();
-			// end::1658d704f26a06e8f37c6430361c3f26[]
-
-			response0.MatchesExample(@"PUT /keep_types_exclude_example
-			{
-			    ""settings"" : {
-			        ""analysis"" : {
-			            ""analyzer"" : {
-			                ""my_analyzer"" : {
-			                    ""tokenizer"" : ""standard"",
-			                    ""filter"" : [""lowercase"", ""remove_numbers""]
-			                }
-			            },
-			            ""filter"" : {
-			                ""remove_numbers"" : {
-			                    ""type"" : ""keep_types"",
-			                    ""mode"" : ""exclude"",
-			                    ""types"" : [ ""<NUM>"" ]
-			                }
-			            }
-			        }
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""keep_types"",
+			      ""types"": [ ""<NUM>"" ],
+			      ""mode"": ""exclude""
 			    }
+			  ],
+			  ""text"": ""1 quick fox 2 lazy dogs""
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line106()
+		public void Line182()
 		{
-			// tag::4d5ded2eede9a987df094dc4a91893d7[]
+			// tag::13b02da42d3afe7f0b649e1c98ac9549[]
 			var response0 = new SearchResponse<object>();
-			// end::4d5ded2eede9a987df094dc4a91893d7[]
+			// end::13b02da42d3afe7f0b649e1c98ac9549[]
 
-			response0.MatchesExample(@"POST /keep_types_exclude_example/_analyze
+			response0.MatchesExample(@"PUT keep_types_example
 			{
-			  ""analyzer"" : ""my_analyzer"",
-			  ""text"" : ""hello 101 world""
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_analyzer"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""extract_alpha"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""extract_alpha"": {
+			          ""type"": ""keep_types"",
+			          ""types"": [ ""<ALPHANUM>"" ]
+			        }
+			      }
+			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/KeepWordsTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeepWordsTokenfilterPage.cs
@@ -6,38 +6,58 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeepWordsTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line22()
+		public void Line26()
 		{
-			// tag::44cb20732770bb9a5f114a7517db774f[]
+			// tag::9a036a792be1d39af9fd0d1adb5f3402[]
 			var response0 = new SearchResponse<object>();
-			// end::44cb20732770bb9a5f114a7517db774f[]
+			// end::9a036a792be1d39af9fd0d1adb5f3402[]
 
-			response0.MatchesExample(@"PUT /keep_words_example
+			response0.MatchesExample(@"GET _analyze
 			{
-			    ""settings"" : {
-			        ""analysis"" : {
-			            ""analyzer"" : {
-			                ""example_1"" : {
-			                    ""tokenizer"" : ""standard"",
-			                    ""filter"" : [""lowercase"", ""words_till_three""]
-			                },
-			                ""example_2"" : {
-			                    ""tokenizer"" : ""standard"",
-			                    ""filter"" : [""lowercase"", ""words_in_file""]
-			                }
-			            },
-			            ""filter"" : {
-			                ""words_till_three"" : {
-			                    ""type"" : ""keep"",
-			                    ""keep_words"" : [ ""one"", ""two"", ""three""]
-			                },
-			                ""words_in_file"" : {
-			                    ""type"" : ""keep"",
-			                    ""keep_words_path"" : ""analysis/example_word_list.txt""
-			                }
-			            }
-			        }
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    {
+			      ""type"": ""keep"",
+			      ""keep_words"": [ ""dog"", ""elephant"", ""fox"" ]
 			    }
+			  ],
+			  ""text"": ""the quick fox jumps over the lazy dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line118()
+		{
+			// tag::642c0c1c76e9bf226cd216ebae9ab958[]
+			var response0 = new SearchResponse<object>();
+			// end::642c0c1c76e9bf226cd216ebae9ab958[]
+
+			response0.MatchesExample(@"PUT keep_words_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_keep_word_array"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""keep_word_array"" ]
+			        },
+			        ""standard_keep_word_file"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""keep_word_file"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""keep_word_array"": {
+			          ""type"": ""keep"",
+			          ""keep_words"": [ ""one"", ""two"", ""three"" ]
+			        },
+			        ""keep_word_file"": {
+			          ""type"": ""keep"",
+			          ""keep_words_path"": ""analysis/example_word_list.txt""
+			        }
+			      }
+			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/KeywordMarkerTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeywordMarkerTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeywordMarkerTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line25()
+		public void Line28()
 		{
 			// tag::863c221b28ae5e58d39bd8f138291949[]
 			var response0 = new SearchResponse<object>();
@@ -40,7 +40,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line56()
+		public void Line59()
 		{
 			// tag::abcbf3c246c0d88831b875a601686e35[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line102()
 		{
 			// tag::4ab8f55a8a45d53fb1676112379c212e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/KeywordRepeatTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeywordRepeatTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeywordRepeatTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line16()
+		public void Line19()
 		{
 			// tag::9da83c9a2149bfc6fe215a612ae0a9aa[]
 			var response0 = new SearchResponse<object>();
@@ -35,7 +35,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line42()
+		public void Line45()
 		{
 			// tag::757622a424b8445fee49746862a11b02[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/LengthTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/LengthTokenfilterPage.cs
@@ -1,0 +1,80 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class LengthTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line27()
+		{
+			// tag::1659420311d907d9fc024b96f4150216[]
+			var response0 = new SearchResponse<object>();
+			// end::1659420311d907d9fc024b96f4150216[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    {
+			      ""type"": ""length"",
+			      ""min"": 0,
+			      ""max"": 4
+			    }
+			  ],
+			  ""text"": ""the quick brown fox jumps over the lazy dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line109()
+		{
+			// tag::ea690283f301c6ce957efad93d7d5c5d[]
+			var response0 = new SearchResponse<object>();
+			// end::ea690283f301c6ce957efad93d7d5c5d[]
+
+			response0.MatchesExample(@"PUT length_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_length"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""length"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line149()
+		{
+			// tag::d88f883ed2fb8be35cd3e72ddffcf4ef[]
+			var response0 = new SearchResponse<object>();
+			// end::d88f883ed2fb8be35cd3e72ddffcf4ef[]
+
+			response0.MatchesExample(@"PUT length_custom_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_length_2_to_10_char"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""length_2_to_10_char"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""length_2_to_10_char"": {
+			          ""type"": ""length"",
+			          ""min"": 2,
+			          ""max"": 10
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/LimitTokenCountTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/LimitTokenCountTokenfilterPage.cs
@@ -6,21 +6,62 @@ namespace Examples.Analysis.Tokenfilters
 	public class LimitTokenCountTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line20()
+		public void Line43()
 		{
-			// tag::fdd46bdb2b0b0b5f8e7e502291496db8[]
+			// tag::5a3855f1b3e37d89ab7cbcc4f7ae1dd3[]
 			var response0 = new SearchResponse<object>();
-			// end::fdd46bdb2b0b0b5f8e7e502291496db8[]
+			// end::5a3855f1b3e37d89ab7cbcc4f7ae1dd3[]
 
-			response0.MatchesExample(@"PUT /limit_example
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""standard"",
+			    ""filter"": [
+			    {
+			      ""type"": ""limit"",
+			      ""max_token_count"": 2
+			    }
+			  ],
+			  ""text"": ""quick fox jumps over lazy dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line96()
+		{
+			// tag::b96f465abb658fe32889c3d183f159a3[]
+			var response0 = new SearchResponse<object>();
+			// end::b96f465abb658fe32889c3d183f159a3[]
+
+			response0.MatchesExample(@"PUT limit_example
 			{
 			  ""settings"": {
 			    ""analysis"": {
 			      ""analyzer"": {
-			        ""limit_example"": {
-			          ""type"": ""custom"",
+			        ""standard_one_token_limit"": {
 			          ""tokenizer"": ""standard"",
-			          ""filter"": [""lowercase"", ""five_token_limit""]
+			          ""filter"": [ ""limit"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line123()
+		{
+			// tag::63521e0089c631d6668c44a0a9d7fdcc[]
+			var response0 = new SearchResponse<object>();
+			// end::63521e0089c631d6668c44a0a9d7fdcc[]
+
+			response0.MatchesExample(@"PUT custom_limit_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""whitespace_five_token_limit"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""five_token_limit"" ]
 			        }
 			      },
 			      ""filter"": {

--- a/tests/Examples/Analysis/Tokenfilters/LowercaseTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/LowercaseTokenfilterPage.cs
@@ -6,22 +6,54 @@ namespace Examples.Analysis.Tokenfilters
 	public class LowercaseTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line12()
+		public void Line20()
 		{
-			// tag::5be6349f5da1a7a5658df1d7fdf542db[]
+			// tag::aa3284717241ed79d3d1d3bdbbdce598[]
 			var response0 = new SearchResponse<object>();
-			// end::5be6349f5da1a7a5658df1d7fdf542db[]
+			// end::aa3284717241ed79d3d1d3bdbbdce598[]
 
-			response0.MatchesExample(@"PUT /lowercase_example
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""lowercase""],
+			  ""text"" : ""THE Quick FoX JUMPs""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line82()
+		{
+			// tag::bf173db2ec48059c47eb8a7268545add[]
+			var response0 = new SearchResponse<object>();
+			// end::bf173db2ec48059c47eb8a7268545add[]
+
+			response0.MatchesExample(@"PUT lowercase_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""whitespace_lowercase"" : {
+			                    ""tokenizer"" : ""whitespace"",
+			                    ""filter"" : [""lowercase""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line131()
+		{
+			// tag::f268416813befd13c604642c6fe6eda9[]
+			var response0 = new SearchResponse<object>();
+			// end::f268416813befd13c604642c6fe6eda9[]
+
+			response0.MatchesExample(@"PUT custom_lowercase_example
 			{
 			  ""settings"": {
 			    ""analysis"": {
 			      ""analyzer"": {
-			        ""standard_lowercase_example"": {
-			          ""type"": ""custom"",
-			          ""tokenizer"": ""standard"",
-			          ""filter"": [""lowercase""]
-			        },
 			        ""greek_lowercase_example"": {
 			          ""type"": ""custom"",
 			          ""tokenizer"": ""standard"",

--- a/tests/Examples/Analysis/Tokenfilters/MultiplexerTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/MultiplexerTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class MultiplexerTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line33()
+		public void Line36()
 		{
 			// tag::c306212babadc14fa124b88fd8c43a6b[]
 			var response0 = new SearchResponse<object>();
@@ -34,7 +34,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line58()
+		public void Line61()
 		{
 			// tag::fa9a3ef94470f3d9bd6500b65bf993d1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/NgramTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/NgramTokenfilterPage.cs
@@ -1,0 +1,77 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class NgramTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line30()
+		{
+			// tag::f65abb38dd0cfedeb06e0cef206fbdab[]
+			var response0 = new SearchResponse<object>();
+			// end::f65abb38dd0cfedeb06e0cef206fbdab[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [ ""ngram"" ],
+			  ""text"": ""Quick fox""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line161()
+		{
+			// tag::923aee95078219ee6eb321a252e1121b[]
+			var response0 = new SearchResponse<object>();
+			// end::923aee95078219ee6eb321a252e1121b[]
+
+			response0.MatchesExample(@"PUT ngram_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""standard_ngram"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [ ""ngram"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line204()
+		{
+			// tag::2793fa53b7d269852aa74f6bf57e34dc[]
+			var response0 = new SearchResponse<object>();
+			// end::2793fa53b7d269852aa74f6bf57e34dc[]
+
+			response0.MatchesExample(@"PUT ngram_custom_example
+			{
+			  ""settings"": {
+			    ""index"": {
+			      ""max_ngram_diff"": 2
+			    },
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""default"": {
+			          ""tokenizer"": ""whitespace"",
+			          ""filter"": [ ""3_5_grams"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""3_5_grams"": {
+			          ""type"": ""ngram"",
+			          ""min_gram"": 3,
+			          ""max_gram"": 5
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/PatternCaptureTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/PatternCaptureTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class PatternCaptureTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line51()
 		{
 			// tag::f733b25cd4c448b226bb76862974eef2[]
 			var response0 = new SearchResponse<object>();
@@ -38,7 +38,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line88()
+		public void Line91()
 		{
 			// tag::080c34d8151d02b760571e3a2899fa97[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/PredicateTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/PredicateTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class PredicateTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line19()
+		public void Line22()
 		{
 			// tag::10338787b66a7f93270c3b88dd6197f8[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line51()
 		{
 			// tag::e20493a20d3992a97238b87c6930f08d[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/ReverseTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/ReverseTokenfilterPage.cs
@@ -1,0 +1,45 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class ReverseTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line24()
+		{
+			// tag::e09d30195108bd6a1f6857394a6123ea[]
+			var response0 = new SearchResponse<object>();
+			// end::e09d30195108bd6a1f6857394a6123ea[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""reverse""],
+			  ""text"" : ""quick fox jumps""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line79()
+		{
+			// tag::aa5fbb68d3a8e0d0c894791cb6cf0b13[]
+			var response0 = new SearchResponse<object>();
+			// end::aa5fbb68d3a8e0d0c894791cb6cf0b13[]
+
+			response0.MatchesExample(@"PUT reverse_example
+			{
+			  ""settings"" : {
+			    ""analysis"" : {
+			      ""analyzer"" : {
+			        ""whitespace_reverse"" : {
+			          ""tokenizer"" : ""whitespace"",
+			          ""filter"" : [""reverse""]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/SnowballTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/SnowballTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class SnowballTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line14()
+		public void Line17()
 		{
 			// tag::e776311ef67c972f322b669dc4ab9926[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/StemmerOverrideTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/StemmerOverrideTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class StemmerOverrideTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line22()
+		public void Line25()
 		{
 			// tag::8995e7cf49c4d870aea334645b70ed13[]
 			var response0 = new SearchResponse<object>();
@@ -34,7 +34,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line54()
+		public void Line57()
 		{
 			// tag::35e24a98b35cadd0b1b370ada79249e1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/StemmerTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/StemmerTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class StemmerTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line14()
+		public void Line17()
 		{
 			// tag::1ca618e7d72ec73c1064fa6eae3086d1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/StopTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/StopTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class StopTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line35()
+		public void Line38()
 		{
 			// tag::a4575521493d8d1fbdd450821035f821[]
 			var response0 = new SearchResponse<object>();
@@ -28,7 +28,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line54()
+		public void Line57()
 		{
 			// tag::ded95888c2d68c48426b013284eb896a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/SynonymGraphTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/SynonymGraphTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class SynonymGraphTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line23()
+		public void Line26()
 		{
 			// tag::2f071d36aa4aff5a2fafb3dadaa38b82[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line58()
+		public void Line61()
 		{
 			// tag::3d253e5a0029bc96cce484302319b772[]
 			var response0 = new SearchResponse<object>();
@@ -71,7 +71,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line118()
+		public void Line121()
 		{
 			// tag::1a14fd905941ecbdbc943b05875afc6f[]
 			var response0 = new SearchResponse<object>();
@@ -98,7 +98,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line149()
+		public void Line152()
 		{
 			// tag::f0d7d6d5c878211704d4a5f1b2f6a247[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/SynonymTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/SynonymTokenfilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class SynonymTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line9()
+		public void Line12()
 		{
 			// tag::09f74df1d07d84ee133ce90f7832e712[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line51()
 		{
 			// tag::bcc57126b24c408b5d944928b6f08c94[]
 			var response0 = new SearchResponse<object>();
@@ -71,7 +71,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line109()
+		public void Line112()
 		{
 			// tag::9fb5e28535f396ab2eb8bc710eebc1e6[]
 			var response0 = new SearchResponse<object>();
@@ -98,7 +98,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line140()
+		public void Line143()
 		{
 			// tag::0c0f37e409459dcd40d29ea684db4706[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/TruncateTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/TruncateTokenfilterPage.cs
@@ -1,0 +1,73 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class TruncateTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line24()
+		{
+			// tag::ee2d97090d617ed8aa2a87ea33556dd7[]
+			var response0 = new SearchResponse<object>();
+			// end::ee2d97090d617ed8aa2a87ea33556dd7[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""whitespace"",
+			  ""filter"" : [""truncate""],
+			  ""text"" : ""the quinquennial extravaganza carried on""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line93()
+		{
+			// tag::f8651356ce2e7e93fa306c30f57ed588[]
+			var response0 = new SearchResponse<object>();
+			// end::f8651356ce2e7e93fa306c30f57ed588[]
+
+			response0.MatchesExample(@"PUT custom_truncate_example
+			{
+			  ""settings"" : {
+			    ""analysis"" : {
+			      ""analyzer"" : {
+			        ""standard_truncate"" : {
+			        ""tokenizer"" : ""standard"",
+			        ""filter"" : [""truncate""]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line128()
+		{
+			// tag::af84b3995564a7ca84360a526a4ac896[]
+			var response0 = new SearchResponse<object>();
+			// end::af84b3995564a7ca84360a526a4ac896[]
+
+			response0.MatchesExample(@"PUT 5_char_words_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""lowercase_5_char"": {
+			          ""tokenizer"": ""lowercase"",
+			          ""filter"": [ ""5_char_trunc"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""5_char_trunc"": {
+			          ""type"": ""truncate"",
+			          ""length"": 5
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/UniqueTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/UniqueTokenfilterPage.cs
@@ -1,0 +1,73 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class UniqueTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line26()
+		{
+			// tag::50d5c5b7e8ed9a95b8d9a25a32a77425[]
+			var response0 = new SearchResponse<object>();
+			// end::50d5c5b7e8ed9a95b8d9a25a32a77425[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""whitespace"",
+			  ""filter"" : [""unique""],
+			  ""text"" : ""the quick fox jumps the lazy fox""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line95()
+		{
+			// tag::a428d518162918733d49261ffd65cfc1[]
+			var response0 = new SearchResponse<object>();
+			// end::a428d518162918733d49261ffd65cfc1[]
+
+			response0.MatchesExample(@"PUT custom_unique_example
+			{
+			  ""settings"" : {
+			    ""analysis"" : {
+			      ""analyzer"" : {
+			        ""standard_truncate"" : {
+			        ""tokenizer"" : ""standard"",
+			        ""filter"" : [""unique""]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line130()
+		{
+			// tag::6e1157f3184fa192d47a3d0e3ea17a6c[]
+			var response0 = new SearchResponse<object>();
+			// end::6e1157f3184fa192d47a3d0e3ea17a6c[]
+
+			response0.MatchesExample(@"PUT letter_unique_pos_example
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""letter_unique_pos"": {
+			          ""tokenizer"": ""letter"",
+			          ""filter"": [ ""unique_pos"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""unique_pos"": {
+			          ""type"": ""unique"",
+			          ""only_on_same_position"": true
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/UppercaseTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/UppercaseTokenfilterPage.cs
@@ -1,0 +1,45 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class UppercaseTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line29()
+		{
+			// tag::9f7671119236423e0e40801ef6485af1[]
+			var response0 = new SearchResponse<object>();
+			// end::9f7671119236423e0e40801ef6485af1[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"" : ""standard"",
+			  ""filter"" : [""uppercase""],
+			  ""text"" : ""the Quick FoX JUMPs""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line91()
+		{
+			// tag::9db72fe811ee61ee3f7baa45916d20e0[]
+			var response0 = new SearchResponse<object>();
+			// end::9db72fe811ee61ee3f7baa45916d20e0[]
+
+			response0.MatchesExample(@"PUT uppercase_example
+			{
+			    ""settings"" : {
+			        ""analysis"" : {
+			            ""analyzer"" : {
+			                ""whitespace_uppercase"" : {
+			                    ""tokenizer"" : ""whitespace"",
+			                    ""filter"" : [""uppercase""]
+			                }
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenizers/EdgengramTokenizerPage.cs
+++ b/tests/Examples/Analysis/Tokenizers/EdgengramTokenizerPage.cs
@@ -20,7 +20,7 @@ namespace Examples.Analysis.Tokenizers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line104()
+		public void Line141()
 		{
 			// tag::a61389da4033bd7b73a63ff2ee258125[]
 			var response0 = new SearchResponse<object>();
@@ -60,7 +60,7 @@ namespace Examples.Analysis.Tokenizers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line220()
+		public void Line261()
 		{
 			// tag::b8893e8f2b1aea4b093e0c4f037cfff7[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenizers/NgramTokenizerPage.cs
+++ b/tests/Examples/Analysis/Tokenizers/NgramTokenizerPage.cs
@@ -20,7 +20,7 @@ namespace Examples.Analysis.Tokenizers
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line209()
+		public void Line217()
 		{
 			// tag::9efcafd1f28490fd658d88df7d93c66c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Autoscaling/Apis/GetAutoscalingDecisionPage.cs
+++ b/tests/Examples/Autoscaling/Apis/GetAutoscalingDecisionPage.cs
@@ -1,0 +1,28 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Autoscaling.Apis
+{
+	public class GetAutoscalingDecisionPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line15()
+		{
+			// tag::0d142c34961983f6aab5f12965407bab[]
+			var response0 = new SearchResponse<object>();
+			// end::0d142c34961983f6aab5f12965407bab[]
+
+			response0.MatchesExample(@"GET /_autoscaling/decision/");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line40()
+		{
+			// tag::f1335bacda32b273ecc9603498eff65c[]
+			var response0 = new SearchResponse<object>();
+			// end::f1335bacda32b273ecc9603498eff65c[]
+
+			response0.MatchesExample(@"GET /_autoscaling/decision");
+		}
+	}
+}

--- a/tests/Examples/Cat/AnomalyDetectorsPage.cs
+++ b/tests/Examples/Cat/AnomalyDetectorsPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Cat
+{
+	public class AnomalyDetectorsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line267()
+		{
+			// tag::bb03aeaba69c110f86505fa0e4e5035d[]
+			var response0 = new SearchResponse<object>();
+			// end::bb03aeaba69c110f86505fa0e4e5035d[]
+
+			response0.MatchesExample(@"GET _cat/ml/anomaly_detectors?h=id,s,dpr,mb&v");
+		}
+	}
+}

--- a/tests/Examples/Cat/DatafeedsPage.cs
+++ b/tests/Examples/Cat/DatafeedsPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Cat
+{
+	public class DatafeedsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line118()
+		{
+			// tag::4f57307b38318e9d8416923e12ff47ed[]
+			var response0 = new SearchResponse<object>();
+			// end::4f57307b38318e9d8416923e12ff47ed[]
+
+			response0.MatchesExample(@"GET _cat/ml/datafeeds?v");
+		}
+	}
+}

--- a/tests/Examples/Cat/DataframeanalyticsPage.cs
+++ b/tests/Examples/Cat/DataframeanalyticsPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Cat
+{
+	public class DataframeanalyticsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line124()
+		{
+			// tag::7c6f205c98da14c68d3d936639462dd3[]
+			var response0 = new SearchResponse<object>();
+			// end::7c6f205c98da14c68d3d936639462dd3[]
+
+			response0.MatchesExample(@"GET _cat/ml/data_frame/analytics?v");
+		}
+	}
+}

--- a/tests/Examples/Cat/HealthPage.cs
+++ b/tests/Examples/Cat/HealthPage.cs
@@ -5,24 +5,24 @@ namespace Examples.Cat
 {
 	public class HealthPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line69()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
-			var response0 = new SearchResponse<object>();
+			var catResponse = client.Cat.Health(h => h.Verbose());
 			// end::f8cc4b331a19ff4df8e4a490f906ee69[]
 
-			response0.MatchesExample(@"GET /_cat/health?v");
+			catResponse.MatchesExample(@"GET /_cat/health?v");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line89()
 		{
 			// tag::ccd9e2cf7181de67cf9ab0df1a02c575[]
-			var response0 = new SearchResponse<object>();
+			var catResponse = client.Cat.Health(h => h.Verbose().IncludeTimestamp(false));
 			// end::ccd9e2cf7181de67cf9ab0df1a02c575[]
 
-			response0.MatchesExample(@"GET /_cat/health?v&ts=false");
+			catResponse.MatchesExample(@"GET /_cat/health?v&ts=false");
 		}
 	}
 }

--- a/tests/Examples/Cat/TasksPage.cs
+++ b/tests/Examples/Cat/TasksPage.cs
@@ -5,18 +5,9 @@ namespace Examples.Cat
 {
 	public class TasksPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
-		public void Line79()
-		{
-			// tag::611a684aab4aa256dd9eb873f8b1e450[]
-			var response0 = new SearchResponse<object>();
-			// end::611a684aab4aa256dd9eb873f8b1e450[]
-
-			response0.MatchesExample(@"GET _cat/tasks/oTUltX4IQMOUUVeiohTt8A:124?v");
-		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line67()
 		{
 			// tag::f3422381d36398fcb2612692b11b1e96[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cat/TrainedmodelPage.cs
+++ b/tests/Examples/Cat/TrainedmodelPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Cat
+{
+	public class TrainedmodelPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line113()
+		{
+			// tag::1d56d3532d30d60c1d93d75b6a377a49[]
+			var response0 = new SearchResponse<object>();
+			// end::1d56d3532d30d60c1d93d75b6a377a49[]
+
+			response0.MatchesExample(@"GET _cat/ml/trained_models?h=c,o,l,ct,v&v");
+		}
+	}
+}

--- a/tests/Examples/Ccr/Apis/AutoFollow/PauseAutoFollowPatternPage.cs
+++ b/tests/Examples/Ccr/Apis/AutoFollow/PauseAutoFollowPatternPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ccr.Apis.AutoFollow
 	public class PauseAutoFollowPatternPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line69()
+		public void Line76()
 		{
 			// tag::b25256ed615cd837461b0bfa590526b7[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ccr/Apis/AutoFollow/ResumeAutoFollowPatternPage.cs
+++ b/tests/Examples/Ccr/Apis/AutoFollow/ResumeAutoFollowPatternPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ccr.Apis.AutoFollow
 	public class ResumeAutoFollowPatternPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line77()
 		{
 			// tag::f2e854b6c99659ccc1824e86c096e433[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ccr/GettingStartedPage.cs
+++ b/tests/Examples/Ccr/GettingStartedPage.cs
@@ -39,7 +39,7 @@ namespace Examples.Ccr
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line164()
+		public void Line165()
 		{
 			// tag::74ed3197e0e77750f5255c6df0cc0fe5[]
 			var response0 = new SearchResponse<object>();
@@ -82,7 +82,7 @@ namespace Examples.Ccr
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line213()
+		public void Line214()
 		{
 			// tag::278da0495c9008e6d9f25a5d5f0339b7[]
 			var response0 = new SearchResponse<object>();
@@ -96,7 +96,7 @@ namespace Examples.Ccr
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line275()
+		public void Line276()
 		{
 			// tag::6b104a66ab47fc1e1f24a5738f82feb4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ccr/OverviewPage.cs
+++ b/tests/Examples/Ccr/OverviewPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ccr
 	public class OverviewPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line194()
+		public void Line205()
 		{
 			// tag::7c5e41a7c0075d87b8f8348a6efa990c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/AllocationExplainPage.cs
+++ b/tests/Examples/Cluster/AllocationExplainPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Cluster
 	{
 
 		[U(Skip = "Example not implemented")]
-		public void Line74()
+		public void Line77()
 		{
 			// tag::2663038cfc46b106edaef607d553c99c[]
 			var response0 = new SearchResponse<object>();
@@ -22,7 +22,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line87()
+		public void Line90()
 		{
 			// tag::75fb2de2b47c564833ab14049c295384[]
 			var response0 = new SearchResponse<object>();
@@ -38,20 +38,20 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line104()
+		public void Line114()
 		{
-			// tag::a21f2014288a2d2c82585be4eb85708c[]
+			// tag::9db57741b46cc9f088cebd6a34ba147d[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::a21f2014288a2d2c82585be4eb85708c[]
+			// end::9db57741b46cc9f088cebd6a34ba147d[]
 
-			response0.MatchesExample(@"PUT /idx?master_timeout=1s&timeout=1s
+			response0.MatchesExample(@"PUT /my_index?master_timeout=1s&timeout=1s
 			{""settings"": {""index.routing.allocation.include._name"": ""non_existent_node""} }");
 
 			response1.MatchesExample(@"GET /_cluster/allocation/explain
 			{
-			  ""index"": ""idx"",
+			  ""index"": ""my_index"",
 			  ""shard"": 0,
 			  ""primary"": true
 			}");

--- a/tests/Examples/Cluster/HealthPage.cs
+++ b/tests/Examples/Cluster/HealthPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class HealthPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line32()
+		public void Line35()
 		{
 			// tag::04f5dd677c777bcb15d7d5fa63275fc8[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line140()
+		public void Line143()
 		{
 			// tag::b02e4907c9936c1adc16ccce9d49900d[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line176()
+		public void Line179()
 		{
 			// tag::c48264ec5d9b9679fddd72e5c44425b9[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/NodesHotThreadsPage.cs
+++ b/tests/Examples/Cluster/NodesHotThreadsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class NodesHotThreadsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line61()
+		public void Line64()
 		{
 			// tag::77c099c97ea6911e2dd6e996da7dcca0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/NodesInfoPage.cs
+++ b/tests/Examples/Cluster/NodesInfoPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Cluster
 	{
 
 		[U(Skip = "Example not implemented")]
-		public void Line162()
+		public void Line165()
 		{
 			// tag::3c4d7ef8422d2db423a8f23effcddaa1[]
 			var response0 = new SearchResponse<object>();
@@ -53,7 +53,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line189()
+		public void Line192()
 		{
 			// tag::68b64313bf89ec3f2c645da61999dbb4[]
 			var response0 = new SearchResponse<object>();
@@ -63,7 +63,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line260()
+		public void Line263()
 		{
 			// tag::0c464965126cc09e6812716a145991d4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/NodesReloadSecureSettingsPage.cs
+++ b/tests/Examples/Cluster/NodesReloadSecureSettingsPage.cs
@@ -1,0 +1,22 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Cluster
+{
+	public class NodesReloadSecureSettingsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line54()
+		{
+			// tag::72f20e645e118715b6197c2087b4db86[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::72f20e645e118715b6197c2087b4db86[]
+
+			response0.MatchesExample(@"POST _nodes/reload_secure_settings");
+
+			response1.MatchesExample(@"POST _nodes/nodeId1,nodeId2/reload_secure_settings");
+		}
+	}
+}

--- a/tests/Examples/Cluster/NodesStatsPage.cs
+++ b/tests/Examples/Cluster/NodesStatsPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Cluster
 	{
 
 		[U(Skip = "Example not implemented")]
-		public void Line440()
+		public void Line1363()
 		{
 			// tag::5457c94f0039c6b95c7f9f305d0c6b58[]
 			var response0 = new SearchResponse<object>();
@@ -37,7 +37,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line458()
+		public void Line1381()
 		{
 			// tag::150b5fee5678bf8cdf0932da73eada80[]
 			var response0 = new SearchResponse<object>();
@@ -75,7 +75,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line476()
+		public void Line1399()
 		{
 			// tag::bd68666ca2e0be12f7624016317a62bc[]
 			var response0 = new SearchResponse<object>();
@@ -97,7 +97,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line492()
+		public void Line1415()
 		{
 			// tag::09769561f082b50558fb7d8707719963[]
 			var response0 = new SearchResponse<object>();
@@ -107,7 +107,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line500()
+		public void Line1423()
 		{
 			// tag::ef9c29759459904fef162acd223462c4[]
 			var response0 = new SearchResponse<object>();
@@ -117,7 +117,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line508()
+		public void Line1431()
 		{
 			// tag::f160561efab38e40c2feebf5a2542ab5[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/NodesUsagePage.cs
+++ b/tests/Examples/Cluster/NodesUsagePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class NodesUsagePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line58()
+		public void Line61()
 		{
 			// tag::3d6a56dd3d93ece0e3da3fb66b4696d3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/ReroutePage.cs
+++ b/tests/Examples/Cluster/ReroutePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class ReroutePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line177()
+		public void Line180()
 		{
 			// tag::c5488b3888749d3d5b9808ab28d384eb[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/StatePage.cs
+++ b/tests/Examples/Cluster/StatePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class StatePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line128()
+		public void Line133()
 		{
 			// tag::b66be1daf6c220eb66d94e708b2fae39[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line135()
+		public void Line140()
 		{
 			// tag::0fa220ee3fb267020382f74aa70eb1e9[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line142()
+		public void Line147()
 		{
 			// tag::a3cfd350c73a104b99a998c6be931408[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/StatsPage.cs
+++ b/tests/Examples/Cluster/StatsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Cluster
 	public class StatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line43()
+		public void Line347()
 		{
 			// tag::861f5f61409dc87f3671293b87839ff7[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line266()
+		public void Line591()
 		{
 			// tag::71c629c44bf3c542a0daacbfc253c4b0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/UpdateSettingsPage.cs
+++ b/tests/Examples/Cluster/UpdateSettingsPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Cluster
 	{
 
 		[U(Skip = "Example not implemented")]
-		public void Line62()
+		public void Line65()
 		{
 			// tag::37f4bd6dd220db648998fc340b3dfa69[]
 			var response0 = new SearchResponse<object>();
@@ -22,7 +22,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line75()
+		public void Line78()
 		{
 			// tag::8c05281b724106e703c05df661188c4f[]
 			var response0 = new SearchResponse<object>();
@@ -37,7 +37,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line104()
+		public void Line107()
 		{
 			// tag::1f25c9ef11f574f1ba0ad974bf653cd4[]
 			var response0 = new SearchResponse<object>();
@@ -52,7 +52,7 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line134()
 		{
 			// tag::32496570a397852bece96f4da5d17a7e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Docs/BulkPage.cs
+++ b/tests/Examples/Docs/BulkPage.cs
@@ -1,6 +1,4 @@
 using Elastic.Xunit.XunitPlumbing;
-using Elasticsearch.Net;
-using Nest;
 using Newtonsoft.Json.Linq;
 
 namespace Examples.Docs

--- a/tests/Examples/Docs/DeleteByQueryPage.cs
+++ b/tests/Examples/Docs/DeleteByQueryPage.cs
@@ -44,7 +44,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line347()
+		public void Line349()
 		{
 			// tag::e21e1c26dc8687e7bf7bd2bf019a6698[]
 			var deleteByQueryResponse = client.DeleteByQuery<Tweet>(d => d
@@ -63,7 +63,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line360()
+		public void Line362()
 		{
 			// tag::c22b72c4a52ee098331b3f252c22860d[]
 			var deleteByQueryResponse = client.DeleteByQuery<object>(d => d
@@ -81,7 +81,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line374()
+		public void Line376()
 		{
 			// tag::c32a3f8071d87f0a3f5a78e07fe7a669[]
 			var deleteByQueryResponse = client.DeleteByQuery<Tweet>(d => d
@@ -117,7 +117,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line392()
+		public void Line394()
 		{
 			// tag::dfb1fe96d806a644214d06f9b4b87878[]
 			var deleteByQueryResponse = client.DeleteByQuery<Tweet>(d => d
@@ -151,7 +151,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line412()
+		public void Line414()
 		{
 			// tag::1e49eba5b9042c1900a608fe5105ba43[]
 			var deleteByQueryResponse = client.DeleteByQuery<Tweet>(d => d
@@ -231,7 +231,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line447()
+		public void Line449()
 		{
 			// tag::3e573bfabe00f8bfb8bb69aa5820768e[]
 			var refreshResponse = client.Indices.Refresh();
@@ -280,7 +280,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line485()
+		public void Line487()
 		{
 			// tag::a5a7050fb9dcb9574e081957ade28617[]
 			var deleteByQueryResponse = client.DeleteByQuery<Tweet>(d => d
@@ -319,7 +319,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line502()
+		public void Line504()
 		{
 			// tag::14701dcc0cca9665fce2aace0cb62af7[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -358,7 +358,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line570()
+		public void Line572()
 		{
 			// tag::52c7e4172a446c394210a07c464c57d2[]
 			var rethrottleResponse = client.DeleteByQueryRethrottle("r1A2WoRbTwKZ516z6NEs5A:36619",
@@ -371,7 +371,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line584()
+		public void Line586()
 		{
 			// tag::216848930c2d344fe0bed0daa70c35b9[]
 			var listTasksResponse = client.Tasks.List(t => t
@@ -384,7 +384,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line638()
+		public void Line640()
 		{
 			// tag::be3a6431d01846950dc1a39a7a6a1faa[]
 			var getTaskResponse = client.Tasks.GetTask("r1A2WoRbTwKZ516z6NEs5A:36619");
@@ -394,7 +394,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line658()
+		public void Line660()
 		{
 			// tag::18ddb7e7a4bcafd449df956e828ed7a8[]
 			var cancelTaskResponse = client.Tasks.Cancel(t => t

--- a/tests/Examples/Docs/IndexPage.cs
+++ b/tests/Examples/Docs/IndexPage.cs
@@ -10,7 +10,7 @@ namespace Examples.Docs
 	{
 
 		[U]
-		public void Line145()
+		public void Line146()
 		{
 			// tag::804a97ff4d0613e6568e4efb19c52021[]
 			var putSettingsResponse = client.Cluster.PutSettings(s => s
@@ -55,7 +55,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line194()
+		public void Line195()
 		{
 			// tag::36818c6d9f434d387819c30bd9addb14[]
 			var indexResponse = client.Index(new Tweet
@@ -78,7 +78,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line243()
+		public void Line244()
 		{
 			// tag::625dc94df1f9affb49a082fd99d41620[]
 			var indexResponse = client.Index(new Tweet
@@ -102,7 +102,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line365()
+		public void Line366()
 		{
 			// tag::b918d6b798da673a33e49b94f61dcdc0[]
 			var indexResponse = client.Index(new Tweet
@@ -127,7 +127,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line394()
+		public void Line395()
 		{
 			// tag::1f336ecc62480c1d56351cc2f82d0d08[]
 			var indexResponse = client.Index(new Tweet
@@ -148,7 +148,7 @@ namespace Examples.Docs
 			}");
 		}
 		[U]
-		public void Line452()
+		public void Line453()
 		{
 			// tag::bb143628fd04070683eeeadc9406d9cc[]
 			var indexResponse = client.Index(new Tweet
@@ -169,7 +169,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line485()
+		public void Line486()
 		{
 			// tag::048d8abd42d094bbdcf4452a58ccb35b[]
 			var createResponse = client.Create(new Tweet
@@ -193,7 +193,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line498()
+		public void Line499()
 		{
 			// tag::d718b63cf1b6591a1d59a0cf4fd995eb[]
 			var indexResponse = client.Index(new Tweet

--- a/tests/Examples/Docs/ReindexPage.cs
+++ b/tests/Examples/Docs/ReindexPage.cs
@@ -1,18 +1,25 @@
+using System;
+using System.Collections.Generic;
 using Elastic.Xunit.XunitPlumbing;
-using Nest;
+using Elasticsearch.Net;
+using Examples.Models;
+using Newtonsoft.Json.Linq;
 
 namespace Examples.Docs
 {
 	public class ReindexPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line20()
 		{
 			// tag::0cc991e3f7f8511a34730e154b3c5edc[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter"))
+				 .Destination(d => d.Index("new_twitter"))
+			);
 			// end::0cc991e3f7f8511a34730e154b3c5edc[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter""
@@ -23,26 +30,34 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line161()
 		{
 			// tag::68738b4fd0dda177022be45be95b4c84[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexRethrottle("r1A2WoRbTwKZ516z6NEs5A:36619", d =>
+				d.RequestsPerSecond(-1)
+			);
 			// end::68738b4fd0dda177022be45be95b4c84[]
 
-			response0.MatchesExample(@"POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1");
+			reindexResponse.MatchesExample(@"POST _reindex/r1A2WoRbTwKZ516z6NEs5A:36619/_rethrottle?requests_per_second=-1");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line191()
 		{
 			// tag::1b8655e6ba99fe39933c6eafe78728b7[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse1 = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter").Slice<Tweet>(r => r.Id(0).Max(2)))
+				 .Destination(d => d.Index("new_twitter"))
+			);
 
-			var response1 = new SearchResponse<object>();
+			var reindexResponse2 = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter").Slice<Tweet>(r => r.Id(1).Max(2)))
+				 .Destination(d => d.Index("new_twitter"))
+			);
 			// end::1b8655e6ba99fe39933c6eafe78728b7[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse1.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter"",
@@ -56,7 +71,7 @@ namespace Examples.Docs
 			  }
 			}");
 
-			response1.MatchesExample(@"POST _reindex
+			reindexResponse2.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter"",
@@ -71,28 +86,41 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line224()
 		{
 			// tag::3ae03ba3b56e5e287953094050766738[]
-			var response0 = new SearchResponse<object>();
+			var refreshResponse = client.Indices.Refresh();
 
-			var response1 = new SearchResponse<object>();
+			var searchResponse = client.Search<Tweet>(s => s.Index("new_twitter").Size(0).FilterPath(new[] { "hits.total" }));
 			// end::3ae03ba3b56e5e287953094050766738[]
 
-			response0.MatchesExample(@"GET _refresh");
+			refreshResponse.MatchesExample(@"GET _refresh", e =>
+			{
+				e.Method = HttpMethod.POST;
+				return e;
+			});
 
-			response1.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total");
+			searchResponse.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total", e =>
+			{
+				e.MoveQueryStringToBody("size", 0);
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line251()
 		{
 			// tag::cb01106bf524df5e0501d4c655c1aa7b[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter"))
+				 .Destination(d => d.Index("new_twitter"))
+				 .Slices(5)
+				 .Refresh()
+			);
 			// end::cb01106bf524df5e0501d4c655c1aa7b[]
 
-			response0.MatchesExample(@"POST _reindex?slices=5&refresh
+			reindexResponse.MatchesExample(@"POST _reindex?slices=5&refresh
 			{
 			  ""source"": {
 			    ""index"": ""twitter""
@@ -103,24 +131,33 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line267()
 		{
 			// tag::e567e6dbf86300142573c73789c8fce4[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<Tweet>(s => s.Index("new_twitter").Size(0).FilterPath(new[] { "hits.total" }));
 			// end::e567e6dbf86300142573c73789c8fce4[]
 
-			response0.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total");
+			searchResponse.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total", e =>
+			{
+				e.MoveQueryStringToBody("size", 0);
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line359()
 		{
 			// tag::78c96113ae4ed0054e581b17542528a7[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("source").Query<object>(q => q.Match(m => m.Field("company").Query("cat"))))
+				 .Destination(d => d.Index("dest").Routing("=cat"))
+				 .Slices(5)
+				 .Refresh()
+			);
 			// end::78c96113ae4ed0054e581b17542528a7[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""source"",
@@ -134,17 +171,23 @@ namespace Examples.Docs
 			    ""index"": ""dest"",
 			    ""routing"": ""=cat""
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["source"]["query"]["match"]["company"].ToLongFormQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line384()
 		{
 			// tag::400e89eb46ead8e9c9e40f123fd5e590[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("source").Size(100))
+				 .Destination(d => d.Index("dest").Routing("=cat"))
+			);
 			// end::400e89eb46ead8e9c9e40f123fd5e590[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""source"",
@@ -157,14 +200,17 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line403()
 		{
 			// tag::b1efa1c51a34dd5ab5511b71a399f5b1[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("source"))
+				 .Destination(d => d.Index("dest").Pipeline("some_ingest_pipeline"))
+			);
 			// end::b1efa1c51a34dd5ab5511b71a399f5b1[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""source""
@@ -176,14 +222,17 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line592()
 		{
 			// tag::764f9884b370cbdc82a1c5c42ed40ff3[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter").Query<Tweet>(q => q.Term(f => f.User, "kimchy")))
+				 .Destination(d => d.Index("new_twitter"))
+			);
 			// end::764f9884b370cbdc82a1c5c42ed40ff3[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter"",
@@ -196,17 +245,24 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""new_twitter""
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["source"]["query"]["term"]["user"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line618()
 		{
 			// tag::52b2bfbdd78f8283b6f4891c48013237[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter"))
+				 .Destination(d => d.Index("new_twitter"))
+				 .MaximumDocuments(1)
+			);
 			// end::52b2bfbdd78f8283b6f4891c48013237[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""max_docs"": 1,
 			  ""source"": {
@@ -218,14 +274,17 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line640()
 		{
 			// tag::6f097c298a7abf4c032c4314920c49c8[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index(new [] { "twitter", "blog" }))
+				 .Destination(d => d.Index("all_together"))
+			);
 			// end::6f097c298a7abf4c032c4314920c49c8[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": [""twitter"", ""blog""]
@@ -233,17 +292,24 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""all_together""
 			  }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(b => { b["source"]["index"] = b["source"]["index"].Flatten<string>(); });
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line666()
 		{
 			// tag::e9c2e15b36372d5281c879d336322b6c[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter").Source<object>(s => s.Fields("user", "_doc")))
+				 .Destination(d => d.Index("new_twitter"))
+			);
 			// end::e9c2e15b36372d5281c879d336322b6c[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter"",
@@ -255,28 +321,37 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line687()
 		{
 			// tag::1577e6e806b3283c9e99f1596d310754[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new { text = "words words", flag = "foo" },
+				i =>  i.Index("test").Id(1).Refresh(Refresh.True));
 			// end::1577e6e806b3283c9e99f1596d310754[]
 
-			response0.MatchesExample(@"POST test/_doc/1?refresh
+			indexResponse.MatchesExample(@"POST test/_doc/1?refresh
 			{
 			  ""text"": ""words words"",
 			  ""flag"": ""foo""
-			}");
+			}", e =>
+			{
+				e.Method = HttpMethod.PUT;
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line699()
 		{
 			// tag::1216f8f7367df3aa823012cef310c08a[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("test"))
+				 .Destination(d => d.Index("test2"))
+				 .Script(@"ctx._source.tag = ctx._source.remove(""flag"")")
+			);
 			// end::1216f8f7367df3aa823012cef310c08a[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""test""
@@ -290,40 +365,46 @@ namespace Examples.Docs
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line718()
 		{
 			// tag::cfc37446bd892d1ac42a3c8e8b204e6c[]
-			var response0 = new SearchResponse<object>();
+			var getResponse = client.Get<object>(1, d => d.Index("test2"));
 			// end::cfc37446bd892d1ac42a3c8e8b204e6c[]
 
-			response0.MatchesExample(@"GET test2/_doc/1");
+			getResponse.MatchesExample(@"GET test2/_doc/1");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line751()
 		{
 			// tag::9a4d5e41c52c20635d1fd9c6e13f6c7a[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse1 = client.Index(new Dictionary<string, double> { { "system.cpu.idle.pct", 0.908 } },
+				i =>  i.Index("metricbeat-2016.05.30").Id(1).Refresh(Refresh.True));
 
-			var response1 = new SearchResponse<object>();
+			var indexResponse2 = client.Index(new Dictionary<string, double> { { "system.cpu.idle.pct", 0.105 } },
+				i =>  i.Index("metricbeat-2016.05.31").Id(1).Refresh(Refresh.True));
 			// end::9a4d5e41c52c20635d1fd9c6e13f6c7a[]
 
-			response0.MatchesExample(@"PUT metricbeat-2016.05.30/_doc/1?refresh
+			indexResponse1.MatchesExample(@"PUT metricbeat-2016.05.30/_doc/1?refresh
 			{""system.cpu.idle.pct"": 0.908}");
 
-			response1.MatchesExample(@"PUT metricbeat-2016.05.31/_doc/1?refresh
+			indexResponse2.MatchesExample(@"PUT metricbeat-2016.05.31/_doc/1?refresh
 			{""system.cpu.idle.pct"": 0.105}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line767()
 		{
 			// tag::973a3ff47fc4ce036ecd9bd363fef9f7[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("metricbeat-*"))
+				 .Destination(d => d.Index("metricbeat"))
+				 .Script(@"ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'")
+			);
 			// end::973a3ff47fc4ce036ecd9bd363fef9f7[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""metricbeat-*""
@@ -335,31 +416,39 @@ namespace Examples.Docs
 			    ""lang"": ""painless"",
 			    ""source"": ""ctx._index = 'metricbeat-' + (ctx._index.substring('metricbeat-'.length(), ctx._index.length())) + '-1'""
 			  }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(o => ((JObject)o["script"]).Remove("lang"));
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line787()
 		{
 			// tag::3b04cc894e6a47d57983484010feac0c[]
-			var response0 = new SearchResponse<object>();
+			var getResponse1 = client.Get<object>(1, i => i.Index("metricbeat-2016.05.30-1"));
 
-			var response1 = new SearchResponse<object>();
+			var getResponse2 = client.Get<object>(1, i => i.Index("metricbeat-2016.05.31-1"));
 			// end::3b04cc894e6a47d57983484010feac0c[]
 
-			response0.MatchesExample(@"GET metricbeat-2016.05.30-1/_doc/1");
+			getResponse1.MatchesExample(@"GET metricbeat-2016.05.30-1/_doc/1");
 
-			response1.MatchesExample(@"GET metricbeat-2016.05.31-1/_doc/1");
+			getResponse2.MatchesExample(@"GET metricbeat-2016.05.31-1/_doc/1");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line802()
 		{
 			// tag::1bc731a4df952228af6dfa6b48627332[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.MaximumDocuments(10)
+				 .Source(s => s.Index("twitter").Query<object>(q => q.FunctionScore(f => f.Functions(ff => ff.RandomScore()).MinScore(0.9))))
+				 .Destination(d => d.Index("random_twitter"))
+			);
 			// end::1bc731a4df952228af6dfa6b48627332[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""max_docs"": 10,
 			  ""source"": {
@@ -374,17 +463,31 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""random_twitter""
 			  }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(o =>
+				{
+					((JObject)o["source"]["query"]["function_score"]).Remove("random_score");
+					var array = new JArray { JToken.FromObject(new { random_score = new object() }) };
+					((JObject)o["source"]["query"]["function_score"]).Add("functions", array);
+				});;
+
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line833()
 		{
 			// tag::8871b8fcb6de4f0c7dff22798fb10fb7[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s.Index("twitter"))
+				 .Destination(d => d.Index("new_twitter").VersionType(VersionType.External))
+				 .Script(@"if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}")
+			);
 			// end::8871b8fcb6de4f0c7dff22798fb10fb7[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""index"": ""twitter""
@@ -397,17 +500,30 @@ namespace Examples.Docs
 			    ""source"": ""if (ctx._source.foo == 'bar') {ctx._version++; ctx._source.remove('foo')}"",
 			    ""lang"": ""painless""
 			  }
-			}");
+			}", e =>
+			{
+				e.ApplyBodyChanges(o => ((JObject)o["script"]).Remove("lang"));
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line888()
 		{
 			// tag::36b2778f23d0955255f52c075c4d213d[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s
+						.Index("source")
+						.Remote(r => r
+							.Host(new Uri("http://otherhost:9200"))
+							.Username("user")
+							.Password("pass"))
+						.Query<object>(q => q.Match(m => m.Field("test").Query("data"))))
+				 .Destination(d => d.Index("dest"))
+			);
 			// end::36b2778f23d0955255f52c075c4d213d[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""remote"": {
@@ -425,17 +541,27 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""dest""
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["source"]["query"]["match"]["test"].ToLongFormQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line955()
 		{
 			// tag::64b9baa6d7556b960b29698f3383aa31[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s
+						.Remote(r => r.Host(new Uri("http://otherhost:9200")))
+						.Index("source")
+						.Size(10)
+						.Query<object>(q => q.Match(m => m.Field("test").Query("data"))))
+					.Destination(d => d.Index("dest"))
+			);
 			// end::64b9baa6d7556b960b29698f3383aa31[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""remote"": {
@@ -452,17 +578,30 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""dest""
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["source"]["query"]["match"]["test"].ToLongFormQuery();
+			});
 		}
 
 		[U(Skip = "Example not implemented")]
 		public void Line986()
 		{
 			// tag::7f697eb436dfa3c30dfe610d8c32d132[]
-			var response0 = new SearchResponse<object>();
+			var reindexResponse = client.ReindexOnServer(d =>
+				d.Source(s => s
+						.Index("source")
+						.Remote(r => r
+							.Host(new Uri("http://otherhost:9200"))
+							//.SocketTimeout("1m")
+							//.ConnectTimeout("10s")
+							.Password("pass"))
+						.Query<object>(q => q.Match(m => m.Field("test").Query("data"))))
+					.Destination(d => d.Index("dest"))
+			);
 			// end::7f697eb436dfa3c30dfe610d8c32d132[]
 
-			response0.MatchesExample(@"POST _reindex
+			reindexResponse.MatchesExample(@"POST _reindex
 			{
 			  ""source"": {
 			    ""remote"": {
@@ -480,7 +619,10 @@ namespace Examples.Docs
 			  ""dest"": {
 			    ""index"": ""dest""
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["source"]["query"]["match"]["test"].ToLongFormQuery();
+			});
 		}
 	}
 }

--- a/tests/Examples/Docs/ReindexPage.cs
+++ b/tests/Examples/Docs/ReindexPage.cs
@@ -177,7 +177,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line587()
+		public void Line592()
 		{
 			// tag::764f9884b370cbdc82a1c5c42ed40ff3[]
 			var response0 = new SearchResponse<object>();
@@ -200,7 +200,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line613()
+		public void Line618()
 		{
 			// tag::52b2bfbdd78f8283b6f4891c48013237[]
 			var response0 = new SearchResponse<object>();
@@ -219,27 +219,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line634()
-		{
-			// tag::96064cf450ccd198ac03cd0c33d3be3d[]
-			var response0 = new SearchResponse<object>();
-			// end::96064cf450ccd198ac03cd0c33d3be3d[]
-
-			response0.MatchesExample(@"POST _reindex
-			{
-			  ""max_docs"": 10000,
-			  ""source"": {
-			    ""index"": ""twitter"",
-			    ""sort"": { ""date"": ""desc"" }
-			  },
-			  ""dest"": {
-			    ""index"": ""new_twitter""
-			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line657()
+		public void Line640()
 		{
 			// tag::6f097c298a7abf4c032c4314920c49c8[]
 			var response0 = new SearchResponse<object>();
@@ -257,7 +237,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line683()
+		public void Line666()
 		{
 			// tag::e9c2e15b36372d5281c879d336322b6c[]
 			var response0 = new SearchResponse<object>();
@@ -276,7 +256,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line704()
+		public void Line687()
 		{
 			// tag::1577e6e806b3283c9e99f1596d310754[]
 			var response0 = new SearchResponse<object>();
@@ -290,7 +270,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line716()
+		public void Line699()
 		{
 			// tag::1216f8f7367df3aa823012cef310c08a[]
 			var response0 = new SearchResponse<object>();
@@ -311,7 +291,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line735()
+		public void Line718()
 		{
 			// tag::cfc37446bd892d1ac42a3c8e8b204e6c[]
 			var response0 = new SearchResponse<object>();
@@ -321,7 +301,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line768()
+		public void Line751()
 		{
 			// tag::9a4d5e41c52c20635d1fd9c6e13f6c7a[]
 			var response0 = new SearchResponse<object>();
@@ -337,7 +317,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line784()
+		public void Line767()
 		{
 			// tag::973a3ff47fc4ce036ecd9bd363fef9f7[]
 			var response0 = new SearchResponse<object>();
@@ -359,7 +339,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line804()
+		public void Line787()
 		{
 			// tag::3b04cc894e6a47d57983484010feac0c[]
 			var response0 = new SearchResponse<object>();
@@ -373,11 +353,11 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line819()
+		public void Line802()
 		{
-			// tag::8b33c9257041fabad8cea43fa049f98f[]
+			// tag::1bc731a4df952228af6dfa6b48627332[]
 			var response0 = new SearchResponse<object>();
-			// end::8b33c9257041fabad8cea43fa049f98f[]
+			// end::1bc731a4df952228af6dfa6b48627332[]
 
 			response0.MatchesExample(@"POST _reindex
 			{
@@ -386,11 +366,10 @@ namespace Examples.Docs
 			    ""index"": ""twitter"",
 			    ""query"": {
 			      ""function_score"" : {
-			        ""query"" : { ""match_all"": {} },
-			        ""random_score"" : {}
+			        ""random_score"" : {},
+			        ""min_score"" : 0.9    <1>
 			      }
-			    },
-			    ""sort"": ""_score""    \<1>
+			    }
 			  },
 			  ""dest"": {
 			    ""index"": ""random_twitter""
@@ -399,7 +378,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line851()
+		public void Line833()
 		{
 			// tag::8871b8fcb6de4f0c7dff22798fb10fb7[]
 			var response0 = new SearchResponse<object>();
@@ -422,7 +401,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line906()
+		public void Line888()
 		{
 			// tag::36b2778f23d0955255f52c075c4d213d[]
 			var response0 = new SearchResponse<object>();
@@ -450,7 +429,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line973()
+		public void Line955()
 		{
 			// tag::64b9baa6d7556b960b29698f3383aa31[]
 			var response0 = new SearchResponse<object>();
@@ -477,7 +456,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1004()
+		public void Line986()
 		{
 			// tag::7f697eb436dfa3c30dfe610d8c32d132[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Docs/ReindexPage.cs
+++ b/tests/Examples/Docs/ReindexPage.cs
@@ -584,7 +584,7 @@ namespace Examples.Docs
 			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line986()
 		{
 			// tag::7f697eb436dfa3c30dfe610d8c32d132[]
@@ -593,9 +593,8 @@ namespace Examples.Docs
 						.Index("source")
 						.Remote(r => r
 							.Host(new Uri("http://otherhost:9200"))
-							//.SocketTimeout("1m")
-							//.ConnectTimeout("10s")
-							.Password("pass"))
+							.SocketTimeout("1m")
+							.ConnectTimeout("10s"))
 						.Query<object>(q => q.Match(m => m.Field("test").Query("data"))))
 					.Destination(d => d.Index("dest"))
 			);

--- a/tests/Examples/Docs/TermvectorsPage.cs
+++ b/tests/Examples/Docs/TermvectorsPage.cs
@@ -72,11 +72,11 @@ namespace Examples.Docs
 		[U(Skip = "Example not implemented")]
 		public void Line212()
 		{
-			// tag::3dbccd70f0a20ff7a8a2a4ee7ec406ed[]
+			// tag::c75bd2b34c51aecf55ece4137612d4c7[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::3dbccd70f0a20ff7a8a2a4ee7ec406ed[]
+			// end::c75bd2b34c51aecf55ece4137612d4c7[]
 
 			response0.MatchesExample(@"PUT /twitter/_doc/1
 			{
@@ -84,7 +84,7 @@ namespace Examples.Docs
 			  ""text"" : ""twitter test test test ""
 			}");
 
-			response1.MatchesExample(@"PUT /twitter/_doc/2
+			response1.MatchesExample(@"PUT /twitter/_doc/2?refresh=wait_for
 			{
 			  ""fullname"" : ""Jane Doe"",
 			  ""text"" : ""Another twitter test ...""

--- a/tests/Examples/Docs/UpdateByQueryPage.cs
+++ b/tests/Examples/Docs/UpdateByQueryPage.cs
@@ -341,19 +341,19 @@ namespace Examples.Docs
 			);
 
 			var indexResponse1 = client.Index(new
-				{
-					Text = "words words",
-					Flag = "bar"
-				},
+			{
+				Text = "words words",
+				Flag = "bar"
+			},
 				i => i
 					.Index("test")
 			);
 
 			var indexResponse2 = client.Index(new
-				{
-					Text = "words words",
-					Flag = "foo"
-				},
+			{
+				Text = "words words",
+				Flag = "foo"
+			},
 				i => i
 					.Index("test")
 			);

--- a/tests/Examples/Docs/UpdateByQueryPage.cs
+++ b/tests/Examples/Docs/UpdateByQueryPage.cs
@@ -23,7 +23,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line298()
+		public void Line300()
 		{
 			// tag::52a87b81e4e0b6b11e23e85db1602a63[]
 			var updateByQueryResponse = client.UpdateByQuery<Tweet>(u => u
@@ -54,11 +54,11 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line318()
+		public void Line319()
 		{
 			// tag::cde4dddae5c06e7f1d38c9d933dbc7ac[]
 			var updateByQueryResponse = client.UpdateByQuery<object>(u => u
-				.Index(new [] { "twitter", "blog" })
+				.Index(new[] { "twitter", "blog" })
 			);
 			// end::cde4dddae5c06e7f1d38c9d933dbc7ac[]
 
@@ -79,7 +79,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line337()
+		public void Line336()
 		{
 			// tag::54a770f053f3225ea0d1e34334232411[]
 			var updateByQueryResponse = client.UpdateByQuery<object>(u => u
@@ -92,7 +92,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line350()
+		public void Line348()
 		{
 			// tag::2fd69fb0538e4f36ac69a8b8f8bf5ae8[]
 			var updateByQueryResponse = client.UpdateByQuery<Tweet>(u => u
@@ -130,7 +130,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line392()
+		public void Line389()
 		{
 			// tag::c4b278ba293abd0d02a0b5ad1a99f84a[]
 			var putPipelineResponse = client.Ingest.PutPipeline("set-foo", p => p
@@ -164,7 +164,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line417()
+		public void Line413()
 		{
 			// tag::7df191cc7f814e410a4ac7261065e6ef[]
 			var listTasksResponse = client.Tasks.List(t => t
@@ -177,7 +177,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line475()
+		public void Line471()
 		{
 			// tag::be3a6431d01846950dc1a39a7a6a1faa[]
 			var getTaskResponse = client.Tasks.GetTask("r1A2WoRbTwKZ516z6NEs5A:36619");
@@ -187,7 +187,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line495()
+		public void Line491()
 		{
 			// tag::18ddb7e7a4bcafd449df956e828ed7a8[]
 			var cancelTasksResponse = client.Tasks.Cancel(c => c
@@ -199,7 +199,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line514()
+		public void Line510()
 		{
 			// tag::bdb30dd52d32f50994008f4f9c0da5f0[]
 			var updateByQueryRethrottleResponse = client.UpdateByQueryRethrottle(
@@ -212,7 +212,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line534()
+		public void Line530()
 		{
 			// tag::0d664883151008b1051ef2c9ab2d0373[]
 			var updateByQueryResponse = client.UpdateByQuery<Tweet>(u => u
@@ -262,7 +262,7 @@ namespace Examples.Docs
 		}
 
 		[U]
-		public void Line561()
+		public void Line557()
 		{
 			// tag::4acf902c2598b2558f34f20c1744c433[]
 			var refreshResponse = client.Indices.Refresh();
@@ -271,7 +271,7 @@ namespace Examples.Docs
 				.Index("twitter")
 				.Size(0)
 				.QueryOnQueryString("extra:test")
-				.FilterPath(new [] { "hits.total" }) // <1> Using filter path can result in a response that cannot be parsed by the client's serializer. In these cases, using the low level client and parsing the JSON response may be preferred.
+				.FilterPath(new[] { "hits.total" }) // <1> Using filter path can result in a response that cannot be parsed by the client's serializer. In these cases, using the low level client and parsing the JSON response may be preferred.
 			);
 			// end::4acf902c2598b2558f34f20c1744c433[]
 
@@ -289,7 +289,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line590()
+		public void Line586()
 		{
 			// tag::ea02de2dbe05091fcb0dac72c8ba5f83[]
 			var response0 = new SearchResponse<object>();
@@ -304,7 +304,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line603()
+		public void Line599()
 		{
 			// tag::025b54db0edc50c24ea48a2bd94366ad[]
 			var response0 = new SearchResponse<object>();
@@ -314,7 +314,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line659()
+		public void Line655()
 		{
 			// tag::2fe28d9a91b3081a9ec4601af8fb7b1c[]
 			var response0 = new SearchResponse<object>();
@@ -358,7 +358,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line697()
+		public void Line693()
 		{
 			// tag::abd4fc3ce7784413a56fe2dcfe2809b5[]
 			var response0 = new SearchResponse<object>();
@@ -375,7 +375,7 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line724()
+		public void Line720()
 		{
 			// tag::97babc8d19ef0866774576716eb6d19e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Docs/UpdatePage.cs
+++ b/tests/Examples/Docs/UpdatePage.cs
@@ -292,7 +292,7 @@ namespace Examples.Docs
 						})
 					)
 				)
-				.Upsert(new {})
+				.Upsert(new { })
 			);
 			// end::f9636d7ef1a45be4f36418c875cf6bef[]
 

--- a/tests/Examples/Eql/SearchPage.cs
+++ b/tests/Examples/Eql/SearchPage.cs
@@ -1,0 +1,40 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Eql
+{
+	public class SearchPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line17()
+		{
+			// tag::b34d7bd889b73989ea905a4565274ea3[]
+			var response0 = new SearchResponse<object>();
+			// end::b34d7bd889b73989ea905a4565274ea3[]
+
+			response0.MatchesExample(@"PUT sec_logs/_bulk?refresh
+			{""index"":{""_index"" : ""sec_logs""}}
+			{ ""@timestamp"": ""2020-12-07T11:06:07.000Z"", ""agent"": { ""id"": ""8a4f500d"" }, ""event"": { ""category"": ""process"" }, ""process"": { ""name"": ""cmd.exe"", ""path"": ""C:\\Windows\\System32\\cmd.exe"" } }
+			{""index"":{""_index"" : ""sec_logs""}}
+			{ ""@timestamp"": ""2020-12-07T11:07:08.000Z"", ""agent"": { ""id"": ""8a4f500d"" }, ""event"": { ""category"": ""image_load"" }, ""file"": { ""name"": ""cmd.exe"", ""path"": ""C:\\Windows\\System32\\cmd.exe"" }, ""process"": { ""name"": ""cmd.exe"", ""path"": ""C:\\Windows\\System32\\cmd.exe"" } }
+			{""index"":{""_index"" : ""sec_logs""}}
+			{ ""@timestamp"": ""2020-12-07T11:07:09.000Z"", ""agent"": { ""id"": ""8a4f500d"" }, ""event"": { ""category"": ""process"" }, ""process"": { ""name"": ""regsvr32.exe"", ""path"": ""C:\\Windows\\System32\\regsvr32.exe"" } }");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line34()
+		{
+			// tag::6022b11c1f1e3bbfb44395554c78827f[]
+			var response0 = new SearchResponse<object>();
+			// end::6022b11c1f1e3bbfb44395554c78827f[]
+
+			response0.MatchesExample(@"GET sec_logs/_eql/search
+			{
+			  ""event_type_field"": ""event.category"",
+			  ""rule"": """"""
+			    process where process.name == ""cmd.exe""
+			  """"""
+			}");
+		}
+	}
+}

--- a/tests/Examples/HowTo/SearchSpeedPage.cs
+++ b/tests/Examples/HowTo/SearchSpeedPage.cs
@@ -118,7 +118,7 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line187()
+		public void Line181()
 		{
 			// tag::102c7de25d13c87cf28839ada9f63c95[]
 			var response0 = new SearchResponse<object>();
@@ -149,7 +149,7 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line213()
+		public void Line207()
 		{
 			// tag::17dd67a66c49f7eb618dd17430e48dfa[]
 			var response0 = new SearchResponse<object>();
@@ -173,7 +173,7 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line246()
+		public void Line240()
 		{
 			// tag::abc7a670a47516b58b6b07d7497b140c[]
 			var response0 = new SearchResponse<object>();
@@ -219,7 +219,7 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line318()
+		public void Line312()
 		{
 			// tag::971c7a36ee79f2b3aa82c64ea338de70[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/DeleteLifecyclePage.cs
+++ b/tests/Examples/Ilm/Apis/DeleteLifecyclePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class DeleteLifecyclePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line77()
 		{
 			// tag::af517b6936fa41d124d68b107b2efdc3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/ExplainPage.cs
+++ b/tests/Examples/Ilm/Apis/ExplainPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class ExplainPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line91()
+		public void Line97()
 		{
 			// tag::0f6fa3a706a7c17858d3dbe329839ea6[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/GetLifecyclePage.cs
+++ b/tests/Examples/Ilm/Apis/GetLifecyclePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class GetLifecyclePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line69()
+		public void Line76()
 		{
 			// tag::2e7f4b9be999422a12abb680572b13c8[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/GetStatusPage.cs
+++ b/tests/Examples/Ilm/Apis/GetStatusPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class GetStatusPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line38()
+		public void Line44()
 		{
 			// tag::182df084f028479ecbe8d7648ddad892[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/MoveToStepPage.cs
+++ b/tests/Examples/Ilm/Apis/MoveToStepPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class MoveToStepPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line86()
+		public void Line93()
 		{
 			// tag::e3c5f93b3c85e8519f801defc20b0ce0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/PutLifecyclePage.cs
+++ b/tests/Examples/Ilm/Apis/PutLifecyclePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class PutLifecyclePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line46()
+		public void Line52()
 		{
 			// tag::daa2d4811bec05ac4546b66bd5a615c7[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/RemovePolicyFromIndexPage.cs
+++ b/tests/Examples/Ilm/Apis/RemovePolicyFromIndexPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class RemovePolicyFromIndexPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line76()
+		public void Line83()
 		{
 			// tag::8bec5a437f4aea6f3f897c9df2ce2442[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/StartPage.cs
+++ b/tests/Examples/Ilm/Apis/StartPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class StartPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line76()
 		{
 			// tag::72ae3851160fcf02b8e2cdfd4e57d238[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/Apis/StopPage.cs
+++ b/tests/Examples/Ilm/Apis/StopPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ilm.Apis
 	public class StopPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line74()
+		public void Line80()
 		{
 			// tag::585a34ad79aee16678b37da785933ac8[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/GettingStartedIlmPage.cs
+++ b/tests/Examples/Ilm/GettingStartedIlmPage.cs
@@ -6,28 +6,28 @@ namespace Examples.Ilm
 	public class GettingStartedIlmPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line29()
+		public void Line46()
 		{
-			// tag::993a81c69d26d94810172bee4043f0fd[]
+			// tag::f2dc1a1a2a6ba3c7c4273ce41ada4207[]
 			var response0 = new SearchResponse<object>();
-			// end::993a81c69d26d94810172bee4043f0fd[]
+			// end::f2dc1a1a2a6ba3c7c4273ce41ada4207[]
 
-			response0.MatchesExample(@"PUT _ilm/policy/datastream_policy   \<1>
+			response0.MatchesExample(@"PUT _ilm/policy/datastream_policy
 			{
-			  ""policy"": {                       \<2>
+			  ""policy"": {
 			    ""phases"": {
-			      ""hot"": {                      \<3>
+			      ""hot"": {                      <1>
 			        ""actions"": {
-			          ""rollover"": {             \<4>
-			            ""max_size"": ""50GB"",
+			          ""rollover"": {
+			            ""max_size"": ""50GB"",     <2>
 			            ""max_age"": ""30d""
 			          }
 			        }
 			      },
 			      ""delete"": {
-			        ""min_age"": ""90d"",           \<5>
+			        ""min_age"": ""90d"",           <3>
 			        ""actions"": {
-			          ""delete"": {}              \<6>
+			          ""delete"": {}              <4>
 			        }
 			      }
 			    }
@@ -36,7 +36,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line79()
+		public void Line93()
 		{
 			// tag::e3d7b19f993382750719cdfaad2fdd90[]
 			var response0 = new SearchResponse<object>();
@@ -55,7 +55,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line112()
+		public void Line135()
 		{
 			// tag::55ee835d7c28e933ad8fcb9e45af2bf2[]
 			var response0 = new SearchResponse<object>();
@@ -72,7 +72,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line155()
+		public void Line173()
 		{
 			// tag::a1dbaff15cf8166f74c443ca58258d7e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/IlmWithExistingIndicesPage.cs
+++ b/tests/Examples/Ilm/IlmWithExistingIndicesPage.cs
@@ -63,7 +63,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line118()
+		public void Line128()
 		{
 			// tag::75097f73665235b20df09739c820ad35[]
 			var response0 = new SearchResponse<object>();
@@ -106,7 +106,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line161()
+		public void Line171()
 		{
 			// tag::3feab5c602192b8dc58435654b17d3fe[]
 			var response0 = new SearchResponse<object>();
@@ -142,7 +142,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line203()
+		public void Line213()
 		{
 			// tag::ec195297eb804cba1cb19c9926773059[]
 			var response0 = new SearchResponse<object>();
@@ -159,13 +159,13 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line245()
+		public void Line255()
 		{
-			// tag::39bbb602c95c606725eefea252437514[]
+			// tag::8d39a0f0116702e981545d13371cd0eb[]
 			var response0 = new SearchResponse<object>();
-			// end::39bbb602c95c606725eefea252437514[]
+			// end::8d39a0f0116702e981545d13371cd0eb[]
 
-			response0.MatchesExample(@"PUT _ilm/policy/sample_policy
+			response0.MatchesExample(@"PUT _ilm/policy/mylogs_condensed_policy
 			{
 			  ""policy"": {
 			    ""phases"": {
@@ -183,7 +183,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line268()
+		public void Line278()
 		{
 			// tag::bce0d86353e212cee466ccbc90bdc6e7[]
 			var response0 = new SearchResponse<object>();
@@ -218,7 +218,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line307()
+		public void Line317()
 		{
 			// tag::89115f8d40d9a13b0b01dc7c33ffd1cc[]
 			var response0 = new SearchResponse<object>();
@@ -235,7 +235,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line336()
+		public void Line356()
 		{
 			// tag::5df1ed33b5fcf3b9d85c20d100780d43[]
 			var response0 = new SearchResponse<object>();
@@ -250,7 +250,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line363()
+		public void Line387()
 		{
 			// tag::41f211cc838f1bee7eac264784f905e2[]
 			var response0 = new SearchResponse<object>();
@@ -270,7 +270,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line393()
+		public void Line417()
 		{
 			// tag::227e19aecb349f31e74898384322ae01[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/PolicyDefinitionsPage.cs
+++ b/tests/Examples/Ilm/PolicyDefinitionsPage.cs
@@ -36,7 +36,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line156()
+		public void Line166()
 		{
 			// tag::1116c769f39f0c7fe86ec2a4871efcd5[]
 			var response0 = new SearchResponse<object>();
@@ -59,7 +59,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line178()
+		public void Line188()
 		{
 			// tag::0518c673094fb18ecb491a3b78af4695[]
 			var response0 = new SearchResponse<object>();
@@ -84,7 +84,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line203()
+		public void Line213()
 		{
 			// tag::9d461ae140ddc018efd2650559800cd1[]
 			var response0 = new SearchResponse<object>();
@@ -110,7 +110,30 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line233()
+		public void Line250()
+		{
+			// tag::83062a543163370328cf2e21a68c1bd3[]
+			var response0 = new SearchResponse<object>();
+			// end::83062a543163370328cf2e21a68c1bd3[]
+
+			response0.MatchesExample(@"PUT _ilm/policy/my_policy
+			{
+			  ""policy"": {
+			    ""phases"": {
+			      ""delete"": {
+			        ""actions"": {
+			          ""wait_for_snapshot"" : {
+			            ""policy"": ""slm-policy-name""
+			          }
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line277()
 		{
 			// tag::053497b6960f80fd7b005b7c6d54358f[]
 			var response0 = new SearchResponse<object>();
@@ -131,7 +154,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line271()
+		public void Line324()
 		{
 			// tag::eb5486d2fe4283475bf9e0e09280be16[]
 			var response0 = new SearchResponse<object>();
@@ -154,7 +177,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line297()
+		public void Line350()
 		{
 			// tag::0345fbd95c4516a89ac5ad261a16be8f[]
 			var response0 = new SearchResponse<object>();
@@ -175,7 +198,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line331()
+		public void Line384()
 		{
 			// tag::fc9a1b1173690a911725cff3912e9755[]
 			var response0 = new SearchResponse<object>();
@@ -196,7 +219,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line369()
+		public void Line422()
 		{
 			// tag::d7e7489b7d176aa854dfc785a12feab3[]
 			var response0 = new SearchResponse<object>();
@@ -217,7 +240,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line413()
+		public void Line466()
 		{
 			// tag::19211ccf772f1dee7b500c21f4a9a805[]
 			var response0 = new SearchResponse<object>();
@@ -240,7 +263,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line436()
+		public void Line489()
 		{
 			// tag::cfd4b34f35e531a20739a3b308d57134[]
 			var response0 = new SearchResponse<object>();
@@ -263,7 +286,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line459()
+		public void Line512()
 		{
 			// tag::d4a41fb74b41b41a0ee114a2311f2815[]
 			var response0 = new SearchResponse<object>();
@@ -286,7 +309,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line483()
+		public void Line536()
 		{
 			// tag::8940f2b911220acc9afef6360b6c13c4[]
 			var response0 = new SearchResponse<object>();
@@ -310,7 +333,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line508()
+		public void Line561()
 		{
 			// tag::f6c79fa1c01bb4539d0cba0bd62c1ce0[]
 			var response0 = new SearchResponse<object>();
@@ -339,7 +362,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line559()
+		public void Line612()
 		{
 			// tag::149a0eea54cdf6ea3052af6dba2d2a63[]
 			var response0 = new SearchResponse<object>();
@@ -362,7 +385,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line611()
+		public void Line664()
 		{
 			// tag::f3b4ddce8ff21fc1a76a7c0d9c36650e[]
 			var response0 = new SearchResponse<object>();
@@ -385,7 +408,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line666()
+		public void Line721()
 		{
 			// tag::a5a58e8ad66afe831bc295500e3e8739[]
 			var response0 = new SearchResponse<object>();
@@ -406,7 +429,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line691()
+		public void Line746()
 		{
 			// tag::d14a2a6c2a8b084495b8a64708226650[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/SetUpLifecyclePolicyPage.cs
+++ b/tests/Examples/Ilm/SetUpLifecyclePolicyPage.cs
@@ -54,7 +54,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line75()
+		public void Line85()
 		{
 			// tag::25737fd456fd317cc4cc2db76b6cf28e[]
 			var response0 = new SearchResponse<object>();
@@ -71,7 +71,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line98()
+		public void Line108()
 		{
 			// tag::160d259243d0800900b065c4b9d2b187[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/UsingPoliciesRolloverPage.cs
+++ b/tests/Examples/Ilm/UsingPoliciesRolloverPage.cs
@@ -54,7 +54,7 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line108()
+		public void Line118()
 		{
 			// tag::454e0e11e2bbb4718109a53662f8c45d[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/IndexModules/Allocation/FilteringPage.cs
+++ b/tests/Examples/IndexModules/Allocation/FilteringPage.cs
@@ -33,7 +33,7 @@ namespace Examples.IndexModules.Allocation
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line108()
+		public void Line109()
 		{
 			// tag::28ac880057135e46b3b00c7f3976538c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/IndexModules/SimilarityPage.cs
+++ b/tests/Examples/IndexModules/SimilarityPage.cs
@@ -8,25 +8,25 @@ namespace Examples.IndexModules
 		[U(Skip = "Example not implemented")]
 		public void Line22()
 		{
-			// tag::ce12fedff96537d4a5169724225f4287[]
+			// tag::2342a56279106ea643026df657bf7f88[]
 			var response0 = new SearchResponse<object>();
-			// end::ce12fedff96537d4a5169724225f4287[]
+			// end::2342a56279106ea643026df657bf7f88[]
 
 			response0.MatchesExample(@"PUT /index
 			{
-			    ""settings"" : {
-			        ""index"" : {
-			            ""similarity"" : {
-			              ""my_similarity"" : {
-			                ""type"" : ""DFR"",
-			                ""basic_model"" : ""g"",
-			                ""after_effect"" : ""l"",
-			                ""normalization"" : ""h2"",
-			                ""normalization.h2.c"" : ""3.0""
-			              }
-			            }
+			  ""settings"": {
+			    ""index"": {
+			      ""similarity"": {
+			        ""my_similarity"": {
+			          ""type"": ""DFR"",
+			          ""basic_model"": ""g"",
+			          ""after_effect"": ""l"",
+			          ""normalization"": ""h2"",
+			          ""normalization.h2.c"": ""3.0""
 			        }
+			      }
 			    }
+			  }
 			}");
 		}
 

--- a/tests/Examples/IndexModules/StorePage.cs
+++ b/tests/Examples/IndexModules/StorePage.cs
@@ -6,22 +6,22 @@ namespace Examples.IndexModules
 	public class StorePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line26()
+		public void Line30()
 		{
-			// tag::509322c2cfd2bcb2f4cbfd14666e1f43[]
+			// tag::fba99da14d4323c91794703438979912[]
 			var response0 = new SearchResponse<object>();
-			// end::509322c2cfd2bcb2f4cbfd14666e1f43[]
+			// end::fba99da14d4323c91794703438979912[]
 
 			response0.MatchesExample(@"PUT /my_index
 			{
 			  ""settings"": {
-			    ""index.store.type"": ""niofs""
+			    ""index.store.type"": ""hybridfs""
 			  }
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line116()
+		public void Line120()
 		{
 			// tag::9ba2e779fe3e9d12ed5fca1ba3f8be97[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/AliasExistsPage.cs
+++ b/tests/Examples/Indices/AliasExistsPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line64()
+		public void Line62()
 		{
 			// tag::666785827827be4b5252ec859c354d30[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/AliasesPage.cs
+++ b/tests/Examples/Indices/AliasesPage.cs
@@ -21,7 +21,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line156()
+		public void Line155()
 		{
 			// tag::b4392116f2cc57ce8064ccbad30318d5[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line172()
+		public void Line171()
 		{
 			// tag::3653567181f43a5f64c74f934aa821c2[]
 			var response0 = new SearchResponse<object>();
@@ -51,7 +51,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line190()
+		public void Line189()
 		{
 			// tag::af3fb9fa5691a7b37a6dc2a69ff66e64[]
 			var response0 = new SearchResponse<object>();
@@ -67,7 +67,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line208()
+		public void Line207()
 		{
 			// tag::f0e21e03a07c8fa0209b0aafdb3791e6[]
 			var response0 = new SearchResponse<object>();
@@ -83,7 +83,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line222()
+		public void Line221()
 		{
 			// tag::5f210f74725ea0c9265190346edfa246[]
 			var response0 = new SearchResponse<object>();
@@ -98,7 +98,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line239()
+		public void Line238()
 		{
 			// tag::6799d132c1c7ca3970763acde2337ef9[]
 			var response0 = new SearchResponse<object>();
@@ -113,7 +113,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line258()
+		public void Line257()
 		{
 			// tag::de176bc4788ea286fff9e92418a43ea8[]
 			var response0 = new SearchResponse<object>();
@@ -137,7 +137,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line286()
+		public void Line285()
 		{
 			// tag::23ab0f1023b1b2cd5cdf2a8f9ccfd57b[]
 			var response0 = new SearchResponse<object>();
@@ -156,7 +156,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line302()
+		public void Line301()
 		{
 			// tag::7cf71671859be7c1ecf673396db377cd[]
 			var response0 = new SearchResponse<object>();
@@ -177,7 +177,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line330()
+		public void Line329()
 		{
 			// tag::bc1ad5cc6d3eab98e3ce01f209ba7094[]
 			var response0 = new SearchResponse<object>();
@@ -198,7 +198,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line350()
+		public void Line349()
 		{
 			// tag::fa0f4485cd48f986b7ae8cbb24e331c4[]
 			var response0 = new SearchResponse<object>();
@@ -220,7 +220,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line376()
+		public void Line375()
 		{
 			// tag::427f6b5c5376cbf0f71f242a60ca3d9e[]
 			var response0 = new SearchResponse<object>();
@@ -230,7 +230,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line397()
+		public void Line396()
 		{
 			// tag::f6d6889667f56b8f49d2858070571a6b[]
 			var response0 = new SearchResponse<object>();
@@ -257,7 +257,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line423()
+		public void Line422()
 		{
 			// tag::b0ec418bf416c62bed602b0a32a6d5f5[]
 			var response0 = new SearchResponse<object>();
@@ -270,7 +270,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line435()
+		public void Line434()
 		{
 			// tag::67bba546d835bca8f31df13e3587c348[]
 			var response0 = new SearchResponse<object>();
@@ -280,7 +280,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line444()
+		public void Line443()
 		{
 			// tag::ad79228630684d950fe9792a768d24c5[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/Apis/FreezePage.cs
+++ b/tests/Examples/Indices/Apis/FreezePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Indices.Apis
 	public class FreezePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line43()
+		public void Line44()
 		{
 			// tag::ffea06f77c9df5720412aa06be964118[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/Apis/ReloadAnalyzersPage.cs
+++ b/tests/Examples/Indices/Apis/ReloadAnalyzersPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Indices.Apis
 	public class ReloadAnalyzersPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line14()
+		public void Line12()
 		{
 			// tag::b0015e63323171f38995b8e4aa2b52d5[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/ClearcachePage.cs
+++ b/tests/Examples/Indices/ClearcachePage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line101()
 		{
 			// tag::e97b14be2c4030bfc92e5d09a27e9fc9[]
 			var response0 = new SearchResponse<object>();
@@ -34,7 +34,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line119()
+		public void Line121()
 		{
 			// tag::62069c4118d79daf9612b29659b16627[]
 			var response0 = new SearchResponse<object>();
@@ -44,7 +44,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line133()
 		{
 			// tag::2f43c5e976713a5c5cd8eb4b08cfffca[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line141()
+		public void Line143()
 		{
 			// tag::c4a1d03dcfb82913d0724a42b0a89f20[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/ClosePage.cs
+++ b/tests/Examples/Indices/ClosePage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line64()
+		public void Line66()
 		{
 			// tag::3a6b9143f3de6258d44ff7e0eb38d953[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/CreateIndexPage.cs
+++ b/tests/Examples/Indices/CreateIndexPage.cs
@@ -17,7 +17,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line82()
+		public void Line81()
 		{
 			// tag::e5d2172b524332196cac0f031c043659[]
 			var createIndexResponse = client.Indices.Create("twitter", c => c
@@ -52,7 +52,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line100()
+		public void Line99()
 		{
 			// tag::b9c5d7ca6ca9c6f747201f45337a4abf[]
 			var createIndexResponse = client.Indices.Create("twitter", c => c
@@ -85,7 +85,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line124()
+		public void Line123()
 		{
 			// tag::dfef545b1e2c247bafd1347e8e807ac1[]
 			var createIndexResponse = client.Indices.Create("test", c => c
@@ -127,7 +127,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line148()
+		public void Line143()
 		{
 			// tag::4d56b179242fed59e3d6476f817b6055[]
 			var createIndexResponse = client.Indices.Create("test", c => c
@@ -162,7 +162,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line195()
+		public void Line190()
 		{
 			// tag::4d46dbb96125b27f46299547de9d8709[]
 			var createIndexResponse = client.Indices.Create("test", c => c
@@ -181,7 +181,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line208()
+		public void Line203()
 		{
 			// tag::fabe14480624a99e8ee42c7338672058[]
 			var createIndexResponse = client.Indices.Create("test", c => c

--- a/tests/Examples/Indices/FlushPage.cs
+++ b/tests/Examples/Indices/FlushPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line116()
+		public void Line117()
 		{
 			// tag::cefde3553fdbd516813e73a603c72c24[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line126()
+		public void Line127()
 		{
 			// tag::66db9f5108a3936115f1fb64c844934a[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line136()
+		public void Line137()
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/ForcemergePage.cs
+++ b/tests/Examples/Indices/ForcemergePage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line139()
+		public void Line141()
 		{
 			// tag::6733f91e27b6d5907d7c58546bc45ca1[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line149()
+		public void Line151()
 		{
 			// tag::480e531db799c4c909afd8e2a73a8d0b[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line165()
+		public void Line167()
 		{
 			// tag::64d97cda667be166f3df49e87e713560[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/GetAliasPage.cs
+++ b/tests/Examples/Indices/GetAliasPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line74()
+		public void Line76()
 		{
 			// tag::8118bad980d7afd31677b5060361ecd2[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line92()
+		public void Line94()
 		{
 			// tag::e85f2b38878f745a16edc575e78d7cde[]
 			var response0 = new SearchResponse<object>();
@@ -46,7 +46,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line125()
+		public void Line127()
 		{
 			// tag::a71c929ed2e322f91092d5dc625b6440[]
 			var response0 = new SearchResponse<object>();
@@ -56,7 +56,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line156()
+		public void Line158()
 		{
 			// tag::56aa1bff647d1db49dabf175c1e56919[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/GetIndexTemplatePage.cs
+++ b/tests/Examples/Indices/GetIndexTemplatePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Indices
 	public class GetIndexTemplatePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line24()
+		public void Line31()
 		{
 			// tag::02f65c6bab8f40bf3ce18160623d1870[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line64()
+		public void Line69()
 		{
 			// tag::24aee6033bf77a68ced74e3fd9d34283[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line73()
+		public void Line78()
 		{
 			// tag::ba6040de55afb2c8fb9e5b24bb038820[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line82()
+		public void Line87()
 		{
 			// tag::fd2d289e6b725fcc3cbe8fe7ffe02ea0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/GetMappingPage.cs
+++ b/tests/Examples/Indices/GetMappingPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line65()
+		public void Line60()
 		{
 			// tag::cf02e3d8b371bd59f0224967c36330da[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line75()
+		public void Line70()
 		{
 			// tag::09cdd5ae8114c49886026fef8d00a19c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/GetSettingsPage.cs
+++ b/tests/Examples/Indices/GetSettingsPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line66()
+		public void Line68()
 		{
 			// tag::c538fc182f433e7141aee9d75c3e42d2[]
 			var response0 = new SearchResponse<object>();
@@ -34,7 +34,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line82()
+		public void Line84()
 		{
 			// tag::9748682dcfb24b7d4893f534f7040370[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/OpenClosePage.cs
+++ b/tests/Examples/Indices/OpenClosePage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line101()
+		public void Line103()
 		{
 			// tag::37e6177bf8803971d30a4252498c07a4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/PutMappingPage.cs
+++ b/tests/Examples/Indices/PutMappingPage.cs
@@ -31,7 +31,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line90()
+		public void Line84()
 		{
 			// tag::12433d2b637d002e8d5c9a1adce69d3b[]
 			var putMappingResponse = client.Indices.Create("publications");
@@ -41,7 +41,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line98()
+		public void Line92()
 		{
 			// tag::e4be53736bcc02b03068fd72fdbfe271[]
 			var putMappingResponse = client.Map<object>(m => m
@@ -61,7 +61,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line115()
+		public void Line109()
 		{
 			// tag::1da77e114459e0b77d78a3dcc8fae429[]
 			var createIndex1Response = client.Indices.Create("twitter-1");
@@ -91,7 +91,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line150()
+		public void Line144()
 		{
 			// tag::d9474f66970c6955e24b17c7447e7b5f[]
 			var createIndexResponse = client.Indices.Create("my_index", m => m
@@ -131,7 +131,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line172()
+		public void Line166()
 		{
 			// tag::0bbd30b9be3e54ff3028b9f4459634d2[]
 			var putMappingResponse = client.Map<object>(m => m
@@ -168,7 +168,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line192()
+		public void Line186()
 		{
 			// tag::210cf5c76bff517f48e80fa1c2d63907[]
 			var getMappingResponse = client.Indices.GetMapping<object>(r => r.Index("my_index"));
@@ -178,7 +178,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line240()
+		public void Line234()
 		{
 			// tag::c849c6c8f8659dbb93e1c14356f74e37[]
 			var createIndexResponse = client.Indices.Create("my_index", m => m
@@ -203,7 +203,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line263()
+		public void Line257()
 		{
 			// tag::5f3a3eefeefe6fa85ec49d499212d245[]
 			var putMappingResponse = client.Map<object>(m => m
@@ -235,7 +235,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line333()
+		public void Line327()
 		{
 			// tag::1f6fe6833686e38c3711c6f2aa00a078[]
 			var createIndexResponse = client.Indices.Create("my_index", m => m
@@ -264,7 +264,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line352()
+		public void Line346()
 		{
 			// tag::17de0020b228df961ad3c6b06233c948[]
 			var putMappingResponse = client.Map<object>(m => m
@@ -290,7 +290,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line415()
+		public void Line409()
 		{
 			// tag::bd5918ab903c0889bb1f09c8c2466e43[]
 			var createIndexResponse = client.Indices.Create("users", m => m
@@ -318,7 +318,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line433()
+		public void Line427()
 		{
 			// tag::0989cc65d8924f666ce3eb0820d2d244[]
 			var indexResponse1 = client.Index<object>(new { user_id = 12345 }, r => r.Index("users").Refresh(Refresh.WaitFor));
@@ -338,7 +338,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line452()
+		public void Line446()
 		{
 			// tag::734c2e2a1e45b84f1e4e65b51356fcd7[]
 			var createIndexResponse = client.Indices.Create("new_users", m => m
@@ -365,7 +365,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line471()
+		public void Line465()
 		{
 			// tag::53d938c754f36a912fcbe6473abb463f[]
 			var reindexOnServerResponse = client.ReindexOnServer(r => r
@@ -386,7 +386,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line525()
+		public void Line519()
 		{
 			// tag::6bf63f2ec6ba55fcaf1092f48212bf25[]
 			var createIndexResponse = client.Indices.Create("my_index", m => m
@@ -413,7 +413,7 @@ namespace Examples.Indices
 		}
 
 		[U]
-		public void Line542()
+		public void Line536()
 		{
 			// tag::afc29b61c532cf683f749baf013e7bfe[]
 			var putMappingResponse = client.Map<object>(m => m

--- a/tests/Examples/Indices/RefreshPage.cs
+++ b/tests/Examples/Indices/RefreshPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line91()
+		public void Line93()
 		{
 			// tag::0e98949e80e665795bc6cfc997165241[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line101()
+		public void Line103()
 		{
 			// tag::d7898526d239d2aea83727fb982f8f77[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/RolloverIndexPage.cs
+++ b/tests/Examples/Indices/RolloverIndexPage.cs
@@ -23,7 +23,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line162()
+		public void Line160()
 		{
 			// tag::593c11e8a9f88ec2629f2eb33cded9b7[]
 			var response0 = new SearchResponse<object>();
@@ -53,7 +53,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line222()
+		public void Line220()
 		{
 			// tag::75f887596c4972bc679929ca996698f2[]
 			var response0 = new SearchResponse<object>();
@@ -82,7 +82,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line256()
+		public void Line254()
 		{
 			// tag::659247d91f61ceb17cbcc60801fd3456[]
 			var response0 = new SearchResponse<object>();
@@ -99,7 +99,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line280()
+		public void Line278()
 		{
 			// tag::8f6ef669c09e0c8bfc2731f422471770[]
 			var response0 = new SearchResponse<object>();
@@ -142,7 +142,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line339()
+		public void Line337()
 		{
 			// tag::03584e88046614ec7727db506d866f48[]
 			var response0 = new SearchResponse<object>();
@@ -156,7 +156,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line354()
+		public void Line352()
 		{
 			// tag::896eb7487a512fc43a2af7e16717f40d[]
 			var response0 = new SearchResponse<object>();
@@ -173,7 +173,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line382()
+		public void Line380()
 		{
 			// tag::9e9a3ad495e6305563a88dd4c74a5fda[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/SegmentsPage.cs
+++ b/tests/Examples/Indices/SegmentsPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line106()
+		public void Line108()
 		{
 			// tag::940e8c2c7ff92d71f489bdb7183c1ce6[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line115()
+		public void Line117()
 		{
 			// tag::975b4b92464d52068516aa2f0f955cc1[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line124()
+		public void Line126()
 		{
 			// tag::6414b9276ba1c63898c3ff5cbe03c54e[]
 			var response0 = new SearchResponse<object>();
@@ -46,7 +46,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line184()
+		public void Line186()
 		{
 			// tag::1b21d886f6e9619c73079d14581ccbe4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/ShardStoresPage.cs
+++ b/tests/Examples/Indices/ShardStoresPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line101()
 		{
 			// tag::cd93919e13f656ad2e6629f45c579b93[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line109()
+		public void Line111()
 		{
 			// tag::af970eb8b93cdea52209e1256eba9d8c[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line119()
+		public void Line121()
 		{
 			// tag::00b3b6d76a368ae71277ea24af318693[]
 			var response0 = new SearchResponse<object>();
@@ -46,7 +46,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line135()
+		public void Line137()
 		{
 			// tag::3545261682af72f4bee57f2bac0a9590[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/TemplatesPage.cs
+++ b/tests/Examples/Indices/TemplatesPage.cs
@@ -1,18 +1,32 @@
 using Elastic.Xunit.XunitPlumbing;
+using Examples.Models;
 using Nest;
+using Newtonsoft.Json.Linq;
 
 namespace Examples.Indices
 {
 	public class TemplatesPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line10()
 		{
 			// tag::e5f50b31f165462d883ecbff45f74985[]
-			var response0 = new SearchResponse<object>();
+			var putIndexTemplateResponse = client.Indices.PutTemplate("template_1", t => t
+				.IndexPatterns("te*", "bar*")
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Map(m => m
+					.SourceField(s => s.Enabled(false))
+					.Properties(p => p
+						.Keyword(k => k.Name("host_name"))
+						.Date(d => d.Name("created_at").Format("EEE MMM dd HH:mm:ss Z yyyy"))
+					)
+				)
+			);
 			// end::e5f50b31f165462d883ecbff45f74985[]
 
-			response0.MatchesExample(@"PUT _template/template_1
+			putIndexTemplateResponse.MatchesExample(@"PUT _template/template_1
 			{
 			  ""index_patterns"": [""te*"", ""bar*""],
 			  ""settings"": {
@@ -32,17 +46,36 @@ namespace Examples.Indices
 			      }
 			    }
 			  }
-			}");
+			}", e =>
+			{
+				e.AdjustIndexSettings();
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line138()
 		{
 			// tag::1b8caf0a6741126c6d0ad83b56fce290[]
-			var response0 = new SearchResponse<object>();
+			var putIndexTemplateResponse = client.Indices.PutTemplate("template_1", t => t
+				.IndexPatterns("te*")
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Aliases(a => a
+					.Alias("alias1")
+					.Alias("alias2", aa => aa
+						.Filter<Tweet>(f => f
+							.Term(t => t.User, "kimchy")
+						)
+						.Routing("kimchy")
+					)
+					.Alias("{index}-alias")
+				)
+			);
 			// end::1b8caf0a6741126c6d0ad83b56fce290[]
 
-			response0.MatchesExample(@"PUT _template/template_1
+			putIndexTemplateResponse.MatchesExample(@"PUT _template/template_1
 			{
 			    ""index_patterns"" : [""te*""],
 			    ""settings"" : {
@@ -58,19 +91,42 @@ namespace Examples.Indices
 			        },
 			        ""{index}-alias"" : {} \<1>
 			    }
-			}");
+			}", e =>
+			{
+				e.AdjustIndexSettings();
+				e.ApplyBodyChanges(o => o["aliases"]["alias2"]["filter"]["term"]["user"].ToLongFormTermQuery());
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line172()
 		{
 			// tag::b5f95bc097a201b29c7200fc8d3d31c1[]
-			var response0 = new SearchResponse<object>();
+			var putIndexTemplateResponse1 = client.Indices.PutTemplate("template_1", t => t
+				.IndexPatterns("*")
+				.Order(0)
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Map(m => m
+					.SourceField(s => s.Enabled(false))
+				)
+			);
 
-			var response1 = new SearchResponse<object>();
+			var putIndexTemplateResponse2 = client.Indices.PutTemplate("template_2", t => t
+				.IndexPatterns("te*")
+				.Order(1)
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Map(m => m
+					.SourceField(s => s.Enabled(true))
+				)
+			);
 			// end::b5f95bc097a201b29c7200fc8d3d31c1[]
 
-			response0.MatchesExample(@"PUT /_template/template_1
+			putIndexTemplateResponse1.MatchesExample(@"PUT /_template/template_1
 			{
 			    ""index_patterns"" : [""*""],
 			    ""order"" : 0,
@@ -80,9 +136,13 @@ namespace Examples.Indices
 			    ""mappings"" : {
 			        ""_source"" : { ""enabled"" : false }
 			    }
-			}");
+			}", e =>
+			{
+				e.AdjustIndexSettings();
+				return e;
+			});
 
-			response1.MatchesExample(@"PUT /_template/template_2
+			putIndexTemplateResponse2.MatchesExample(@"PUT /_template/template_2
 			{
 			    ""index_patterns"" : [""te*""],
 			    ""order"" : 1,
@@ -92,17 +152,28 @@ namespace Examples.Indices
 			    ""mappings"" : {
 			        ""_source"" : { ""enabled"" : true }
 			    }
-			}");
+			}", e =>
+			{
+				e.AdjustIndexSettings();
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line223()
 		{
 			// tag::9166cf38427d5cde5d2ec12a2012b669[]
-			var response0 = new SearchResponse<object>();
+			var putIndexTemplateResponse1 = client.Indices.PutTemplate("template_1", t => t
+				.IndexPatterns("*")
+				.Order(0)
+				.Settings(s => s
+					.NumberOfShards(1)
+				)
+				.Version(123)
+			);
 			// end::9166cf38427d5cde5d2ec12a2012b669[]
 
-			response0.MatchesExample(@"PUT /_template/template_1
+			putIndexTemplateResponse1.MatchesExample(@"PUT /_template/template_1
 			{
 			    ""index_patterns"" : [""*""],
 			    ""order"" : 0,
@@ -110,17 +181,21 @@ namespace Examples.Indices
 			        ""number_of_shards"" : 1
 			    },
 			    ""version"": 123
-			}");
+			}", e =>
+			{
+				e.AdjustIndexSettings();
+				return e;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line241()
 		{
 			// tag::46658f00edc4865dfe472a392374cd0f[]
-			var response0 = new SearchResponse<object>();
+			var getIndexTemplateResponse = client.Indices.GetTemplate("template_1", t => t.FilterPath(new[] { "*.version" }));
 			// end::46658f00edc4865dfe472a392374cd0f[]
 
-			response0.MatchesExample(@"GET /_template/template_1?filter_path=*.version");
+			getIndexTemplateResponse.MatchesExample(@"GET /_template/template_1?filter_path=*.version");
 		}
 	}
 }

--- a/tests/Examples/Indices/TemplatesPage.cs
+++ b/tests/Examples/Indices/TemplatesPage.cs
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line138()
 		{
 			// tag::1b8caf0a6741126c6d0ad83b56fce290[]
 			var response0 = new SearchResponse<object>();
@@ -62,7 +62,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line166()
+		public void Line172()
 		{
 			// tag::b5f95bc097a201b29c7200fc8d3d31c1[]
 			var response0 = new SearchResponse<object>();
@@ -96,7 +96,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line218()
+		public void Line223()
 		{
 			// tag::9166cf38427d5cde5d2ec12a2012b669[]
 			var response0 = new SearchResponse<object>();
@@ -114,7 +114,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line236()
+		public void Line241()
 		{
 			// tag::46658f00edc4865dfe472a392374cd0f[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/UpdateSettingsPage.cs
+++ b/tests/Examples/Indices/UpdateSettingsPage.cs
@@ -21,7 +21,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line71()
+		public void Line73()
 		{
 			// tag::42744a175125df5be0ef77413bf8f608[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line95()
+		public void Line97()
 		{
 			// tag::dfac8d098b50aa0181161bcd17b38ef4[]
 			var response0 = new SearchResponse<object>();
@@ -51,7 +51,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line112()
+		public void Line114()
 		{
 			// tag::0be2c28ee65384774b1e479b47dc3d92[]
 			var response0 = new SearchResponse<object>();
@@ -66,7 +66,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line125()
+		public void Line127()
 		{
 			// tag::fe5763d32955e8b65eb3048e97b1580c[]
 			var response0 = new SearchResponse<object>();
@@ -76,7 +76,7 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line143()
+		public void Line145()
 		{
 			// tag::ba0b4081c98f3387f76b77847c52ee9a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Apis/Enrich/DeleteEnrichPolicyPage.cs
+++ b/tests/Examples/Ingest/Apis/Enrich/DeleteEnrichPolicyPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ingest.Apis.Enrich
 	public class DeleteEnrichPolicyPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line29()
+		public void Line37()
 		{
 			// tag::cdd29b01e730b3996de68a2788050021[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Apis/Enrich/GetEnrichPolicyPage.cs
+++ b/tests/Examples/Ingest/Apis/Enrich/GetEnrichPolicyPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ingest.Apis.Enrich
 	public class GetEnrichPolicyPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line37()
+		public void Line44()
 		{
 			// tag::af18f5c5fb2364ae23c6a14431820aba[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Ingest.Apis.Enrich
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line116()
+		public void Line123()
 		{
 			// tag::8684589e31d96ab229e8c4feb4d704bb[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Ingest.Apis.Enrich
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line168()
+		public void Line175()
 		{
 			// tag::c97fd95ebdcf56cc973582e37f732ed2[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Apis/Enrich/PutEnrichPolicyPage.cs
+++ b/tests/Examples/Ingest/Apis/Enrich/PutEnrichPolicyPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ingest.Apis.Enrich
 	public class PutEnrichPolicyPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line19()
+		public void Line26()
 		{
 			// tag::e15a5bb869d24668207b9b4629744be4[]
 			var response0 = new SearchResponse<object>();
@@ -20,120 +20,6 @@ namespace Examples.Ingest.Apis.Enrich
 			        ""enrich_fields"": [""first_name"", ""last_name"", ""city"", ""zip"", ""state""]
 			    }
 			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line182()
-		{
-			// tag::0c8bce944c1189a8551e8dbd99c365f2[]
-			var response0 = new SearchResponse<object>();
-			// end::0c8bce944c1189a8551e8dbd99c365f2[]
-
-			response0.MatchesExample(@"PUT /postal_codes
-			{
-			    ""mappings"": {
-			        ""properties"": {
-			            ""location"": {
-			                ""type"": ""geo_shape""
-			            },
-			            ""postal_code"": {
-			                ""type"": ""keyword""
-			            }
-			        }
-			    }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line202()
-		{
-			// tag::497a51622ef123efc44e54ba2106385e[]
-			var response0 = new SearchResponse<object>();
-			// end::497a51622ef123efc44e54ba2106385e[]
-
-			response0.MatchesExample(@"PUT /postal_codes/_doc/1?refresh=wait_for
-			{
-			    ""location"": {
-			        ""type"": ""envelope"",
-			        ""coordinates"": [[13.0, 53.0], [14.0, 52.0]]
-			    },
-			    ""postal_code"": ""96598""
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line227()
-		{
-			// tag::99da25a3d63f98c16df47f21acbf37e7[]
-			var response0 = new SearchResponse<object>();
-			// end::99da25a3d63f98c16df47f21acbf37e7[]
-
-			response0.MatchesExample(@"PUT /_enrich/policy/postal_policy
-			{
-			    ""geo_match"": {
-			        ""indices"": ""postal_codes"",
-			        ""match_field"": ""location"",
-			        ""enrich_fields"": [""location"",""postal_code""]
-			    }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line245()
-		{
-			// tag::207c04ccbdce0e8a289070a3b0a79ecb[]
-			var response0 = new SearchResponse<object>();
-			// end::207c04ccbdce0e8a289070a3b0a79ecb[]
-
-			response0.MatchesExample(@"POST /_enrich/policy/postal_policy/_execute");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line267()
-		{
-			// tag::83b4a737514a047d31f12f110bed0b5e[]
-			var response0 = new SearchResponse<object>();
-			// end::83b4a737514a047d31f12f110bed0b5e[]
-
-			response0.MatchesExample(@"PUT /_ingest/pipeline/postal_lookup
-			{
-			  ""description"": ""Enrich postal codes"",
-			  ""processors"": [
-			    {
-			      ""enrich"": {
-			        ""policy_name"": ""postal_policy"",
-			        ""field"": ""geo_location"",
-			        ""target_field"": ""geo_data"",
-			        ""shape_relation"": ""INTERSECTS""
-			      }
-			    }
-			  ]
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line292()
-		{
-			// tag::ad3b9d676187bebdb62e0f1de9a202e0[]
-			var response0 = new SearchResponse<object>();
-			// end::ad3b9d676187bebdb62e0f1de9a202e0[]
-
-			response0.MatchesExample(@"PUT /users/_doc/0?pipeline=postal_lookup
-			{
-			    ""first_name"": ""Mardy"",
-			    ""last_name"": ""Brown"",
-			    ""geo_location"": ""POINT (13.5 52.5)""
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line308()
-		{
-			// tag::a3f3c1f3f31dbd225da5fd14633bc4a0[]
-			var response0 = new SearchResponse<object>();
-			// end::a3f3c1f3f31dbd225da5fd14633bc4a0[]
-
-			response0.MatchesExample(@"GET /users/_doc/0");
 		}
 	}
 }

--- a/tests/Examples/Ingest/EnrichPage.cs
+++ b/tests/Examples/Ingest/EnrichPage.cs
@@ -6,7 +6,121 @@ namespace Examples.Ingest
 	public class EnrichPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line72()
+		public void Line305()
+		{
+			// tag::0c8bce944c1189a8551e8dbd99c365f2[]
+			var response0 = new SearchResponse<object>();
+			// end::0c8bce944c1189a8551e8dbd99c365f2[]
+
+			response0.MatchesExample(@"PUT /postal_codes
+			{
+			    ""mappings"": {
+			        ""properties"": {
+			            ""location"": {
+			                ""type"": ""geo_shape""
+			            },
+			            ""postal_code"": {
+			                ""type"": ""keyword""
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line324()
+		{
+			// tag::497a51622ef123efc44e54ba2106385e[]
+			var response0 = new SearchResponse<object>();
+			// end::497a51622ef123efc44e54ba2106385e[]
+
+			response0.MatchesExample(@"PUT /postal_codes/_doc/1?refresh=wait_for
+			{
+			    ""location"": {
+			        ""type"": ""envelope"",
+			        ""coordinates"": [[13.0, 53.0], [14.0, 52.0]]
+			    },
+			    ""postal_code"": ""96598""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line346()
+		{
+			// tag::99da25a3d63f98c16df47f21acbf37e7[]
+			var response0 = new SearchResponse<object>();
+			// end::99da25a3d63f98c16df47f21acbf37e7[]
+
+			response0.MatchesExample(@"PUT /_enrich/policy/postal_policy
+			{
+			    ""geo_match"": {
+			        ""indices"": ""postal_codes"",
+			        ""match_field"": ""location"",
+			        ""enrich_fields"": [""location"",""postal_code""]
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line362()
+		{
+			// tag::207c04ccbdce0e8a289070a3b0a79ecb[]
+			var response0 = new SearchResponse<object>();
+			// end::207c04ccbdce0e8a289070a3b0a79ecb[]
+
+			response0.MatchesExample(@"POST /_enrich/policy/postal_policy/_execute");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line381()
+		{
+			// tag::83b4a737514a047d31f12f110bed0b5e[]
+			var response0 = new SearchResponse<object>();
+			// end::83b4a737514a047d31f12f110bed0b5e[]
+
+			response0.MatchesExample(@"PUT /_ingest/pipeline/postal_lookup
+			{
+			  ""description"": ""Enrich postal codes"",
+			  ""processors"": [
+			    {
+			      ""enrich"": {
+			        ""policy_name"": ""postal_policy"",
+			        ""field"": ""geo_location"",
+			        ""target_field"": ""geo_data"",
+			        ""shape_relation"": ""INTERSECTS""
+			      }
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line403()
+		{
+			// tag::ad3b9d676187bebdb62e0f1de9a202e0[]
+			var response0 = new SearchResponse<object>();
+			// end::ad3b9d676187bebdb62e0f1de9a202e0[]
+
+			response0.MatchesExample(@"PUT /users/_doc/0?pipeline=postal_lookup
+			{
+			    ""first_name"": ""Mardy"",
+			    ""last_name"": ""Brown"",
+			    ""geo_location"": ""POINT (13.5 52.5)""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line417()
+		{
+			// tag::a3f3c1f3f31dbd225da5fd14633bc4a0[]
+			var response0 = new SearchResponse<object>();
+			// end::a3f3c1f3f31dbd225da5fd14633bc4a0[]
+
+			response0.MatchesExample(@"GET /users/_doc/0");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line478()
 		{
 			// tag::927dd38daa489175a5008799452e870a[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +140,7 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line103()
+		public void Line502()
 		{
 			// tag::9ab4e8a564e13475cb3a0376be56bb8e[]
 			var response0 = new SearchResponse<object>();
@@ -43,7 +157,7 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line130()
+		public void Line518()
 		{
 			// tag::af4f82ce86672a9bafd834f334c8e1c9[]
 			var response0 = new SearchResponse<object>();
@@ -53,7 +167,7 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line161()
+		public void Line535()
 		{
 			// tag::958b661d89b2beeb0cfefe8edbe3e408[]
 			var response0 = new SearchResponse<object>();
@@ -76,7 +190,7 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line217()
+		public void Line557()
 		{
 			// tag::7495d7e8d99e4f5ac8034988b706e09d[]
 			var response0 = new SearchResponse<object>();
@@ -89,7 +203,7 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line230()
+		public void Line569()
 		{
 			// tag::ce20ab8067b6e4ad68e8ad7a5a0b73fd[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Processors/GeoipPage.cs
+++ b/tests/Examples/Ingest/Processors/GeoipPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ingest.Processors
 	public class GeoipPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line45()
+		public void Line46()
 		{
 			// tag::0b6aa8f2d6916951959d6186b25d2b54[]
 			var response0 = new SearchResponse<object>();
@@ -37,7 +37,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line92()
+		public void Line93()
 		{
 			// tag::573a466d7a3a8e31194666e2ecc1d92a[]
 			var response0 = new SearchResponse<object>();
@@ -70,7 +70,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line143()
+		public void Line144()
 		{
 			// tag::c5681f52305e065ef13c3e0ad5393263[]
 			var response0 = new SearchResponse<object>();
@@ -101,7 +101,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line192()
+		public void Line193()
 		{
 			// tag::0737ebaea33631f001fb3f4226948492[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Processors/GrokPage.cs
+++ b/tests/Examples/Ingest/Processors/GrokPage.cs
@@ -6,7 +6,37 @@ namespace Examples.Ingest.Processors
 	public class GrokPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line159()
+		public void Line72()
+		{
+			// tag::5024c524a7db0d6bb44c1820007cc5f4[]
+			var response0 = new SearchResponse<object>();
+			// end::5024c524a7db0d6bb44c1820007cc5f4[]
+
+			response0.MatchesExample(@"POST _ingest/pipeline/_simulate
+			{
+			  ""pipeline"": {
+			    ""description"" : ""..."",
+			    ""processors"": [
+			      {
+			        ""grok"": {
+			          ""field"": ""message"",
+			          ""patterns"": [""%{IP:client} %{WORD:method} %{URIPATHPARAM:request} %{NUMBER:bytes:int} %{NUMBER:duration:double}""]
+			        }
+			      }
+			    ]
+			  },
+			  ""docs"":[
+			    {
+			      ""_source"": {
+			        ""message"": ""55.3.244.1 GET /index.html 15824 0.043""
+			      }
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line164()
 		{
 			// tag::77828fcaecc3f058c48b955928198ff6[]
 			var response0 = new SearchResponse<object>();
@@ -40,7 +70,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line283()
+		public void Line288()
 		{
 			// tag::98574a419b6be603a0af8f7f22a92d23[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ingest/Processors/PipelinePage.cs
+++ b/tests/Examples/Ingest/Processors/PipelinePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ingest.Processors
 	public class PipelinePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line29()
+		public void Line31()
 		{
 			// tag::8494d09c39e109a012094eb9d6ec52ac[]
 			var response0 = new SearchResponse<object>();
@@ -27,7 +27,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line47()
+		public void Line49()
 		{
 			// tag::02c48d461536709c3fc8a0e8147c3787[]
 			var response0 = new SearchResponse<object>();
@@ -53,7 +53,7 @@ namespace Examples.Ingest.Processors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line72()
+		public void Line74()
 		{
 			// tag::88647e818ffcbe39e5cf627f5b9a676c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/JTokenExtensions.cs
+++ b/tests/Examples/JTokenExtensions.cs
@@ -45,6 +45,21 @@ namespace Examples
 			o.Replace(a);
 			return a;
 		}
+
+		/// <summary>
+		/// Flattens an array into a comma-seperated representation of that array.
+		/// <code>"index": ["twitter", "blog"]</code>
+		/// Will be converted to
+		/// <code>"index": "twitter, blog"</code>
+		/// </summary>
+		public static JToken Flatten<T>(this JToken o)
+		{
+			var array = (JArray)o;
+			var values = array.Values<T>();
+			var flat = string.Join(",", values);
+			return JToken.FromObject(flat);
+		}
+
 		/// <summary>
 		/// Docs document bool query without the clauses as arrays, NEST only every sends them as arrays
 		/// This fixes the examples

--- a/tests/Examples/JTokenExtensions.cs
+++ b/tests/Examples/JTokenExtensions.cs
@@ -46,6 +46,15 @@ namespace Examples
 			return a;
 		}
 
+		public static void AdjustIndexSettings(this Example e) =>
+			e.ApplyBodyChanges(o =>
+			{
+				var settings = ((JObject)o["settings"]);
+				var existing = settings["number_of_shards"].Value<int>();
+				settings.Remove("number_of_shards");
+				settings.Add("index.number_of_shards", existing);
+			});
+
 		/// <summary>
 		/// Flattens an array into a comma-seperated representation of that array.
 		/// <code>"index": ["twitter", "blog"]</code>

--- a/tests/Examples/Licensing/DeleteLicensePage.cs
+++ b/tests/Examples/Licensing/DeleteLicensePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Licensing
 	public class DeleteLicensePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line35()
+		public void Line36()
 		{
 			// tag::4f8a4ad49e2bca6784c88ede18a1a709[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Licensing/UpdateLicensePage.cs
+++ b/tests/Examples/Licensing/UpdateLicensePage.cs
@@ -6,13 +6,13 @@ namespace Examples.Licensing
 	public class UpdateLicensePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line59()
+		public void Line61()
 		{
-			// tag::4fb399ee372ae8837cbb9aa66be30f62[]
+			// tag::85f2839beeb71edb66988e5c82188be0[]
 			var response0 = new SearchResponse<object>();
-			// end::4fb399ee372ae8837cbb9aa66be30f62[]
+			// end::85f2839beeb71edb66988e5c82188be0[]
 
-			response0.MatchesExample(@"POST /_license
+			response0.MatchesExample(@"PUT _license
 			{
 			  ""licenses"": [
 			    {
@@ -30,13 +30,13 @@ namespace Examples.Licensing
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line135()
+		public void Line137()
 		{
-			// tag::efe30c2a1611afdc85ae522e4f5a457b[]
+			// tag::46b1c1f6e0c86528be84c373eeb8d425[]
 			var response0 = new SearchResponse<object>();
-			// end::efe30c2a1611afdc85ae522e4f5a457b[]
+			// end::46b1c1f6e0c86528be84c373eeb8d425[]
 
-			response0.MatchesExample(@"POST /_license?acknowledge=true
+			response0.MatchesExample(@"PUT _license?acknowledge=true
 			{
 			  ""licenses"": [
 			    {

--- a/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
+++ b/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Mapping.Dynamic
 	public class TemplatesPage : ExampleBase
 	{
 		[U]
-		public void Line71()
+		public void Line84()
 		{
 			// tag::bb33e638fdeded7d721d9bbac2305fda[]
 			var createIndexResponse = client.Indices.Create("my_index", c => c
@@ -82,7 +82,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U]
-		public void Line125()
+		public void Line138()
 		{
 			// tag::4f54b88e05c7a62901062e9e0ed13e5a[]
 			var createIndexResponse = client.Indices.Create("my_index", c => c
@@ -134,7 +134,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U]
-		public void Line179()
+		public void Line192()
 		{
 			// tag::0b91c082258ce623cc716b679aace653[]
 			var createIndexResponse = client.Indices.Create("my_index", c => c
@@ -204,7 +204,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U]
-		public void Line214()
+		public void Line227()
 		{
 			// tag::be51ed37c8425d281a8153abe56b04cb[]
 			var indexResponse = client.Index<object>(new
@@ -236,7 +236,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line239()
+		public void Line252()
 		{
 			// tag::6873971eb4e4577d76d0a5bd7cd15ef9[]
 			var response0 = new SearchResponse<object>();
@@ -279,7 +279,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line291()
+		public void Line304()
 		{
 			// tag::87f85bb49d18f73d0eed0b704e05eb90[]
 			var response0 = new SearchResponse<object>();
@@ -303,7 +303,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line319()
+		public void Line332()
 		{
 			// tag::1a59fa2708ccb3a24c71e8306b81f17f[]
 			var response0 = new SearchResponse<object>();
@@ -327,7 +327,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line344()
+		public void Line357()
 		{
 			// tag::3e60c0b29bd3931927e6f2ee7d2ed0ef[]
 			var response0 = new SearchResponse<object>();
@@ -358,7 +358,7 @@ namespace Examples.Mapping.Dynamic
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line382()
+		public void Line395()
 		{
 			// tag::9a91f7d0bf52d6c582c62daef5c9d040[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
+++ b/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
@@ -235,16 +235,38 @@ namespace Examples.Mapping.Dynamic
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line252()
 		{
 			// tag::6873971eb4e4577d76d0a5bd7cd15ef9[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.DynamicTemplates(dt => dt
+						.DynamicTemplate("named_analyzers", d => d
+							.MatchMappingType("string")
+							.Match("*")
+							.Mapping(mm => mm
+								.Text(n => n.Analyzer("{name}"))
+							)
+						)
+						.DynamicTemplate("no_doc_values", d => d
+							.MatchMappingType("*")
+							.Mapping(mm => mm
+								.Generic(n => n.Type("{dynamic_type}").DocValues(false))
+							)
+						)
+					)
+				)
+			);
 
-			var response1 = new SearchResponse<object>();
+			var indexResponse = client.Index<object>(new
+			{
+				english = "Some English text",
+				count = 5
+			}, i => i.Index("my_index").Id(1));
 			// end::6873971eb4e4577d76d0a5bd7cd15ef9[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""dynamic_templates"": [
@@ -271,21 +293,32 @@ namespace Examples.Mapping.Dynamic
 			  }
 			}");
 
-			response1.MatchesExample(@"PUT my_index/_doc/1
+			indexResponse.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""english"": ""Some English text"", \<1>
 			  ""count"":   5 \<2>
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line304()
 		{
 			// tag::87f85bb49d18f73d0eed0b704e05eb90[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.DynamicTemplates(dt => dt
+						.DynamicTemplate("strings_as_keywords", d => d
+							.MatchMappingType("string")
+							.Mapping(mm => mm
+								.Keyword(n => n)
+							)
+						)
+					)
+				)
+			);
 			// end::87f85bb49d18f73d0eed0b704e05eb90[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""dynamic_templates"": [
@@ -302,14 +335,25 @@ namespace Examples.Mapping.Dynamic
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line332()
 		{
 			// tag::1a59fa2708ccb3a24c71e8306b81f17f[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.DynamicTemplates(dt => dt
+						.DynamicTemplate("strings_as_text", d => d
+							.MatchMappingType("string")
+							.Mapping(mm => mm
+								.Text(n => n)
+							)
+						)
+					)
+				)
+			);
 			// end::1a59fa2708ccb3a24c71e8306b81f17f[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""dynamic_templates"": [
@@ -326,14 +370,25 @@ namespace Examples.Mapping.Dynamic
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line357()
 		{
 			// tag::3e60c0b29bd3931927e6f2ee7d2ed0ef[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.DynamicTemplates(dt => dt
+						.DynamicTemplate("strings_as_keywords", d => d
+							.MatchMappingType("string")
+							.Mapping(mm => mm
+								.Text(n => n.Norms(false).Fields(f => f.Keyword(k => k.Name("keyword").IgnoreAbove(256))))
+							)
+						)
+					)
+				)
+			);
 			// end::3e60c0b29bd3931927e6f2ee7d2ed0ef[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""dynamic_templates"": [
@@ -357,14 +412,31 @@ namespace Examples.Mapping.Dynamic
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line395()
 		{
 			// tag::9a91f7d0bf52d6c582c62daef5c9d040[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.DynamicTemplates(dt => dt
+						.DynamicTemplate("unindexed_longs", d => d
+							.MatchMappingType("long")
+							.Mapping(mm => mm
+								.Number(n => n.Type(NumberType.Long).Index(false))
+							)
+						)
+						.DynamicTemplate("unindexed_doubles", d => d
+							.MatchMappingType("double")
+							.Mapping(mm => mm
+								.Number(n => n.Type(NumberType.Float).Index(false))
+							)
+						)
+					)
+				)
+			);
 			// end::9a91f7d0bf52d6c582c62daef5c9d040[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""dynamic_templates"": [

--- a/tests/Examples/Mapping/Fields/IdFieldPage.cs
+++ b/tests/Examples/Mapping/Fields/IdFieldPage.cs
@@ -8,7 +8,7 @@ namespace Examples.Mapping.Fields
 		[U(Skip = "Example not implemented")]
 		public void Line12()
 		{
-			// tag::3abdbdc99e203e87332d387cfbdeafaa[]
+			// tag::8d9a63d7c31f08bd27d92ece3de1649c[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Mapping.Fields
 			var response2 = new SearchResponse<object>();
 
 			var response3 = new SearchResponse<object>();
-			// end::3abdbdc99e203e87332d387cfbdeafaa[]
+			// end::8d9a63d7c31f08bd27d92ece3de1649c[]
 
 			response0.MatchesExample(@"# Example documents");
 
@@ -25,7 +25,7 @@ namespace Examples.Mapping.Fields
 			  ""text"": ""Document with ID 1""
 			}");
 
-			response2.MatchesExample(@"PUT my_index/_doc/2&refresh=true
+			response2.MatchesExample(@"PUT my_index/_doc/2?refresh=true
 			{
 			  ""text"": ""Document with ID 2""
 			}");
@@ -34,7 +34,7 @@ namespace Examples.Mapping.Fields
 			{
 			  ""query"": {
 			    ""terms"": {
-			      ""_id"": [ ""1"", ""2"" ] \<1>
+			      ""_id"": [ ""1"", ""2"" ] <1>
 			    }
 			  }
 			}");

--- a/tests/Examples/Mapping/Fields/IndexFieldPage.cs
+++ b/tests/Examples/Mapping/Fields/IndexFieldPage.cs
@@ -6,48 +6,44 @@ namespace Examples.Mapping.Fields
 	public class IndexFieldPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line17()
+		public void Line11()
 		{
-			// tag::e8146b1dda248705f7fb1fb6306d9d86[]
+			// tag::3c04f75bcbb07125d51b21b9b2c9f6f0[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
 
 			var response2 = new SearchResponse<object>();
+			// end::3c04f75bcbb07125d51b21b9b2c9f6f0[]
 
-			var response3 = new SearchResponse<object>();
-			// end::e8146b1dda248705f7fb1fb6306d9d86[]
-
-			response0.MatchesExample(@"# Example documents");
-
-			response1.MatchesExample(@"PUT index_1/_doc/1
+			response0.MatchesExample(@"PUT index_1/_doc/1
 			{
 			  ""text"": ""Document in index 1""
 			}");
 
-			response2.MatchesExample(@"PUT index_2/_doc/2?refresh=true
+			response1.MatchesExample(@"PUT index_2/_doc/2?refresh=true
 			{
 			  ""text"": ""Document in index 2""
 			}");
 
-			response3.MatchesExample(@"GET index_1,index_2/_search
+			response2.MatchesExample(@"GET index_1,index_2/_search
 			{
 			  ""query"": {
 			    ""terms"": {
-			      ""_index"": [""index_1"", ""index_2""] \<1>
+			      ""_index"": [""index_1"", ""index_2""] <1>
 			    }
 			  },
 			  ""aggs"": {
 			    ""indices"": {
 			      ""terms"": {
-			        ""field"": ""_index"", \<2>
+			        ""field"": ""_index"", <2>
 			        ""size"": 10
 			      }
 			    }
 			  },
 			  ""sort"": [
 			    {
-			      ""_index"": { \<3>
+			      ""_index"": { <3>
 			        ""order"": ""asc""
 			      }
 			    }
@@ -56,7 +52,7 @@ namespace Examples.Mapping.Fields
 			    ""index_name"": {
 			      ""script"": {
 			        ""lang"": ""painless"",
-			        ""source"": ""doc['_index']"" \<4>
+			        ""source"": ""doc['_index']"" <4>
 			      }
 			    }
 			  }

--- a/tests/Examples/Mapping/Fields/TypeFieldPage.cs
+++ b/tests/Examples/Mapping/Fields/TypeFieldPage.cs
@@ -8,15 +8,11 @@ namespace Examples.Mapping.Fields
 		[U(Skip = "Example not implemented")]
 		public void Line14()
 		{
-			// tag::1e867a2d4e10e70350d458a473544022[]
+			// tag::cb639c02d28945379ba10dbfb982186f[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-
-			var response2 = new SearchResponse<object>();
-
-			var response3 = new SearchResponse<object>();
-			// end::1e867a2d4e10e70350d458a473544022[]
+			// end::cb639c02d28945379ba10dbfb982186f[]
 
 			response0.MatchesExample(@"# Example documents");
 
@@ -24,25 +20,33 @@ namespace Examples.Mapping.Fields
 			{
 			  ""text"": ""Document with type 'doc'""
 			}");
+		}
 
-			response2.MatchesExample(@"GET my_index/_search
+		[U(Skip = "Example not implemented")]
+		public void Line25()
+		{
+			// tag::0d7b0f40446e2001c63bef29f84530eb[]
+			var response0 = new SearchResponse<object>();
+			// end::0d7b0f40446e2001c63bef29f84530eb[]
+
+			response0.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""term"": {
-			      ""_type"": ""_doc""  \<1>
+			      ""_type"": ""_doc""  <1>
 			    }
 			  },
 			  ""aggs"": {
 			    ""types"": {
 			      ""terms"": {
-			        ""field"": ""_type"", \<2>
+			        ""field"": ""_type"", <2>
 			        ""size"": 10
 			      }
 			    }
 			  },
 			  ""sort"": [
 			    {
-			      ""_type"": { \<3>
+			      ""_type"": { <3>
 			        ""order"": ""desc""
 			      }
 			    }
@@ -51,13 +55,11 @@ namespace Examples.Mapping.Fields
 			    ""type"": {
 			      ""script"": {
 			        ""lang"": ""painless"",
-			        ""source"": ""doc['_type']"" \<4>
+			        ""source"": ""doc['_type']"" <4>
 			      }
 			    }
 			  }
 			}");
-
-			response3.MatchesExample(@"");
 		}
 	}
 }

--- a/tests/Examples/Mapping/Params/MetaPage.cs
+++ b/tests/Examples/Mapping/Params/MetaPage.cs
@@ -1,0 +1,30 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Mapping.Params
+{
+	public class MetaPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line9()
+		{
+			// tag::bb49cbbeef6afe2dae0db46c4a10df3b[]
+			var response0 = new SearchResponse<object>();
+			// end::bb49cbbeef6afe2dae0db46c4a10df3b[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""latency"": {
+			        ""type"": ""long"",
+			        ""meta"": {
+			          ""unit"": ""ms""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Mapping/RemovalOfTypesPage.cs
+++ b/tests/Examples/Mapping/RemovalOfTypesPage.cs
@@ -8,14 +8,14 @@ namespace Examples.Mapping
 		[U(Skip = "Example not implemented")]
 		public void Line458()
 		{
-			// tag::9ee37bb017ab2f08dc870d9b2f937819[]
+			// tag::cfb7654fa2e29c83807da58f77b27599[]
 			var response0 = new SearchResponse<object>();
-			// end::9ee37bb017ab2f08dc870d9b2f937819[]
+			// end::cfb7654fa2e29c83807da58f77b27599[]
 
-			response0.MatchesExample(@"PUT index?include_type_name=false
+			response0.MatchesExample(@"PUT index
 			{
 			  ""mappings"": {
-			    ""properties"": { \<1>
+			    ""properties"": { <1>
 			      ""foo"": {
 			        ""type"": ""keyword""
 			      }
@@ -27,13 +27,13 @@ namespace Examples.Mapping
 		[U(Skip = "Example not implemented")]
 		public void Line474()
 		{
-			// tag::21aedb3425f773979be01722661b6a89[]
+			// tag::11c9b5d511fd839f4affeb018d17200d[]
 			var response0 = new SearchResponse<object>();
-			// end::21aedb3425f773979be01722661b6a89[]
+			// end::11c9b5d511fd839f4affeb018d17200d[]
 
-			response0.MatchesExample(@"PUT index/_mappings?include_type_name=false
+			response0.MatchesExample(@"PUT index/_mappings
 			{
-			  ""properties"": { \<1>
+			  ""properties"": { <1>
 			    ""bar"": {
 			      ""type"": ""text""
 			    }
@@ -44,11 +44,11 @@ namespace Examples.Mapping
 		[U(Skip = "Example not implemented")]
 		public void Line489()
 		{
-			// tag::c81959a312a5715c52cacfe01cb0576e[]
+			// tag::0afeb69cc1474ac6d35223e615dc8c91[]
 			var response0 = new SearchResponse<object>();
-			// end::c81959a312a5715c52cacfe01cb0576e[]
+			// end::0afeb69cc1474ac6d35223e615dc8c91[]
 
-			response0.MatchesExample(@"GET index/_mappings?include_type_name=false");
+			response0.MatchesExample(@"GET index/_mappings");
 		}
 
 		[U(Skip = "Example not implemented")]
@@ -110,15 +110,13 @@ namespace Examples.Mapping
 		[U(Skip = "Example not implemented")]
 		public void Line612()
 		{
-			// tag::c6f5467904b8182d9203d98414a1bb76[]
+			// tag::a1114fcb15a01180db9918231e495bbc[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
 
 			var response2 = new SearchResponse<object>();
-
-			var response3 = new SearchResponse<object>();
-			// end::c6f5467904b8182d9203d98414a1bb76[]
+			// end::a1114fcb15a01180db9918231e495bbc[]
 
 			response0.MatchesExample(@"PUT _template/template1
 			{
@@ -132,34 +130,18 @@ namespace Examples.Mapping
 			  }
 			}");
 
-			response1.MatchesExample(@"PUT _template/template2?include_type_name=true
+			response1.MatchesExample(@"PUT index-1-01
 			{
-			  ""index_patterns"":[ ""index-2-*"" ],
 			  ""mappings"": {
-			    ""type"": {
-			      ""properties"": {
-			        ""foo"": {
-			          ""type"": ""keyword""
-			        }
+			    ""properties"": {
+			      ""bar"": {
+			        ""type"": ""long""
 			      }
 			    }
 			  }
 			}");
 
-			response2.MatchesExample(@"PUT index-1-01?include_type_name=true
-			{
-			  ""mappings"": {
-			    ""type"": {
-			      ""properties"": {
-			        ""bar"": {
-			          ""type"": ""long""
-			        }
-			      }
-			    }
-			  }
-			}");
-
-			response3.MatchesExample(@"PUT index-2-01
+			response2.MatchesExample(@"PUT index-2-01
 			{
 			  ""mappings"": {
 			    ""properties"": {

--- a/tests/Examples/Mapping/Types/DateNanosPage.cs
+++ b/tests/Examples/Mapping/Types/DateNanosPage.cs
@@ -8,7 +8,7 @@ namespace Examples.Mapping.Types
 		[U(Skip = "Example not implemented")]
 		public void Line32()
 		{
-			// tag::14dc06a4c28ffdc1f9dde97dc6838c1e[]
+			// tag::46dd5948cfc34adf1dfe024fc960bb01[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
@@ -22,33 +22,31 @@ namespace Examples.Mapping.Types
 			var response5 = new SearchResponse<object>();
 
 			var response6 = new SearchResponse<object>();
-			// end::14dc06a4c28ffdc1f9dde97dc6838c1e[]
+			// end::46dd5948cfc34adf1dfe024fc960bb01[]
 
-			response0.MatchesExample(@"PUT my_index?include_type_name=true
+			response0.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
-			    ""_doc"": {
-			      ""properties"": {
-			        ""date"": {
-			          ""type"": ""date_nanos"" \<1>
-			        }
+			    ""properties"": {
+			      ""date"": {
+			        ""type"": ""date_nanos"" <1>
 			      }
 			    }
 			  }
 			}");
 
 			response1.MatchesExample(@"PUT my_index/_doc/1
-			{ ""date"": ""2015-01-01"" } \<2>");
+			{ ""date"": ""2015-01-01"" } <2>");
 
 			response2.MatchesExample(@"PUT my_index/_doc/2
-			{ ""date"": ""2015-01-01T12:10:30.123456789Z"" } \<3>");
+			{ ""date"": ""2015-01-01T12:10:30.123456789Z"" } <3>");
 
 			response3.MatchesExample(@"PUT my_index/_doc/3
-			{ ""date"": 1420070400 } \<4>");
+			{ ""date"": 1420070400 } <4>");
 
 			response4.MatchesExample(@"GET my_index/_search
 			{
-			  ""sort"": { ""date"": ""asc""} \<5>
+			  ""sort"": { ""date"": ""asc""} <5>
 			}");
 
 			response5.MatchesExample(@"GET my_index/_search
@@ -57,7 +55,7 @@ namespace Examples.Mapping.Types
 			    ""my_field"" : {
 			      ""script"" : {
 			        ""lang"" : ""painless"",
-			        ""source"" : ""doc['date'].date.nanos"" \<6>
+			        ""source"" : ""doc['date'].value.nano"" <6>
 			      }
 			    }
 			  }
@@ -68,7 +66,7 @@ namespace Examples.Mapping.Types
 			  ""docvalue_fields"" : [
 			    {
 			      ""field"" : ""my_ip_field"",
-			      ""format"": ""strict_date_time"" \<7>
+			      ""format"": ""strict_date_time"" <7>
 			    }
 			  ]
 			}");

--- a/tests/Examples/Mapping/Types/DenseVectorPage.cs
+++ b/tests/Examples/Mapping/Types/DenseVectorPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Mapping.Types
 	public class DenseVectorPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line22()
+		public void Line20()
 		{
 			// tag::7c7b74084cc9f18b085c25a208bd1306[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/GeoShapePage.cs
+++ b/tests/Examples/Mapping/Types/GeoShapePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Mapping.Types
 	public class GeoShapePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line219()
+		public void Line212()
 		{
 			// tag::3fef996cf6795e881918ffedc273c642[]
 			var response0 = new SearchResponse<object>();
@@ -25,7 +25,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line307()
+		public void Line304()
 		{
 			// tag::f851d1be5d5e5fe5455ba81344d01133[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line320()
+		public void Line317()
 		{
 			// tag::d673a2c008015ac6f754661ae336131c[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line337()
+		public void Line334()
 		{
 			// tag::21a9348800406e09b8bdaab192245096[]
 			var response0 = new SearchResponse<object>();
@@ -70,7 +70,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line350()
+		public void Line347()
 		{
 			// tag::48625e23b05d33977451cde7b98b634a[]
 			var response0 = new SearchResponse<object>();
@@ -83,7 +83,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line369()
+		public void Line366()
 		{
 			// tag::1d6ee162260a21f6e4597eadbea88650[]
 			var response0 = new SearchResponse<object>();
@@ -101,7 +101,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line384()
+		public void Line381()
 		{
 			// tag::18c34a2c5820e330a125dfddf2624c69[]
 			var response0 = new SearchResponse<object>();
@@ -114,7 +114,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line396()
+		public void Line393()
 		{
 			// tag::f83e3ea198f6e87046aab2c5dea60d61[]
 			var response0 = new SearchResponse<object>();
@@ -133,7 +133,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line412()
+		public void Line409()
 		{
 			// tag::00eb71b03b73e605da6368041a64a8ad[]
 			var response0 = new SearchResponse<object>();
@@ -146,7 +146,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line439()
+		public void Line436()
 		{
 			// tag::4c42c8835876a2271e7ba63d6bd3149f[]
 			var response0 = new SearchResponse<object>();
@@ -165,7 +165,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line458()
+		public void Line455()
 		{
 			// tag::60294ea29c96c432047d4fffcb3cc8b4[]
 			var response0 = new SearchResponse<object>();
@@ -184,7 +184,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line478()
+		public void Line475()
 		{
 			// tag::2eca42af76c6ddc657fca3948f3865bd[]
 			var response0 = new SearchResponse<object>();
@@ -202,7 +202,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line493()
+		public void Line490()
 		{
 			// tag::f1e1f4f37194a899e7056d0782804790[]
 			var response0 = new SearchResponse<object>();
@@ -215,7 +215,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line507()
+		public void Line504()
 		{
 			// tag::c4ba19b62e87ed837dc6f1f9fe184244[]
 			var response0 = new SearchResponse<object>();
@@ -235,7 +235,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line524()
+		public void Line521()
 		{
 			// tag::117096e1830e7acedf38bd6a92a9c8b4[]
 			var response0 = new SearchResponse<object>();
@@ -248,7 +248,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line538()
+		public void Line535()
 		{
 			// tag::4be91bb5ac3a1b83b767a060c58e0b12[]
 			var response0 = new SearchResponse<object>();
@@ -268,7 +268,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line555()
+		public void Line552()
 		{
 			// tag::9290410340f0e66e67fa96aacc83bbdc[]
 			var response0 = new SearchResponse<object>();
@@ -281,7 +281,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line569()
+		public void Line566()
 		{
 			// tag::a99750fb5d296fa8df97ee71a34c698c[]
 			var response0 = new SearchResponse<object>();
@@ -306,7 +306,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line591()
+		public void Line588()
 		{
 			// tag::71bb89f56d847b636a050c553c0cd0a7[]
 			var response0 = new SearchResponse<object>();
@@ -319,7 +319,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line607()
+		public void Line604()
 		{
 			// tag::f893fffd649507119d0a9afd98a0cf87[]
 			var response0 = new SearchResponse<object>();
@@ -335,7 +335,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line622()
+		public void Line619()
 		{
 			// tag::65208190e9640cb4ca67271f1694814d[]
 			var response0 = new SearchResponse<object>();
@@ -348,7 +348,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line639()
+		public void Line636()
 		{
 			// tag::76039c2fd422a6bb6340848cc0a78bbd[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/HistogramPage.cs
+++ b/tests/Examples/Mapping/Types/HistogramPage.cs
@@ -1,0 +1,58 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Mapping.Types
+{
+	public class HistogramPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line74()
+		{
+			// tag::7d6b1797b1178e96d287831a94bb9658[]
+			var response0 = new SearchResponse<object>();
+			// end::7d6b1797b1178e96d287831a94bb9658[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""my_histogram"": {
+			        ""type"" : ""histogram""
+			      },
+			      ""my_text"" : {
+			        ""type"" : ""keyword""
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line94()
+		{
+			// tag::09774dd1a8613672844caadb2bc8dc1e[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::09774dd1a8613672844caadb2bc8dc1e[]
+
+			response0.MatchesExample(@"PUT my_index/_doc/1
+			{
+			  ""my_text"" : ""histogram_1"",
+			  ""my_histogram"" : {
+			      ""values"" : [0.1, 0.2, 0.3, 0.4, 0.5], <1>
+			      ""counts"" : [3, 7, 23, 12, 6] <2>
+			   }
+			}");
+
+			response1.MatchesExample(@"PUT my_index/_doc/2
+			{
+			  ""my_text"" : ""histogram_2"",
+			  ""my_histogram"" : {
+			      ""values"" : [0.1, 0.25, 0.35, 0.4, 0.45, 0.5], <1>
+			      ""counts"" : [8, 17, 8, 7, 6, 2] <2>
+			   }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Mapping/Types/IpPage.cs
+++ b/tests/Examples/Mapping/Types/IpPage.cs
@@ -43,7 +43,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line82()
+		public void Line77()
 		{
 			// tag::96d3e3ee5d410507ca6ffb64a7e3d88e[]
 			var response0 = new SearchResponse<object>();
@@ -60,7 +60,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line96()
+		public void Line91()
 		{
 			// tag::f880cf334c8d355edc3abf196d9a8b67[]
 			var response0 = new SearchResponse<object>();
@@ -77,7 +77,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line113()
+		public void Line108()
 		{
 			// tag::db5fe7de772a7607b8d104cc35a6bc6c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/ParentJoinPage.cs
+++ b/tests/Examples/Mapping/Types/ParentJoinPage.cs
@@ -8,18 +8,21 @@ namespace Examples.Mapping.Types
 		[U(Skip = "Example not implemented")]
 		public void Line14()
 		{
-			// tag::59a6a91a43e92b9f7035eadae9e1b8b9[]
+			// tag::adbb85423739e45e6d072fd6bebb140e[]
 			var response0 = new SearchResponse<object>();
-			// end::59a6a91a43e92b9f7035eadae9e1b8b9[]
+			// end::adbb85423739e45e6d072fd6bebb140e[]
 
 			response0.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""properties"": {
-			      ""my_join_field"": { \<1>
+			      ""my_id"": {
+			        ""type"": ""keyword""
+			      },
+			      ""my_join_field"": { <1>
 			        ""type"": ""join"",
 			        ""relations"": {
-			          ""question"": ""answer"" \<2>
+			          ""question"": ""answer"" <2>
 			        }
 			      }
 			    }
@@ -28,24 +31,26 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line38()
+		public void Line41()
 		{
-			// tag::3a9297c0898dfe7b38da82635b7dc1ff[]
+			// tag::ce09baf41be8157b688e19e36b6050c9[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::3a9297c0898dfe7b38da82635b7dc1ff[]
+			// end::ce09baf41be8157b688e19e36b6050c9[]
 
 			response0.MatchesExample(@"PUT my_index/_doc/1?refresh
 			{
+			  ""my_id"": ""1"",
 			  ""text"": ""This is a question"",
 			  ""my_join_field"": {
-			    ""name"": ""question"" \<1>
+			    ""name"": ""question"" <1>
 			  }
 			}");
 
 			response1.MatchesExample(@"PUT my_index/_doc/2?refresh
 			{
+			  ""my_id"": ""2"",
 			  ""text"": ""This is another question"",
 			  ""my_join_field"": {
 			    ""name"": ""question""
@@ -54,47 +59,51 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line63()
+		public void Line68()
 		{
-			// tag::fcfe9592f9c8a59fe2b2110246b9a462[]
+			// tag::34a90fc67bf423c562cfbc91ca1016cf[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::fcfe9592f9c8a59fe2b2110246b9a462[]
+			// end::34a90fc67bf423c562cfbc91ca1016cf[]
 
 			response0.MatchesExample(@"PUT my_index/_doc/1?refresh
 			{
+			  ""my_id"": ""1"",
 			  ""text"": ""This is a question"",
-			  ""my_join_field"": ""question"" \<1>
+			  ""my_join_field"": ""question"" <1>
 			}");
 
 			response1.MatchesExample(@"PUT my_index/_doc/2?refresh
 			{
+			  ""my_id"": ""2"",
 			  ""text"": ""This is another question"",
 			  ""my_join_field"": ""question""
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line89()
+		public void Line96()
 		{
-			// tag::1d13c92896ed8a8bd273773481c90a3c[]
+			// tag::f2b074b37e37cc12abf1b5c795965912[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::1d13c92896ed8a8bd273773481c90a3c[]
+			// end::f2b074b37e37cc12abf1b5c795965912[]
 
-			response0.MatchesExample(@"PUT my_index/_doc/3?routing=1&refresh \<1>
+			response0.MatchesExample(@"PUT my_index/_doc/3?routing=1&refresh <1>
 			{
+			  ""my_id"": ""3"",
 			  ""text"": ""This is an answer"",
 			  ""my_join_field"": {
-			    ""name"": ""answer"", \<2>
-			    ""parent"": ""1"" \<3>
+			    ""name"": ""answer"", <2>
+			    ""parent"": ""1"" <3>
 			  }
 			}");
 
 			response1.MatchesExample(@"PUT my_index/_doc/4?routing=1&refresh
 			{
+			  ""my_id"": ""4"",
 			  ""text"": ""This is another answer"",
 			  ""my_join_field"": {
 			    ""name"": ""answer"",
@@ -104,23 +113,23 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line156()
+		public void Line165()
 		{
-			// tag::a5e3a4c6dbda1f1cd7f22720ef362de2[]
+			// tag::275353b0245fde574d0b11f2aba2836e[]
 			var response0 = new SearchResponse<object>();
-			// end::a5e3a4c6dbda1f1cd7f22720ef362de2[]
+			// end::275353b0245fde574d0b11f2aba2836e[]
 
 			response0.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""match_all"": {}
 			  },
-			  ""sort"": [""_id""]
+			  ""sort"": [""my_id""]
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line259()
+		public void Line272()
 		{
 			// tag::26fe7b3c9aeab972725b6d708cc6df22[]
 			var response0 = new SearchResponse<object>();
@@ -153,7 +162,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line312()
+		public void Line325()
 		{
 			// tag::e0b414b45460d424ab838b5136492fa1[]
 			var response0 = new SearchResponse<object>();
@@ -176,7 +185,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line333()
+		public void Line346()
 		{
 			// tag::2c090fe7ec7b66b3f5c178d71c46323b[]
 			var response0 = new SearchResponse<object>();
@@ -198,7 +207,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line347()
+		public void Line360()
 		{
 			// tag::bc358cfd219faf9353cb65820981a0df[]
 			var response0 = new SearchResponse<object>();
@@ -220,7 +229,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line374()
+		public void Line387()
 		{
 			// tag::1cc03b9715d9a3f876f7b7bb7fe66394[]
 			var response0 = new SearchResponse<object>();
@@ -243,7 +252,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line409()
+		public void Line422()
 		{
 			// tag::6eecf0fbf95d132beb0f49b3181da419[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/ShapePage.cs
+++ b/tests/Examples/Mapping/Types/ShapePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Mapping.Types
 	public class ShapePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line84()
+		public void Line77()
 		{
 			// tag::04409304cd13f4cfa8efbed87aea9b15[]
 			var response0 = new SearchResponse<object>();
@@ -25,7 +25,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line148()
+		public void Line141()
 		{
 			// tag::a55bdc75b139d947d64b32dc9824e558[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line161()
+		public void Line154()
 		{
 			// tag::8fb11f30a609b13c1373ce4a26124159[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line178()
+		public void Line171()
 		{
 			// tag::bff745b32238691bae88de22530643cb[]
 			var response0 = new SearchResponse<object>();
@@ -70,7 +70,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line191()
+		public void Line184()
 		{
 			// tag::c4f62c66f967c6e0da3616957efbeccf[]
 			var response0 = new SearchResponse<object>();
@@ -83,7 +83,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line207()
+		public void Line200()
 		{
 			// tag::567829f263dd472bf76500db05d2200a[]
 			var response0 = new SearchResponse<object>();
@@ -101,7 +101,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line222()
+		public void Line215()
 		{
 			// tag::ae5f9956a525e976bfc37dcb4e7414ae[]
 			var response0 = new SearchResponse<object>();
@@ -114,7 +114,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line234()
+		public void Line227()
 		{
 			// tag::4f869e56eb25586ac402ccfb00aa0359[]
 			var response0 = new SearchResponse<object>();
@@ -133,7 +133,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line250()
+		public void Line243()
 		{
 			// tag::a5816a58c1fa769c23c6211ab449e6f3[]
 			var response0 = new SearchResponse<object>();
@@ -146,7 +146,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line272()
+		public void Line265()
 		{
 			// tag::1f1ccd9af526b2251bf960a85288fc97[]
 			var response0 = new SearchResponse<object>();
@@ -165,7 +165,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line292()
+		public void Line285()
 		{
 			// tag::02da8c5d098d9e7cc263efac344a96de[]
 			var response0 = new SearchResponse<object>();
@@ -183,7 +183,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line307()
+		public void Line300()
 		{
 			// tag::577b09f45256ff855252d29e1d1cd433[]
 			var response0 = new SearchResponse<object>();
@@ -196,7 +196,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line321()
+		public void Line314()
 		{
 			// tag::76c551d13c3d907ad6dc56b85bec76de[]
 			var response0 = new SearchResponse<object>();
@@ -216,7 +216,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line338()
+		public void Line331()
 		{
 			// tag::9aeca1d56bb2ff0701587b269163311e[]
 			var response0 = new SearchResponse<object>();
@@ -229,7 +229,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line352()
+		public void Line345()
 		{
 			// tag::9d2464f0dce99d47f2699d953ee55b37[]
 			var response0 = new SearchResponse<object>();
@@ -249,7 +249,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line369()
+		public void Line362()
 		{
 			// tag::e7f366d76e3e53b4c0c30f7b0c21fbc0[]
 			var response0 = new SearchResponse<object>();
@@ -262,7 +262,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line383()
+		public void Line376()
 		{
 			// tag::4b3ef0f1d3cb9598a3fb94c03948e9e2[]
 			var response0 = new SearchResponse<object>();
@@ -287,7 +287,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line405()
+		public void Line398()
 		{
 			// tag::72ef8c634b3594963f203d2b3631c12e[]
 			var response0 = new SearchResponse<object>();
@@ -300,7 +300,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line420()
+		public void Line413()
 		{
 			// tag::6dd3c5a716302fdd39fcf5c150b826bc[]
 			var response0 = new SearchResponse<object>();
@@ -316,7 +316,7 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line435()
+		public void Line428()
 		{
 			// tag::70932f56df27fb502d2095fefcaa83d6[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/CloseJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/CloseJobPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class CloseJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line102()
+		public void Line92()
 		{
-			// tag::cf6e928ae9efc2b9f59aa1ccb4605bee[]
+			// tag::75957a7d1b67e3d47899c5f18b32cb61[]
 			var response0 = new SearchResponse<object>();
-			// end::cf6e928ae9efc2b9f59aa1ccb4605bee[]
+			// end::75957a7d1b67e3d47899c5f18b32cb61[]
 
-			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_close");
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/low_request_rate/_close");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarEventPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarEventPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteCalendarEventPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line47()
+		public void Line45()
 		{
 			// tag::f6982ff80b9a64cd5fcac5b20908c906[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarJobPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteCalendarJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line40()
+		public void Line38()
 		{
 			// tag::1b0b29e5cd7550c648d0892378e93804[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteCalendarPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteCalendarPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line41()
+		public void Line40()
 		{
 			// tag::63893e7e9479a9b60db71dcddcc79aaf[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteDatafeedPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line46()
+		public void Line45()
 		{
 			// tag::8a12cd824404d74f098d854716a26899[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteFilterPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteFilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteFilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line42()
+		public void Line41()
 		{
 			// tag::8c5d48252cd6d1ee26a2bb817f89c78e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/DeleteJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/DeleteJobPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class DeleteJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line62()
+		public void Line60()
 		{
 			// tag::3ac8b5234e9d53859245cf8ab0094ca5[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line79()
+		public void Line77()
 		{
 			// tag::ccec66fb20d5ede6c691e0890cfe402a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/FindFileStructurePage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/FindFileStructurePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class FindFileStructurePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line226()
+		public void Line247()
 		{
 			// tag::7a145f2c4ad1c3c9fea24afeadb847ef[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/FlushJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/FlushJobPage.cs
@@ -6,20 +6,20 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class FlushJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line72()
+		public void Line71()
 		{
-			// tag::6a9931992ce1b0c2c2c82635d32f32cd[]
+			// tag::02520ac7816b2c4cf8fb413fd16122f2[]
 			var response0 = new SearchResponse<object>();
-			// end::6a9931992ce1b0c2c2c82635d32f32cd[]
+			// end::02520ac7816b2c4cf8fb413fd16122f2[]
 
-			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_flush
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/low_request_rate/_flush
 			{
 			  ""calc_interim"": true
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line98()
 		{
 			// tag::3033133e8675524fd8f969db0625b62e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/ForecastPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/ForecastPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class ForecastPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line62()
+		public void Line61()
 		{
-			// tag::5bed6929ccc86ef27f9468cf844169c8[]
+			// tag::591c7fb7451069829a14bba593136f1f[]
 			var response0 = new SearchResponse<object>();
-			// end::5bed6929ccc86ef27f9468cf844169c8[]
+			// end::591c7fb7451069829a14bba593136f1f[]
 
-			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_forecast
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/low_request_rate/_forecast
 			{
 			  ""duration"": ""10d""
 			}");

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetBucketPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetBucketPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetBucketPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line93()
+		public void Line174()
 		{
-			// tag::2c7fce4025e8e429e1ae8d50f5eb4b88[]
+			// tag::f96d4614f2fc294339fef325b794355f[]
 			var response0 = new SearchResponse<object>();
-			// end::2c7fce4025e8e429e1ae8d50f5eb4b88[]
+			// end::f96d4614f2fc294339fef325b794355f[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/it-ops-kpi/results/buckets
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/low_request_rate/results/buckets
 			{
 			  ""anomaly_score"": 80,
 			  ""start"": ""1454530200001""

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetCalendarEventPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetCalendarEventPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetCalendarEventPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line90()
+		public void Line85()
 		{
 			// tag::39d6f575c9458d9c941364dfd0493fa0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetCalendarPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetCalendarPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetCalendarPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line72()
+		public void Line68()
 		{
 			// tag::5fca6671bc8eaddc44ac488d1c3c6909[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetCategoryPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetCategoryPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetCategoryPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line100()
 		{
 			// tag::e8f1c9ee003d115ec8f55e57990df6e4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line89()
+		public void Line77()
 		{
-			// tag::d7b3862eb61595fc02d64d5f6ed60c88[]
+			// tag::4fa9ee04188cbf0b38cfc28f6a56527d[]
 			var response0 = new SearchResponse<object>();
-			// end::d7b3862eb61595fc02d64d5f6ed60c88[]
+			// end::4fa9ee04188cbf0b38cfc28f6a56527d[]
 
-			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-total-requests");
+			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-high_sum_total_sales");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedStatsPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetDatafeedStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line93()
+		public void Line135()
 		{
-			// tag::62ef8873988dc63f37ed93114072e4a8[]
+			// tag::f44d287c6937785eb09b91353c1deb1e[]
 			var response0 = new SearchResponse<object>();
-			// end::62ef8873988dc63f37ed93114072e4a8[]
+			// end::f44d287c6937785eb09b91353c1deb1e[]
 
-			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-total-requests/_stats");
+			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-high_sum_total_sales/_stats");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetFilterPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetFilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetFilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line67()
 		{
 			// tag::800861c15bb33ca01a46fb97dde7537a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetInfluencerPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetInfluencerPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetInfluencerPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line77()
+		public void Line128()
 		{
-			// tag::c644b2026414830b6265f7a14dd37ce9[]
+			// tag::5bbccf103107e505c17ae59863753efd[]
 			var response0 = new SearchResponse<object>();
-			// end::c644b2026414830b6265f7a14dd37ce9[]
+			// end::5bbccf103107e505c17ae59863753efd[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/it_ops_new_kpi/results/influencers
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/high_sum_total_sales/results/influencers
 			{
 			  ""sort"": ""influencer_score"",
 			  ""desc"": true

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetJobPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line86()
+		public void Line90()
 		{
-			// tag::29278b6d24dd544da186019301dd4f40[]
+			// tag::86280dcb49aa89083be4b2644daf1b7c[]
 			var response0 = new SearchResponse<object>();
-			// end::29278b6d24dd544da186019301dd4f40[]
+			// end::86280dcb49aa89083be4b2644daf1b7c[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/total-requests");
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/high_sum_total_sales");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetJobStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line86()
+		public void Line328()
 		{
-			// tag::e3d706e32f9bd1496072beb46e4c488e[]
+			// tag::9298aaf8232a819e79b3bf8471245e98[]
 			var response0 = new SearchResponse<object>();
-			// end::e3d706e32f9bd1496072beb46e4c488e[]
+			// end::9298aaf8232a819e79b3bf8471245e98[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/farequote/_stats");
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/low_request_rate/_stats");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetOverallBucketsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetOverallBucketsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetOverallBucketsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line110()
+		public void Line124()
 		{
 			// tag::e48e7da65c2b32d724fd7e3bfa175c6f[]
 			var response0 = new SearchResponse<object>();
@@ -20,7 +20,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line155()
+		public void Line169()
 		{
 			// tag::405db6f3a01eceacfaa8b0ed3e4b3ac2[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetRecordPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetRecordPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetRecordPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line76()
+		public void Line202()
 		{
-			// tag::16337a7169486ffea5bfe185b6426b9c[]
+			// tag::20e3b181114e00c943a27a9bbcf85f15[]
 			var response0 = new SearchResponse<object>();
-			// end::16337a7169486ffea5bfe185b6426b9c[]
+			// end::20e3b181114e00c943a27a9bbcf85f15[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/it-ops-kpi/results/records
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/low_request_rate/results/records
 			{
 			  ""sort"": ""record_score"",
 			  ""desc"": true,

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetSnapshotPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetSnapshotPage.cs
@@ -6,15 +6,15 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetSnapshotPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line70()
+		public void Line193()
 		{
-			// tag::51393160fedca39ea733488044d06f8e[]
+			// tag::c873f9cd093e26515148f052e28c7805[]
 			var response0 = new SearchResponse<object>();
-			// end::51393160fedca39ea733488044d06f8e[]
+			// end::c873f9cd093e26515148f052e28c7805[]
 
-			response0.MatchesExample(@"GET _ml/anomaly_detectors/farequote/model_snapshots
+			response0.MatchesExample(@"GET _ml/anomaly_detectors/high_sum_total_sales/model_snapshots
 			{
-			  ""start"": ""1491852977000""
+			  ""start"": ""1575402236000""
 			}");
 		}
 	}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/OpenJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/OpenJobPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class OpenJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line56()
+		public void Line54()
 		{
-			// tag::72cb058a415b56a8964c05195114b5c0[]
+			// tag::a6204edaa0bcf7b82a89ab4f6bda0914[]
 			var response0 = new SearchResponse<object>();
-			// end::72cb058a415b56a8964c05195114b5c0[]
+			// end::a6204edaa0bcf7b82a89ab4f6bda0914[]
 
-			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_open
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/low_request_rate/_open
 			{
 			  ""timeout"": ""35m""
 			}");

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PostCalendarEventPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PostCalendarEventPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PostCalendarEventPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line64()
+		public void Line63()
 		{
 			// tag::c067182d385f59ce5952fb9a716fbf05[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PreviewDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PreviewDatafeedPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PreviewDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line52()
+		public void Line51()
 		{
-			// tag::27b20b345329fc72d8a0c7d440596ea1[]
+			// tag::38eed000de433b540116928681c520d3[]
 			var response0 = new SearchResponse<object>();
-			// end::27b20b345329fc72d8a0c7d440596ea1[]
+			// end::38eed000de433b540116928681c520d3[]
 
-			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-farequote/_preview");
+			response0.MatchesExample(@"GET _ml/datafeeds/datafeed-high_sum_total_sales/_preview");
 		}
 	}
 }

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutCalendarJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutCalendarJobPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutCalendarJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line37()
+		public void Line38()
 		{
 			// tag::1b2ab75d3c8064fac6ecc63104396c02[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutCalendarPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutCalendarPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutCalendarPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line45()
+		public void Line46()
 		{
 			// tag::e61b5abe85000cc954a42e2cd74f3a26[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutDatafeedPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line118()
+		public void Line110()
 		{
 			// tag::23067c5e8da958fa4d914f3b5c9bf607[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutFilterPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutFilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutFilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line53()
+		public void Line52()
 		{
 			// tag::b4aec2a1d353852507c091bdb629b765[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutJobPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line100()
+		public void Line239()
 		{
 			// tag::9c11e238772d67dbc9d273776de9916c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/RevertSnapshotPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/RevertSnapshotPage.cs
@@ -6,14 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class RevertSnapshotPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line63()
+		public void Line62()
 		{
-			// tag::f28c58902bdefd9e2b36001e8d682d35[]
+			// tag::b173b1b5bab610668ab74d5b2ab03f78[]
 			var response0 = new SearchResponse<object>();
-			// end::f28c58902bdefd9e2b36001e8d682d35[]
+			// end::b173b1b5bab610668ab74d5b2ab03f78[]
 
-			response0.MatchesExample(@"POST
-			_ml/anomaly_detectors/it_ops_new_kpi/model_snapshots/1491856080/_revert
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/high_sum_total_sales/model_snapshots/1575402237/_revert
 			{
 			  ""delete_intervening_results"": true
 			}");

--- a/tests/Examples/Ml/AnomalyDetection/Apis/StartDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/StartDatafeedPage.cs
@@ -6,15 +6,15 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class StartDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line100()
+		public void Line99()
 		{
-			// tag::c85f09d9a0622d32788bd56b0a008592[]
+			// tag::d7ae456f119246e95f2f4c37e7544b8c[]
 			var response0 = new SearchResponse<object>();
-			// end::c85f09d9a0622d32788bd56b0a008592[]
+			// end::d7ae456f119246e95f2f4c37e7544b8c[]
 
-			response0.MatchesExample(@"POST _ml/datafeeds/datafeed-total-requests/_start
+			response0.MatchesExample(@"POST _ml/datafeeds/datafeed-low_request_rate/_start
 			{
-			  ""start"": ""2017-04-07T18:22:16Z""
+			  ""start"": ""2019-04-07T18:22:16Z""
 			}");
 		}
 	}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/StopDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/StopDatafeedPage.cs
@@ -6,13 +6,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class StopDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line86()
+		public void Line74()
 		{
-			// tag::9b1e808ac4cca788990b497fb59ba455[]
+			// tag::fd60b4092c6552164862cec287359676[]
 			var response0 = new SearchResponse<object>();
-			// end::9b1e808ac4cca788990b497fb59ba455[]
+			// end::fd60b4092c6552164862cec287359676[]
 
-			response0.MatchesExample(@"POST _ml/datafeeds/datafeed-total-requests/_stop
+			response0.MatchesExample(@"POST _ml/datafeeds/datafeed-low_request_rate/_stop
 			{
 			  ""timeout"": ""30s""
 			}");

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateDatafeedPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line123()
+		public void Line112()
 		{
 			// tag::df6d5b5f8e1c8785503269ccb7b34763[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateFilterPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateFilterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateFilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line46()
 		{
 			// tag::4d21725453955582ff12b4a1104aa7b6[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateJobPage.cs
@@ -6,32 +6,27 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line101()
+		public void Line172()
 		{
-			// tag::d51232b6f1be5730519ca7733b3232df[]
+			// tag::421e68e2b9789f0e8c08760d9e685d1c[]
 			var response0 = new SearchResponse<object>();
-			// end::d51232b6f1be5730519ca7733b3232df[]
+			// end::421e68e2b9789f0e8c08760d9e685d1c[]
 
-			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_update
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/low_request_rate/_update
 			{
 			  ""description"":""An updated job"",
-			  ""groups"": [""group1"",""group2""],
+			  ""detectors"": {
+			    ""detector_index"": 0,
+			    ""description"": ""An updated detector description""
+			  },
+			  ""groups"": [""kibana_sample_data"",""kibana_sample_web_logs""],
 			  ""model_plot_config"": {
 			    ""enabled"": true
-			  },
-			  ""analysis_limits"": {
-			    ""model_memory_limit"": ""1024mb""
 			  },
 			  ""renormalization_window_days"": 30,
 			  ""background_persist_interval"": ""2h"",
 			  ""model_snapshot_retention_days"": 7,
-			  ""results_retention_days"": 60,
-			  ""custom_settings"": {
-			    ""custom_urls"" : [{
-			      ""url_name"" : ""Lookup IP"",
-			      ""url_value"" : ""http://geoiplookup.net/ip/$clientip$""
-			    }]
-			  }
+			  ""results_retention_days"": 60
 			}");
 		}
 	}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateSnapshotPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateSnapshotPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateSnapshotPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line54()
+		public void Line52()
 		{
 			// tag::3b9c54604535d97e8368d47148aecc6f[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/DeleteDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/DeleteDfanalyticsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class DeleteDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line37()
+		public void Line54()
 		{
 			// tag::1c8b6768c4eefc76fcb38708152f561b[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/DeleteInferenceTrainedModelPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/DeleteInferenceTrainedModelPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Ml.DfAnalytics.Apis
+{
+	public class DeleteInferenceTrainedModelPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line57()
+		{
+			// tag::334e28ff99f12b721b9942bad3a78f94[]
+			var response0 = new SearchResponse<object>();
+			// end::334e28ff99f12b721b9942bad3a78f94[]
+
+			response0.MatchesExample(@"DELETE _ml/inference/regression-job-one-1574775307356");
+		}
+	}
+}

--- a/tests/Examples/Ml/DfAnalytics/Apis/EvaluateDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/EvaluateDfanalyticsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class EvaluateDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line81()
+		public void Line197()
 		{
 			// tag::eae68412d998bc0f65b09711f007a4b7[]
 			var response0 = new SearchResponse<object>();
@@ -25,7 +25,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line142()
+		public void Line259()
 		{
 			// tag::e6e7586a81068773d18cca848346b69f[]
 			var response0 = new SearchResponse<object>();
@@ -55,7 +55,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line179()
+		public void Line296()
 		{
 			// tag::862efc8d548a9202597c72c7e98a599d[]
 			var response0 = new SearchResponse<object>();
@@ -85,7 +85,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line218()
+		public void Line335()
 		{
 			// tag::051b2682d386d49616b18a5db591afdf[]
 			var response0 = new SearchResponse<object>();
@@ -111,6 +111,28 @@ namespace Examples.Ml.DfAnalytics.Apis
 			      }
 			    }
 			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line374()
+		{
+			// tag::388d3eda4f792d3fce044777739217e6[]
+			var response0 = new SearchResponse<object>();
+			// end::388d3eda4f792d3fce044777739217e6[]
+
+			response0.MatchesExample(@"POST _ml/data_frame/_evaluate
+			{
+			   ""index"": ""animal_classification"",
+			   ""evaluation"": {
+			      ""classification"": { <1>
+			         ""actual_field"": ""animal_class"", <2>
+			         ""predicted_field"": ""ml.animal_class_prediction"", <3>
+			         ""metrics"": {
+			           ""multiclass_confusion_matrix"" : {} <4>
+			         }
+			      }
+			   }
 			}");
 		}
 	}

--- a/tests/Examples/Ml/DfAnalytics/Apis/ExplainDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/ExplainDfanalyticsPage.cs
@@ -1,0 +1,30 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Ml.DfAnalytics.Apis
+{
+	public class ExplainDfanalyticsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line88()
+		{
+			// tag::1e75b0e71294527b43015cc333f9d9f7[]
+			var response0 = new SearchResponse<object>();
+			// end::1e75b0e71294527b43015cc333f9d9f7[]
+
+			response0.MatchesExample(@"POST _ml/data_frame/analytics/_explain
+			{
+			  ""data_frame_analytics_config"": {
+			    ""source"": {
+			      ""index"": ""houses_sold_last_10_yrs""
+			    },
+			    ""analysis"": {
+			      ""regression"": {
+			        ""dependent_variable"": ""price""
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class GetDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line93()
+		public void Line98()
 		{
 			// tag::5ccfd9f4698dcd7cdfbc6bad60081aab[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsStatsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsStatsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class GetDfanalyticsStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line109()
+		public void Line85()
 		{
 			// tag::cfc52956b005d57111c49dfe1735634e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Ml.DfAnalytics.Apis
+{
+	public class GetInferenceTrainedModelPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line100()
+		{
+			// tag::f97c7791a0dd23aad5f96fd38ec7d12e[]
+			var response0 = new SearchResponse<object>();
+			// end::f97c7791a0dd23aad5f96fd38ec7d12e[]
+
+			response0.MatchesExample(@"GET _ml/inference/");
+		}
+	}
+}

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelStatsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelStatsPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Ml.DfAnalytics.Apis
+{
+	public class GetInferenceTrainedModelStatsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line85()
+		{
+			// tag::2dde95ba98c5d5e19725fbb10435d283[]
+			var response0 = new SearchResponse<object>();
+			// end::2dde95ba98c5d5e19725fbb10435d283[]
+
+			response0.MatchesExample(@"GET _ml/inference/_stats");
+		}
+	}
+}

--- a/tests/Examples/Ml/DfAnalytics/Apis/PutDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/PutDfanalyticsPage.cs
@@ -6,7 +6,55 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class PutDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line164()
+		public void Line291()
+		{
+			// tag::8c6f3bb8abae9ff1d21e776f16ad1c86[]
+			var response0 = new SearchResponse<object>();
+			// end::8c6f3bb8abae9ff1d21e776f16ad1c86[]
+
+			response0.MatchesExample(@"PUT _ml/data_frame/analytics/model-flight-delays-pre
+			{
+			  ""source"": {
+			    ""index"": [
+			      ""kibana_sample_data_flights"" <1>
+			    ],
+			    ""query"": { <2>
+			      ""range"": {
+			        ""DistanceKilometers"": {
+			          ""gt"": 0
+			        }
+			      }
+			    },
+			    ""_source"": { <3>
+			      ""includes"": [],
+			      ""excludes"": [
+			        ""FlightDelay"",
+			        ""FlightDelayType""
+			      ]
+			    }
+			  },
+			  ""dest"": { <4>
+			    ""index"": ""df-flight-delays"",
+			    ""results_field"": ""ml-results""
+			  },
+			  ""analysis"": {
+			  ""regression"": {
+			    ""dependent_variable"": ""FlightDelayMin"",
+			    ""training_percent"": 90
+			    }
+			  },
+			  ""analyzed_fields"": { <5>
+			    ""includes"": [],
+			    ""excludes"": [
+			      ""FlightNum""
+			    ]
+			  },
+			  ""model_memory_limit"": ""100mb""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line363()
 		{
 			// tag::ce3c391c2b1915cfc44a2917bca71d19[]
 			var response0 = new SearchResponse<object>();
@@ -32,7 +80,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line227()
+		public void Line426()
 		{
 			// tag::e8211247c280a3fbbbdd32850b743b7b[]
 			var response0 = new SearchResponse<object>();
@@ -56,11 +104,11 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line284()
+		public void Line483()
 		{
-			// tag::c04ad5bba1b5df4cfaf663052ab4f009[]
+			// tag::ae82eb17c23cb8e5761cb6240a5ed0a6[]
 			var response0 = new SearchResponse<object>();
-			// end::c04ad5bba1b5df4cfaf663052ab4f009[]
+			// end::ae82eb17c23cb8e5761cb6240a5ed0a6[]
 
 			response0.MatchesExample(@"PUT _ml/data_frame/analytics/student_performance_mathematics_0.3
 			{
@@ -74,9 +122,35 @@ namespace Examples.Ml.DfAnalytics.Apis
 			   {
 			     ""regression"": {
 			       ""dependent_variable"": ""G3"",
-			       ""training_percent"": 70  <1>
+			       ""training_percent"": 70,  <1>
+			       ""randomize_seed"": 19673948271  <2>
 			     }
 			   }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line517()
+		{
+			// tag::4fb0629146ca78b85e823edd405497bb[]
+			var response0 = new SearchResponse<object>();
+			// end::4fb0629146ca78b85e823edd405497bb[]
+
+			response0.MatchesExample(@"PUT _ml/data_frame/analytics/loan_classification
+			{
+			  ""source"" : {
+			    ""index"": ""loan-applicants""
+			  },
+			  ""dest"" : {
+			    ""index"": ""loan-applicants-classified""
+			  },
+			  ""analysis"" : {
+			    ""classification"": {
+			      ""dependent_variable"": ""label"",
+			      ""training_percent"": 75,
+			      ""num_top_classes"": 2
+			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/Ml/DfAnalytics/Apis/StartDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/StartDfanalyticsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class StartDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line49()
+		public void Line57()
 		{
 			// tag::1a3a4b8a4bfee4ab84ddd13d8835f560[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/StopDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/StopDfanalyticsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class StopDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line71()
+		public void Line76()
 		{
 			// tag::db19cc7a26ca80106d86d688f4be67a8[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Modules/Cluster/AllocationFilteringPage.cs
+++ b/tests/Examples/Modules/Cluster/AllocationFilteringPage.cs
@@ -21,7 +21,7 @@ namespace Examples.Modules.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line60()
+		public void Line65()
 		{
 			// tag::07474768b8f9d532b524c15e512736f4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Modules/CrossClusterSearchPage.cs
+++ b/tests/Examples/Modules/CrossClusterSearchPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Modules
 	public class CrossClusterSearchPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line25()
+		public void Line36()
 		{
 			// tag::a8d39396d741e768083808bb11443e9b[]
 			var response0 = new SearchResponse<object>();
@@ -39,7 +39,7 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line62()
+		public void Line73()
 		{
 			// tag::972c0c1b6c0b8327fadd77cc1c71b532[]
 			var response0 = new SearchResponse<object>();
@@ -56,7 +56,7 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line133()
+		public void Line144()
 		{
 			// tag::6a570214755e38fd587e406d5b19b371[]
 			var response0 = new SearchResponse<object>();
@@ -73,7 +73,7 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line232()
+		public void Line243()
 		{
 			// tag::9949bcc64c9cd6f4041819546d7fce78[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Modules/HttpPage.cs
+++ b/tests/Examples/Modules/HttpPage.cs
@@ -1,0 +1,39 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Modules
+{
+	public class HttpPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line119()
+		{
+			// tag::45df8177c5f8a3cc4e36867742e8250c[]
+			var response0 = new SearchResponse<object>();
+			// end::45df8177c5f8a3cc4e36867742e8250c[]
+
+			response0.MatchesExample(@"PUT _cluster/settings
+			{
+			   ""transient"" : {
+			      ""logger.org.elasticsearch.http.HttpTracer"" : ""TRACE""
+			   }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line132()
+		{
+			// tag::fa4e5b5cd144dd03cd507ffa9dec5b7e[]
+			var response0 = new SearchResponse<object>();
+			// end::fa4e5b5cd144dd03cd507ffa9dec5b7e[]
+
+			response0.MatchesExample(@"PUT _cluster/settings
+			{
+			   ""transient"" : {
+			      ""http.tracer.include"" : ""*"",
+			      ""http.tracer.exclude"" : """"
+			   }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Modules/Indices/RequestCachePage.cs
+++ b/tests/Examples/Modules/Indices/RequestCachePage.cs
@@ -6,7 +6,7 @@ namespace Examples.Modules.Indices
 	public class RequestCachePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line44()
+		public void Line47()
 		{
 			// tag::00629ea43db6ee1704183170df085495[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Modules.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line56()
+		public void Line59()
 		{
 			// tag::adebfecf7485326e9f7fae9de9169abc[]
 			var response0 = new SearchResponse<object>();
@@ -31,7 +31,7 @@ namespace Examples.Modules.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line69()
+		public void Line72()
 		{
 			// tag::f22e069bc0c6f9dae57e084c662a86fd[]
 			var response0 = new SearchResponse<object>();
@@ -42,7 +42,7 @@ namespace Examples.Modules.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line83()
+		public void Line86()
 		{
 			// tag::13e9c7cdd43161f1336c94fd70a0db0c[]
 			var response0 = new SearchResponse<object>();
@@ -62,7 +62,7 @@ namespace Examples.Modules.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line140()
+		public void Line139()
 		{
 			// tag::36da9668fef56910370f16bfb772cc40[]
 			var response0 = new SearchResponse<object>();
@@ -72,7 +72,7 @@ namespace Examples.Modules.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line147()
+		public void Line146()
 		{
 			// tag::90631797c7fbda43902abf2cc0ea8304[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Modules/RemoteClustersPage.cs
+++ b/tests/Examples/Modules/RemoteClustersPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Modules
 	public class RemoteClustersPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line103()
+		public void Line109()
 		{
 			// tag::d4ce5a9672f85094e6d833d08debc018[]
 			var response0 = new SearchResponse<object>();
@@ -42,7 +42,7 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line139()
+		public void Line145()
 		{
 			// tag::328b7b4d0de6fac3a91205251de6e9b5[]
 			var response0 = new SearchResponse<object>();
@@ -72,7 +72,7 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line171()
+		public void Line177()
 		{
 			// tag::2a0d451f9e13aca39467883b16270cc2[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Monitoring/CollectingMonitoringDataPage.cs
+++ b/tests/Examples/Monitoring/CollectingMonitoringDataPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Monitoring
 	public class CollectingMonitoringDataPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line53()
+		public void Line61()
 		{
 			// tag::fb2b8d642e16132eebcff4f8b6d592d1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Monitoring/EsmsPage.cs
+++ b/tests/Examples/Monitoring/EsmsPage.cs
@@ -1,0 +1,42 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Monitoring
+{
+	public class EsmsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line34()
+		{
+			// tag::fb2b8d642e16132eebcff4f8b6d592d1[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::fb2b8d642e16132eebcff4f8b6d592d1[]
+
+			response0.MatchesExample(@"GET _cluster/settings");
+
+			response1.MatchesExample(@"PUT _cluster/settings
+			{
+			  ""persistent"": {
+			    ""xpack.monitoring.collection.enabled"": true
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line43()
+		{
+			// tag::519603821dc5b883fc2cf50e3d164084[]
+			var response0 = new SearchResponse<object>();
+			// end::519603821dc5b883fc2cf50e3d164084[]
+
+			response0.MatchesExample(@"PUT _cluster/settings
+			{
+			  ""persistent"": {
+			    ""xpack.monitoring.elasticsearch.collection.enabled"": false
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Monitoring/ProductionPage.cs
+++ b/tests/Examples/Monitoring/ProductionPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Monitoring
 	public class ProductionPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line38()
+		public void Line50()
 		{
 			// tag::a941fd568f2e20e13df909ab24506073[]
 			var response0 = new SearchResponse<object>();
@@ -25,7 +25,7 @@ namespace Examples.Monitoring
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line76()
+		public void Line88()
 		{
 			// tag::0b47b0bef81b9b5eecfb3775695bd6ad[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/BoolQueryPage.cs
+++ b/tests/Examples/QueryDsl/BoolQueryPage.cs
@@ -82,7 +82,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U]
-		public void Line75()
+		public void Line88()
 		{
 			// tag::f70a54cd9a9f4811bf962e469f2ca2ea[]
 			var searchResponse = client.Search<Blog>(s => s
@@ -114,7 +114,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U]
-		public void Line94()
+		public void Line107()
 		{
 			// tag::fa88f6f5a7d728ec4f1d05244228cb09[]
 			var searchResponse = client.Search<Blog>(s => s
@@ -150,14 +150,14 @@ namespace Examples.QueryDsl
 		}
 
 		[U]
-		public void Line117()
+		public void Line130()
 		{
 			// tag::162b5b693b713f0bfab1209d59443c46[]
 			var searchResponse = client.Search<Blog>(s => s
 				.AllIndices()
 				.Query(q =>
-					q.ConstantScore(cs=>cs
-						.Filter(f=>f
+					q.ConstantScore(cs => cs
+						.Filter(f => f
 							.Term(p => p.Status, PublishStatus.Active)
 						)
 					)

--- a/tests/Examples/QueryDsl/DisMaxQueryPage.cs
+++ b/tests/Examples/QueryDsl/DisMaxQueryPage.cs
@@ -6,7 +6,7 @@ namespace Examples.QueryDsl
 	public class DisMaxQueryPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line21()
+		public void Line18()
 		{
 			// tag::fcf5a593cfe8809d98a5239ad9c82038[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/FunctionScoreQueryPage.cs
+++ b/tests/Examples/QueryDsl/FunctionScoreQueryPage.cs
@@ -83,7 +83,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line168()
+		public void Line175()
 		{
 			// tag::b68c85fe1b0d2f264dc0d1cbf530f319[]
 			var response0 = new SearchResponse<object>();
@@ -111,7 +111,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line234()
+		public void Line241()
 		{
 			// tag::645c4c6e209719d3a4d25b1a629cb23b[]
 			var response0 = new SearchResponse<object>();
@@ -131,7 +131,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line262()
+		public void Line269()
 		{
 			// tag::8eaf4d5dd4ab1335deefa7749fdbbcc3[]
 			var response0 = new SearchResponse<object>();
@@ -153,7 +153,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line373()
+		public void Line380()
 		{
 			// tag::ec27afee074001b0e4e393611010842b[]
 			var response0 = new SearchResponse<object>();
@@ -177,7 +177,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line571()
+		public void Line578()
 		{
 			// tag::df17f920b0deab3529b98df88b781f55[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/GeoBoundingBoxQueryPage.cs
+++ b/tests/Examples/QueryDsl/GeoBoundingBoxQueryPage.cs
@@ -74,7 +74,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line132()
 		{
 			// tag::2cbaaab829728c46359d2f68b71c446e[]
 			var response0 = new SearchResponse<object>();
@@ -101,7 +101,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line158()
+		public void Line159()
 		{
 			// tag::bbf04a7f7a8858e911d6a53fe88127b0[]
 			var response0 = new SearchResponse<object>();
@@ -128,7 +128,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line183()
+		public void Line184()
 		{
 			// tag::417dcb29f5547d4de9d75d8b6a7a53c8[]
 			var response0 = new SearchResponse<object>();
@@ -154,7 +154,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line207()
+		public void Line208()
 		{
 			// tag::d84695e3db2c92cd3faebf729e482bf0[]
 			var response0 = new SearchResponse<object>();
@@ -181,7 +181,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line241()
+		public void Line242()
 		{
 			// tag::32ffcae9e1d13df0b7295c349d9145ec[]
 			var response0 = new SearchResponse<object>();
@@ -201,7 +201,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line270()
+		public void Line271()
 		{
 			// tag::370750b2f51bd097f4578e5b105babdf[]
 			var response0 = new SearchResponse<object>();
@@ -230,7 +230,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line319()
+		public void Line320()
 		{
 			// tag::15eee00f09d2290e0f350d420029906e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/IntervalsQueryPage.cs
+++ b/tests/Examples/QueryDsl/IntervalsQueryPage.cs
@@ -44,7 +44,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line276()
+		public void Line312()
 		{
 			// tag::7471e97aaaf21c3a200abdd89f15c3cc[]
 			var response0 = new SearchResponse<object>();
@@ -73,7 +73,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line307()
+		public void Line343()
 		{
 			// tag::2de6885bacb8769b8f22dce253c96b0c[]
 			var response0 = new SearchResponse<object>();
@@ -99,7 +99,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line338()
+		public void Line374()
 		{
 			// tag::e2a22c6fd58cc0becf4c383134a08f8b[]
 			var response0 = new SearchResponse<object>();
@@ -127,7 +127,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line373()
+		public void Line409()
 		{
 			// tag::5f79c42b0f74fdf71359cef82843fad3[]
 			var response0 = new SearchResponse<object>();
@@ -158,7 +158,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line406()
+		public void Line442()
 		{
 			// tag::e7811867397b305efbbe8925d8a01c1a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/MatchAllQueryPage.cs
+++ b/tests/Examples/QueryDsl/MatchAllQueryPage.cs
@@ -5,14 +5,16 @@ namespace Examples.QueryDsl
 {
 	public class MatchAllQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line11()
 		{
 			// tag::09d617863a103c82fb4101e6165ea7fe[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.MatchAll(m => m));
 			// end::09d617863a103c82fb4101e6165ea7fe[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match_all"": {}
@@ -20,14 +22,16 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line23()
 		{
 			// tag::75330ec1305d2beb0e2f34d2195464e2[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.MatchAll(m => m.Boost(1.2)));
 			// end::75330ec1305d2beb0e2f34d2195464e2[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match_all"": { ""boost"" : 1.2 }
@@ -35,14 +39,17 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line39()
 		{
 			// tag::81c9aa2678d6166a9662ddf2c011a6a5[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q.MatchNone())
+			);
 			// end::81c9aa2678d6166a9662ddf2c011a6a5[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""match_none"": {}

--- a/tests/Examples/QueryDsl/MatchQueryPage.cs
+++ b/tests/Examples/QueryDsl/MatchQueryPage.cs
@@ -56,7 +56,8 @@ namespace Examples.QueryDsl
 			    }
 			}", e =>
 			{
-				e.ApplyBodyChanges(b => {
+				e.ApplyBodyChanges(b =>
+				{
 					b["query"]["match"]["message"].ToLongFormQuery();
 				});
 				return e;

--- a/tests/Examples/QueryDsl/QueryStringSyntaxPage.cs
+++ b/tests/Examples/QueryDsl/QueryStringSyntaxPage.cs
@@ -6,7 +6,7 @@ namespace Examples.QueryDsl
 	public class QueryStringSyntaxPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line282()
+		public void Line294()
 		{
 			// tag::8ca595edc1e1f1ae6bc3ee05e0aa1e32[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/RangeQueryPage.cs
+++ b/tests/Examples/QueryDsl/RangeQueryPage.cs
@@ -6,24 +6,14 @@ namespace Examples.QueryDsl
 {
 	public class RangeQueryPage : ExampleBase
 	{
-		[U]
+		[U(Skip = "Example not implemented")]
 		public void Line16()
 		{
-			// tag::97bcd92ef148312d41e69f0d18284327[]
-			var searchResponse = client.Search<object>(s => s
-				.AllIndices()
-				.Query(q => q
-					.LongRange(r => r
-						.Field("age")
-						.GreaterThanOrEquals(10)
-						.LessThanOrEquals(20)
-						.Boost(2)
-					)
-				)
-			);
-			// end::97bcd92ef148312d41e69f0d18284327[]
+			// tag::a116949e446f34dc25ae57d4b703d0c1[]
+			var response0 = new SearchResponse<object>();
+			// end::a116949e446f34dc25ae57d4b703d0c1[]
 
-			searchResponse.MatchesExample(@"GET _search
+			response0.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""range"" : {
@@ -37,23 +27,14 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U]
-		public void Line152()
+		[U(Skip = "Example not implemented")]
+		public void Line157()
 		{
-			// tag::4466d410e06712c63328de4db249e6da[]
-			var searchResponse = client.Search<object>(s => s
-				.AllIndices()
-				.Query(q => q
-					.DateRange(r => r
-						.Field("timestamp")
-						.GreaterThanOrEquals("now-1d/d")
-						.LessThan("now/d")
-					)
-				)
-			);
-			// end::4466d410e06712c63328de4db249e6da[]
+			// tag::67ceac4bf2d9ac7cc500390544cdcb41[]
+			var response0 = new SearchResponse<object>();
+			// end::67ceac4bf2d9ac7cc500390544cdcb41[]
 
-			searchResponse.MatchesExample(@"GET _search
+			response0.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""range"" : {
@@ -66,34 +47,24 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U]
-		public void Line214()
+		[U(Skip = "Example not implemented")]
+		public void Line219()
 		{
-			// tag::5d13a71fa7fda73b15111803b1c7cfd3[]
-			var searchResponse = client.Search<object>(s => s
-				.AllIndices()
-				.Query(q => q
-					.DateRange(r => r
-						.Field("timestamp")
-						.TimeZone("+01:00")
-						.GreaterThanOrEquals("2015-01-01 00:00:00")
-						.LessThanOrEquals("now")
-					)
-				)
-			);
-			// end::5d13a71fa7fda73b15111803b1c7cfd3[]
+			// tag::5c2f486c27bd5346e512265f93375d16[]
+			var response0 = new SearchResponse<object>();
+			// end::5c2f486c27bd5346e512265f93375d16[]
 
-			searchResponse.MatchesExample(@"GET _search
+			response0.MatchesExample(@"GET /_search
 			{
-			    ""query"": {
-			        ""range"" : {
-			            ""timestamp"" : {
-			                ""time_zone"": ""+01:00"", \<1>
-			                ""gte"": ""2015-01-01 00:00:00"", \<2>
-			                ""lte"": ""now"" \<3>
-			            }
-			        }
+			  ""query"": {
+			    ""range"": {
+			      ""timestamp"": {
+			        ""time_zone"": ""+01:00"",        <1>
+			        ""gte"": ""2020-01-01T00:00:00"", <2>
+			        ""lte"": ""now""                  <3>
+			      }
 			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/QueryDsl/ScriptScoreQueryPage.cs
+++ b/tests/Examples/QueryDsl/ScriptScoreQueryPage.cs
@@ -28,7 +28,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line338()
+		public void Line345()
 		{
 			// tag::e5240a59149072e8bc7532603fa813bd[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/ShapeQueryPage.cs
+++ b/tests/Examples/QueryDsl/ShapeQueryPage.cs
@@ -8,11 +8,11 @@ namespace Examples.QueryDsl
 		[U(Skip = "Example not implemented")]
 		public void Line28()
 		{
-			// tag::32afa78603025e0917a2bdd7e2e39ac8[]
+			// tag::9208f0823deacf3e3a2cc2b5d78f1e33[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::32afa78603025e0917a2bdd7e2e39ac8[]
+			// end::9208f0823deacf3e3a2cc2b5d78f1e33[]
 
 			response0.MatchesExample(@"PUT /example
 			{
@@ -25,10 +25,10 @@ namespace Examples.QueryDsl
 			    }
 			}");
 
-			response1.MatchesExample(@"POST /example/_doc?refresh
+			response1.MatchesExample(@"PUT /example/_doc/1?refresh=wait_for
 			{
 			    ""name"": ""Lucky Landing"",
-			    ""location"": {
+			    ""geometry"": {
 			        ""type"": ""point"",
 			        ""coordinates"": [1355.400544, 5255.530286]
 			    }
@@ -59,7 +59,7 @@ namespace Examples.QueryDsl
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line92()
+		public void Line133()
 		{
 			// tag::86388922e307dd94c0f5f93890f13832[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/QueryDsl/TermQueryPage.cs
+++ b/tests/Examples/QueryDsl/TermQueryPage.cs
@@ -1,18 +1,23 @@
 using Elastic.Xunit.XunitPlumbing;
+using Examples.Models;
 using Nest;
 
 namespace Examples.QueryDsl
 {
 	public class TermQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line28()
 		{
 			// tag::d0a8a938a2fa913b6fdbc871079a59dd[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<Tweet>(s => s
+				.Query(q => q
+					.Term(f => f.User, "Kimchy", 1.0))
+				.AllIndices()
+			);
 			// end::d0a8a938a2fa913b6fdbc871079a59dd[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""term"": {
@@ -25,14 +30,19 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line94()
 		{
 			// tag::2a1de18774f9c68cafa169847832b2bc[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map(m => m
+					.Properties(p => p
+						.Text(t => t.Name("full_text")))
+				)
+			);
 			// end::2a1de18774f9c68cafa169847832b2bc[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			    ""mappings"" : {
 			        ""properties"" : {
@@ -42,51 +52,65 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line113()
 		{
 			// tag::d4b4cefba4318caeba7480187faf2b13[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new { full_text = "Quick Brown Foxes!" }, i => i.Index("my_index").Id(1));
 			// end::d4b4cefba4318caeba7480187faf2b13[]
 
-			response0.MatchesExample(@"PUT my_index/_doc/1
+			indexResponse.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""full_text"":   ""Quick Brown Foxes!""
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line132()
 		{
 			// tag::cdedd5f33f7e5f7acde561e97bff61de[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.Query(q => q
+					.Term("full_text", "Quick Brown Foxes!"))
+				.Index("my_index")
+			);
 			// end::cdedd5f33f7e5f7acde561e97bff61de[]
 
-			response0.MatchesExample(@"GET my_index/_search?pretty
+			searchResponse.MatchesExample(@"GET my_index/_search?pretty
 			{
 			  ""query"": {
 			    ""term"": {
 			      ""full_text"": ""Quick Brown Foxes!""
 			    }
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["full_text"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line165()
 		{
 			// tag::a80f5db4357bb25b8704d374c18318ed[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.Query(q => q
+					.Match(m => m.Field("full_text").Query("Quick Brown Foxes!")))
+				.Index("my_index")
+			);
 			// end::a80f5db4357bb25b8704d374c18318ed[]
 
-			response0.MatchesExample(@"GET my_index/_search?pretty
+			searchResponse.MatchesExample(@"GET my_index/_search?pretty
 			{
 			  ""query"": {
 			    ""match"": {
 			      ""full_text"": ""Quick Brown Foxes!""
 			    }
 			  }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["match"]["full_text"].ToLongFormQuery();
+			});
 		}
 	}
 }

--- a/tests/Examples/RestApi/InfoPage.cs
+++ b/tests/Examples/RestApi/InfoPage.cs
@@ -16,7 +16,7 @@ namespace Examples.RestApi
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line157()
+		public void Line163()
 		{
 			// tag::b11a0675e49df0709be693297ca73a2c[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.RestApi
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line164()
+		public void Line170()
 		{
 			// tag::4ed946065faa92f9950f04e402676a97[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/RestApi/UsagePage.cs
+++ b/tests/Examples/RestApi/UsagePage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.RestApi
+{
+	public class UsagePage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line32()
+		{
+			// tag::43fe75fa9f3fca846598fdad58fd98cb[]
+			var response0 = new SearchResponse<object>();
+			// end::43fe75fa9f3fca846598fdad58fd98cb[]
+
+			response0.MatchesExample(@"GET /_xpack/usage");
+		}
+	}
+}

--- a/tests/Examples/Rollup/Apis/PutJobPage.cs
+++ b/tests/Examples/Rollup/Apis/PutJobPage.cs
@@ -6,11 +6,11 @@ namespace Examples.Rollup.Apis
 	public class PutJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line74()
+		public void Line223()
 		{
-			// tag::2d20c42e9664febeccaff61581605cbe[]
+			// tag::2025834fab7efbb0542275c30d9d0bfe[]
 			var response0 = new SearchResponse<object>();
-			// end::2d20c42e9664febeccaff61581605cbe[]
+			// end::2025834fab7efbb0542275c30d9d0bfe[]
 
 			response0.MatchesExample(@"PUT _rollup/job/sensor
 			{
@@ -18,7 +18,7 @@ namespace Examples.Rollup.Apis
 			    ""rollup_index"": ""sensor_rollup"",
 			    ""cron"": ""*/30 * * * * ?"",
 			    ""page_size"" :1000,
-			    ""groups"" : {
+			    ""groups"" : { <1>
 			      ""date_histogram"": {
 			        ""field"": ""timestamp"",
 			        ""fixed_interval"": ""1h"",
@@ -28,7 +28,7 @@ namespace Examples.Rollup.Apis
 			        ""fields"": [""node""]
 			      }
 			    },
-			    ""metrics"": [
+			    ""metrics"": [ <2>
 			        {
 			            ""field"": ""temperature"",
 			            ""metrics"": [""min"", ""max"", ""sum""]

--- a/tests/Examples/Rollup/Apis/RollupCapsPage.cs
+++ b/tests/Examples/Rollup/Apis/RollupCapsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Rollup.Apis
 	public class RollupCapsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line55()
+		public void Line57()
 		{
 			// tag::2d20c42e9664febeccaff61581605cbe[]
 			var response0 = new SearchResponse<object>();
@@ -42,7 +42,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line89()
+		public void Line92()
 		{
 			// tag::a00311843b5f8f3e9f7d511334a828b1[]
 			var response0 = new SearchResponse<object>();
@@ -52,7 +52,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line157()
+		public void Line164()
 		{
 			// tag::944806221eb89f5af2298ccdf2902277[]
 			var response0 = new SearchResponse<object>();
@@ -62,7 +62,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line165()
+		public void Line173()
 		{
 			// tag::f8cb1a04c2e487ff006b5ae0e1a7afbd[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Rollup/Apis/RollupIndexCapsPage.cs
+++ b/tests/Examples/Rollup/Apis/RollupIndexCapsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Rollup.Apis
 	public class RollupIndexCapsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line46()
+		public void Line53()
 		{
 			// tag::2d20c42e9664febeccaff61581605cbe[]
 			var response0 = new SearchResponse<object>();
@@ -42,7 +42,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line81()
+		public void Line88()
 		{
 			// tag::73d1a6c5ef90b7e35d43a0bfdc1e158d[]
 			var response0 = new SearchResponse<object>();
@@ -52,7 +52,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line152()
+		public void Line163()
 		{
 			// tag::642161d70dacf7d153767d37d3726838[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Rollup/Apis/RollupSearchPage.cs
+++ b/tests/Examples/Rollup/Apis/RollupSearchPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Rollup.Apis
 	public class RollupSearchPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line55()
+		public void Line71()
 		{
 			// tag::2d20c42e9664febeccaff61581605cbe[]
 			var response0 = new SearchResponse<object>();
@@ -42,7 +42,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line91()
+		public void Line108()
 		{
 			// tag::4e63a0fd56cc5d59595baa0b0721f971[]
 			var response0 = new SearchResponse<object>();
@@ -62,7 +62,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line143()
+		public void Line163()
 		{
 			// tag::3d1cea1ad861d1ee62e5f34b84371943[]
 			var response0 = new SearchResponse<object>();
@@ -82,7 +82,7 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line186()
+		public void Line206()
 		{
 			// tag::adcd760ef029f744ab59460818d2342e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Rollup/RollupGettingStartedPage.cs
+++ b/tests/Examples/Rollup/RollupGettingStartedPage.cs
@@ -41,7 +41,7 @@ namespace Examples.Rollup
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line117()
+		public void Line139()
 		{
 			// tag::618c9d42284c067891fb57034a4fd834[]
 			var response0 = new SearchResponse<object>();
@@ -51,7 +51,7 @@ namespace Examples.Rollup
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line153()
 		{
 			// tag::4e63a0fd56cc5d59595baa0b0721f971[]
 			var response0 = new SearchResponse<object>();
@@ -71,7 +71,7 @@ namespace Examples.Rollup
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line188()
+		public void Line210()
 		{
 			// tag::e0f8ecc665f547d5365699ab8773e298[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Root/CatPage.cs
+++ b/tests/Examples/Root/CatPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Root
 	public class CatPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line28()
+		public void Line36()
 		{
 			// tag::45bde49f35ffae3f3dabc77a592241b4[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line49()
+		public void Line57()
 		{
 			// tag::179dabbc531ede7a1813d1a11ce5b5fd[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line77()
+		public void Line85()
 		{
 			// tag::d940059e16675a40e3d278073331eeed[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,17 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line192()
+		public void Line121()
+		{
+			// tag::53b027c2d3ac80e93d398762c55894eb[]
+			var response0 = new SearchResponse<object>();
+			// end::53b027c2d3ac80e93d398762c55894eb[]
+
+			response0.MatchesExample(@"GET /_cat/indices?bytes=b&s=store.size:desc&v");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line211()
 		{
 			// tag::794fa23d07c42900b5e97fb9bf323941[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Root/GettingStartedPage.cs
+++ b/tests/Examples/Root/GettingStartedPage.cs
@@ -11,7 +11,7 @@ namespace Examples.Root
 	public class GettingStartedPage : ExampleBase
 	{
 		[U]
-		public void Line169()
+		public void Line167()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
 			var catResponse = client.Cat.Health(h => h.Verbose());
@@ -21,7 +21,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line214()
+		public void Line251()
 		{
 			// tag::311c4b632a29b9ead63b02d01f10096b[]
 			var indexResponse = client.Index(new Customer
@@ -40,7 +40,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line253()
+		public void Line290()
 		{
 			// tag::3f3b3e207f79303ce6f86e03e928e062[]
 			var getResponse = client.Get<Customer>(1, g => g
@@ -52,7 +52,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line355()
+		public void Line392()
 		{
 			// tag::506844befdc5691d835771bcbb1c1a60[]
 			var searchResponse = client.Search<Account>(s => s
@@ -81,7 +81,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line424()
+		public void Line461()
 		{
 			// tag::4b90feb9d5d3dbfce424dac0341320b7[]
 			var response0 = client.Search<Account>(s => s
@@ -116,7 +116,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line445()
+		public void Line482()
 		{
 			// tag::cd247f267968aa0927bfdad56852f8f5[]
 			var searchResponse = client.Search<Account>(s => s
@@ -145,7 +145,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line458()
+		public void Line495()
 		{
 			// tag::231aa0bb39c35fe199d28fe0e4a62b2e[]
 			var searchResponse = client.Search<Account>(s => s
@@ -174,7 +174,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line475()
+		public void Line512()
 		{
 			// tag::47bb632c6091ad0cd94bc660bdd309a5[]
 			var searchResponse = client.Search<Account>(s => s
@@ -223,7 +223,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line507()
+		public void Line544()
 		{
 			// tag::251ea12c1248385ab409906ac64d9ee9[]
 			var searchResponse = client.Search<Account>(s => s
@@ -277,7 +277,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line541()
+		public void Line578()
 		{
 			// tag::feefeb68144002fd1fff57b77b95b85e[]
 			var searchResponse = client.Search<Account>(s => s
@@ -305,7 +305,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line628()
+		public void Line665()
 		{
 			// tag::cfbaea6f0df045c5d940bbb6a9c69cd8[]
 			var searchResponse = client.Search<Account>(s => s
@@ -345,7 +345,7 @@ namespace Examples.Root
 		}
 
 		[U]
-		public void Line654()
+		public void Line691()
 		{
 			// tag::645796e8047967ca4a7635a22a876f4c[]
 			var searchResponse = client.Search<Account>(s => s

--- a/tests/Examples/Root/MappingPage.cs
+++ b/tests/Examples/Root/MappingPage.cs
@@ -14,7 +14,7 @@ namespace Examples.Root
 			var createIndexResponse = client.Indices.Create("my-index", c => c
 				.Map<Employee>(m => m
 					.Properties(props => props
-						.Number(n => n.Name(p=>p.Age).Type(NumberType.Integer))
+						.Number(n => n.Name(p => p.Age).Type(NumberType.Integer))
 						.Keyword(k => k.Name(p => p.Email))
 						.Text(k => k.Name(p => p.Name))
 					)
@@ -75,7 +75,7 @@ namespace Examples.Root
 		{
 			// tag::99a52be903945b17e734a1d02a57e958[]
 			var getMappingResponse = client.Indices.GetFieldMapping<Employee>(
-				Field<Employee>(p=>p.EmployeeId),
+				Field<Employee>(p => p.EmployeeId),
 				m => m.Index("my-index")
 			);
 			// end::99a52be903945b17e734a1d02a57e958[]

--- a/tests/Examples/Scripting/UsingPage.cs
+++ b/tests/Examples/Scripting/UsingPage.cs
@@ -52,7 +52,23 @@ namespace Examples.Scripting
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line161()
+		public void Line163()
+		{
+			// tag::548a09b4630ae38cf8af33581ae614e6[]
+			var response0 = new SearchResponse<object>();
+			// end::548a09b4630ae38cf8af33581ae614e6[]
+
+			response0.MatchesExample(@"POST _scripts/calculate-score/score
+			{
+			  ""script"": {
+			    ""lang"": ""painless"",
+			    ""source"": ""Math.log(_score * 2) + params.my_modifier""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line177()
 		{
 			// tag::08e08feb514b24006e13f258d617d873[]
 			var response0 = new SearchResponse<object>();
@@ -62,7 +78,7 @@ namespace Examples.Scripting
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line169()
+		public void Line185()
 		{
 			// tag::b3423b00c6336ee0a1720b4ed7031cd7[]
 			var response0 = new SearchResponse<object>();
@@ -89,7 +105,7 @@ namespace Examples.Scripting
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line194()
+		public void Line210()
 		{
 			// tag::4061fd5ba7221ca85805ed14d59a6bc5[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/CountPage.cs
+++ b/tests/Examples/Search/CountPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line90()
+		public void Line92()
 		{
 			// tag::8f0511f8a5cb176ff2afdd4311799a33[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/FieldCapsPage.cs
+++ b/tests/Examples/Search/FieldCapsPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line89()
+		public void Line97()
 		{
 			// tag::614bd49400b6ebf47c5b12839dd1ecb8[]
 			var response0 = new SearchResponse<object>();
@@ -26,7 +26,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line99()
+		public void Line107()
 		{
 			// tag::a985e6b7b2ead9c3f30a9bc97d8b598e[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +36,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line147()
+		public void Line155()
 		{
 			// tag::4e931cfac74e46e221cf4a9ab88a182d[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/MultiSearchPage.cs
+++ b/tests/Examples/Search/MultiSearchPage.cs
@@ -6,7 +6,21 @@ namespace Examples.Search
 	public class MultiSearchPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line127()
+		public void Line7()
+		{
+			// tag::58a2a71be35e770b50914753740ec91e[]
+			var response0 = new SearchResponse<object>();
+			// end::58a2a71be35e770b50914753740ec91e[]
+
+			response0.MatchesExample(@"GET twitter/_msearch
+			{ }
+			{""query"" : {""match"" : { ""message"": ""this is a test""}}}
+			{""index"": ""twitter2""}
+			{""query"" : {""match_all"" : {}}}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line282()
 		{
 			// tag::05af5eab63bf98d0078dfe661cd81124[]
 			var response0 = new SearchResponse<object>();
@@ -22,7 +36,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line160()
+		public void Line315()
 		{
 			// tag::a914be2ff7dd0cbdec0257f0ad50b625[]
 			var response0 = new SearchResponse<object>();
@@ -36,7 +50,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line173()
+		public void Line328()
 		{
 			// tag::28e66ff0ecdd71cb1426880115eab5dd[]
 			var response0 = new SearchResponse<object>();
@@ -58,7 +72,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line192()
+		public void Line347()
 		{
 			// tag::72e72cb3aa1b10b903d8cadcaddf7d10[]
 			var response0 = new SearchResponse<object>();
@@ -80,7 +94,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line212()
+		public void Line367()
 		{
 			// tag::8b4c8f395c0a6f952a42051a0d357154[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/ProfilePage.cs
+++ b/tests/Examples/Search/ProfilePage.cs
@@ -22,7 +22,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line547()
+		public void Line533()
 		{
 			// tag::d8621790a416f05557c8df037a3722ac[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/RankEvalPage.cs
+++ b/tests/Examples/Search/RankEvalPage.cs
@@ -31,7 +31,31 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line267()
+		public void Line278()
+		{
+			// tag::b0b86fd5ac0d4814fc70cb0642cee258[]
+			var response0 = new SearchResponse<object>();
+			// end::b0b86fd5ac0d4814fc70cb0642cee258[]
+
+			response0.MatchesExample(@"GET /twitter/_rank_eval
+			{
+			    ""requests"": [
+			    {
+			        ""id"": ""JFK query"",
+			        ""request"": { ""query"": { ""match_all"": {}}},
+			        ""ratings"": []
+			    }],
+			    ""metric"": {
+			      ""recall"": {
+			        ""k"" : 20,
+			        ""relevant_rating_threshold"": 1
+			      }
+			   }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line319()
 		{
 			// tag::351775a1f73e47025463bd937948f7b4[]
 			var response0 = new SearchResponse<object>();
@@ -55,7 +79,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line311()
+		public void Line363()
 		{
 			// tag::c4f013ff1a8b80c87c0265a91ed12648[]
 			var response0 = new SearchResponse<object>();
@@ -79,7 +103,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line367()
+		public void Line419()
 		{
 			// tag::12c4a9be9ffc26cdc0e9343d53c1fd5d[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/RequestBodyPage.cs
+++ b/tests/Examples/Search/RequestBodyPage.cs
@@ -34,7 +34,8 @@ namespace Examples.Search
 			});
 		}
 
-		[U] public void Line156()
+		[U]
+		public void Line156()
 		{
 			// tag::bfcd65ab85d684d36a8550080032958d[]
 			var searchResponse = client.Search<object>(s => s

--- a/tests/Examples/Search/SearchPage.cs
+++ b/tests/Examples/Search/SearchPage.cs
@@ -21,7 +21,7 @@ namespace Examples.Search
 		}
 
 		[U]
-		public void Line340()
+		public void Line342()
 		{
 			// tag::be49260e1b3496c4feac38c56ebb0669[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -34,7 +34,7 @@ namespace Examples.Search
 		}
 
 		[U]
-		public void Line386()
+		public void Line388()
 		{
 			// tag::f5569945024b9d664828693705c27c1a[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -47,7 +47,7 @@ namespace Examples.Search
 		}
 
 		[U]
-		public void Line398()
+		public void Line400()
 		{
 			// tag::168bfdde773570cfc6dd3ab3574e413b[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -60,7 +60,7 @@ namespace Examples.Search
 		}
 
 		[U]
-		public void Line407()
+		public void Line409()
 		{
 			// tag::8022e6a690344035b6472a43a9d122e0[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -73,7 +73,7 @@ namespace Examples.Search
 		}
 
 		[U]
-		public void Line413()
+		public void Line415()
 		{
 			// tag::43682666e1abcb14770c99f02eb26a0d[]
 			var searchResponse = client.Search<Tweet>(s => s

--- a/tests/Examples/Search/SearchShardsPage.cs
+++ b/tests/Examples/Search/SearchShardsPage.cs
@@ -16,7 +16,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line142()
+		public void Line144()
 		{
 			// tag::a44b7da0091ac75e5571475a4e99bb16[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/SearchTemplatePage.cs
+++ b/tests/Examples/Search/SearchTemplatePage.cs
@@ -27,7 +27,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line110()
+		public void Line112()
 		{
 			// tag::b19dc078255bfa1237206913ae94012f[]
 			var response0 = new SearchResponse<object>();
@@ -49,7 +49,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line145()
+		public void Line147()
 		{
 			// tag::e51c88800679913981757542bc639816[]
 			var response0 = new SearchResponse<object>();
@@ -59,7 +59,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line171()
+		public void Line173()
 		{
 			// tag::ed639528456671b302ecc887f5a60987[]
 			var response0 = new SearchResponse<object>();
@@ -69,7 +69,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line183()
+		public void Line185()
 		{
 			// tag::de5b9f1211876f6ba7a4c93e87c27d3a[]
 			var response0 = new SearchResponse<object>();
@@ -85,7 +85,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line203()
+		public void Line205()
 		{
 			// tag::4b13f649aa2eca6f7ee4221f708430c1[]
 			var response0 = new SearchResponse<object>();
@@ -103,7 +103,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line256()
+		public void Line258()
 		{
 			// tag::99e29a569f37ea83b02687e6e2793529[]
 			var response0 = new SearchResponse<object>();
@@ -120,7 +120,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line275()
+		public void Line277()
 		{
 			// tag::3462452c6fdba8dc1efe2cca101246e8[]
 			var response0 = new SearchResponse<object>();
@@ -137,7 +137,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line292()
+		public void Line294()
 		{
 			// tag::4697b9aa952ac1613ee1a6ec7b3223c1[]
 			var response0 = new SearchResponse<object>();
@@ -159,7 +159,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line316()
+		public void Line318()
 		{
 			// tag::eb1f3134f28a9ba8406b0f10199cf5be[]
 			var response0 = new SearchResponse<object>();
@@ -177,7 +177,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line348()
+		public void Line350()
 		{
 			// tag::6be45fa02e779a727ddf48f871610aa8[]
 			var response0 = new SearchResponse<object>();
@@ -196,7 +196,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line393()
+		public void Line395()
 		{
 			// tag::33bb4a6ec63a709a14dfa15a5e2cca88[]
 			var response0 = new SearchResponse<object>();
@@ -218,7 +218,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line426()
+		public void Line428()
 		{
 			// tag::02f0012ca77fdc409592e524e5647fb8[]
 			var response0 = new SearchResponse<object>();
@@ -248,7 +248,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line615()
+		public void Line612()
 		{
 			// tag::a5cc9a86f0f9525cd86564421c721d2f[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/Suggesters/CompletionSuggestPage.cs
+++ b/tests/Examples/Search/Suggesters/CompletionSuggestPage.cs
@@ -44,7 +44,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line110()
+		public void Line120()
 		{
 			// tag::5e9f3b7246f4549624fa5b9dd3719d75[]
 			var response0 = new SearchResponse<object>();
@@ -66,7 +66,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line131()
+		public void Line141()
 		{
 			// tag::7c3414279d47e9c29105d061ed316ef8[]
 			var response0 = new SearchResponse<object>();
@@ -79,7 +79,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line148()
+		public void Line158()
 		{
 			// tag::7f951981bd8ed09e56aebeb13adb96ce[]
 			var response0 = new SearchResponse<object>();
@@ -99,7 +99,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line216()
+		public void Line226()
 		{
 			// tag::565ef4aad0c7765879325cc5d2e3c530[]
 			var response0 = new SearchResponse<object>();
@@ -121,7 +121,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line306()
+		public void Line316()
 		{
 			// tag::b2a6fb1a94dd10bf594dafe727647e1d[]
 			var response0 = new SearchResponse<object>();
@@ -142,7 +142,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line331()
+		public void Line341()
 		{
 			// tag::a4eac3c0bac550247e8c7d3f9bcaac1c[]
 			var response0 = new SearchResponse<object>();
@@ -165,7 +165,7 @@ namespace Examples.Search.Suggesters
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line389()
+		public void Line399()
 		{
 			// tag::62280b8a1ec0c214b3110a2c42a55fce[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/ValidatePage.cs
+++ b/tests/Examples/Search/ValidatePage.cs
@@ -16,7 +16,7 @@ namespace Examples.Search
 			response0.MatchesExample(@"GET twitter/_validate/query?q=user:foo");
 		}
 		[U(Skip = "Example not implemented")]
-		public void Line73()
+		public void Line75()
 		{
 			// tag::a0a6e4abbf0a5d064d06d06ddc585f4c[]
 			var response0 = new SearchResponse<object>();
@@ -30,7 +30,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line102()
+		public void Line104()
 		{
 			// tag::1a0ce57a5e6d73765601de98a5d60d80[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line129()
+		public void Line131()
 		{
 			// tag::9989c7860423519c7357936a73c2a5ce[]
 			var response0 = new SearchResponse<object>();
@@ -72,7 +72,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line153()
+		public void Line155()
 		{
 			// tag::b5cd0cc45db5f2fba30ac310630ad172[]
 			var response0 = new SearchResponse<object>();
@@ -90,7 +90,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line194()
+		public void Line196()
 		{
 			// tag::fd74d7518bab5f1dbc1fed588b9bc2a6[]
 			var response0 = new SearchResponse<object>();
@@ -110,7 +110,7 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line252()
+		public void Line254()
 		{
 			// tag::d253135ac0a4b3b04531b1a5d2a19279[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Setup/RestartClusterPage.cs
+++ b/tests/Examples/Setup/RestartClusterPage.cs
@@ -21,7 +21,7 @@ namespace Examples.Setup
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line30()
+		public void Line30_1() // Manually changed due to: https://github.com/elastic/docs/issues/1760
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Setup/RestartClusterPage.cs
+++ b/tests/Examples/Setup/RestartClusterPage.cs
@@ -1,0 +1,106 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Setup
+{
+	public class RestartClusterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line30()
+		{
+			// tag::1cd3b9d65576a9212eef898eb3105758[]
+			var response0 = new SearchResponse<object>();
+			// end::1cd3b9d65576a9212eef898eb3105758[]
+
+			response0.MatchesExample(@"PUT _cluster/settings
+			{
+			  ""persistent"": {
+			    ""cluster.routing.allocation.enable"": ""primaries""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line30()
+		{
+			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
+			var response0 = new SearchResponse<object>();
+			// end::f27c28ddbf4c266b5f42d14da837b8de[]
+
+			response0.MatchesExample(@"POST /_flush");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line50()
+		{
+			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
+			var response0 = new SearchResponse<object>();
+			// end::a21a7bf052b41f5b996dc58f7b69770f[]
+
+			response0.MatchesExample(@"POST _ml/set_upgrade_mode?enabled=true");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line89()
+		{
+			// tag::c0a4b0c1c6eff14da8b152ceb19c1c31[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::c0a4b0c1c6eff14da8b152ceb19c1c31[]
+
+			response0.MatchesExample(@"GET _cat/health");
+
+			response1.MatchesExample(@"GET _cat/nodes");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line123()
+		{
+			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
+			var response0 = new SearchResponse<object>();
+			// end::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
+
+			response0.MatchesExample(@"PUT _cluster/settings
+			{
+			  ""persistent"": {
+			    ""cluster.routing.allocation.enable"": null
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line143()
+		{
+			// tag::2d9b30acd6b5683f39d53494c0dd779c[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::2d9b30acd6b5683f39d53494c0dd779c[]
+
+			response0.MatchesExample(@"GET _cat/health");
+
+			response1.MatchesExample(@"GET _cat/recovery");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line158()
+		{
+			// tag::3c5d5a5c34a62724942329658c688f5e[]
+			var response0 = new SearchResponse<object>();
+			// end::3c5d5a5c34a62724942329658c688f5e[]
+
+			response0.MatchesExample(@"POST _ml/set_upgrade_mode?enabled=false");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line204()
+		{
+			// tag::7e49705769c42895fb7b1e2ca028ff47[]
+			var response0 = new SearchResponse<object>();
+			// end::7e49705769c42895fb7b1e2ca028ff47[]
+
+			response0.MatchesExample(@"GET _cat/nodes");
+		}
+	}
+}

--- a/tests/Examples/Setup/SecureSettingsPage.cs
+++ b/tests/Examples/Setup/SecureSettingsPage.cs
@@ -6,13 +6,16 @@ namespace Examples.Setup
 	public class SecureSettingsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line125()
+		public void Line35()
 		{
-			// tag::6e87271a5a10dbb8d27b25c7dbfa868a[]
+			// tag::32732207b66d0fd661e8e7638aef5176[]
 			var response0 = new SearchResponse<object>();
-			// end::6e87271a5a10dbb8d27b25c7dbfa868a[]
+			// end::32732207b66d0fd661e8e7638aef5176[]
 
-			response0.MatchesExample(@"POST _nodes/reload_secure_settings");
+			response0.MatchesExample(@"POST _nodes/reload_secure_settings
+			{
+			  ""reload_secure_settings"": ""s3cr3t"" <1>
+			}");
 		}
 	}
 }

--- a/tests/Examples/Slm/Apis/SlmDeletePage.cs
+++ b/tests/Examples/Slm/Apis/SlmDeletePage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmDeletePage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line66()
+		{
+			// tag::1a1f3421717ff744ed83232729289bb0[]
+			var response0 = new SearchResponse<object>();
+			// end::1a1f3421717ff744ed83232729289bb0[]
+
+			response0.MatchesExample(@"DELETE /_slm/policy/daily-snapshots");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmExecutePage.cs
+++ b/tests/Examples/Slm/Apis/SlmExecutePage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmExecutePage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line45()
+		{
+			// tag::0ab002c6618af75e1041a23c692327ad[]
+			var response0 = new SearchResponse<object>();
+			// end::0ab002c6618af75e1041a23c692327ad[]
+
+			response0.MatchesExample(@"POST /_slm/policy/daily-snapshots/_execute");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmExecuteRetentionPage.cs
+++ b/tests/Examples/Slm/Apis/SlmExecuteRetentionPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmExecuteRetentionPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line35()
+		{
+			// tag::e71d300cd87f09a9527cf45395dd7eb1[]
+			var response0 = new SearchResponse<object>();
+			// end::e71d300cd87f09a9527cf45395dd7eb1[]
+
+			response0.MatchesExample(@"POST /_slm/_execute_retention");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmGetPage.cs
+++ b/tests/Examples/Slm/Apis/SlmGetPage.cs
@@ -1,0 +1,28 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmGetPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line72()
+		{
+			// tag::b4f9fe8808cb27a210b162e7aaba261d[]
+			var response0 = new SearchResponse<object>();
+			// end::b4f9fe8808cb27a210b162e7aaba261d[]
+
+			response0.MatchesExample(@"GET /_slm/policy/daily-snapshots?human");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line123()
+		{
+			// tag::bc2dd9e5ed37f98016ecf53f968d2211[]
+			var response0 = new SearchResponse<object>();
+			// end::bc2dd9e5ed37f98016ecf53f968d2211[]
+
+			response0.MatchesExample(@"GET /_slm/policy");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmGetStatusPage.cs
+++ b/tests/Examples/Slm/Apis/SlmGetStatusPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmGetStatusPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line43()
+		{
+			// tag::cde4104a29dfe942d55863cdd8718627[]
+			var response0 = new SearchResponse<object>();
+			// end::cde4104a29dfe942d55863cdd8718627[]
+
+			response0.MatchesExample(@"GET _slm/status");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmPutPage.cs
+++ b/tests/Examples/Slm/Apis/SlmPutPage.cs
@@ -1,0 +1,33 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmPutPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line151()
+		{
+			// tag::aa7cf5df36b867aee5e3314ac4b4fa68[]
+			var response0 = new SearchResponse<object>();
+			// end::aa7cf5df36b867aee5e3314ac4b4fa68[]
+
+			response0.MatchesExample(@"PUT /_slm/policy/daily-snapshots
+			{
+			  ""schedule"": ""0 30 1 * * ?"", <1>
+			  ""name"": ""<daily-snap-{now/d}>"", <2>
+			  ""repository"": ""my_repository"", <3>
+			  ""config"": { <4>
+			    ""indices"": [""data-*"", ""important""], <5>
+			    ""ignore_unavailable"": false,
+			    ""include_global_state"": false
+			  },
+			  ""retention"": { <6>
+			    ""expire_after"": ""30d"", <7>
+			    ""min_count"": 5, <8>
+			    ""max_count"": 50 <9>
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmStartPage.cs
+++ b/tests/Examples/Slm/Apis/SlmStartPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmStartPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line42()
+		{
+			// tag::371962cf63e65c10026177c6a1bad0b6[]
+			var response0 = new SearchResponse<object>();
+			// end::371962cf63e65c10026177c6a1bad0b6[]
+
+			response0.MatchesExample(@"POST _slm/start");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmStatsPage.cs
+++ b/tests/Examples/Slm/Apis/SlmStatsPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmStatsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line27()
+		{
+			// tag::55e8ddf643726dec51531ada0bec7143[]
+			var response0 = new SearchResponse<object>();
+			// end::55e8ddf643726dec51531ada0bec7143[]
+
+			response0.MatchesExample(@"GET /_slm/stats");
+		}
+	}
+}

--- a/tests/Examples/Slm/Apis/SlmStopPage.cs
+++ b/tests/Examples/Slm/Apis/SlmStopPage.cs
@@ -1,0 +1,18 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm.Apis
+{
+	public class SlmStopPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line48()
+		{
+			// tag::41195ef13af0465cdee1ae18f6c00fde[]
+			var response0 = new SearchResponse<object>();
+			// end::41195ef13af0465cdee1ae18f6c00fde[]
+
+			response0.MatchesExample(@"POST _slm/stop");
+		}
+	}
+}

--- a/tests/Examples/Slm/GettingStartedSlmPage.cs
+++ b/tests/Examples/Slm/GettingStartedSlmPage.cs
@@ -1,0 +1,67 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm
+{
+	public class GettingStartedSlmPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line23()
+		{
+			// tag::89b72dd7f747f6297c2b089e8bc807be[]
+			var response0 = new SearchResponse<object>();
+			// end::89b72dd7f747f6297c2b089e8bc807be[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_repository
+			{
+			  ""type"": ""fs"",
+			  ""settings"": {
+			    ""location"": ""my_backup_location""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line48()
+		{
+			// tag::0da01289c561448254d521504d5122dd[]
+			var response0 = new SearchResponse<object>();
+			// end::0da01289c561448254d521504d5122dd[]
+
+			response0.MatchesExample(@"PUT /_slm/policy/nightly-snapshots
+			{
+			  ""schedule"": ""0 30 2 * * ?"", <1>
+			  ""name"": ""<nightly-snap-{now/d}>"", <2>
+			  ""repository"": ""my_repository"", <3>
+			  ""config"": { <4>
+			    ""indices"": [""*""] <5>
+			  },
+			  ""retention"": { <6>
+			    ""expire_after"": ""30d"", <7>
+			    ""min_count"": 5, <8>
+			    ""max_count"": 50 <9>
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line105()
+		{
+			// tag::af5ff39759d3af0525d941634a6cdb82[]
+			var response0 = new SearchResponse<object>();
+			// end::af5ff39759d3af0525d941634a6cdb82[]
+
+			response0.MatchesExample(@"POST /_slm/policy/nightly-snapshots/_execute");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line117()
+		{
+			// tag::f1b545d3c3eeedf8ae09c56070c26053[]
+			var response0 = new SearchResponse<object>();
+			// end::f1b545d3c3eeedf8ae09c56070c26053[]
+
+			response0.MatchesExample(@"GET /_slm/policy/nightly-snapshots?human");
+		}
+	}
+}

--- a/tests/Examples/Slm/IndexPage.cs
+++ b/tests/Examples/Slm/IndexPage.cs
@@ -1,0 +1,46 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm
+{
+	public class IndexPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line38()
+		{
+			// tag::1d7abeea98f6ed64cc8371794c90a921[]
+			var response0 = new SearchResponse<object>();
+			// end::1d7abeea98f6ed64cc8371794c90a921[]
+
+			response0.MatchesExample(@"POST /_security/role/slm-admin
+			{
+			  ""cluster"": [""manage_slm"", ""cluster:admin/snapshot/*""],
+			  ""indices"": [
+			    {
+			      ""names"": ["".slm-history-*""],
+			      ""privileges"": [""all""]
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line56()
+		{
+			// tag::ef76d0e4cdc2881c161a5557a98a3446[]
+			var response0 = new SearchResponse<object>();
+			// end::ef76d0e4cdc2881c161a5557a98a3446[]
+
+			response0.MatchesExample(@"POST /_security/role/slm-read-only
+			{
+			  ""cluster"": [""read_slm""],
+			  ""indices"": [
+			    {
+			      ""names"": ["".slm-history-*""],
+			      ""privileges"": [""read""]
+			    }
+			  ]
+			}");
+		}
+	}
+}

--- a/tests/Examples/Slm/SlmRetentionPage.cs
+++ b/tests/Examples/Slm/SlmRetentionPage.cs
@@ -1,0 +1,38 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.Slm
+{
+	public class SlmRetentionPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line31()
+		{
+			// tag::1527fe79aa1ae25a155a060bac788e7f[]
+			var response0 = new SearchResponse<object>();
+			// end::1527fe79aa1ae25a155a060bac788e7f[]
+
+			response0.MatchesExample(@"PUT /_slm/policy/daily-snapshots
+			{
+			  ""schedule"": ""0 30 1 * * ?"",
+			  ""name"": ""<daily-snap-{now/d}>"",
+			  ""repository"": ""my_repository"",
+			  ""retention"": { <1>
+			    ""expire_after"": ""30d"", <2>
+			    ""min_count"": 5, <3>
+			    ""max_count"": 50 <4>
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line80()
+		{
+			// tag::55e8ddf643726dec51531ada0bec7143[]
+			var response0 = new SearchResponse<object>();
+			// end::55e8ddf643726dec51531ada0bec7143[]
+
+			response0.MatchesExample(@"GET /_slm/stats");
+		}
+	}
+}

--- a/tests/Examples/SnapshotRestore/MonitorSnapshotRestorePage.cs
+++ b/tests/Examples/SnapshotRestore/MonitorSnapshotRestorePage.cs
@@ -1,0 +1,38 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.SnapshotRestore
+{
+	public class MonitorSnapshotRestorePage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line32()
+		{
+			// tag::020c56e520ff6556ebfaf98efaef56aa[]
+			var response0 = new SearchResponse<object>();
+			// end::020c56e520ff6556ebfaf98efaef56aa[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_1");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line43()
+		{
+			// tag::e566ca0098be82a2847c17069711a822[]
+			var response0 = new SearchResponse<object>();
+			// end::e566ca0098be82a2847c17069711a822[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_1/_status");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line72()
+		{
+			// tag::86c723fc6212d34166661e7dac223491[]
+			var response0 = new SearchResponse<object>();
+			// end::86c723fc6212d34166661e7dac223491[]
+
+			response0.MatchesExample(@"DELETE /_snapshot/my_backup/snapshot_1");
+		}
+	}
+}

--- a/tests/Examples/SnapshotRestore/RegisterRepositoryPage.cs
+++ b/tests/Examples/SnapshotRestore/RegisterRepositoryPage.cs
@@ -1,0 +1,151 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.SnapshotRestore
+{
+	public class RegisterRepositoryPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line24()
+		{
+			// tag::92b3749a473cf2e7ff4055316662a4fe[]
+			var response0 = new SearchResponse<object>();
+			// end::92b3749a473cf2e7ff4055316662a4fe[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_backup
+			{
+			  ""type"": ""fs"",
+			  ""settings"": {
+			    ""location"": ""my_backup_location""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line38()
+		{
+			// tag::ff930e6409b6a923ef1c9e7fc99f24cc[]
+			var response0 = new SearchResponse<object>();
+			// end::ff930e6409b6a923ef1c9e7fc99f24cc[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line63()
+		{
+			// tag::b9e4f7a80d21c85f88f578219df8e192[]
+			var response0 = new SearchResponse<object>();
+			// end::b9e4f7a80d21c85f88f578219df8e192[]
+
+			response0.MatchesExample(@"GET /_snapshot/repo*,*backup*");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line71()
+		{
+			// tag::0d754b0d8d13c6d39ea353978dfe5992[]
+			var response0 = new SearchResponse<object>();
+			// end::0d754b0d8d13c6d39ea353978dfe5992[]
+
+			response0.MatchesExample(@"GET /_snapshot");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line78()
+		{
+			// tag::37432cda12eb63ce59d186b55233c6e1[]
+			var response0 = new SearchResponse<object>();
+			// end::37432cda12eb63ce59d186b55233c6e1[]
+
+			response0.MatchesExample(@"GET /_snapshot/_all");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line111()
+		{
+			// tag::44b410249d477c640c127bfc7320e365[]
+			var response0 = new SearchResponse<object>();
+			// end::44b410249d477c640c127bfc7320e365[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_fs_backup
+			{
+			    ""type"": ""fs"",
+			    ""settings"": {
+			        ""location"": ""/mount/backups/my_fs_backup_location"",
+			        ""compress"": true
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line127()
+		{
+			// tag::8988215f3a4fc4b7a7ef4a9c5be3391e[]
+			var response0 = new SearchResponse<object>();
+			// end::8988215f3a4fc4b7a7ef4a9c5be3391e[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_fs_backup
+			{
+			    ""type"": ""fs"",
+			    ""settings"": {
+			        ""location"": ""my_fs_backup_location"",
+			        ""compress"": true
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line205()
+		{
+			// tag::98ee9bfa32b64ca22e4338544b36c370[]
+			var response0 = new SearchResponse<object>();
+			// end::98ee9bfa32b64ca22e4338544b36c370[]
+
+			response0.MatchesExample(@"PUT _snapshot/my_src_only_repository
+			{
+			  ""type"": ""source"",
+			  ""settings"": {
+			    ""delegate_type"": ""fs"",
+			    ""location"": ""my_backup_location""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line236()
+		{
+			// tag::f1a7cf532da3a8f9a52a401a90e3a998[]
+			var response0 = new SearchResponse<object>();
+			// end::f1a7cf532da3a8f9a52a401a90e3a998[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_unverified_backup?verify=false
+			{
+			  ""type"": ""fs"",
+			  ""settings"": {
+			    ""location"": ""my_unverified_backup_location""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line250()
+		{
+			// tag::337cd2c3f9e11665f00786705037f86c[]
+			var response0 = new SearchResponse<object>();
+			// end::337cd2c3f9e11665f00786705037f86c[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_unverified_backup/_verify");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line267()
+		{
+			// tag::6aca241c0361d26f134712821e2d09a9[]
+			var response0 = new SearchResponse<object>();
+			// end::6aca241c0361d26f134712821e2d09a9[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_repository/_cleanup");
+		}
+	}
+}

--- a/tests/Examples/SnapshotRestore/RestoreSnapshotPage.cs
+++ b/tests/Examples/SnapshotRestore/RestoreSnapshotPage.cs
@@ -1,0 +1,95 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.SnapshotRestore
+{
+	public class RestoreSnapshotPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line28()
+		{
+			// tag::853ca73db9b596cc4ddda66b3ec8faa2[]
+			var response0 = new SearchResponse<object>();
+			// end::853ca73db9b596cc4ddda66b3ec8faa2[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_backup/snapshot_1/_restore");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line45()
+		{
+			// tag::47dcf95e3d398b9bdcb0a483f705bb4b[]
+			var response0 = new SearchResponse<object>();
+			// end::47dcf95e3d398b9bdcb0a483f705bb4b[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_backup/snapshot_1/_restore
+			{
+			  ""indices"": ""index_1,index_2"",
+			  ""ignore_unavailable"": true,
+			  ""include_global_state"": true,
+			  ""rename_pattern"": ""index_(.+)"",
+			  ""rename_replacement"": ""restored_index_$1""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line83()
+		{
+			// tag::922df55507c66533fcadc850eecabcff[]
+			var response0 = new SearchResponse<object>();
+			// end::922df55507c66533fcadc850eecabcff[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_backup/snapshot_1/_restore
+			{
+			  ""indices"": ""index_1"",
+			  ""ignore_unavailable"": true,
+			  ""index_settings"": {
+			    ""index.number_of_replicas"": 0
+			  },
+			  ""ignore_index_settings"": [
+			    ""index.refresh_interval""
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line128()
+		{
+			// tag::1ae301364751c376b3d26581a36d8975[]
+			var response0 = new SearchResponse<object>();
+			// end::1ae301364751c376b3d26581a36d8975[]
+
+			response0.MatchesExample(@"GET /_snapshot/_status");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line137()
+		{
+			// tag::db1913b97109b86cfc5efc7cfcd65d93[]
+			var response0 = new SearchResponse<object>();
+			// end::db1913b97109b86cfc5efc7cfcd65d93[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/_status");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line146()
+		{
+			// tag::e566ca0098be82a2847c17069711a822[]
+			var response0 = new SearchResponse<object>();
+			// end::e566ca0098be82a2847c17069711a822[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_1/_status");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line202()
+		{
+			// tag::2432f86346177533cabdabbd4eb41b30[]
+			var response0 = new SearchResponse<object>();
+			// end::2432f86346177533cabdabbd4eb41b30[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_1,snapshot_2/_status");
+		}
+	}
+}

--- a/tests/Examples/SnapshotRestore/TakeSnapshotPage.cs
+++ b/tests/Examples/SnapshotRestore/TakeSnapshotPage.cs
@@ -1,0 +1,129 @@
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Examples.SnapshotRestore
+{
+	public class TakeSnapshotPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		public void Line27()
+		{
+			// tag::2ab78817eacb5030a447e7fac6b91591[]
+			var response0 = new SearchResponse<object>();
+			// end::2ab78817eacb5030a447e7fac6b91591[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_backup/snapshot_1?wait_for_completion=true");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line40()
+		{
+			// tag::4a0353692bb14c5fccdc97903af0aa13[]
+			var response0 = new SearchResponse<object>();
+			// end::4a0353692bb14c5fccdc97903af0aa13[]
+
+			response0.MatchesExample(@"PUT /_snapshot/my_backup/snapshot_2?wait_for_completion=true
+			{
+			  ""indices"": ""index_1,index_2"",
+			  ""ignore_unavailable"": true,
+			  ""include_global_state"": false,
+			  ""metadata"": {
+			    ""taken_by"": ""kimchy"",
+			    ""taken_because"": ""backup before upgrading""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line72()
+		{
+			// tag::7eb0303e39243fbb9bf51a99270cd022[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::7eb0303e39243fbb9bf51a99270cd022[]
+
+			response0.MatchesExample(@"# PUT /_snapshot/my_backup/<snapshot-{now/d}>");
+
+			response1.MatchesExample(@"PUT /_snapshot/my_backup/%3Csnapshot-%7Bnow%2Fd%7D%3E");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line102()
+		{
+			// tag::020c56e520ff6556ebfaf98efaef56aa[]
+			var response0 = new SearchResponse<object>();
+			// end::020c56e520ff6556ebfaf98efaef56aa[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_1");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line139()
+		{
+			// tag::0b77ebfb06c63ccbad857b39bb4ff851[]
+			var response0 = new SearchResponse<object>();
+			// end::0b77ebfb06c63ccbad857b39bb4ff851[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/snapshot_*,some_other_snapshot");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line147()
+		{
+			// tag::fb224f0ae2a03567b6d9b165e7dd24b6[]
+			var response0 = new SearchResponse<object>();
+			// end::fb224f0ae2a03567b6d9b165e7dd24b6[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/_all");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line167()
+		{
+			// tag::677fdf84ac97bb107207b6966143144b[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+
+			var response2 = new SearchResponse<object>();
+			// end::677fdf84ac97bb107207b6966143144b[]
+
+			response0.MatchesExample(@"GET /_snapshot/_all");
+
+			response1.MatchesExample(@"GET /_snapshot/my_backup,my_fs_backup");
+
+			response2.MatchesExample(@"GET /_snapshot/my*/snap*");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line177()
+		{
+			// tag::155c438e215890cdcb4879eaaadf4046[]
+			var response0 = new SearchResponse<object>();
+			// end::155c438e215890cdcb4879eaaadf4046[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_backup/_current");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line185()
+		{
+			// tag::0784fbe88299be4f02eaa86368e93203[]
+			var response0 = new SearchResponse<object>();
+			// end::0784fbe88299be4f02eaa86368e93203[]
+
+			response0.MatchesExample(@"DELETE /_snapshot/my_backup/snapshot_2");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line199()
+		{
+			// tag::2b8d2065be3002b0be26598d6ad803a6[]
+			var response0 = new SearchResponse<object>();
+			// end::2b8d2065be3002b0be26598d6ad803a6[]
+
+			response0.MatchesExample(@"DELETE /_snapshot/my_backup");
+		}
+	}
+}

--- a/tests/Examples/Sql/Endpoints/RestPage.cs
+++ b/tests/Examples/Sql/Endpoints/RestPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Sql.Endpoints
 	public class RestPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line21()
+		public void Line22()
 		{
 			// tag::4870ece3455f2b5c34eccaa9492f3894[]
 			var response0 = new SearchResponse<object>();
@@ -19,7 +19,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line110()
+		public void Line114()
 		{
 			// tag::b649c4dc7d187a27d2112f59e62cecea[]
 			var response0 = new SearchResponse<object>();
@@ -33,7 +33,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line135()
+		public void Line139()
 		{
 			// tag::8b8c48b5fcfaaec794875537d3be2e62[]
 			var response0 = new SearchResponse<object>();
@@ -47,7 +47,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line170()
+		public void Line174()
 		{
 			// tag::92d82b9d1bda5a8ae1117d03413f4e67[]
 			var response0 = new SearchResponse<object>();
@@ -61,7 +61,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line196()
+		public void Line200()
 		{
 			// tag::a972c38ee41dc899708825790a113cb8[]
 			var response0 = new SearchResponse<object>();
@@ -75,7 +75,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line223()
+		public void Line227()
 		{
 			// tag::d38b8ef18ca89eafb1e175ec9a393259[]
 			var response0 = new SearchResponse<object>();
@@ -89,7 +89,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line277()
+		public void Line282()
 		{
 			// tag::212042898296f208dbf957f33c07e3b2[]
 			var response0 = new SearchResponse<object>();
@@ -102,7 +102,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line314()
+		public void Line319()
 		{
 			// tag::cc5dfc9aa125e3fd03f523fc2c356f63[]
 			var response0 = new SearchResponse<object>();
@@ -115,7 +115,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line341()
+		public void Line346()
 		{
 			// tag::683da0a8624bc03c79a3db8ffab43f0b[]
 			var response0 = new SearchResponse<object>();
@@ -137,7 +137,25 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line379()
+		public void Line380()
+		{
+			// tag::acc0bf5e777f8fc833b7928fdd17ea3e[]
+			var response0 = new SearchResponse<object>();
+			// end::acc0bf5e777f8fc833b7928fdd17ea3e[]
+
+			response0.MatchesExample(@"POST /_sql?format=txt
+			{
+			    ""query"": ""SELECT * FROM library"",
+			    ""filter"": {
+			        ""terms"": {
+			            ""_routing"": [""abc""]
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line404()
 		{
 			// tag::c11dc94839b861235b4943f046e15997[]
 			var response0 = new SearchResponse<object>();
@@ -152,7 +170,7 @@ namespace Examples.Sql.Endpoints
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line415()
+		public void Line440()
 		{
 			// tag::15089efd5a5a72234fdb91c111adb3c1[]
 			var response0 = new SearchResponse<object>();
@@ -162,6 +180,33 @@ namespace Examples.Sql.Endpoints
 			{
 			    ""cursor"": ""sDXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAEWWWdrRlVfSS1TbDYtcW9lc1FJNmlYdw==:BAFmBmF1dGhvcgFmBG5hbWUBZgpwYWdlX2NvdW50AWYMcmVsZWFzZV9kYXRl+v///w8="",
 			    ""columnar"": true
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line473()
+		{
+			// tag::172d150e56a225155a62c7b18bf8da67[]
+			var response0 = new SearchResponse<object>();
+			// end::172d150e56a225155a62c7b18bf8da67[]
+
+			response0.MatchesExample(@"POST /_sql?format=txt
+			{
+				""query"": ""SELECT YEAR(release_date) AS year FROM library WHERE page_count > 300 AND author = 'Frank Herbert' GROUP BY year HAVING COUNT(*) > 0""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line484()
+		{
+			// tag::d9e0cba8e150681d861f5fd1545514e2[]
+			var response0 = new SearchResponse<object>();
+			// end::d9e0cba8e150681d861f5fd1545514e2[]
+
+			response0.MatchesExample(@"POST /_sql?format=txt
+			{
+				""query"": ""SELECT YEAR(release_date) AS year FROM library WHERE page_count > ? AND author = ? GROUP BY year HAVING COUNT(*) > ?"",
+				""params"": [300, ""Frank Herbert"", 0]
 			}");
 		}
 	}

--- a/tests/Examples/Transform/Apis/DeleteTransformPage.cs
+++ b/tests/Examples/Transform/Apis/DeleteTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class DeleteTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line47()
 		{
 			// tag::70c736ecb3746dbe839af0e468712805[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/GetTransformPage.cs
+++ b/tests/Examples/Transform/Apis/GetTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class GetTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line97()
+		public void Line92()
 		{
 			// tag::c65b00a285f510dcd2865aa3539b4e03[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Transform.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line106()
+		public void Line101()
 		{
 			// tag::c8ebbecc372bcfa5f4a6e7242395ab5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/GetTransformStatsPage.cs
+++ b/tests/Examples/Transform/Apis/GetTransformStatsPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class GetTransformStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line104()
+		public void Line191()
 		{
 			// tag::53c6256295111524d5ff2885bdcb99a9[]
 			var response0 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Transform.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line113()
+		public void Line200()
 		{
 			// tag::5db14291fd57c9cd780c969ae26dfaba[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/PreviewTransformPage.cs
+++ b/tests/Examples/Transform/Apis/PreviewTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class PreviewTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line69()
+		public void Line114()
 		{
 			// tag::a5ee3f40c34bd913a12e0069b6e42611[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/PutTransformPage.cs
+++ b/tests/Examples/Transform/Apis/PutTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class PutTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line143()
+		public void Line153()
 		{
 			// tag::23994a14e6b0681cd279b427324945db[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/StartTransformPage.cs
+++ b/tests/Examples/Transform/Apis/StartTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class StartTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line63()
+		public void Line60()
 		{
 			// tag::01bc0f2ed30eb3dd23511d01ce0ac6e1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/StopTransformPage.cs
+++ b/tests/Examples/Transform/Apis/StopTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class StopTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line106()
+		public void Line91()
 		{
 			// tag::654882f545eca8d7047695f867c63072[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/UpdateTransformPage.cs
+++ b/tests/Examples/Transform/Apis/UpdateTransformPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform.Apis
 	public class UpdateTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line124()
+		public void Line132()
 		{
 			// tag::27384266370152add76471dd0332a2f1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/EcommerceTutorialPage.cs
+++ b/tests/Examples/Transform/EcommerceTutorialPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform
 	public class EcommerceTutorialPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line87()
+		public void Line88()
 		{
 			// tag::8345d2615f43a934fe1871a5120eca1d[]
 			var response0 = new SearchResponse<object>();
@@ -59,7 +59,7 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line163()
+		public void Line164()
 		{
 			// tag::c68404749f090ab191c0fd5f651635cf[]
 			var response0 = new SearchResponse<object>();
@@ -119,7 +119,7 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line239()
+		public void Line243()
 		{
 			// tag::4ded8ad815ac0e83b1c21a6c18fd0763[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/ExamplesPage.cs
+++ b/tests/Examples/Transform/ExamplesPage.cs
@@ -6,7 +6,7 @@ namespace Examples.Transform
 	public class ExamplesPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line31()
+		public void Line29()
 		{
 			// tag::88341b4eba71ec722f3e38fa1696fe87[]
 			var response0 = new SearchResponse<object>();
@@ -37,7 +37,7 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line117()
+		public void Line115()
 		{
 			// tag::be9376b1e354ad9c6bdad83f6a0ce5ad[]
 			var response0 = new SearchResponse<object>();
@@ -81,26 +81,25 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line209()
+		public void Line207()
 		{
-			// tag::18beab68b15a44fc9bcbc5c00700376d[]
+			// tag::0bad2211181281b6cc5df8e364bcc111[]
 			var response0 = new SearchResponse<object>();
-			// end::18beab68b15a44fc9bcbc5c00700376d[]
+			// end::0bad2211181281b6cc5df8e364bcc111[]
 
-			response0.MatchesExample(@"POST _transform/_preview
+			response0.MatchesExample(@"PUT _transform/suspicious_client_ips
 			{
 			  ""source"": {
-			    ""index"": ""kibana_sample_data_logs"",
-			    ""query"": { <1>
-			      ""range"" : {
-			        ""timestamp"" : {
-			          ""gte"" : ""now-30d/d""
-			        }
-			      }
-			    }
+			    ""index"": ""kibana_sample_data_logs""
 			  },
-			  ""dest"" : { <2>
+			  ""dest"" : { <1>
 			    ""index"" : ""sample_weblogs_by_clientip""
+			  },
+			  ""sync"" : { <2>
+			    ""time"": {
+			      ""field"": ""timestamp"",
+			      ""delay"": ""60s""
+			    }
 			  },
 			  ""pivot"": {
 			    ""group_by"": {  <3>
@@ -152,6 +151,26 @@ namespace Examples.Transform
 			    }
 			  }
 			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line288()
+		{
+			// tag::4bd42e31ac4a5cf237777f1a0e97aba8[]
+			var response0 = new SearchResponse<object>();
+			// end::4bd42e31ac4a5cf237777f1a0e97aba8[]
+
+			response0.MatchesExample(@"POST _transform/suspicious_client_ips/_start");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line297()
+		{
+			// tag::14f2dab0583c5a9fcc39931d33194872[]
+			var response0 = new SearchResponse<object>();
+			// end::14f2dab0583c5a9fcc39931d33194872[]
+
+			response0.MatchesExample(@"GET sample_weblogs_by_clientip/_search");
 		}
 	}
 }

--- a/tests/Examples/Upgrade/ClusterRestartPage.cs
+++ b/tests/Examples/Upgrade/ClusterRestartPage.cs
@@ -21,17 +21,17 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line33()
+		public void Line31()
 		{
-			// tag::31b4eec9ac4c2c3fdfbaeee8d2f83513[]
+			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();
-			// end::31b4eec9ac4c2c3fdfbaeee8d2f83513[]
+			// end::f27c28ddbf4c266b5f42d14da837b8de[]
 
-			response0.MatchesExample(@"POST _flush/synced");
+			response0.MatchesExample(@"POST /_flush");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line64()
+		public void Line66()
 		{
 			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line89()
+		public void Line91()
 		{
 			// tag::c0a4b0c1c6eff14da8b152ceb19c1c31[]
 			var response0 = new SearchResponse<object>();
@@ -55,7 +55,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line122()
+		public void Line124()
 		{
 			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
 			var response0 = new SearchResponse<object>();
@@ -70,7 +70,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line141()
+		public void Line143()
 		{
 			// tag::2d9b30acd6b5683f39d53494c0dd779c[]
 			var response0 = new SearchResponse<object>();
@@ -84,7 +84,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line157()
+		public void Line159()
 		{
 			// tag::3c5d5a5c34a62724942329658c688f5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Upgrade/RollingUpgradePage.cs
+++ b/tests/Examples/Upgrade/RollingUpgradePage.cs
@@ -21,17 +21,17 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line48()
+		public void Line47()
 		{
-			// tag::31b4eec9ac4c2c3fdfbaeee8d2f83513[]
+			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();
-			// end::31b4eec9ac4c2c3fdfbaeee8d2f83513[]
+			// end::f27c28ddbf4c266b5f42d14da837b8de[]
 
-			response0.MatchesExample(@"POST _flush/synced");
+			response0.MatchesExample(@"POST /_flush");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line80()
+		public void Line82()
 		{
 			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line93()
+		public void Line97()
 		{
 			// tag::7e49705769c42895fb7b1e2ca028ff47[]
 			var response0 = new SearchResponse<object>();
@@ -51,7 +51,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line106()
+		public void Line110()
 		{
 			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
 			var response0 = new SearchResponse<object>();
@@ -66,7 +66,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line124()
+		public void Line128()
 		{
 			// tag::5c53944aec2ce3e55854e315f0482029[]
 			var response0 = new SearchResponse<object>();
@@ -76,7 +76,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line154()
+		public void Line158()
 		{
 			// tag::6b74ff6df5d7583add837b34a6c80a43[]
 			var response0 = new SearchResponse<object>();
@@ -86,7 +86,27 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line180()
+		public void Line175()
+		{
+			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
+			var response0 = new SearchResponse<object>();
+			// end::f8cc4b331a19ff4df8e4a490f906ee69[]
+
+			response0.MatchesExample(@"GET /_cat/health?v");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line182()
+		{
+			// tag::c4270d3851c76898fc8b112c6c597444[]
+			var response0 = new SearchResponse<object>();
+			// end::c4270d3851c76898fc8b112c6c597444[]
+
+			response0.MatchesExample(@"GET /_cat/nodes?h=ip,name,version&v");
+		}
+
+		[U(Skip = "Example not implemented")]
+		public void Line197()
 		{
 			// tag::3c5d5a5c34a62724942329658c688f5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Upgrade/RollingUpgradePage.cs
+++ b/tests/Examples/Upgrade/RollingUpgradePage.cs
@@ -85,14 +85,14 @@ namespace Examples.Upgrade
 			response0.MatchesExample(@"GET _cat/recovery");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		public void Line175()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
-			var response0 = new SearchResponse<object>();
+			var catResponse = client.Cat.Health(h => h.Verbose());
 			// end::f8cc4b331a19ff4df8e4a490f906ee69[]
 
-			response0.MatchesExample(@"GET /_cat/health?v");
+			catResponse.MatchesExample(@"GET /_cat/health?v");
 		}
 
 		[U(Skip = "Example not implemented")]

--- a/tests/Examples/Vectors/VectorFunctionsPage.cs
+++ b/tests/Examples/Vectors/VectorFunctionsPage.cs
@@ -6,9 +6,9 @@ namespace Examples.Vectors
 	public class VectorFunctionsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line21()
+		public void Line15()
 		{
-			// tag::0f621a396f26e1a8d1a724329260af07[]
+			// tag::f4bdad6ecd4a53cabee95883731e1bc7[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
@@ -16,7 +16,7 @@ namespace Examples.Vectors
 			var response2 = new SearchResponse<object>();
 
 			var response3 = new SearchResponse<object>();
-			// end::0f621a396f26e1a8d1a724329260af07[]
+			// end::f4bdad6ecd4a53cabee95883731e1bc7[]
 
 			response0.MatchesExample(@"PUT my_index
 			{
@@ -25,9 +25,6 @@ namespace Examples.Vectors
 			      ""my_dense_vector"": {
 			        ""type"": ""dense_vector"",
 			        ""dims"": 3
-			      },
-			      ""my_sparse_vector"" : {
-			        ""type"" : ""sparse_vector""
 			      },
 			      ""status"" : {
 			        ""type"" : ""keyword""
@@ -39,26 +36,24 @@ namespace Examples.Vectors
 			response1.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""my_dense_vector"": [0.5, 10, 6],
-			  ""my_sparse_vector"": {""2"": 1.5, ""15"" : 2, ""50"": -1.1, ""4545"": 1.1},
 			  ""status"" : ""published""
 			}");
 
 			response2.MatchesExample(@"PUT my_index/_doc/2
 			{
 			  ""my_dense_vector"": [-0.5, 10, 10],
-			  ""my_sparse_vector"": {""2"": 2.5, ""10"" : 1.3, ""55"": -2.3, ""113"": 1.6},
 			  ""status"" : ""published""
 			}");
 
-			response3.MatchesExample(@"");
+			response3.MatchesExample(@"POST my_index/_refresh");
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line61()
+		public void Line52()
 		{
-			// tag::e077e86607f272568cff9cd950c21bb6[]
+			// tag::fb7eaa05e4b418cb3da04e56d3eefa71[]
 			var response0 = new SearchResponse<object>();
-			// end::e077e86607f272568cff9cd950c21bb6[]
+			// end::fb7eaa05e4b418cb3da04e56d3eefa71[]
 
 			response0.MatchesExample(@"GET my_index/_search
 			{
@@ -68,15 +63,15 @@ namespace Examples.Vectors
 			        ""bool"" : {
 			          ""filter"" : {
 			            ""term"" : {
-			              ""status"" : ""published"" \<1>
+			              ""status"" : ""published"" <1>
 			            }
 			          }
 			        }
 			      },
 			      ""script"": {
-			        ""source"": ""cosineSimilarity(params.query_vector, doc['my_dense_vector']) + 1.0"", \<2>
+			        ""source"": ""cosineSimilarity(params.query_vector, 'my_dense_vector') + 1.0"", <2>
 			        ""params"": {
-			          ""query_vector"": [4, 3.4, -0.2]  \<3>
+			          ""query_vector"": [4, 3.4, -0.2]  <3>
 			        }
 			      }
 			    }
@@ -85,42 +80,11 @@ namespace Examples.Vectors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line97()
+		public void Line88()
 		{
-			// tag::d6b15235dd3238e8b94caa42d0c0c32e[]
+			// tag::5f3793dbe5223db53fc67861388ecb10[]
 			var response0 = new SearchResponse<object>();
-			// end::d6b15235dd3238e8b94caa42d0c0c32e[]
-
-			response0.MatchesExample(@"GET my_index/_search
-			{
-			  ""query"": {
-			    ""script_score"": {
-			      ""query"" : {
-			        ""bool"" : {
-			          ""filter"" : {
-			            ""term"" : {
-			              ""status"" : ""published""
-			            }
-			          }
-			        }
-			      },
-			      ""script"": {
-			        ""source"": ""cosineSimilaritySparse(params.query_vector, doc['my_sparse_vector']) + 1.0"",
-			        ""params"": {
-			          ""query_vector"": {""2"": 0.5, ""10"" : 111.3, ""50"": -1.3, ""113"": 14.8, ""4545"": 156.0}
-			        }
-			      }
-			    }
-			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line126()
-		{
-			// tag::3ab88f9b42d28940835c6a6cd91f50fd[]
-			var response0 = new SearchResponse<object>();
-			// end::3ab88f9b42d28940835c6a6cd91f50fd[]
+			// end::5f3793dbe5223db53fc67861388ecb10[]
 
 			response0.MatchesExample(@"GET my_index/_search
 			{
@@ -137,8 +101,8 @@ namespace Examples.Vectors
 			      },
 			      ""script"": {
 			        ""source"": """"""
-			          double value = dotProduct(params.query_vector, doc['my_dense_vector']);
-			          return sigmoid(1, Math.E, -value); \<1>
+			          double value = dotProduct(params.query_vector, 'my_dense_vector');
+			          return sigmoid(1, Math.E, -value); <1>
 			        """""",
 			        ""params"": {
 			          ""query_vector"": [4, 3.4, -0.2]
@@ -150,11 +114,11 @@ namespace Examples.Vectors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line160()
+		public void Line123()
 		{
-			// tag::a7ac82b206e859c187678c62681ba380[]
+			// tag::7453c76da9d525b8c5fb5b86f1207667[]
 			var response0 = new SearchResponse<object>();
-			// end::a7ac82b206e859c187678c62681ba380[]
+			// end::7453c76da9d525b8c5fb5b86f1207667[]
 
 			response0.MatchesExample(@"GET my_index/_search
 			{
@@ -170,41 +134,7 @@ namespace Examples.Vectors
 			        }
 			      },
 			      ""script"": {
-			        ""source"": """"""
-			          double value = dotProductSparse(params.query_vector, doc['my_sparse_vector']);
-			          return sigmoid(1, Math.E, -value);
-			        """""",
-			         ""params"": {
-			          ""query_vector"": {""2"": 0.5, ""10"" : 111.3, ""50"": -1.3, ""113"": 14.8, ""4545"": 156.0}
-			        }
-			      }
-			    }
-			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line193()
-		{
-			// tag::36fc6170ce7ff17b719f988ae03a50c9[]
-			var response0 = new SearchResponse<object>();
-			// end::36fc6170ce7ff17b719f988ae03a50c9[]
-
-			response0.MatchesExample(@"GET my_index/_search
-			{
-			  ""query"": {
-			    ""script_score"": {
-			      ""query"" : {
-			        ""bool"" : {
-			          ""filter"" : {
-			            ""term"" : {
-			              ""status"" : ""published""
-			            }
-			          }
-			        }
-			      },
-			      ""script"": {
-			        ""source"": ""1 / (1 + l1norm(params.queryVector, doc['my_dense_vector']))"", \<1>
+			        ""source"": ""1 / (1 + l1norm(params.queryVector, 'my_dense_vector'))"", <1>
 			        ""params"": {
 			          ""queryVector"": [4, 3.4, -0.2]
 			        }
@@ -215,11 +145,11 @@ namespace Examples.Vectors
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line231()
+		public void Line162()
 		{
-			// tag::ab123056145692c7e7e0d7a95aa7ea72[]
+			// tag::98e4bd19706e57405b6e810de72ea4df[]
 			var response0 = new SearchResponse<object>();
-			// end::ab123056145692c7e7e0d7a95aa7ea72[]
+			// end::98e4bd19706e57405b6e810de72ea4df[]
 
 			response0.MatchesExample(@"GET my_index/_search
 			{
@@ -235,71 +165,9 @@ namespace Examples.Vectors
 			        }
 			      },
 			      ""script"": {
-			        ""source"": ""1 / (1 + l1normSparse(params.queryVector, doc['my_sparse_vector']))"",
-			        ""params"": {
-			          ""queryVector"": {""2"": 0.5, ""10"" : 111.3, ""50"": -1.3, ""113"": 14.8, ""4545"": 156.0}
-			        }
-			      }
-			    }
-			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line261()
-		{
-			// tag::b0e60ffce9edecba49a8b0cce869a85d[]
-			var response0 = new SearchResponse<object>();
-			// end::b0e60ffce9edecba49a8b0cce869a85d[]
-
-			response0.MatchesExample(@"GET my_index/_search
-			{
-			  ""query"": {
-			    ""script_score"": {
-			      ""query"" : {
-			        ""bool"" : {
-			          ""filter"" : {
-			            ""term"" : {
-			              ""status"" : ""published""
-			            }
-			          }
-			        }
-			      },
-			      ""script"": {
-			        ""source"": ""1 / (1 + l2norm(params.queryVector, doc['my_dense_vector']))"",
+			        ""source"": ""1 / (1 + l2norm(params.queryVector, 'my_dense_vector'))"",
 			        ""params"": {
 			          ""queryVector"": [4, 3.4, -0.2]
-			        }
-			      }
-			    }
-			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		public void Line290()
-		{
-			// tag::20a6db9d4b71d551d6864e95d5b93c4f[]
-			var response0 = new SearchResponse<object>();
-			// end::20a6db9d4b71d551d6864e95d5b93c4f[]
-
-			response0.MatchesExample(@"GET my_index/_search
-			{
-			  ""query"": {
-			    ""script_score"": {
-			      ""query"" : {
-			        ""bool"" : {
-			          ""filter"" : {
-			            ""term"" : {
-			              ""status"" : ""published""
-			            }
-			          }
-			        }
-			      },
-			      ""script"": {
-			        ""source"": ""1 / (1 + l2normSparse(params.queryVector, doc['my_sparse_vector']))"",
-			        ""params"": {
-			          ""queryVector"": {""2"": 0.5, ""10"" : 111.3, ""50"": -1.3, ""113"": 14.8, ""4545"": 156.0}
 			        }
 			      }
 			    }

--- a/tests/Examples/XPack/Docs/En/RestApi/Security/GetTokensPage.cs
+++ b/tests/Examples/XPack/Docs/En/RestApi/Security/GetTokensPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 	public class GetTokensPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line102()
+		public void Line111()
 		{
 			// tag::cee591c1fc70d4f180c623a3a6d07755[]
 			var response0 = new SearchResponse<object>();
@@ -19,7 +19,7 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line137()
+		public void Line146()
 		{
 			// tag::e1337c6b76defd5a46d05220f9d9c9fc[]
 			var response0 = new SearchResponse<object>();
@@ -34,7 +34,7 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line167()
+		public void Line176()
 		{
 			// tag::1873f8a8a291e6fcd6c1c83ea6928759[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/RestApi/Security/SamlAuthenticateApiPage.cs
+++ b/tests/Examples/XPack/Docs/En/RestApi/Security/SamlAuthenticateApiPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 	public class SamlAuthenticateApiPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line73()
+		public void Line79()
 		{
 			// tag::8e208098a0156c4c92afe0a06960b230[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/BuiltInUsersPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/BuiltInUsersPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class BuiltInUsersPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line138()
+		public void Line142()
 		{
 			// tag::6f0389ac52808df23bb6081a1acd4eed[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringActiveDirectoryRealmPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringActiveDirectoryRealmPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class ConfiguringActiveDirectoryRealmPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line189()
+		public void Line178()
 		{
 			// tag::21e95d29bc37deb5689a654aa323b4ba[]
 			var response0 = new SearchResponse<object>();
@@ -23,7 +23,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line203()
+		public void Line192()
 		{
 			// tag::bd0d30a7683037e1ebadd163514765d4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringKerberosRealmPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringKerberosRealmPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class ConfiguringKerberosRealmPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line155()
+		public void Line151()
 		{
 			// tag::9584b042223982e0bfde8d12d42c9705[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringLdapRealmPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringLdapRealmPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class ConfiguringLdapRealmPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line150()
+		public void Line138()
 		{
 			// tag::21e95d29bc37deb5689a654aa323b4ba[]
 			var response0 = new SearchResponse<object>();
@@ -23,7 +23,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line164()
+		public void Line152()
 		{
 			// tag::38ffa96674b5fd4042589af0ebb0437b[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringPkiRealmPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/ConfiguringPkiRealmPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class ConfiguringPkiRealmPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line174()
+		public void Line158()
 		{
 			// tag::70bbe14bc4d5a5d58e81ab2b02408817[]
 			var response0 = new SearchResponse<object>();
@@ -23,7 +23,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line269()
+		public void Line251()
 		{
 			// tag::1f8a6d2cc57ed8997a52354aca371aac[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/OidcGuidePage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/OidcGuidePage.cs
@@ -8,13 +8,13 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		[U(Skip = "Example not implemented")]
 		public void Line427()
 		{
-			// tag::66555cd727c474abae640ebb6c4d0a75[]
+			// tag::10de9fd4a38755020a07c4ec964d44c9[]
 			var response0 = new SearchResponse<object>();
-			// end::66555cd727c474abae640ebb6c4d0a75[]
+			// end::10de9fd4a38755020a07c4ec964d44c9[]
 
-			response0.MatchesExample(@"PUT /_security/role_mapping/oidc-kibana
+			response0.MatchesExample(@"PUT /_security/role_mapping/oidc-example
 			{
-			  ""roles"": [ ""kibana_user"" ],
+			  ""roles"": [ ""example_role"" ], <1>
 			  ""enabled"": true,
 			  ""rules"": {
 			    ""field"": { ""realm.name"": ""oidc1"" }
@@ -23,7 +23,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line462()
+		public void Line466()
 		{
 			// tag::f3ab820e1f2f54ea718017aeae865742[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line600()
+		public void Line604()
 		{
 			// tag::a325f31e94fb1e8739258910593504a8[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line609()
+		public void Line613()
 		{
 			// tag::53e4ac5a4009fd21024f4b31e54aa83f[]
 			var response0 = new SearchResponse<object>();
@@ -68,7 +68,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line629()
+		public void Line633()
 		{
 			// tag::e3019fd5f23458ae49ad9854c97d321c[]
 			var response0 = new SearchResponse<object>();
@@ -81,7 +81,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line652()
+		public void Line656()
 		{
 			// tag::9e5d5a6c9adcba75b906e81c1496bd01[]
 			var response0 = new SearchResponse<object>();
@@ -97,7 +97,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line670()
+		public void Line674()
 		{
 			// tag::2a1eece9a59ac1773edcf0a932c26de0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/SamlGuidePage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/SamlGuidePage.cs
@@ -6,15 +6,15 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 	public class SamlGuidePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line644()
+		public void Line646()
 		{
-			// tag::d08f4dfec37979c1442564e64bd74617[]
+			// tag::862907653d1c18d2e80eff7f421200e2[]
 			var response0 = new SearchResponse<object>();
-			// end::d08f4dfec37979c1442564e64bd74617[]
+			// end::862907653d1c18d2e80eff7f421200e2[]
 
-			response0.MatchesExample(@"PUT /_security/role_mapping/saml-kibana
+			response0.MatchesExample(@"PUT /_security/role_mapping/saml-example
 			{
-			  ""roles"": [ ""kibana_user"" ],
+			  ""roles"": [ ""example_role"" ], <1>
 			  ""enabled"": true,
 			  ""rules"": {
 			    ""field"": { ""realm.name"": ""saml1"" }
@@ -23,7 +23,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line679()
+		public void Line685()
 		{
 			// tag::3806cae804fe77bf38b85561592c745b[]
 			var response0 = new SearchResponse<object>();
@@ -41,7 +41,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line897()
+		public void Line903()
 		{
 			// tag::49cb3f48a0097bfc597c52fa51c6d379[]
 			var response0 = new SearchResponse<object>();
@@ -54,7 +54,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line905()
+		public void Line911()
 		{
 			// tag::b2b26f8568c5dba7649e79f09b859272[]
 			var response0 = new SearchResponse<object>();
@@ -68,7 +68,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line925()
+		public void Line931()
 		{
 			// tag::a5dfcfd1cfb3558e7912456669c92eee[]
 			var response0 = new SearchResponse<object>();
@@ -81,7 +81,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line948()
+		public void Line954()
 		{
 			// tag::8e208098a0156c4c92afe0a06960b230[]
 			var response0 = new SearchResponse<object>();
@@ -95,7 +95,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line977()
+		public void Line983()
 		{
 			// tag::9eda9c39428b0c2c53cbd8ee7ae0f888[]
 			var response0 = new SearchResponse<object>();
@@ -109,7 +109,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line992()
+		public void Line998()
 		{
 			// tag::553904c175a76d5ba83bc5d46fff7373[]
 			var response0 = new SearchResponse<object>();
@@ -123,7 +123,7 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line1010()
+		public void Line1016()
 		{
 			// tag::a71154ea11a5214f409ecfd118e9b5e3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authorization/ManagingRolesPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authorization/ManagingRolesPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.Authorization
 	public class ManagingRolesPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line149()
+		public void Line158()
 		{
 			// tag::d3e5edac5b461020017fd9d8ec7a91fa[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/CcsClientsIntegrations/CrossClusterPage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/CcsClientsIntegrations/CrossClusterPage.cs
@@ -6,7 +6,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 	public class CrossClusterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		public void Line49()
+		public void Line54()
 		{
 			// tag::b13d05599a1c186137f81cad94f3fcc1[]
 			var response0 = new SearchResponse<object>();
@@ -30,7 +30,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line82()
+		public void Line85()
 		{
 			// tag::b06c2363c9071d9d5027a8562dd1b7ab[]
 			var response0 = new SearchResponse<object>();
@@ -45,7 +45,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line97()
+		public void Line100()
 		{
 			// tag::f479f0f364da5ddd096eac93bb4dd207[]
 			var response0 = new SearchResponse<object>();
@@ -57,7 +57,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line107()
+		public void Line110()
 		{
 			// tag::743c2583a226963fec7bd6a29e40205f[]
 			var response0 = new SearchResponse<object>();
@@ -81,7 +81,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line128()
+		public void Line131()
 		{
 			// tag::b6f04e699bbf90f233bb0253f6844958[]
 			var response0 = new SearchResponse<object>();
@@ -98,7 +98,7 @@ namespace Examples.XPack.Docs.En.Security.CcsClientsIntegrations
 		}
 
 		[U(Skip = "Example not implemented")]
-		public void Line143()
+		public void Line146()
 		{
 			// tag::efe3cb41fcafd981b8fb51fc7337d1d0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Watcher/ActionsPage.cs
+++ b/tests/Examples/XPack/Docs/En/Watcher/ActionsPage.cs
@@ -8,9 +8,9 @@ namespace Examples.XPack.Docs.En.Watcher
 		[U(Skip = "Example not implemented")]
 		public void Line49()
 		{
-			// tag::ec4e4462b5394f991a4384425feee8a4[]
+			// tag::85d2e33791f1a74a69dfb04a60e69306[]
 			var response0 = new SearchResponse<object>();
-			// end::ec4e4462b5394f991a4384425feee8a4[]
+			// end::85d2e33791f1a74a69dfb04a60e69306[]
 
 			response0.MatchesExample(@"PUT _watcher/watch/error_logs_alert
 			{
@@ -34,14 +34,14 @@ namespace Examples.XPack.Docs.En.Watcher
 			    }
 			  },
 			  ""condition"" : {
-			    ""compare"" : { ""ctx.payload.hits.total.value"" : { ""gt"" : 5 }}
+			    ""compare"" : { ""ctx.payload.hits.total"" : { ""gt"" : 5 }}
 			  },
 			  ""actions"" : {
 			    ""email_administrator"" : {
 			      ""throttle_period"": ""15m"", <1>
 			      ""email"" : { <2>
 			        ""to"" : ""sys.admino@host.domain"",
-			        ""subject"" : ""Encountered {{ctx.payload.hits.total.value}} errors"",
+			        ""subject"" : ""Encountered {{ctx.payload.hits.total}} errors"",
 			        ""body"" : ""Too many error in the system, see attached data"",
 			        ""attachments"" : {
 			          ""attached_data"" : {
@@ -60,9 +60,9 @@ namespace Examples.XPack.Docs.En.Watcher
 		[U(Skip = "Example not implemented")]
 		public void Line104()
 		{
-			// tag::a8e923739fdc7c9118b7b4a0ba791195[]
+			// tag::406a0f1c1aac947bcee58f86b6d036c1[]
 			var response0 = new SearchResponse<object>();
-			// end::a8e923739fdc7c9118b7b4a0ba791195[]
+			// end::406a0f1c1aac947bcee58f86b6d036c1[]
 
 			response0.MatchesExample(@"PUT _watcher/watch/log_event_watch
 			{
@@ -81,14 +81,14 @@ namespace Examples.XPack.Docs.En.Watcher
 			    }
 			  },
 			  ""condition"" : {
-			    ""compare"" : { ""ctx.payload.hits.total.value"" : { ""gt"" : 5 }}
+			    ""compare"" : { ""ctx.payload.hits.total"" : { ""gt"" : 5 }}
 			  },
 			  ""throttle_period"" : ""15m"", <1>
 			  ""actions"" : {
 			    ""email_administrator"" : {
 			      ""email"" : {
 			        ""to"" : ""sys.admino@host.domain"",
-			        ""subject"" : ""Encountered {{ctx.payload.hits.total.value}} errors"",
+			        ""subject"" : ""Encountered {{ctx.payload.hits.total}} errors"",
 			        ""body"" : ""Too many error in the system, see attached data"",
 			        ""attachments"" : {
 			          ""attached_data"" : {
@@ -106,7 +106,7 @@ namespace Examples.XPack.Docs.En.Watcher
 			        ""host"" : ""pager.service.domain"",
 			        ""port"" : 1234,
 			        ""path"" : ""/{{watch_id}}"",
-			        ""body"" : ""Encountered {{ctx.payload.hits.total.value}} errors""
+			        ""body"" : ""Encountered {{ctx.payload.hits.total}} errors""
 			      }
 			    }
 			  }
@@ -163,9 +163,9 @@ namespace Examples.XPack.Docs.En.Watcher
 		[U(Skip = "Example not implemented")]
 		public void Line250()
 		{
-			// tag::ece81947e2669ce5921723be11e995a5[]
+			// tag::f67d8aab9106ad24b1d2c771d3840ed1[]
 			var response0 = new SearchResponse<object>();
-			// end::ece81947e2669ce5921723be11e995a5[]
+			// end::f67d8aab9106ad24b1d2c771d3840ed1[]
 
 			response0.MatchesExample(@"PUT _watcher/watch/log_event_watch
 			{
@@ -184,13 +184,13 @@ namespace Examples.XPack.Docs.En.Watcher
 			    }
 			  },
 			  ""condition"" : {
-			    ""compare"" : { ""ctx.payload.hits.total.value"" : { ""gt"" : 0 } }
+			    ""compare"" : { ""ctx.payload.hits.total"" : { ""gt"" : 0 } }
 			  },
 			  ""actions"" : {
 			    ""email_administrator"" : {
 			      ""email"" : {
 			        ""to"" : ""sys.admino@host.domain"",
-			        ""subject"" : ""Encountered {{ctx.payload.hits.total.value}} errors"",
+			        ""subject"" : ""Encountered {{ctx.payload.hits.total}} errors"",
 			        ""body"" : ""Too many error in the system, see attached data"",
 			        ""attachments"" : {
 			          ""attached_data"" : {
@@ -204,14 +204,14 @@ namespace Examples.XPack.Docs.En.Watcher
 			    },
 			    ""notify_pager"" : {
 			      ""condition"": { <1>
-			        ""compare"" : { ""ctx.payload.hits.total.value"" : { ""gt"" : 5 } }
+			        ""compare"" : { ""ctx.payload.hits.total"" : { ""gt"" : 5 } }
 			      },
 			      ""webhook"" : {
 			        ""method"" : ""POST"",
 			        ""host"" : ""pager.service.domain"",
 			        ""port"" : 1234,
 			        ""path"" : ""/{{watch_id}}"",
-			        ""body"" : ""Encountered {{ctx.payload.hits.total.value}} errors""
+			        ""body"" : ""Encountered {{ctx.payload.hits.total}} errors""
 			      }
 			    }
 			  }

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
@@ -29,7 +29,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 					{
 						host = "http://myremoteserver.example:9200",
 						username = "user",
-						password = "changeme"
+						password = "changeme",
+						socket_timeout = "1m",
+						connect_timeout = "10s"
 					},
 					index = CallIsolatedValue,
 					size = 100
@@ -38,7 +40,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 
 		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
 			.Source(s => s
-				.Remote(r => r.Host(_host).Username("user").Password("changeme"))
+				.Remote(r => r.Host(_host).Username("user").Password("changeme").SocketTimeout("1m").ConnectTimeout("10s"))
 				.Index(CallIsolatedValue)
 				.Size(100)
 			)
@@ -56,7 +58,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 				{
 					Host = _host,
 					Username = "user",
-					Password = "changeme"
+					Password = "changeme",
+					SocketTimeout = "1m",
+					ConnectTimeout = "10s"
 				},
 				Index = CallIsolatedValue,
 				Size = 100


### PR DESCRIPTION
Closes: https://github.com/elastic/elasticsearch-net/issues/4461

- Update program to provide a hint to alternatives_report.json location. Suggesting https://raw.githubusercontent.com/elastic/built-docs/master/raw/en/elasticsearch/reference/master/alternatives_report.json as the example path.