### PR TITLE
implement IPercentageScoreHeuristic on PercentageScoreHeuristic

### DIFF
--- a/src/Nest/Aggregations/Bucket/SignificantTerms/Heuristics/PercentageScoreHeuristic.cs
+++ b/src/Nest/Aggregations/Bucket/SignificantTerms/Heuristics/PercentageScoreHeuristic.cs
@@ -6,7 +6,7 @@ namespace Nest
 	[ReadAs(typeof(PercentageScoreHeuristic))]
 	public interface IPercentageScoreHeuristic { }
 
-	public class PercentageScoreHeuristic { }
+	public class PercentageScoreHeuristic : IPercentageScoreHeuristic { }
 
 	public class PercentageScoreHeuristicDescriptor
 		: DescriptorBase<PercentageScoreHeuristicDescriptor, IPercentageScoreHeuristic>, IPercentageScoreHeuristic { }

--- a/tests/Tests.Reproduce/GitHubIssue4573.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4573.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4573
+	{
+		[U]
+		public void SerializePercentageScore()
+		{
+			Func<ISearchResponse<object>> action = () => TestClient.DefaultInMemoryClient.Search<object>(b => b
+				.Aggregations(a => a
+					.SignificantTerms("related_organisations", sigTerms => sigTerms
+						.Field("organisations.keyword")
+						.Size(10)
+						.PercentageScore(p => p)
+						.MinimumDocumentCount(5)
+					)
+				)
+			);
+
+			action.Should().NotThrow();
+
+			var response = action();
+
+			var json = Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes);
+			json.Should().Contain("\"percentage\":{}");
+		}
+	}
+}


### PR DESCRIPTION
This commit implements IPercentageScoreHeuristic on
PercentageScoreHeuristic in order to fix an exception
when attempting to serialize PercentageScore on
SignificantTerms aggregation.

Fixes #4573