### PR TITLE
ApiGenerator should remove old specification files from disk before redownloading.

### DIFF
--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -36,7 +36,11 @@ namespace ApiGenerator
 			var lowLevelOnly = generateCode && Ask("Generate low level client only?", false);
 
 			if (redownloadCoreSpecification)
+			{
+				Directory.Delete(Path.Combine(GeneratorLocations.RestSpecificationFolder, "Core"), true);
+				Directory.Delete(Path.Combine(GeneratorLocations.RestSpecificationFolder, "XPack"), true);
 				RestSpecDownloader.Download(downloadBranch);
+			}
 
 			if (generateCode)
 				await Generator.ApiGenerator.Generate(downloadBranch, lowLevelOnly, "Core", "XPack");


### PR DESCRIPTION
This is to ensure that the specifications are up-to-date and accurate from the download branch and no "orphans" are carried forward.

Fixes #4636