### PR TITLE
Implement hidden indices and aliases

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/FixedIndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/FixedIndexSettings.cs
@@ -11,6 +11,12 @@ namespace Nest
 		public const string RoutingPartitionSize = "index.routing_partition_size";
 
 		/// <summary>
+		/// Indicates whether the index should be hidden by default.
+		/// Hidden indices are not returned by default when using a wildcard expression.
+		/// </summary>
+		public const string Hidden = "index.hidden";
+
+		/// <summary>
 		/// If a field referred to in a percolator query does not exist,
 		/// it will be handled as a default text field so that adding the percolator query doesn't fail.
 		/// Defaults to <c>false</c>

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettings.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettings.cs
@@ -40,6 +40,12 @@ namespace Nest
 		int? RoutingPartitionSize { get; set; }
 
 		/// <summary>
+		/// Indicates whether the index should be hidden by default.
+		/// Hidden indices are not returned by default when using a wildcard expression.
+		/// </summary>
+		bool? Hidden { get; set; }
+
+		/// <summary>
 		///  Settings associated with index sorting.
 		/// https://www.elastic.co/guide/en/elasticsearch/reference/6.0/index-modules-index-sorting.html
 		/// </summary>
@@ -71,6 +77,9 @@ namespace Nest
 		/// <inheritdoc cref="IIndexSettings.RoutingPartitionSize" />
 		public int? RoutingPartitionSize { get; set; }
 
+		/// <inheritdoc cref="IIndexSettings.Hidden" />
+		public bool? Hidden { get; set; }
+
 		/// <inheritdoc cref="IIndexSettings.Sorting" />
 		public ISortingSettings Sorting { get; set; }
 
@@ -94,6 +103,10 @@ namespace Nest
 		/// <inheritdoc cref="IIndexSettings.RoutingPartitionSize" />
 		public IndexSettingsDescriptor RoutingPartitionSize(int? routingPartitionSize) =>
 			Assign(routingPartitionSize, (a, v) => a.RoutingPartitionSize = v);
+
+		/// <inheritdoc cref="IIndexSettings.Hidden" />
+		public IndexSettingsDescriptor Hidden(bool? hidden = true) =>
+			Assign(hidden, (a, v) => a.Hidden = v);
 
 		/// <inheritdoc cref="IIndexSettings.FileSystemStorageImplementation" />
 		public IndexSettingsDescriptor FileSystemStorageImplementation(FileSystemStorageImplementation? fs) =>

--- a/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/IndexSettingsFormatter.cs
@@ -124,6 +124,7 @@ namespace Nest
 				Set(NumberOfShards, indexSettings.NumberOfShards);
 				Set(NumberOfRoutingShards, indexSettings.NumberOfRoutingShards);
 				Set(RoutingPartitionSize, indexSettings.RoutingPartitionSize);
