### PR TITLE
Deduplicate example method names

### DIFF
--- a/src/ExamplesGenerator/AsciiDocParser.cs
+++ b/src/ExamplesGenerator/AsciiDocParser.cs
@@ -13,7 +13,7 @@ namespace ExamplesGenerator
 	{
 		private static readonly Regex NameRegex =
 			new Regex(@"(?<name>.*?)\.a(?:scii)?doc$");
-		
+
 		private static readonly Regex ReferencePageNameRegex =
 			new Regex(@"^(?<prefix>Line\d+_)(?<increment>\d+)$");
 
@@ -61,9 +61,17 @@ namespace ExamplesGenerator
 					}
 
 					var methodName = $"Line{lineNumber}";
+					var foundDuplicate = false;
 
-					while (page.Examples.Any(e => e.Name == methodName))
+					// do we have duplicate line numbers with different examples?
+					while (page.Examples.Any(e => e.Name == methodName && e.Hash != hash))
 					{
+						if (!foundDuplicate)
+						{
+							foundDuplicate = true;
+							Console.WriteLine($"Found duplicate line {lineNumber} in {name}");
+						}
+
 						match = ReferencePageNameRegex.Match(methodName);
 						if (match.Success)
 						{
@@ -73,7 +81,7 @@ namespace ExamplesGenerator
 						else
 							methodName += "_2";
 					}
-					
+
 					var example = new ReferenceExample(file, hash, lineNumber, methodName, content);
 					example.Languages.AddRange(languages);
 

--- a/src/ExamplesGenerator/AsciiDocParser.cs
+++ b/src/ExamplesGenerator/AsciiDocParser.cs
@@ -13,6 +13,9 @@ namespace ExamplesGenerator
 	{
 		private static readonly Regex NameRegex =
 			new Regex(@"(?<name>.*?)\.a(?:scii)?doc$");
+		
+		private static readonly Regex ReferencePageNameRegex =
+			new Regex(@"^(?<prefix>Line\d+_)(?<increment>\d+)$");
 
 		public static List<ReferencePage> ParsePages(string path)
 		{
@@ -57,7 +60,21 @@ namespace ExamplesGenerator
 						pages.Add(name, page);
 					}
 
-					var example = new ReferenceExample(file, hash, lineNumber, content);
+					var methodName = $"Line{lineNumber}";
+
+					while (page.Examples.Any(e => e.Name == methodName))
+					{
+						match = ReferencePageNameRegex.Match(methodName);
+						if (match.Success)
+						{
+							var increment = int.Parse(match.Groups["increment"].Value);
+							methodName = match.Groups["prefix"].Value + (increment + 1);
+						}
+						else
+							methodName += "_2";
+					}
+					
+					var example = new ReferenceExample(file, hash, lineNumber, methodName, content);
 					example.Languages.AddRange(languages);
 
 					if (!page.Examples.Contains(example))

--- a/src/ExamplesGenerator/CSharpGenerator.cs
+++ b/src/ExamplesGenerator/CSharpGenerator.cs
@@ -92,12 +92,19 @@ namespace ExamplesGenerator
 				}
 				else
 				{
-					if (!methodDeclaration.AttributeLists.Any(a => a.ToString().Contains("Description")))
+					// add or update the Description attribute
+					var descriptionAttribute = methodDeclaration.AttributeLists.SingleOrDefault(a => a.ToString().Contains("Description"));
+					if (descriptionAttribute == null)
 						methodDeclaration = methodDeclaration.AddAttributeLists(AttributeList(GetReferencePageAttribute(example)));
+					else
+						methodDeclaration = methodDeclaration
+							.ReplaceNode(descriptionAttribute, AttributeList(GetReferencePageAttribute(example)));
 
 					// ensure that the method name is the same i.e. same line number
 					if (methodDeclaration.Identifier.Text != example.Name)
+					{
 						newClassDeclaration = newClassDeclaration.AddMembers(methodDeclaration.WithIdentifier(Identifier(example.Name)));
+					}
 					else
 						newClassDeclaration = newClassDeclaration.AddMembers(methodDeclaration);
 				}

--- a/src/ExamplesGenerator/CSharpGenerator.cs
+++ b/src/ExamplesGenerator/CSharpGenerator.cs
@@ -102,9 +102,7 @@ namespace ExamplesGenerator
 
 					// ensure that the method name is the same i.e. same line number
 					if (methodDeclaration.Identifier.Text != example.Name)
-					{
 						newClassDeclaration = newClassDeclaration.AddMembers(methodDeclaration.WithIdentifier(Identifier(example.Name)));
-					}
 					else
 						newClassDeclaration = newClassDeclaration.AddMembers(methodDeclaration);
 				}

