### PR TITLE
Change SnapshotShardFailure shard_id to int

### DIFF
--- a/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotShardFailure.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Snapshot/SnapshotShardFailure.cs
@@ -15,7 +15,7 @@ namespace Nest
 		public string Reason { get; set; }
 
 		[DataMember(Name ="shard_id")]
-		public string ShardId { get; set; }
+		public int ShardId { get; set; }
 
 		[DataMember(Name ="status")]
 		public string Status { get; set; }


### PR DESCRIPTION
This commit changes the type of property ShardId
on SnapshotShardFailure to int, to match Elasticsearch.

Fixes #4537