### PR TITLE
Implement ConstantKeyword property

### DIFF
--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -133,6 +133,10 @@ namespace Nest
 		public IProperty SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector) =>
 			selector?.Invoke(new SearchAsYouTypePropertyDescriptor<T>());
 
+		/// <inheritdoc />
+		public IProperty ConstantKeyword(Func<ConstantKeywordPropertyDescriptor<T>, IConstantKeywordProperty> selector) =>
+			selector?.Invoke(new ConstantKeywordPropertyDescriptor<T>());
+
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector = null) =>
 			selector.InvokeOrDefault(new NumberPropertyDescriptor<T>().Name(field).Type(NumberType.Integer));

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -141,6 +141,9 @@ namespace Nest
 		Shape,
 
 		[EnumMember(Value = "histogram")]
-		Histogram
+		Histogram,
+
+		[EnumMember(Value = "constant_keyword")]
+		ConstantKeyword
 	}
 }

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -138,6 +138,9 @@ namespace Nest
 
 		/// <inheritdoc cref="ISearchAsYouTypeProperty"/>
 		TReturnType SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector);
+
+		/// <inheritdoc cref="IConstantKeywordProperty"/>
+		TReturnType ConstantKeyword(Func<ConstantKeywordPropertyDescriptor<T>, IConstantKeywordProperty> selector);
 	}
 
 	public partial class PropertiesDescriptor<T> where T : class
@@ -217,6 +220,10 @@ namespace Nest
 
 		/// <inheritdoc cref="IHistogramProperty"/>
 		public PropertiesDescriptor<T> Histogram(Func<HistogramPropertyDescriptor<T>, IHistogramProperty> selector) => SetProperty(selector);
+
+		/// <inheritdoc cref="IConstantKeywordProperty"/>
+		public PropertiesDescriptor<T> ConstantKeyword(Func<ConstantKeywordPropertyDescriptor<T>, IConstantKeywordProperty> selector) =>
+			SetProperty(selector);
 
 		public PropertiesDescriptor<T> Custom(IProperty customType) => SetProperty(customType);
 

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -95,6 +95,7 @@ namespace Nest
 				case FieldType.RankFeatures: return Deserialize<RankFeaturesProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Flattened: return Deserialize<FlattenedProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Histogram: return Deserialize<HistogramProperty>(ref segmentReader, formatterResolver);
+				case FieldType.ConstantKeyword: return Deserialize<ConstantKeywordProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping, or FieldType enum could not be parsed from typeString
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -202,6 +203,9 @@ namespace Nest
 					break;
 				case IHistogramProperty histogramProperty:
 					Serialize(ref writer, histogramProperty, formatterResolver);
+					break;
+				case IConstantKeywordProperty constantKeywordProperty:
+					Serialize(ref writer, constantKeywordProperty, formatterResolver);
 					break;
 				case IGenericProperty genericProperty:
 					Serialize(ref writer, genericProperty, formatterResolver);

--- a/src/Nest/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordAttribute.cs
@@ -1,0 +1,11 @@
+﻿namespace Nest
+{
+	/// <inheritdoc cref="IConstantKeywordProperty"/>
+	public class ConstantKeywordAttribute : ElasticsearchPropertyAttributeBase, IConstantKeywordProperty
+	{
+		public ConstantKeywordAttribute() : base(FieldType.ConstantKeyword) { }
+
+		/// <inheritdoc />
+		public object Value { get; set; }
+	}
+}

--- a/src/Nest/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordProperty.cs
@@ -1,0 +1,48 @@
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// Constant keyword is a specialization of the keyword field for the case that all documents in the index have the same value.
+	/// <para />
+	/// Available in Elasticsearch 7.7.0+ with at least a basic license level
+	/// </summary>
+	[InterfaceDataContract]
+	public interface IConstantKeywordProperty : IProperty
+	{
+		/// <summary>
+		/// The value to associate with all documents in the index.
+		/// If this parameter is not provided, it is set based on the first document that gets indexed.
+		/// <para />
+		/// Value must be a string or a numeric value
+		/// </summary>
+		[DataMember(Name ="value")]
+		object Value { get; set; }
+	}
+
+	/// <inheritdoc cref="IConstantKeywordProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class ConstantKeywordProperty : PropertyBase, IConstantKeywordProperty
+	{
+		public ConstantKeywordProperty() : base(FieldType.ConstantKeyword) { }
+
+		/// <inheritdoc cref="IConstantKeywordProperty.Value" />
+		public object Value { get; set; }
+	}
+
+	/// <inheritdoc cref="IConstantKeywordProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class ConstantKeywordPropertyDescriptor<T>
+		: PropertyDescriptorBase<ConstantKeywordPropertyDescriptor<T>, IConstantKeywordProperty, T>, IConstantKeywordProperty
+		where T : class
+	{
+		public ConstantKeywordPropertyDescriptor() : base(FieldType.ConstantKeyword) { }
+
+		object IConstantKeywordProperty.Value { get; set; }
+
+		/// <inheritdoc cref="IConstantKeywordProperty.Value" />
+		public ConstantKeywordPropertyDescriptor<T> Value(object value) => Assign(value, (a, v) => a.Value = v);
+	}
+}

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -63,6 +63,8 @@
 		void Visit(IFlattenedProperty property);
 
 		void Visit(IHistogramProperty property);
+
+		void Visit(IConstantKeywordProperty property);
 	}
 
 	public class NoopMappingVisitor : IMappingVisitor
@@ -128,5 +130,7 @@
 		public virtual void Visit(IFlattenedProperty property) { }
 
 		public virtual void Visit(IHistogramProperty property) { }