--- a/src/ExamplesGenerator/ReferenceExample.cs
+++ b/src/ExamplesGenerator/ReferenceExample.cs
@@ -20,14 +20,14 @@ namespace ExamplesGenerator
 	/// </summary>
 	public class ReferenceExample
 	{
-		public ReferenceExample(string file, string hash, int lineNumber, string content)
+		public ReferenceExample(string file, string hash, int lineNumber, string name, string content)
 		{
 			File = file;
 			Hash = hash ?? throw new ArgumentNullException(nameof(hash));
 			LineNumber = lineNumber;
 			Content = content ?? throw new ArgumentNullException(nameof(content));
 
-			Name = $"Line{LineNumber}";
+			Name = name;
 			StartTag = $"// tag::{Hash}[]";
 			EndTag = $"// end::{Hash}[]";
 		}

--- a/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
@@ -10,11 +10,11 @@ namespace Examples.Aggregations.Metrics
 		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:12")]
 		public void Line12()
 		{
-			// tag::8fa80d369028e9ac0432f5c2d64ac574[]
+			// tag::d0321ef6bc9aae91b7fcfb76af085404[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::8fa80d369028e9ac0432f5c2d64ac574[]
+			// end::d0321ef6bc9aae91b7fcfb76af085404[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {}}
@@ -29,7 +29,7 @@ namespace Examples.Aggregations.Metrics
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metric"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""v""},
 			        ""sort"": {""s"": ""desc""}
 			      }
 			    }
