### PR TITLE
Fix spelling of client in VirtualizedCluster

### DIFF
--- a/src/Elasticsearch.Net.VirtualizedCluster/Elasticsearch.Net.VirtualizedCluster.csproj
+++ b/src/Elasticsearch.Net.VirtualizedCluster/Elasticsearch.Net.VirtualizedCluster.csproj
@@ -3,7 +3,7 @@
     <PackageId>Elasticsearch.Net.VirtualizedCluster</PackageId>
     <Title>Elasticsearch.Net.VirtualizedCluster - A highly configurable in memory IConnection</Title>
     <PackageTags>elasticsearch;elastic;search;lucene;nest</PackageTags>
-    <Description>Provides a way to assert cluent behaviour through a rule engine backed VirtualClusterConnection</Description>
+    <Description>Provides a way to assert client behaviour through a rule engine backed VirtualClusterConnection</Description>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
This commit fixes the spelling in VirtualizedCluster description.