### PR TITLE
Fix InternalsVisibleTo for versioned assemblies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,3 +84,4 @@ project.lock.json
 /src/.vs/restore.dg
 # temporary location for doc generation
 docs-temp
+*.binlog

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>$(SolutionRoot)\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="$(IsPackable) == True">
-
+    <OutDir>bin/$(Configuration)/$(TargetFramework)/</OutDir>
     <NoWarn>1591,1572,1571,1573,1587,1570,NU5048,</NoWarn>
     <Prefer32Bit>false</Prefer32Bit>
     <DebugSymbols>true</DebugSymbols>
@@ -23,8 +23,7 @@
   >
     <PropertyGroup>
       <ExposedAssembly>%(InternalsVisibleTo.Identity)</ExposedAssembly>
-      <VersionNamespaced>$(ExposedAssembly.Replace("Nest","Nest$(MajorVersion)").Replace("Elasticsearch.Net","Elasticsearch.Net$(MajorVersion
-        )"))</VersionNamespaced>
+      <VersionNamespaced>$(ExposedAssembly.Replace("Nest", "Nest$(MajorVersion)").Replace("Elasticsearch.Net","Elasticsearch.Net$(MajorVersion)"))</VersionNamespaced>
     </PropertyGroup>
     <ItemGroup>
       <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">

--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -164,8 +164,6 @@ module Versioning =
         | true -> validate dll name 
         | _ -> failwithf "Attempted to verify signature of %s but it was not found!" dll
 
-    let private assemblyRewriter = "assembly-rewriter"
-    
     let BuiltArtifacts (version: AnchoredVersion) = 
         let packages =
             let allPackages = !! "build/output/_packages/*.nupkg" |> Seq.toList


### PR DESCRIPTION
This commit fixes the inclusion of InternalsVisibleToAttributes for
versioned assemblies.

Directory.Build.Targets defines an AssemblyInfos target that
writes InternalsVisibleTo elements for friend assemblies and
versioned friend assemblies, based on the InternalsVisibleTo
elements in the target csproj and the version being built. This worked
fine when built from Rider IDE (and likely Visual Studio too) due to
the way in which MsBuild is invoked from IDE, but did not work as intended
when built from the commandline with the build script, which calls
dotnet build; The Nest InternalsVisibleTo was correctly written, but
none of the InternalsVisibleTo for generated Elasticsearch.Net assemblies
were. Looking at the binarylog for MsBuild with the Structured Log Viewer
indicated that the task was working as expected from the command line and
`\obj\$(Configuration\AssemblyInfo.cs` generated file was written correctly,
but inspection of the file revealed that the InternalsVisibleTo attributes
were in fact not generated correctly.

In researching friend assemblies, https://docs.microsoft.com/en-us/dotnet/standard/assembly/friend
notes the following

> When you compile an assembly like AssemblyB that will access internal types or
internal members of another assembly like Assembly A, you must explicitly specify
the name of the output file (.exe or .dll) by using the -out compiler option.
This is required because the compiler has not yet generated the name for the assembly
it is building at the time it is binding to external references.

The build script does not pass an output path, relying on the convention of
output going to `/bin/$(Configuration)/$(TargetFramework)/`. When the IDE
builds projects, it explicitly passes an output path. In summary, the fix to
allow InternalsVisibleTo to work as expected from the commandline is to explicitly
pass an output path. This is done for all projects by adding

```xml
<OutDir>bin/$(Configuration)/$(TargetFramework)/</OutDir>
```

to Directory.Build.Targets.

Fixes #4538