@@ -41,11 +41,45 @@ namespace Examples.Aggregations.Metrics
 		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:82")]
 		public void Line82()
 		{
-			// tag::2c45781caccfc50c0656802fb613a6ea[]
+			// tag::ba2af8de92d3d197d809e2b9a9580ea5[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::2c45781caccfc50c0656802fb613a6ea[]
+			// end::ba2af8de92d3d197d809e2b9a9580ea5[]
+
+			response0.MatchesExample(@"POST /test/_bulk?refresh
+			{""index"": {}}
+			{""s"": 1, ""v"": 3.1415, ""m"": 1.9}
+			{""index"": {}}
+			{""s"": 2, ""v"": 1.0, ""m"": 6.7}
+			{""index"": {}}
+			{""s"": 3, ""v"": 2.71828, ""m"": -12.2}");
+
+			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
+			{
+			  ""aggs"": {
+			    ""tm"": {
+			      ""top_metrics"": {
+			        ""metrics"": [
+			          {""field"": ""v""},
+			          {""field"": ""m""}
+			        ],
+			        ""sort"": {""s"": ""desc""}
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:132")]
+		public void Line132()
+		{
+			// tag::c4f657319298f90db11c954bb09403da[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+			// end::c4f657319298f90db11c954bb09403da[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {}}
@@ -60,7 +94,7 @@ namespace Examples.Aggregations.Metrics
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metric"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""v""},
 			        ""sort"": {""s"": ""desc""},
 			        ""size"": 2
 			      }
@@ -71,7 +105,7 @@ namespace Examples.Aggregations.Metrics
 
 		[U(Skip = "Example not implemented")]
 		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:130")]
-		public void Line130()
+		public void Line180()
 		{
 			// tag::b63ce79ce4fa1bb9b99a789f4dcfef4e[]
 			var response0 = new SearchResponse<object>();
@@ -84,16 +118,16 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:150")]
-		public void Line150()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:200")]
+		public void Line200()
 		{
-			// tag::a4f89e46f108ddab069bd4b3f798f2c6[]
+			// tag::ed8c8e5006923f771aa4db0936184ac7[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
 
 			var response2 = new SearchResponse<object>();
-			// end::a4f89e46f108ddab069bd4b3f798f2c6[]
+			// end::ed8c8e5006923f771aa4db0936184ac7[]
 
 			response0.MatchesExample(@"PUT /node
 			{
@@ -123,7 +157,7 @@ namespace Examples.Aggregations.Metrics
 			      ""aggs"": {
 			        ""tm"": {
 			          ""top_metrics"": {
-			            ""metric"": {""field"": ""v""},
+			            ""metrics"": {""field"": ""v""},
 			            ""sort"": {""date"": ""desc""}
 			          }
 			        }
@@ -134,12 +168,12 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:221")]
-		public void Line221()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:271")]
+		public void Line271()
 		{
-			// tag::1ba79a9bfab9275c2095e720f5664fab[]
+			// tag::8b1cc4f69975d3fcdaf8ef6d7d71cc81[]
 			var response0 = new SearchResponse<object>();
-			// end::1ba79a9bfab9275c2095e720f5664fab[]
+			// end::8b1cc4f69975d3fcdaf8ef6d7d71cc81[]
 
 			response0.MatchesExample(@"POST /node/_search?filter_path=aggregations
 			{
@@ -152,7 +186,7 @@ namespace Examples.Aggregations.Metrics
 			      ""aggs"": {
 			        ""tm"": {
 			          ""top_metrics"": {
-			            ""metric"": {""field"": ""v""},
+			            ""metrics"": {""field"": ""v""},
 			            ""sort"": {""date"": ""desc""}
 			          }
 			        }
@@ -163,14 +197,14 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:282")]
-		public void Line282()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:332")]
+		public void Line332()
 		{
-			// tag::b160996a6ab06abeed6899e63c2d192b[]
+			// tag::315cae9fbbb552bcdf84ae3af6689489[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::b160996a6ab06abeed6899e63c2d192b[]
+			// end::315cae9fbbb552bcdf84ae3af6689489[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {""_index"": ""test1""}}
@@ -185,7 +219,7 @@ namespace Examples.Aggregations.Metrics
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metric"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""v""},
 			        ""sort"": {""s"": ""asc""}
 			      }
 			    }
@@ -194,19 +228,19 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:322")]
-		public void Line322()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:372")]
+		public void Line372()
 		{
-			// tag::efc492b00b90206ae795f9afda4a1307[]
+			// tag::035805d6f35a2ef517b9cd9ae037da05[]
 			var response0 = new SearchResponse<object>();
-			// end::efc492b00b90206ae795f9afda4a1307[]
+			// end::035805d6f35a2ef517b9cd9ae037da05[]
 
 			response0.MatchesExample(@"POST /test*/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metric"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""v""},
 			        ""sort"": {""s"": {""order"": ""asc"", ""numeric_type"": ""double""}}
 			      }
 			    }

--- a/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
@@ -104,7 +104,7 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:130")]
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:180")]
 		public void Line180()
 		{
 			// tag::b63ce79ce4fa1bb9b99a789f4dcfef4e[]

--- a/tests/Examples/Analysis/Tokenfilters/TrimTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/TrimTokenfilterPage.cs
@@ -8,7 +8,7 @@ namespace Examples.Analysis.Tokenfilters
 	{
 		[U(Skip = "Example not implemented")]
 		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:32")]
-		public void Line32()
+		public void Line34()
 		{
 			// tag::c318fde926842722825a51e5c9c326a9[]
 			var response0 = new SearchResponse<object>();
@@ -23,7 +23,7 @@ namespace Examples.Analysis.Tokenfilters
 
 		[U(Skip = "Example not implemented")]
 		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:62")]
-		public void Line62()
+		public void Line65()
 		{
 			// tag::a3a14f7f0e80725f695a901a7e1d579d[]
 			var response0 = new SearchResponse<object>();
@@ -39,7 +39,7 @@ namespace Examples.Analysis.Tokenfilters
 
 		[U(Skip = "Example not implemented")]
 		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:96")]
-		public void Line96()
+		public void Line99()
 		{
 			// tag::fd26bfdbe95b2d2db374385d12849f77[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/TrimTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/TrimTokenfilterPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Analysis.Tokenfilters
 	public class TrimTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:32")]
+		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:34")]
 		public void Line34()
 		{
 			// tag::c318fde926842722825a51e5c9c326a9[]
@@ -22,7 +22,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:62")]
+		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:65")]
 		public void Line65()
 		{
 			// tag::a3a14f7f0e80725f695a901a7e1d579d[]
@@ -38,7 +38,7 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:96")]
+		[Description("analysis/tokenfilters/trim-tokenfilter.asciidoc:99")]
 		public void Line99()
 		{
 			// tag::fd26bfdbe95b2d2db374385d12849f77[]

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
@@ -8,7 +8,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	{
 		[U(Skip = "Example not implemented")]
 		[Description("ml/anomaly-detection/apis/get-job-stats.asciidoc:328")]
-		public void Line328()
+		public void Line333()
 		{
 			// tag::9298aaf8232a819e79b3bf8471245e98[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
@@ -7,7 +7,7 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetJobStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-job-stats.asciidoc:328")]
+		[Description("ml/anomaly-detection/apis/get-job-stats.asciidoc:333")]
 		public void Line333()
 		{
 			// tag::9298aaf8232a819e79b3bf8471245e98[]

--- a/tests/Examples/Setup/RestartClusterPage.cs
+++ b/tests/Examples/Setup/RestartClusterPage.cs
@@ -24,7 +24,7 @@ namespace Examples.Setup
 
 		[U(Skip = "Example not implemented")]
 		[Description("setup/restart-cluster.asciidoc:30")]
-		public void Line30() // Manually changed due to: https://github.com/elastic/docs/issues/1760
+		public void Line30_2()
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Upgrade/RollingUpgradePage.cs
+++ b/tests/Examples/Upgrade/RollingUpgradePage.cs
@@ -8,7 +8,7 @@ namespace Examples.Upgrade
 	{
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:46")]
-		public void Line46()
+		public void Line62()
 		{
 			// tag::1cd3b9d65576a9212eef898eb3105758[]
 			var response0 = new SearchResponse<object>();
@@ -24,7 +24,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:47")]
-		public void Line47()
+		public void Line63()
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();
@@ -35,7 +35,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:82")]
-		public void Line82()
+		public void Line98()
 		{
 			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
 			var response0 = new SearchResponse<object>();
@@ -46,7 +46,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:97")]
-		public void Line97()
+		public void Line113()
 		{
 			// tag::7e49705769c42895fb7b1e2ca028ff47[]
 			var response0 = new SearchResponse<object>();
@@ -57,7 +57,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:110")]
-		public void Line110()
+		public void Line126()
 		{
 			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
 			var response0 = new SearchResponse<object>();
@@ -73,7 +73,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:128")]
-		public void Line128()
+		public void Line144()
 		{
 			// tag::5c53944aec2ce3e55854e315f0482029[]
 			var response0 = new SearchResponse<object>();
@@ -84,7 +84,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:158")]
-		public void Line158()
+		public void Line174()
 		{
 			// tag::6b74ff6df5d7583add837b34a6c80a43[]
 			var response0 = new SearchResponse<object>();
@@ -95,7 +95,7 @@ namespace Examples.Upgrade
 
 		[U]
 		[Description("upgrade/rolling_upgrade.asciidoc:175")]
-		public void Line175()
+		public void Line191()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
 			var catResponse = client.Cat.Health(h => h.Verbose());
@@ -106,7 +106,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:182")]
-		public void Line182()
+		public void Line198()
 		{
 			// tag::c4270d3851c76898fc8b112c6c597444[]
 			var response0 = new SearchResponse<object>();
@@ -117,7 +117,7 @@ namespace Examples.Upgrade
 
 		[U(Skip = "Example not implemented")]
 		[Description("upgrade/rolling_upgrade.asciidoc:197")]
-		public void Line197()
+		public void Line213()
 		{
 			// tag::3c5d5a5c34a62724942329658c688f5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Upgrade/RollingUpgradePage.cs
+++ b/tests/Examples/Upgrade/RollingUpgradePage.cs
@@ -7,7 +7,7 @@ namespace Examples.Upgrade
 	public class RollingUpgradePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:46")]
+		[Description("upgrade/rolling_upgrade.asciidoc:62")]
 		public void Line62()
 		{
 			// tag::1cd3b9d65576a9212eef898eb3105758[]
@@ -23,7 +23,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:47")]
+		[Description("upgrade/rolling_upgrade.asciidoc:63")]
 		public void Line63()
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
@@ -34,7 +34,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:82")]
+		[Description("upgrade/rolling_upgrade.asciidoc:98")]
 		public void Line98()
 		{
 			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
@@ -45,7 +45,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:97")]
+		[Description("upgrade/rolling_upgrade.asciidoc:113")]
 		public void Line113()
 		{
 			// tag::7e49705769c42895fb7b1e2ca028ff47[]
@@ -56,7 +56,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:110")]
+		[Description("upgrade/rolling_upgrade.asciidoc:126")]
 		public void Line126()
 		{
 			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
@@ -72,7 +72,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:128")]
+		[Description("upgrade/rolling_upgrade.asciidoc:144")]
 		public void Line144()
 		{
 			// tag::5c53944aec2ce3e55854e315f0482029[]
@@ -83,7 +83,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:158")]
+		[Description("upgrade/rolling_upgrade.asciidoc:174")]
 		public void Line174()
 		{
 			// tag::6b74ff6df5d7583add837b34a6c80a43[]
@@ -94,7 +94,7 @@ namespace Examples.Upgrade
 		}
 
 		[U]
-		[Description("upgrade/rolling_upgrade.asciidoc:175")]
+		[Description("upgrade/rolling_upgrade.asciidoc:191")]
 		public void Line191()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
@@ -105,7 +105,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:182")]
+		[Description("upgrade/rolling_upgrade.asciidoc:198")]
 		public void Line198()
 		{
 			// tag::c4270d3851c76898fc8b112c6c597444[]
@@ -116,7 +116,7 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:197")]
+		[Description("upgrade/rolling_upgrade.asciidoc:213")]
 		public void Line213()
 		{
 			// tag::3c5d5a5c34a62724942329658c688f5e[]


### PR DESCRIPTION
This commit deduplicates the generated example method names,
when generating C# methods from the examples. The method names
follow the convention of `Line<linenum>`, where `linenum` is the
line number in the alternative report. The alternative report
can report duplicate line numbers however, as reported in

elastic/docs#1760

so deduplicate in the generator.