### PR TITLE
Adds socket timeout and connect timeout options to reindex on server.

### DIFF
--- a/src/Nest/Document/Multiple/ReindexOnServer/RemoteSource.cs
+++ b/src/Nest/Document/Multiple/ReindexOnServer/RemoteSource.cs
@@ -13,6 +13,12 @@ namespace Nest
 
 		[DataMember(Name ="username")]
 		string Username { get; set; }
+
+		[DataMember(Name ="socket_timeout")]
+		Time SocketTimeout { get; set; }
+
+		[DataMember(Name ="connect_timeout")]
+		Time ConnectTimeout { get; set; }
 	}
 
 	public class RemoteSource : IRemoteSource
@@ -22,6 +28,10 @@ namespace Nest
 		public string Password { get; set; }
 
 		public string Username { get; set; }
+
+		public Time SocketTimeout { get; set; }
+
+		public Time ConnectTimeout { get; set; }
 	}
 
 	public class RemoteSourceDescriptor : DescriptorBase<RemoteSourceDescriptor, IRemoteSource>, IRemoteSource
@@ -30,10 +40,18 @@ namespace Nest
 		string IRemoteSource.Password { get; set; }
 		string IRemoteSource.Username { get; set; }
 
+		Time IRemoteSource.SocketTimeout { get; set; }
+
+		Time IRemoteSource.ConnectTimeout { get; set; }
+
 		public RemoteSourceDescriptor Host(Uri host) => Assign(host, (a, v) => a.Host = v);
 
 		public RemoteSourceDescriptor Username(string username) => Assign(username, (a, v) => a.Username = v);
 
 		public RemoteSourceDescriptor Password(string password) => Assign(password, (a, v) => a.Password = v);
+
+		public RemoteSourceDescriptor SocketTimeout(Time socketTimeout) => Assign(socketTimeout, (a, v) => a.SocketTimeout = v);
+
+		public RemoteSourceDescriptor ConnectTimeout(Time connectTimeout) => Assign(connectTimeout, (a, v) => a.ConnectTimeout = v);
 	}
 }

--- a/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
+++ b/tests/Tests/Document/Multiple/ReindexOnServer/ReindexOnServerRemoteApiTests.cs
@@ -29,7 +29,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 					{
 						host = "http://myremoteserver.example:9200",
 						username = "user",
-						password = "changeme"
+						password = "changeme",
+						socket_timeout = "1m",
+						connect_timeout = "10s"
 					},
 					index = CallIsolatedValue,
 					size = 100
@@ -38,7 +40,7 @@ namespace Tests.Document.Multiple.ReindexOnServer
 
 		protected override Func<ReindexOnServerDescriptor, IReindexOnServerRequest> Fluent => d => d
 			.Source(s => s
-				.Remote(r => r.Host(_host).Username("user").Password("changeme"))
+				.Remote(r => r.Host(_host).Username("user").Password("changeme").SocketTimeout("1m").ConnectTimeout("10s"))
 				.Index(CallIsolatedValue)
 				.Size(100)
 			)
@@ -56,7 +58,9 @@ namespace Tests.Document.Multiple.ReindexOnServer
 				{
 					Host = _host,
 					Username = "user",
-					Password = "changeme"
+					Password = "changeme",
+					SocketTimeout = "1m",
+					ConnectTimeout = "10s"
 				},
 				Index = CallIsolatedValue,
 				Size = 100


### PR DESCRIPTION
Addresses documentation of features here: https://www.elastic.co/guide/en/elasticsearch/reference/master/docs-reindex.html#reindex-from-remote