### PR TITLE
Fix API generator (#4456)

### DIFF
--- a/src/ApiGenerator/Domain/RestApiSpec.cs
+++ b/src/ApiGenerator/Domain/RestApiSpec.cs
@@ -22,13 +22,13 @@ namespace ApiGenerator.Domain
 
 		public IDictionary<string, ApiEndpoint> Endpoints { get; set; }
 
-		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespace =>
+		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespaceLowLevel =>
 			Endpoints.Values.GroupBy(e=>e.CsharpNames.Namespace)
 				.ToImmutableSortedDictionary(kv => kv.Key, kv => kv.ToList().AsReadOnly());
 
 		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespaceHighLevel =>
 			Endpoints.Values
-				.Where(v => !CodeConfiguration.IgnoredApisHighLevel.Contains(v.Name))
+				.Where(v => !CodeConfiguration.IgnoredApisHighLevel.Contains(v.FileName))
 				.GroupBy(e => e.CsharpNames.Namespace)
 				.ToImmutableSortedDictionary(kv => kv.Key, kv => kv.ToList().AsReadOnly());
 

--- a/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/LowLevelClientImplementationGenerator.cs
@@ -22,7 +22,7 @@ namespace ApiGenerator.Generator.Razor
 			var target = GeneratorLocations.LowLevel($"ElasticLowLevelClient.{CsharpNames.RootNamespace}.cs");
 			await DoRazor(spec, view, target);
 
-			var namespaced = spec.EndpointsPerNamespaceHighLevel.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
+			var namespaced = spec.EndpointsPerNamespaceLowLevel.Where(kv => kv.Key != CsharpNames.RootNamespace).ToList();
 			var namespacedView = ViewLocations.LowLevel("Client", "Implementation", "ElasticLowLevelClient.Namespace.cshtml");
 			await DoRazorDependantFiles(progressBar, namespaced, namespacedView, kv => kv.Key,
 				id => GeneratorLocations.LowLevel($"ElasticLowLevelClient.{id}.cs"));

--- a/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
+++ b/src/ApiGenerator/Generator/Razor/RequestParametersGenerator.cs
@@ -20,7 +20,7 @@ namespace ApiGenerator.Generator.Razor
 			var view = ViewLocations.LowLevel("RequestParameters", "RequestParameters.cshtml");
 			string Target(string id) => GeneratorLocations.LowLevel("Api", "RequestParameters", $"RequestParameters.{id}.cs");
 
-			var namespaced = spec.EndpointsPerNamespaceHighLevel.ToList();
+			var namespaced = spec.EndpointsPerNamespaceLowLevel.ToList();
 			await DoRazorDependantFiles(progressBar, namespaced, view, kv => kv.Key, id => Target(id));
 		}
 	}

--- a/src/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Implementation/ElasticLowLevelClient.cshtml
@@ -24,7 +24,7 @@ using static Elasticsearch.Net.HttpMethod;
 
 @{
 	RestApiSpec model = Model;
-	var namespaces = model.EndpointsPerNamespace.Keys.Where(k => k != CsharpNames.RootNamespace);
+	var namespaces = model.EndpointsPerNamespaceLowLevel.Keys.Where(k => k != CsharpNames.RootNamespace);
 <text>
 // ReSharper disable InterpolatedStringExpressionIsNotIFormattable
 // ReSharper disable RedundantExtendsListEntry
@@ -55,7 +55,7 @@ namespace Elasticsearch.Net
 </text>
 	
 
-	foreach (var kv in model.EndpointsPerNamespace)
+	foreach (var kv in model.EndpointsPerNamespaceLowLevel)
 	{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{

--- a/src/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Interface/IElasticLowLevelClient.cshtml
@@ -23,7 +23,7 @@ namespace Elasticsearch.Net
 	///</summary>
 	public partial interface IElasticLowLevelClient 
 	{
-		@foreach(var kv in Model.EndpointsPerNamespace)
+		@foreach(var kv in Model.EndpointsPerNamespaceLowLevel)
 		{
 		if (kv.Key != CsharpNames.RootNamespace)
 		{

--- a/src/ApiGenerator/Views/LowLevel/Client/Usings.cshtml
+++ b/src/ApiGenerator/Views/LowLevel/Client/Usings.cshtml
@@ -3,7 +3,7 @@
 @using ApiGenerator.Domain
 @using ApiGenerator.Domain.Code
 @inherits ApiGenerator.CodeTemplatePage<RestApiSpec>
-@foreach(var kv in Model.EndpointsPerNamespace)
+@foreach(var kv in Model.EndpointsPerNamespaceLowLevel)
 {
 	if (kv.Key != CsharpNames.RootNamespace)
 	{


### PR DESCRIPTION
This commit fixes the API generator:

1. The collection of high level endpoints were being used in some
of the low level generators
2. High level endpoints excluded need to be compared to the list by filename

(cherry-picked from commit 04ed38b09519a19093d2fd2f467c2e6513fbfcc9)