+
+		public virtual void Visit(IConstantKeywordProperty property) { }
 	}
 }

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -61,6 +61,7 @@ namespace Nest
 		void Visit(IFlattenedProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		void Visit(IHistogramProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
 		void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -61,6 +61,7 @@ namespace Nest
 		void Visit(IFlattenedProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		void Visit(IHistogramProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+		void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -257,6 +257,12 @@ namespace Nest
 							_visitor.Visit(t);
 						});
 						break;
+					case FieldType.ConstantKeyword:
+						Visit<IConstantKeywordProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+						});
+						break;
 					case FieldType.None:
 						continue;
 				}

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -61,6 +61,7 @@ namespace Nest
 		public virtual void Visit(IFlattenedProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual void Visit(IHistogramProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => null;
 
@@ -148,6 +149,9 @@ namespace Nest
 					break;
 				case IHistogramProperty histogram:
 					Visit(histogram, propertyInfo, attribute);
+					break;
+				case IConstantKeywordProperty constantKeyword:
+					Visit(constantKeyword, propertyInfo, attribute);
 					break;
 			}
 		}

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -61,6 +61,7 @@ namespace Nest
 		public virtual void Visit(IFlattenedProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual void Visit(IHistogramProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
 		public virtual void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => null;

--- a/tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -377,6 +377,15 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 					.Enabled(false)
 				);
 
+			if (TestConfiguration.Instance.InRange(">=7.7.0"))
+				props.ConstantKeyword(f => f
+					.Name(p => p.VersionControl)
+				);
+			else
+				props.Keyword(f => f
+					.Name(p => p.VersionControl)
+				);
+
 			return props;
 		}
 

--- a/tests/Tests.Domain/Project.cs
+++ b/tests/Tests.Domain/Project.cs
@@ -28,6 +28,8 @@ namespace Tests.Domain
 	{
 		public static string TypeName = "project";
 
+		public static string VersionControlConstant = "git";
+
 		public IEnumerable<string> Branches { get; set; }
 		public IList<Tag> CuratedTags { get; set; }
 		public string DateString { get; set; }
@@ -65,6 +67,8 @@ namespace Tests.Domain
 
 		//the first applies when using internal source serializer the latter when using JsonNetSourceSerializer
 		public Visibility Visibility { get; set; }
+
+		public string VersionControl { get; set; }
 
 		// @formatter:off — enable formatter after this line
 		public static Faker<Project> Generator { get; } =
@@ -112,7 +116,8 @@ namespace Tests.Domain
 									Closed = closedDate.ToUnixTime()
 								}
 						};
-					});
+					})
+				.RuleFor(p => p.VersionControl, VersionControlConstant);
 
 		public static IList<Project> Projects { get; } = Generator.Clone().Generate(100);
 

--- a/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -213,6 +213,8 @@ namespace Tests.Indices.MappingManagement.GetMapping
 
 		public void Visit(IHistogramProperty property) => Increment("histogram");
 
+		public void Visit(IConstantKeywordProperty property) => Increment("constant_keyword");
+
 		private void Increment(string key)
 		{
 			if (!Counts.ContainsKey(key)) Counts.Add(key, 0);

--- a/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -132,6 +132,10 @@ namespace Tests.Indices.MappingManagement.PutMapping
 				{
 					type = "flattened",
 					depth_limit = 4
+				},
+				versionControl = new
+				{
+					type = "keyword"
 				}
 			}
 		};
@@ -195,6 +199,9 @@ namespace Tests.Indices.MappingManagement.PutMapping
 				.Flattened(f => f
 					.Name(p => p.Labels)
 					.DepthLimit(4)
+				)
+				.Keyword(k => k
+					.Name(n => n.VersionControl)
 				)
 			);
 
@@ -314,6 +321,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 				{
 					DepthLimit = 4
 				} },
+				{ p => p.VersionControl, new KeywordProperty() }
 			}
 		};
 

--- a/tests/Tests/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordAttributeTests.cs
@@ -1,0 +1,35 @@
+﻿using Elastic.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Tests.Mapping.Types.Specialized.ConstantKeyword
+{
+	public class ConstantKeywordTest
+	{
+		[ConstantKeyword(Value = "constant_string")]
+		public string ConstantString { get; set; }
+
+		[ConstantKeyword(Value = 42)]
+		public int ConstantInt { get; set; }
+	}
+
+	[SkipVersion("<7.7.0", "introduced in 7.7.0")]
+	public class ConstantKeywordAttributeTests : AttributeTestsBase<ConstantKeywordTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				constantString = new
+				{
+					type = "constant_keyword",
+					value = "constant_string"
+				},
+				constantInt = new
+				{
+					type = "constant_keyword",
+					value = 42
+				}
+			}
+		};
+	}
+}

--- a/tests/Tests/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/ConstantKeyword/ConstantKeywordPropertyTests.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Elastic.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Specialized.ConstantKeyword
+{
+	[SkipVersion("<7.7.0", "introduced in 7.7.0")]
+	public class ConstantKeywordPropertyTests : PropertyTestsBase
+	{
+		public ConstantKeywordPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				versionControl = new
+				{
+					type = "constant_keyword",
+					value = Project.VersionControlConstant,
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.ConstantKeyword(s => s
+				.Name(n => n.VersionControl)
+				.Value(Project.VersionControlConstant)
+			);
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"versionControl", new ConstantKeywordProperty
+				{
+					Value = Project.VersionControlConstant
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/pull/49713

This commit adds the ConstantKeyword property to the client.
Value is exposed as type Object as it can be a string or numeric
value.