### PR TITLE
Update cluster.remote.connect to node.remote_cluster_client

### DIFF
--- a/tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
@@ -53,7 +53,7 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 			Add(AttributeKey("testingcluster"), "true");
 			Add(AttributeKey("gateway"), "true");
 			Add("search.remote.connect", "true", "<8.0.0");
-			Add("cluster.remote.connect", "true", ">=8.0.0-SNAPSHOT");
+			Add("node.remote_cluster_client", "true", ">=8.0.0-SNAPSHOT");
 
 			Add($"script.max_compilations_per_minute", "10000", "<6.0.0-rc1");
 			Add($"script.max_compilations_rate", "10000/1m", ">=6.0.0-rc1");


### PR DESCRIPTION
This commit updates the cluster.remote.connect setting to allow
integration tests to run against master 8.0.0 snapshots