### PR TITLE
Change SumOfDocumentFrequencies and SumOfTotalTermFrequencies to long

### DIFF
--- a/src/Nest/Document/Single/TermVectors/FieldStatistics.cs
+++ b/src/Nest/Document/Single/TermVectors/FieldStatistics.cs
@@ -9,9 +9,9 @@ namespace Nest
 		public int DocumentCount { get; internal set; }
 
 		[DataMember(Name ="sum_doc_freq")]
-		public int SumOfDocumentFrequencies { get; internal set; }
+		public long SumOfDocumentFrequencies { get; internal set; }
 
 		[DataMember(Name ="sum_ttf")]
-		public int SumOfTotalTermFrequencies { get; internal set; }
+		public long SumOfTotalTermFrequencies { get; internal set; }
 	}
 }


### PR DESCRIPTION
This commit changes the SumOfDocumentFrequencies and SumOfTotalTermFrequencies
on TermVector to long. These values can be bigger than int.

Fixes #4578