+				Set(Hidden, indexSettings.Hidden);
 				if (indexSettings.SoftDeletes != null)
 				{
 #pragma warning disable 618
@@ -159,7 +160,7 @@ namespace Nest
 			Dictionary<string, object> current = null
 		)
 		{
-			current = current ?? new Dictionary<string, object>();
+			current ??= new Dictionary<string, object>();
 			foreach (var property in original)
 			{
 				if (property.Value is Dictionary<string, object> objects &&
@@ -251,6 +252,7 @@ namespace Nest
 			Set<int?>(s, settings, NumberOfShards, v => s.NumberOfShards = v, formatterResolver);
 			Set<int?>(s, settings, NumberOfRoutingShards, v => s.NumberOfRoutingShards = v, formatterResolver);
 			Set<int?>(s, settings, RoutingPartitionSize, v => s.RoutingPartitionSize = v, formatterResolver);
+			Set<bool?>(s, settings, Hidden, v => s.Hidden = v, formatterResolver);
 			Set<FileSystemStorageImplementation?>(s, settings, StoreType, v => s.FileSystemStorageImplementation = v, formatterResolver);
 
 			var sorting = s.Sorting = new SortingSettings();

--- a/src/Nest/Indices/AliasManagement/Alias.cs
+++ b/src/Nest/Indices/AliasManagement/Alias.cs
@@ -34,6 +34,8 @@ namespace Nest
 		/// If true, the alias will be excluded from wildcard expressions by default, unless overriden in the request using
 		/// the expand_wildcards parameter, similar to hidden indices.
 		/// This property must be set to the same value on all indices that share an alias. Defaults to false.
+		/// <para />
+		/// Available in Elasticsearch 7.7.0+
 		/// </summary>
 		[DataMember(Name = "is_hidden")]
 		bool? IsHidden { get; set; }

--- a/src/Nest/Indices/AliasManagement/Alias.cs
+++ b/src/Nest/Indices/AliasManagement/Alias.cs
@@ -23,9 +23,20 @@ namespace Nest
 		[DataMember(Name = "index_routing")]
 		Routing IndexRouting { get; set; }
 
-		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex" />
+		/// <summary>
+		/// If an alias points to multiple indices, Elasticsearch will reject the write operations
+		/// unless one is explicitly marked as the write alias using this property.
+		/// </summary>
 		[DataMember(Name = "is_write_index")]
 		bool? IsWriteIndex { get; set; }
+
+		/// <summary>
+		/// If true, the alias will be excluded from wildcard expressions by default, unless overriden in the request using
+		/// the expand_wildcards parameter, similar to hidden indices.
+		/// This property must be set to the same value on all indices that share an alias. Defaults to false.
+		/// </summary>
+		[DataMember(Name = "is_hidden")]
+		bool? IsHidden { get; set; }
 
 		/// <summary>
 		/// Associates routing values with aliases for both index and search operations. This feature can be used together
@@ -52,6 +63,9 @@ namespace Nest
 		/// <inheritdoc />
 		public bool? IsWriteIndex { get; set; }
 		/// <inheritdoc />
+		public bool? IsHidden { get; set; }
+
+		/// <inheritdoc />
 		public Routing Routing { get; set; }
 		/// <inheritdoc />
 		public Routing SearchRouting { get; set; }
@@ -65,6 +79,7 @@ namespace Nest
 		bool? IAlias.IsWriteIndex { get; set; }
 		Routing IAlias.Routing { get; set; }
 		Routing IAlias.SearchRouting { get; set; }
+		bool? IAlias.IsHidden { get; set; }
 
 		/// <inheritdoc cref="IAlias.Filter" />
 		public AliasDescriptor Filter<T>(Func<QueryContainerDescriptor<T>, QueryContainer> filterSelector) where T : class =>
@@ -75,6 +90,9 @@ namespace Nest
 
 		/// <inheritdoc cref="IAlias.IsWriteIndex" />
 		public AliasDescriptor IsWriteIndex(bool? isWriteIndex = true) => Assign(isWriteIndex, (a, v) => a.IsWriteIndex = v);
+
+		/// <inheritdoc cref="IAlias.IsHidden" />
+		public AliasDescriptor IsHidden(bool? isHidden = true) => Assign(isHidden, (a, v) => a.IsHidden = v);
 
 		/// <inheritdoc cref="IAlias.Routing" />
 		public AliasDescriptor Routing(Routing routing) => Assign(routing, (a, v) => a.Routing = v);

--- a/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
+++ b/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAdd.cs
@@ -22,54 +22,70 @@ namespace Nest
 
 		AliasAddOperation IAliasAddAction.Add { get; set; }
 
+		/// <inheritdoc cref="AliasAddOperation.Index"/>
 		public AliasAddDescriptor Index(string index)
 		{
 			Self.Add.Index = index;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.Index"/>
 		public AliasAddDescriptor Index(Type index)
 		{
 			Self.Add.Index = index;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.Index"/>
 		public AliasAddDescriptor Index<T>() where T : class
 		{
 			Self.Add.Index = typeof(T);
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.Alias"/>
 		public AliasAddDescriptor Alias(string alias)
 		{
 			Self.Add.Alias = alias;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.Routing"/>
 		public AliasAddDescriptor Routing(string routing)
 		{
 			Self.Add.Routing = routing;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.IndexRouting"/>
 		public AliasAddDescriptor IndexRouting(string indexRouting)
 		{
 			Self.Add.IndexRouting = indexRouting;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.SearchRouting"/>
 		public AliasAddDescriptor SearchRouting(string searchRouting)
 		{
 			Self.Add.SearchRouting = searchRouting;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.IsWriteIndex"/>
 		public AliasAddDescriptor IsWriteIndex(bool? isWriteIndex = true)
 		{
 			Self.Add.IsWriteIndex = isWriteIndex;
 			return this;
 		}
 
+		/// <inheritdoc cref="AliasAddOperation.IsHidden"/>
+		public AliasAddDescriptor IsHidden(bool? isHidden = true)
+		{
+			Self.Add.IsHidden = isHidden;
+			return this;
+		}
+
+		/// <inheritdoc cref="AliasAddOperation.Filter"/>
 		public AliasAddDescriptor Filter<T>(Func<QueryContainerDescriptor<T>, QueryContainer> filterSelector)
 			where T : class
 		{

--- a/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
+++ b/src/Nest/Indices/AliasManagement/Alias/Actions/AliasAddOperation.cs
@@ -4,28 +4,42 @@ namespace Nest
 {
 	public class AliasAddOperation
 	{
+		/// <summary>
+		/// The name of the alias
+		/// </summary>
 		[DataMember(Name ="alias")]
 		public string Alias { get; set; }
 
+		/// <summary>
+		/// Filter query used to limit the index alias.
+		/// If specified, the index alias only applies to documents returned by the filter.
+		/// </summary>
 		[DataMember(Name ="filter")]
 		public QueryContainer Filter { get; set; }
 
+		/// <summary>
+		/// The index to which to add the alias
+		/// </summary>
 		[DataMember(Name ="index")]
 		public IndexName Index { get; set; }
 
+		/// <inheritdoc cref="IAlias.IndexRouting"/>
 		[DataMember(Name ="index_routing")]
 		public string IndexRouting { get; set; }
 
-		/// <summary>
-		/// If an alias points to multiple indices, Elasticsearch will reject the write operations
-		/// unless one is explicitly marked as the write alias using this property.
-		/// </summary>
+		/// <inheritdoc cref="IAlias.IsWriteIndex"/>
 		[DataMember(Name ="is_write_index")]
 		public bool? IsWriteIndex { get; set; }
 
+		/// <inheritdoc cref="IAlias.IsHidden"/>
+		[DataMember(Name ="is_hidden")]
+		public bool? IsHidden { get; set; }
+
+		/// <inheritdoc cref="IAlias.Routing"/>
 		[DataMember(Name ="routing")]
 		public string Routing { get; set; }
 
+		/// <inheritdoc cref="IAlias.SearchRouting"/>
 		[DataMember(Name ="search_routing")]
 		public string SearchRouting { get; set; }
 	}


### PR DESCRIPTION
Relates: elastic/elasticsearch#52547
Relates: elastic/elasticsearch#53248

This commit adds the ability to mark indices
and aliases as hidden.