### PR TITLE
ISO8601TimeSpanFormatter to use local byte[] array, as opposed to renting from pool.

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/DateTimeFormatter.cs
@@ -929,20 +929,14 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
             var day = 0;
             if (hasDay)
             {
-                var poolArray = JsonSerializer.MemoryPool.Rent();
-                try
+				const int maxDayLength = 8 + 1; // {Day}.
+                var dayCharacters = new byte[maxDayLength];
+                for (; array[i] != '.'; i++)
                 {
-                    for (; array[i] != '.'; i++)
-                    {
-                        poolArray[day++] = array[i];
-                    }
-                    day = new JsonReader(poolArray).ReadInt32();
-                    i++; // skip '.'
+                    dayCharacters[day++] = array[i];
                 }
-                finally
-                {
-					JsonSerializer.MemoryPool.Return(poolArray);
-                }
+                day = new JsonReader(dayCharacters).ReadInt32();
+                i++; // skip '.'
             }
 
             var hour = (array[i++] - (byte)'0') * 10 + (array[i++] - (byte)'0');

--- a/tests/Tests.Reproduce/TimeSpanSerialization.cs
+++ b/tests/Tests.Reproduce/TimeSpanSerialization.cs
@@ -10,6 +10,27 @@ namespace Tests.Reproduce
 	public class TimeSpanSerialization
 	{
 		[U]
+		public void SerializeMaxTimeSpansAsTicksAndStrings()
+		{
+			var timeSpans = new TimeSpans(TimeSpan.MaxValue);
+			var client = new ElasticClient();
+
+			var json = client.RequestResponseSerializer.SerializeToString(timeSpans);
+
+			json.Should()
+				.Be("{\"default\":9223372036854775807,\"defaultNullable\":9223372036854775807,\"string\":\"10675199.02:48:05.4775807\",\"stringNullable\":\"10675199.02:48:05.4775807\"}");
+
+			TimeSpans deserialized;
+			using (var stream = client.ConnectionSettings.MemoryStreamFactory.Create(Encoding.UTF8.GetBytes(json)))
+				deserialized = client.RequestResponseSerializer.Deserialize<TimeSpans>(stream);
+
+			timeSpans.Default.Should().Be(deserialized.Default);
+			timeSpans.DefaultNullable.Should().Be(deserialized.DefaultNullable);
+			timeSpans.String.Should().Be(deserialized.String);
+			timeSpans.StringNullable.Should().Be(deserialized.StringNullable);
+		}
+
+		[U]
 		public void SerializeTimeSpansAsTicksAndStrings()
 		{
 			var timeSpans = new TimeSpans(TimeSpan.FromSeconds(902312));


### PR DESCRIPTION
The minimum buffer size that can be rented from the shared memory pool is 65535 bytes. This amount of memory for the purposes of serializing the day component of a string timespan is excessive. This commit changes the procedure to use a local byte array

Adds test for max size of 64bit value.