### PR TITLE
Use `params` modifier for methods in RequestDescriptorBase

### DIFF
--- a/src/ApiGenerator/Domain/Specification/QueryParameters.cs
+++ b/src/ApiGenerator/Domain/Specification/QueryParameters.cs
@@ -55,8 +55,14 @@ namespace ApiGenerator.Domain.Specification
 			}
 		}
 
-		public string DescriptorArgumentType =>
-			Type == "list" && TypeHighLevel.EndsWith("[]") ? "params " + TypeHighLevel : TypeHighLevel;
+		public bool IsArray => Type == "list" && TypeHighLevel.EndsWith("[]");
+
+		public string DescriptorArgumentType => IsArray ? "params " + TypeHighLevel : TypeHighLevel;
+
+		public string DescriptorEnumerableArgumentType =>
+			IsArray
+				? $"IEnumerable<{TypeHighLevel.TrimEnd('[', ']')}>"
+				: throw new InvalidOperationException("Only array arguments have IEnumerable overload");
 
 		public Func<string, string, string, string, string> FluentGenerator { get; set; }
 		public bool IsFieldParam => TypeHighLevel == "Field";

--- a/src/ApiGenerator/Views/HighLevel/Descriptors/RequestDescriptorBase.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Descriptors/RequestDescriptorBase.cshtml
@@ -7,6 +7,8 @@
 @{
 	RestApiSpec m = Model;
 }
+using System.Collections.Generic;
+
 namespace Nest
 {
 	// ReSharper disable UnusedTypeParameter
@@ -18,8 +20,14 @@ namespace Nest
 	var t = @common.TypeHighLevel;
 	var tSuffix = (t == "bool" || t == "bool?") ? " = true" : "";
 <text>		///<summary>@(Raw(string.Join("", common.DescriptionHighLevel)))</summary>
-		public TDescriptor @(common.ClsName)(@common.TypeHighLevel @common.ClsArgumentName@tSuffix) => Qs("@original", @(common.ClsArgumentName));
+		public TDescriptor @(common.ClsName)(@common.DescriptorArgumentType @common.ClsArgumentName@tSuffix) => Qs("@original", @(common.ClsArgumentName));
 </text>
+	if (common.IsArray)
+	{
+<text>		///<summary>@(Raw(string.Join("", common.DescriptionHighLevel)))</summary>
+		public TDescriptor @(common.ClsName)(@Raw(common.DescriptorEnumerableArgumentType) @common.ClsArgumentName@tSuffix) => Qs("@original", @(common.ClsArgumentName));
+</text>
+	}
 }
 	}
 }

--- a/src/Nest/Descriptors.cs
+++ b/src/Nest/Descriptors.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Nest
 {
 	// ReSharper disable UnusedTypeParameter
@@ -6,7 +8,9 @@ namespace Nest
 		///<summary>Include the stack trace of returned errors.</summary>
 		public TDescriptor ErrorTrace(bool? errortrace = true) => Qs("error_trace", errortrace);
 		///<summary>A comma-separated list of filters used to reduce the response.<para>Use of response filtering can result in a response from Elasticsearch that cannot be correctly deserialized to the respective response type for the request. In such situations, use the low level client to issue the request and handle response deserialization</para></summary>
-		public TDescriptor FilterPath(string[] filterpath) => Qs("filter_path", filterpath);
+		public TDescriptor FilterPath(params string[] filterpath) => Qs("filter_path", filterpath);
+		///<summary>A comma-separated list of filters used to reduce the response.<para>Use of response filtering can result in a response from Elasticsearch that cannot be correctly deserialized to the respective response type for the request. In such situations, use the low level client to issue the request and handle response deserialization</para></summary>
+		public TDescriptor FilterPath(IEnumerable<string> filterpath) => Qs("filter_path", filterpath);
 		///<summary>Return human readable values for statistics.</summary>
 		public TDescriptor Human(bool? human = true) => Qs("human", human);
 		///<summary>Pretty format the returned JSON response.</summary>


### PR DESCRIPTION
Hello!

This PR tries to fix #4471.

The only place I found to fix is `RequestDescriptorBase.FilterPath` so either this is a really low hanging fruit or I'm completely missing something.  I searched for potential places to fix with naive search for `(string[]` and with looking at usings of `TypeHighLevel` in views.

I noticed that methods in `Descriptors.*.cs` already have `params` modifier and then found that it is implemented with `.DescriptorArgumentType` in `Descriptor.cshtml`.  Looks like it is suitable for `RequestDescriptorBase` too.

I'm not sure if `Descriptors.cs` should be commited.  The whole process of testing codegen is a little bit confusing and I didn't figured out the right way to run tests locally for my changes (and will be glad if someone teach me).  Anyway it was a very interesting exercise to look through the code generation tool.