### PR TITLE
Implement client examples 2020-04-02

### DIFF
--- a/examples/Aggregations/Bucket/TermsAggregationPage/028f6d6ac2594e20b78b8a8f8cbad49d.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/028f6d6ac2594e20b78b8a8f8cbad49d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line470 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L309-L363.
+This file is generated from method Line470 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L304-L357.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/033778305d52746f5ce0a2a922c8e521.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/033778305d52746f5ce0a2a922c8e521.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line544 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L394-L425.
+This file is generated from method Line544 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L388-L419.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/0afaf1cad692e6201aa574c8feb6e622.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/0afaf1cad692e6201aa574c8feb6e622.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line626 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L499-L528.
+This file is generated from method Line626 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L493-L522.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/34efeade38445b2834749ced59782e25.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/34efeade38445b2834749ced59782e25.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line397 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L207-L248.
+This file is generated from method Line397 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L204-L244.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/4646764bf09911fee7d58630c72d3137.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/4646764bf09911fee7d58630c72d3137.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line578 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L427-L462.
+This file is generated from method Line578 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L421-L456.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/527324766814561b75aaee853ede49a7.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/527324766814561b75aaee853ede49a7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line503 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L365-L392.
+This file is generated from method Line503 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L359-L386.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/5d9d7b84e2fec7ecd832145cbb951cf1.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line683 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L569-L625.
+This file is generated from method Line683 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L563-L618.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/6a4679531e64c492fce16dc12de6dcb0.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/6a4679531e64c492fce16dc12de6dcb0.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line341 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L94-L127.
+This file is generated from method Line341 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L94-L126.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/71b5b2ba9557d0f296ff2de91727d2f6.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/71b5b2ba9557d0f296ff2de91727d2f6.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line377 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L164-L205.
+This file is generated from method Line377 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L162-L202.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/774d715155cd13713e6e327adf6ce328.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/774d715155cd13713e6e327adf6ce328.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line857 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L715-L742.
+This file is generated from method Line857 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L708-L735.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/7f28f8ae8fcdbd807dadde0b5b007a6d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line775 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L627-L668.
+This file is generated from method Line775 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L620-L661.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/93f1bdd72e79827dcf9a34efa02fd977.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/93f1bdd72e79827dcf9a34efa02fd977.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line358 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L129-L162.
+This file is generated from method Line358 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L128-L160.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/98b121bf47cebd85671a2cb519688d28.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/98b121bf47cebd85671a2cb519688d28.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line654 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L530-L567.
+This file is generated from method Line654 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L524-L561.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/a49169b4622918992411fab4ec48191b.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/a49169b4622918992411fab4ec48191b.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line600 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L464-L497.
+This file is generated from method Line600 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L458-L491.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/cd5bc5bf7cd58d7b1492c9c298b345f6.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line806 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L670-L713.
+This file is generated from method Line806 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L663-L706.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/dc15e2373e5ecbe09b4ea0858eb63d47.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/dc15e2373e5ecbe09b4ea0858eb63d47.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line443 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L250-L307.
+This file is generated from method Line443 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L246-L302.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Aggregations/Bucket/TermsAggregationPage/f085fb032dae56a3b104ab874eaea2ad.asciidoc
+++ b/examples/Aggregations/Bucket/TermsAggregationPage/f085fb032dae56a3b104ab874eaea2ad.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line882 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L744-L771.
+This file is generated from method Line882 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Aggregations/Bucket/TermsAggregationPage.cs#L737-L764.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/BulkPage/8cd00a3aba7c3c158277bc032aac2830.asciidoc
+++ b/examples/Docs/BulkPage/8cd00a3aba7c3c158277bc032aac2830.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line405 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/BulkPage.cs#L47-L114.
+This file is generated from method Line405 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/BulkPage.cs#L47-L113.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/14701dcc0cca9665fce2aace0cb62af7.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/14701dcc0cca9665fce2aace0cb62af7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line504 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L330-L368.
+This file is generated from method Line504 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L322-L359.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/18ddb7e7a4bcafd449df956e828ed7a8.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/18ddb7e7a4bcafd449df956e828ed7a8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line660 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L409-L420.
+This file is generated from method Line660 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L400-L411.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/1e49eba5b9042c1900a608fe5105ba43.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/1e49eba5b9042c1900a608fe5105ba43.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line414 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L159-L238.
+This file is generated from method Line414 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L156-L233.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/216848930c2d344fe0bed0daa70c35b9.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/216848930c2d344fe0bed0daa70c35b9.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line586 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L384-L396.
+This file is generated from method Line586 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L375-L387.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/3e573bfabe00f8bfb8bb69aa5820768e.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/3e573bfabe00f8bfb8bb69aa5820768e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line449 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L240-L288.
+This file is generated from method Line449 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L235-L281.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/52c7e4172a446c394210a07c464c57d2.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/52c7e4172a446c394210a07c464c57d2.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line572 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L370-L382.
+This file is generated from method Line572 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L361-L373.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/a5a7050fb9dcb9574e081957ade28617.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/a5a7050fb9dcb9574e081957ade28617.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line487 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L290-L328.
+This file is generated from method Line487 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L283-L320.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/be3a6431d01846950dc1a39a7a6a1faa.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/be3a6431d01846950dc1a39a7a6a1faa.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line640 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L398-L407.
+This file is generated from method Line640 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L389-L398.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/c22b72c4a52ee098331b3f252c22860d.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/c22b72c4a52ee098331b3f252c22860d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line362 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L68-L85.
+This file is generated from method Line362 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L67-L84.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/c32a3f8071d87f0a3f5a78e07fe7a669.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/c32a3f8071d87f0a3f5a78e07fe7a669.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line376 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L87-L122.
+This file is generated from method Line376 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L86-L120.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/dfb1fe96d806a644214d06f9b4b87878.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/dfb1fe96d806a644214d06f9b4b87878.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line394 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L124-L157.
+This file is generated from method Line394 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L122-L154.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/e21e1c26dc8687e7bf7bd2bf019a6698.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/e21e1c26dc8687e7bf7bd2bf019a6698.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line349 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L48-L66.
+This file is generated from method Line349 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L47-L65.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/DeleteByQueryPage/ebb6b59fbc9325c17e45f524602d6be2.asciidoc
+++ b/examples/Docs/DeleteByQueryPage/ebb6b59fbc9325c17e45f524602d6be2.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line10 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L13-L46.
+This file is generated from method Line10 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/DeleteByQueryPage.cs#L13-L45.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
+++ b/examples/Docs/GetPage/0ba0b2db24852abccb7c0fc1098d566e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line363 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L206-L227.
+This file is generated from method Line363 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L205-L226.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
+++ b/examples/Docs/GetPage/1d65cb6d055c46a1bde809687d835b71.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line86 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L70-L82.
+This file is generated from method Line86 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L69-L81.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
+++ b/examples/Docs/GetPage/2468ab381257d759d8a88af1141f6f9c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line285 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L121-L130.
+This file is generated from method Line285 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L120-L129.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
+++ b/examples/Docs/GetPage/5eabcdbf61bfcb484dc694f25c2bba36.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line320 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L171-L188.
+This file is generated from method Line320 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L170-L187.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
+++ b/examples/Docs/GetPage/69a7be47f85138b10437113ab2f0d72d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line373 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L229-L244.
+This file is generated from method Line373 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L228-L243.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
+++ b/examples/Docs/GetPage/710c7871f20f176d51209b1574b0d61b.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line332 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L190-L204.
+This file is generated from method Line332 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L189-L203.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
+++ b/examples/Docs/GetPage/745f9b8cdb8e91073f6e520e1d9f8c05.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line73 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L51-L68.
+This file is generated from method Line73 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L51-L67.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
+++ b/examples/Docs/GetPage/89a8ac1509936acc272fc2d72907bc45.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line266 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L95-L104.
+This file is generated from method Line266 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L94-L103.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
+++ b/examples/Docs/GetPage/913770050ebbf3b9b549a899bc11060a.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line299 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L132-L169.
+This file is generated from method Line299 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L131-L168.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
+++ b/examples/Docs/GetPage/98234499cfec70487cec5d013e976a84.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line250 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L84-L93.
+This file is generated from method Line250 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L83-L92.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
+++ b/examples/Docs/GetPage/d222c6a6ec7a3beca6c97011b0874512.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line275 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L106-L119.
+This file is generated from method Line275 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/GetPage.cs#L105-L118.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/1216f8f7367df3aa823012cef310c08a.asciidoc
+++ b/examples/Docs/ReindexPage/1216f8f7367df3aa823012cef310c08a.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line699 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L358-L382.
+This file is generated from method Line699 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L353-L377.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/1577e6e806b3283c9e99f1596d310754.asciidoc
+++ b/examples/Docs/ReindexPage/1577e6e806b3283c9e99f1596d310754.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line687 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L338-L356.
+This file is generated from method Line687 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L334-L351.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/1bc731a4df952228af6dfa6b48627332.asciidoc
+++ b/examples/Docs/ReindexPage/1bc731a4df952228af6dfa6b48627332.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line802 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L460-L498.
+This file is generated from method Line802 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L454-L490.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/36b2778f23d0955255f52c075c4d213d.asciidoc
+++ b/examples/Docs/ReindexPage/36b2778f23d0955255f52c075c4d213d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line888 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L532-L571.
+This file is generated from method Line888 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L523-L562.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/3ae03ba3b56e5e287953094050766738.asciidoc
+++ b/examples/Docs/ReindexPage/3ae03ba3b56e5e287953094050766738.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line224 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L93-L114.
+This file is generated from method Line224 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L93-L112.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/3b04cc894e6a47d57983484010feac0c.asciidoc
+++ b/examples/Docs/ReindexPage/3b04cc894e6a47d57983484010feac0c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line787 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L445-L458.
+This file is generated from method Line787 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L439-L452.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/400e89eb46ead8e9c9e40f123fd5e590.asciidoc
+++ b/examples/Docs/ReindexPage/400e89eb46ead8e9c9e40f123fd5e590.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line384 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L188-L210.
+This file is generated from method Line384 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L185-L207.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/52b2bfbdd78f8283b6f4891c48013237.asciidoc
+++ b/examples/Docs/ReindexPage/52b2bfbdd78f8283b6f4891c48013237.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line618 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L265-L287.
+This file is generated from method Line618 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L262-L284.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/64b9baa6d7556b960b29698f3383aa31.asciidoc
+++ b/examples/Docs/ReindexPage/64b9baa6d7556b960b29698f3383aa31.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line955 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L573-L609.
+This file is generated from method Line955 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L564-L600.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/6f097c298a7abf4c032c4314920c49c8.asciidoc
+++ b/examples/Docs/ReindexPage/6f097c298a7abf4c032c4314920c49c8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line640 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L289-L313.
+This file is generated from method Line640 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L286-L309.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/764f9884b370cbdc82a1c5c42ed40ff3.asciidoc
+++ b/examples/Docs/ReindexPage/764f9884b370cbdc82a1c5c42ed40ff3.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line592 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L235-L263.
+This file is generated from method Line592 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L232-L260.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/78c96113ae4ed0054e581b17542528a7.asciidoc
+++ b/examples/Docs/ReindexPage/78c96113ae4ed0054e581b17542528a7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line359 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L155-L186.
+This file is generated from method Line359 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L152-L183.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/7f697eb436dfa3c30dfe610d8c32d132.asciidoc
+++ b/examples/Docs/ReindexPage/7f697eb436dfa3c30dfe610d8c32d132.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line986 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L611-L650.
+This file is generated from method Line986 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L602-L641.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/8871b8fcb6de4f0c7dff22798fb10fb7.asciidoc
+++ b/examples/Docs/ReindexPage/8871b8fcb6de4f0c7dff22798fb10fb7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line833 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L500-L530.
+This file is generated from method Line833 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L492-L521.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/973a3ff47fc4ce036ecd9bd363fef9f7.asciidoc
+++ b/examples/Docs/ReindexPage/973a3ff47fc4ce036ecd9bd363fef9f7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line767 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L414-L443.
+This file is generated from method Line767 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L409-L437.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/9a4d5e41c52c20635d1fd9c6e13f6c7a.asciidoc
+++ b/examples/Docs/ReindexPage/9a4d5e41c52c20635d1fd9c6e13f6c7a.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line751 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L395-L412.
+This file is generated from method Line751 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L390-L407.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/b1efa1c51a34dd5ab5511b71a399f5b1.asciidoc
+++ b/examples/Docs/ReindexPage/b1efa1c51a34dd5ab5511b71a399f5b1.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line403 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L212-L233.
+This file is generated from method Line403 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L209-L230.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/cb01106bf524df5e0501d4c655c1aa7b.asciidoc
+++ b/examples/Docs/ReindexPage/cb01106bf524df5e0501d4c655c1aa7b.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line251 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L116-L138.
+This file is generated from method Line251 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L114-L136.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/cfc37446bd892d1ac42a3c8e8b204e6c.asciidoc
+++ b/examples/Docs/ReindexPage/cfc37446bd892d1ac42a3c8e8b204e6c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line718 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L384-L393.
+This file is generated from method Line718 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L379-L388.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/e567e6dbf86300142573c73789c8fce4.asciidoc
+++ b/examples/Docs/ReindexPage/e567e6dbf86300142573c73789c8fce4.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line267 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L140-L153.
+This file is generated from method Line267 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L138-L150.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/ReindexPage/e9c2e15b36372d5281c879d336322b6c.asciidoc
+++ b/examples/Docs/ReindexPage/e9c2e15b36372d5281c879d336322b6c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line666 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L315-L336.
+This file is generated from method Line666 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/ReindexPage.cs#L311-L332.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/025b54db0edc50c24ea48a2bd94366ad.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/025b54db0edc50c24ea48a2bd94366ad.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line599 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L328-L346.
+This file is generated from method Line599 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L324-L341.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/0d664883151008b1051ef2c9ab2d0373.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/0d664883151008b1051ef2c9ab2d0373.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line530 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L226-L275.
+This file is generated from method Line530 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L224-L273.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/18ddb7e7a4bcafd449df956e828ed7a8.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/18ddb7e7a4bcafd449df956e828ed7a8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line491 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L199-L210.
+This file is generated from method Line491 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L197-L208.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/2fd69fb0538e4f36ac69a8b8f8bf5ae8.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/2fd69fb0538e4f36ac69a8b8f8bf5ae8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line348 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L100-L137.
+This file is generated from method Line348 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L99-L135.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/2fe28d9a91b3081a9ec4601af8fb7b1c.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/2fe28d9a91b3081a9ec4601af8fb7b1c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line655 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L348-L416.
+This file is generated from method Line655 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L343-L411.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/4acf902c2598b2558f34f20c1744c433.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/4acf902c2598b2558f34f20c1744c433.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line557 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L277-L303.
+This file is generated from method Line557 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L275-L299.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/52a87b81e4e0b6b11e23e85db1602a63.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/52a87b81e4e0b6b11e23e85db1602a63.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line300 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L27-L57.
+This file is generated from method Line300 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L27-L56.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/54a770f053f3225ea0d1e34334232411.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/54a770f053f3225ea0d1e34334232411.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line336 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L86-L98.
+This file is generated from method Line336 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L85-L97.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/7df191cc7f814e410a4ac7261065e6ef.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/7df191cc7f814e410a4ac7261065e6ef.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line413 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L174-L186.
+This file is generated from method Line413 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L172-L184.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/97babc8d19ef0866774576716eb6d19e.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/97babc8d19ef0866774576716eb6d19e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line720 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L452-L492.
+This file is generated from method Line720 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L446-L485.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/abd4fc3ce7784413a56fe2dcfe2809b5.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/abd4fc3ce7784413a56fe2dcfe2809b5.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line693 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L418-L450.
+This file is generated from method Line693 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L413-L444.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/bdb30dd52d32f50994008f4f9c0da5f0.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/bdb30dd52d32f50994008f4f9c0da5f0.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line510 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L212-L224.
+This file is generated from method Line510 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L210-L222.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/be3a6431d01846950dc1a39a7a6a1faa.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/be3a6431d01846950dc1a39a7a6a1faa.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line471 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L188-L197.
+This file is generated from method Line471 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L186-L195.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/c4b278ba293abd0d02a0b5ad1a99f84a.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/c4b278ba293abd0d02a0b5ad1a99f84a.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line389 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L139-L172.
+This file is generated from method Line389 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L137-L170.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/cde4dddae5c06e7f1d38c9d933dbc7ac.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/cde4dddae5c06e7f1d38c9d933dbc7ac.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line319 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L59-L70.
+This file is generated from method Line319 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L58-L69.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/d8b115341da772a628a024e7d1644e73.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/d8b115341da772a628a024e7d1644e73.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line327 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L72-L84.
+This file is generated from method Line327 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L71-L83.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdateByQueryPage/ea02de2dbe05091fcb0dac72c8ba5f83.asciidoc
+++ b/examples/Docs/UpdateByQueryPage/ea02de2dbe05091fcb0dac72c8ba5f83.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line586 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L305-L326.
+This file is generated from method Line586 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdateByQueryPage.cs#L301-L322.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/015294a400986295039e52ebc62033be.asciidoc
+++ b/examples/Docs/UpdatePage/015294a400986295039e52ebc62033be.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line251 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L228-L250.
+This file is generated from method Line251 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L226-L248.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/0a958e486ede3f519d48431ab689eded.asciidoc
+++ b/examples/Docs/UpdatePage/0a958e486ede3f519d48431ab689eded.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line271 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L252-L286.
+This file is generated from method Line271 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L250-L284.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/38c1d0f6668e9563c0827f839f9fa505.asciidoc
+++ b/examples/Docs/UpdatePage/38c1d0f6668e9563c0827f839f9fa505.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line198 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L206-L226.
+This file is generated from method Line198 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L204-L224.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/58df61acbfb15b8ef0aaa18b81ae98a6.asciidoc
+++ b/examples/Docs/UpdatePage/58df61acbfb15b8ef0aaa18b81ae98a6.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line164 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L149-L175.
+This file is generated from method Line164 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L148-L173.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/7cac05cb589f1614fd5b8589153bef06.asciidoc
+++ b/examples/Docs/UpdatePage/7cac05cb589f1614fd5b8589153bef06.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line325 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L328-L350.
+This file is generated from method Line325 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L326-L348.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/98aeb275f829b5f7b8eb2147701565ff.asciidoc
+++ b/examples/Docs/UpdatePage/98aeb275f829b5f7b8eb2147701565ff.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line177 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L177-L204.
+This file is generated from method Line177 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L175-L202.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/eb30ba547e4a7b8f54f33ab259aca523.asciidoc
+++ b/examples/Docs/UpdatePage/eb30ba547e4a7b8f54f33ab259aca523.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line153 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L121-L147.
+This file is generated from method Line153 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L121-L146.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Docs/UpdatePage/f9636d7ef1a45be4f36418c875cf6bef.asciidoc
+++ b/examples/Docs/UpdatePage/f9636d7ef1a45be4f36418c875cf6bef.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line296 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L288-L326.
+This file is generated from method Line296 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Docs/UpdatePage.cs#L286-L324.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d46dbb96125b27f46299547de9d8709.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line190 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L170-L188.
+This file is generated from method Line190 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L163-L181.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
+++ b/examples/Indices/CreateIndexPage/4d56b179242fed59e3d6476f817b6055.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line143 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L134-L168.
+This file is generated from method Line143 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L128-L161.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/b9c5d7ca6ca9c6f747201f45337a4abf.asciidoc
+++ b/examples/Indices/CreateIndexPage/b9c5d7ca6ca9c6f747201f45337a4abf.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line99 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L57-L89.
+This file is generated from method Line99 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L55-L85.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
+++ b/examples/Indices/CreateIndexPage/dfef545b1e2c247bafd1347e8e807ac1.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line123 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L91-L132.
+This file is generated from method Line123 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L87-L126.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/e5d2172b524332196cac0f031c043659.asciidoc
+++ b/examples/Indices/CreateIndexPage/e5d2172b524332196cac0f031c043659.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line81 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L21-L55.
+This file is generated from method Line81 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L21-L53.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
+++ b/examples/Indices/CreateIndexPage/fabe14480624a99e8ee42c7338672058.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line203 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L190-L208.
+This file is generated from method Line203 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/CreateIndexPage.cs#L183-L200.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/TemplatesPage/1b8caf0a6741126c6d0ad83b56fce290.asciidoc
+++ b/examples/Indices/TemplatesPage/1b8caf0a6741126c6d0ad83b56fce290.asciidoc
@@ -1,9 +1,9 @@
-// indices/templates.asciidoc:138
+// indices/templates.asciidoc:136
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line138 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L58-L103.
+This file is generated from method Line136 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L57-L101.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/TemplatesPage/46658f00edc4865dfe472a392374cd0f.asciidoc
+++ b/examples/Indices/TemplatesPage/46658f00edc4865dfe472a392374cd0f.asciidoc
@@ -1,9 +1,9 @@
-// indices/templates.asciidoc:241
+// indices/templates.asciidoc:239
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line241 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L196-L205.
+This file is generated from method Line239 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L191-L200.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/TemplatesPage/9166cf38427d5cde5d2ec12a2012b669.asciidoc
+++ b/examples/Indices/TemplatesPage/9166cf38427d5cde5d2ec12a2012b669.asciidoc
@@ -1,9 +1,9 @@
-// indices/templates.asciidoc:223
+// indices/templates.asciidoc:221
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line223 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L166-L194.
+This file is generated from method Line221 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L162-L189.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/TemplatesPage/b5f95bc097a201b29c7200fc8d3d31c1.asciidoc
+++ b/examples/Indices/TemplatesPage/b5f95bc097a201b29c7200fc8d3d31c1.asciidoc
@@ -1,9 +1,9 @@
-// indices/templates.asciidoc:172
+// indices/templates.asciidoc:170
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line172 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L105-L164.
+This file is generated from method Line170 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L103-L160.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Indices/TemplatesPage/e5f50b31f165462d883ecbff45f74985.asciidoc
+++ b/examples/Indices/TemplatesPage/e5f50b31f165462d883ecbff45f74985.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line10 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L11-L56.
+This file is generated from method Line10 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Indices/TemplatesPage.cs#L11-L55.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/0b91c082258ce623cc716b679aace653.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line192 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L139-L208.
+This file is generated from method Line192 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L139-L207.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/1a59fa2708ccb3a24c71e8306b81f17f.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/1a59fa2708ccb3a24c71e8306b81f17f.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line332 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L345-L379.
+This file is generated from method Line332 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L344-L378.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/3e60c0b29bd3931927e6f2ee7d2ed0ef.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/3e60c0b29bd3931927e6f2ee7d2ed0ef.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line357 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L381-L422.
+This file is generated from method Line357 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L380-L421.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/6873971eb4e4577d76d0a5bd7cd15ef9.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/6873971eb4e4577d76d0a5bd7cd15ef9.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line252 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L243-L307.
+This file is generated from method Line252 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L242-L306.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/87f85bb49d18f73d0eed0b704e05eb90.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/87f85bb49d18f73d0eed0b704e05eb90.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line304 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L309-L343.
+This file is generated from method Line304 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L308-L342.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/9a91f7d0bf52d6c582c62daef5c9d040.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/9a91f7d0bf52d6c582c62daef5c9d040.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line395 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L424-L474.
+This file is generated from method Line395 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L423-L473.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
+++ b/examples/Mapping/Dynamic/TemplatesPage/be51ed37c8425d281a8153abe56b04cb.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line227 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L210-L241.
+This file is generated from method Line227 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Dynamic/TemplatesPage.cs#L209-L240.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Params/FormatPage/7f465b7e8ed42df6c42251b4481e699e.asciidoc
+++ b/examples/Mapping/Params/FormatPage/7f465b7e8ed42df6c42251b4481e699e.asciidoc
@@ -1,0 +1,23 @@
+// mapping/params/format.asciidoc:13
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line13 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Params/FormatPage.cs#L9-L37.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map<object>(m => m
+        .Properties(p => p
+            .Date(d => d
+                .Name("date")
+                .Format("yyyy-MM-dd")
+            )
+        )
+    )
+);
+----

--- a/examples/Mapping/Types/NestedPage/8baccd8688a6bad1749b8935f9601ea4.asciidoc
+++ b/examples/Mapping/Types/NestedPage/8baccd8688a6bad1749b8935f9601ea4.asciidoc
@@ -1,0 +1,25 @@
+// mapping/types/nested.asciidoc:19
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line19 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/NestedPage.cs#L10-L43.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var indexResponse = client.Index(new GroupDoc
+{
+    Group = "fans",
+    User = new List<User>
+                    {
+                        new User { First = "John", Last = "Smith" },
+                        new User { First = "Alice", Last = "White" }
+                    }
+}, i => i
+.Index("my_index")
+.Id(1)
+);
+----

--- a/examples/Mapping/Types/NestedPage/b214942b938e47f2c486e523546cb574.asciidoc
+++ b/examples/Mapping/Types/NestedPage/b214942b938e47f2c486e523546cb574.asciidoc
@@ -1,0 +1,28 @@
+// mapping/types/nested.asciidoc:55
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line55 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/NestedPage.cs#L45-L80.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<GroupDoc>(s => s
+    .Index("my_index")
+    .Query(q => q
+        .Match(m => m
+            .Field(f => f.User[0].First) //<1>
+            .Query("Alice")
+        ) && q
+        .Match(m => m
+            .Field(f => f.User[0].Last) //<2>
+            .Query("Smith")
+        )
+    )
+);
+----
+<1> An expression to build a path to the field `user.first` from the `GroupDoc` type.
+<2> An expression to build a path to the field `user.last` from the `GroupDoc` type.

--- a/examples/Mapping/Types/NestedPage/b919f88e6f47a40d5793479440a90ba6.asciidoc
+++ b/examples/Mapping/Types/NestedPage/b919f88e6f47a40d5793479440a90ba6.asciidoc
@@ -1,0 +1,80 @@
+// mapping/types/nested.asciidoc:80
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line80 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/NestedPage.cs#L82-L230.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map<GroupDoc>(m => m
+        .Properties(p => p
+            .Nested<User>(n => n
+                .Name(nn => nn.User)
+            )
+        )
+    )
+);
+
+var indexResponse = client.Index(new GroupDoc
+{
+    Group = "fans",
+    User = new List<User>
+                    {
+                        new User { First = "John", Last = "Smith" },
+                        new User { First = "Alice", Last = "White" }
+                    }
+}, i => i
+    .Index("my_index")
+    .Id(1)
+);
+
+var searchResponse = client.Search<GroupDoc>(s => s
+    .Index("my_index")
+    .Query(q => q
+        .Nested(n => n
+            .Path(p => p.User)
+            .Query(nq => nq
+                .Match(m => m
+                    .Field(f => f.User[0].First)
+                    .Query("Alice")
+                ) && nq
+                .Match(m => m
+                    .Field(f => f.User[0].Last)
+                    .Query("Smith")
+                )
+            )
+        )
+    )
+);
+
+var searchResponse2 = client.Search<GroupDoc>(s => s
+    .Index("my_index")
+    .Query(q => q
+        .Nested(n => n
+            .Path(p => p.User)
+            .Query(nq => nq
+                .Match(m => m
+                    .Field(f => f.User[0].First)
+                    .Query("Alice")
+                ) && nq
+                .Match(m => m
+                    .Field(f => f.User[0].Last)
+                    .Query("White")
+                )
+            )
+            .InnerHits(i => i
+                .Highlight(h => h
+                    .Fields(hf => hf
+                        .Field(f => f.User[0].First)
+                    )
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Mapping/Types/SearchAsYouTypePage/0ced86822f8c0a479af5e1fe28dfc2ec.asciidoc
+++ b/examples/Mapping/Types/SearchAsYouTypePage/0ced86822f8c0a479af5e1fe28dfc2ec.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line147 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L105-L138.
+This file is generated from method Line147 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L104-L136.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Types/SearchAsYouTypePage/867e5fad9c57055712fe2b69fa69a97c.asciidoc
+++ b/examples/Mapping/Types/SearchAsYouTypePage/867e5fad9c57055712fe2b69fa69a97c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line71 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L42-L66.
+This file is generated from method Line71 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L42-L65.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Mapping/Types/SearchAsYouTypePage/9bd25962f177e86dbc5a8030a420cc31.asciidoc
+++ b/examples/Mapping/Types/SearchAsYouTypePage/9bd25962f177e86dbc5a8030a420cc31.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line87 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L68-L103.
+This file is generated from method Line87 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Mapping/Types/SearchAsYouTypePage.cs#L67-L102.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/06afce2955f9094d96d27067ebca32e8.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/06afce2955f9094d96d27067ebca32e8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line36 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L12-L84.
+This file is generated from method Line36 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L12-L83.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/162b5b693b713f0bfab1209d59443c46.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/162b5b693b713f0bfab1209d59443c46.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line130 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L156-L185.
+This file is generated from method Line130 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L154-L183.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/f70a54cd9a9f4811bf962e469f2ca2ea.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/f70a54cd9a9f4811bf962e469f2ca2ea.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line88 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L86-L117.
+This file is generated from method Line88 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L85-L115.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/BoolQueryPage/fa88f6f5a7d728ec4f1d05244228cb09.asciidoc
+++ b/examples/QueryDsl/BoolQueryPage/fa88f6f5a7d728ec4f1d05244228cb09.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line107 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L119-L154.
+This file is generated from method Line107 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/BoolQueryPage.cs#L117-L152.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/ExistsQueryPage/3342c69b2c2303247217532956fcce85.asciidoc
+++ b/examples/QueryDsl/ExistsQueryPage/3342c69b2c2303247217532956fcce85.asciidoc
@@ -1,0 +1,21 @@
+// query-dsl/exists-query.asciidoc:20
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line20 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/ExistsQueryPage.cs#L9-L32.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Exists(e => e
+            .Field("user")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/ExistsQueryPage/43af86de5e49aa06070092fffc138208.asciidoc
+++ b/examples/QueryDsl/ExistsQueryPage/43af86de5e49aa06070092fffc138208.asciidoc
@@ -1,0 +1,21 @@
+// query-dsl/exists-query.asciidoc:56
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line56 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/ExistsQueryPage.cs#L34-L64.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => !q
+        .Exists(e => e
+            .Field("user")
+        )
+    )
+);
+----

--- a/examples/QueryDsl/MatchQueryPage/0ac9916f47a2483b89c1416684af322a.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/0ac9916f47a2483b89c1416684af322a.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line241 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L130-L160.
+This file is generated from method Line241 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L129-L159.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/MatchQueryPage/5043b83a89091fa00edb341ddf7ba370.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/5043b83a89091fa00edb341ddf7ba370.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line219 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L100-L128.
+This file is generated from method Line219 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L99-L127.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/MatchQueryPage/6138d6919f3cbaaf61e1092f817d295c.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/6138d6919f3cbaaf61e1092f817d295c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line175 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L70-L98.
+This file is generated from method Line175 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L69-L97.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/MatchQueryPage/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/7f56755fb6c42f7e6203339a6d0cb6e6.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line268 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L162-L190.
+This file is generated from method Line268 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L161-L189.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/MatchQueryPage/fa2fe60f570bd930d2891778c6efbfe6.asciidoc
+++ b/examples/QueryDsl/MatchQueryPage/fa2fe60f570bd930d2891778c6efbfe6.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line150 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L37-L68.
+This file is generated from method Line150 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/MatchQueryPage.cs#L37-L67.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryFilterContextPage/f29a28fffa7ec604a33a838f48f7ea79.asciidoc
+++ b/examples/QueryDsl/QueryFilterContextPage/f29a28fffa7ec604a33a838f48f7ea79.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line62 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryFilterContextPage.cs#L11-L56.
+This file is generated from method Line62 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryFilterContextPage.cs#L11-L55.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/28aad2c5942bfb221c2bf1bbdc01658e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line306 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L132-L159.
+This file is generated from method Line306 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L131-L158.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/58b5003c0a53a39bf509aa3797aad471.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line342 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L186-L214.
+This file is generated from method Line342 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L185-L213.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/60ee33f3acfdd0fe6f288ac77312c780.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line436 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L245-L276.
+This file is generated from method Line436 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L244-L275.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/6f21a878fee3b43c5332b81aaddbeac7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line518 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L348-L383.
+This file is generated from method Line518 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L347-L382.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/a2a25aad1fea9a541b52ac613c78fb64.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line287 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L93-L130.
+This file is generated from method Line287 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L93-L129.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/be1bd47393646ac6bbee177d1cdb7738.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line462 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L278-L311.
+This file is generated from method Line462 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L277-L310.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/db6cba451ba562abe953d09ad80cc15c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line323 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L161-L184.
+This file is generated from method Line323 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L160-L183.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/f32f0c19b42de3b87dd764fe4ca17e7c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line408 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L216-L243.
+This file is generated from method Line408 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L215-L242.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
+++ b/examples/QueryDsl/QueryStringQueryPage/fdd38f0d248385a444c777e7acd97846.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line486 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L313-L346.
+This file is generated from method Line486 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/QueryStringQueryPage.cs#L312-L345.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/QueryDsl/TermsQueryPage/0c4ad860a485fe53d8140ad3ccd11dcf.asciidoc
+++ b/examples/QueryDsl/TermsQueryPage/0c4ad860a485fe53d8140ad3ccd11dcf.asciidoc
@@ -1,0 +1,23 @@
+// query-dsl/terms-query.asciidoc:19
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line19 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/TermsQueryPage.cs#L9-L35.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Terms(t => t
+            .Field("user")
+            .Terms("kimchy", "elasticsearch")
+            .Boost(1)
+        )
+    )
+);
+----

--- a/examples/QueryDsl/TermsQueryPage/8c5977410335d58217e0626618ce6641.asciidoc
+++ b/examples/QueryDsl/TermsQueryPage/8c5977410335d58217e0626618ce6641.asciidoc
@@ -1,0 +1,20 @@
+// query-dsl/terms-query.asciidoc:160
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line160 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/TermsQueryPage.cs#L83-L101.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var indexResponse = client.Index(new
+{
+    color = "blue"
+}, i => i
+.Index("my_index")
+.Id(2)
+);
+----

--- a/examples/QueryDsl/TermsQueryPage/9e56d79ad9a02b642c361f0b85dd95d7.asciidoc
+++ b/examples/QueryDsl/TermsQueryPage/9e56d79ad9a02b642c361f0b85dd95d7.asciidoc
@@ -1,0 +1,22 @@
+// query-dsl/terms-query.asciidoc:127
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line127 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/TermsQueryPage.cs#L37-L61.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map<object>(p => p
+        .Properties(p => p
+            .Keyword(k => k
+                .Name("color")
+            )
+        )
+    )
+);
+----

--- a/examples/QueryDsl/TermsQueryPage/d1bcf2eb63a462bfdcf01a68e68d5b4a.asciidoc
+++ b/examples/QueryDsl/TermsQueryPage/d1bcf2eb63a462bfdcf01a68e68d5b4a.asciidoc
@@ -1,0 +1,27 @@
+// query-dsl/terms-query.asciidoc:186
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line186 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/TermsQueryPage.cs#L103-L136.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .Index("my_index")
+    .Pretty()
+    .Query(q => q
+        .Terms(t => t
+            .Field("color")
+            .TermsLookup<object>(l => l
+                .Index("my_index")
+                .Id("2")
+                .Path("color")
+            )
+        )
+    )
+);
+----

--- a/examples/QueryDsl/TermsQueryPage/d3088d5fa59b3ab110f64fb4f9b0065c.asciidoc
+++ b/examples/QueryDsl/TermsQueryPage/d3088d5fa59b3ab110f64fb4f9b0065c.asciidoc
@@ -1,0 +1,20 @@
+// query-dsl/terms-query.asciidoc:145
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line145 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/TermsQueryPage.cs#L63-L81.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var indexResponse = client.Index(new
+{
+    color = new[] { "blue", "green" }
+}, i => i
+.Index("my_index")
+.Id(1)
+);
+----

--- a/examples/QueryDsl/WildcardQueryPage/d31062ff8c015387889fed4ad86fd914.asciidoc
+++ b/examples/QueryDsl/WildcardQueryPage/d31062ff8c015387889fed4ad86fd914.asciidoc
@@ -1,0 +1,24 @@
+// query-dsl/wildcard-query.asciidoc:21
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line21 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/QueryDsl/WildcardQueryPage.cs#L9-L39.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Wildcard(w => w
+            .Field("user")
+            .Value("ki*y")
+            .Boost(1)
+            .Rewrite(MultiTermQueryRewrite.ConstantScore)
+        )
+    )
+);
+----

--- a/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
+++ b/examples/Root/GettingStartedPage/231aa0bb39c35fe199d28fe0e4a62b2e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line495 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L154-L182.
+This file is generated from method Line495 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L151-L178.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
+++ b/examples/Root/GettingStartedPage/251ea12c1248385ab409906ac64d9ee9.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line544 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L234-L287.
+This file is generated from method Line544 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L229-L281.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
+++ b/examples/Root/GettingStartedPage/47bb632c6091ad0cd94bc660bdd309a5.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line512 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L184-L232.
+This file is generated from method Line512 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L180-L227.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/4b90feb9d5d3dbfce424dac0341320b7.asciidoc
+++ b/examples/Root/GettingStartedPage/4b90feb9d5d3dbfce424dac0341320b7.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line461 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L88-L122.
+This file is generated from method Line461 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L87-L120.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
+++ b/examples/Root/GettingStartedPage/506844befdc5691d835771bcbb1c1a60.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line392 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L58-L86.
+This file is generated from method Line392 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L58-L85.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
+++ b/examples/Root/GettingStartedPage/645796e8047967ca4a7635a22a876f4c.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line691 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L359-L413.
+This file is generated from method Line691 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L353-L406.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
+++ b/examples/Root/GettingStartedPage/cd247f267968aa0927bfdad56852f8f5.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line482 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L124-L152.
+This file is generated from method Line482 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L122-L149.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
+++ b/examples/Root/GettingStartedPage/cfbaea6f0df045c5d940bbb6a9c69cd8.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line665 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L318-L357.
+This file is generated from method Line665 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L312-L351.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
+++ b/examples/Root/GettingStartedPage/feefeb68144002fd1fff57b77b95b85e.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line578 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L289-L316.
+This file is generated from method Line578 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/GettingStartedPage.cs#L283-L310.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/609260ad1d5998be2ca09ff1fe237efa.asciidoc
+++ b/examples/Root/MappingPage/609260ad1d5998be2ca09ff1fe237efa.asciidoc
@@ -1,9 +1,9 @@
-// mapping.asciidoc:211
+// mapping.asciidoc:204
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line211 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L66-L75.
+This file is generated from method Line204 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L66-L75.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/71ba9033107882f61cdc3b32fc73568d.asciidoc
+++ b/examples/Root/MappingPage/71ba9033107882f61cdc3b32fc73568d.asciidoc
@@ -1,9 +1,9 @@
-// mapping.asciidoc:173
+// mapping.asciidoc:166
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line173 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L39-L64.
+This file is generated from method Line166 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L39-L64.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/99a52be903945b17e734a1d02a57e958.asciidoc
+++ b/examples/Root/MappingPage/99a52be903945b17e734a1d02a57e958.asciidoc
@@ -1,9 +1,9 @@
-// mapping.asciidoc:257
+// mapping.asciidoc:250
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line257 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L77-L89.
+This file is generated from method Line250 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L77-L89.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/MappingPage/d8b2a88b5eca99d3691ad3cd40266736.asciidoc
+++ b/examples/Root/MappingPage/d8b2a88b5eca99d3691ad3cd40266736.asciidoc
@@ -1,9 +1,9 @@
-// mapping.asciidoc:144
+// mapping.asciidoc:137
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line144 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L11-L37.
+This file is generated from method Line137 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/MappingPage.cs#L11-L37.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
+++ b/examples/Root/SearchPage/189a921df2f5b1fe580937210ce9c1c2.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line96 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L103-L131.
+This file is generated from method Line96 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Root/SearchPage.cs#L103-L130.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/Request/SortPage/04fe1e3a0047b0cdb10987b79fc3f3f3.asciidoc
+++ b/examples/Search/Request/SortPage/04fe1e3a0047b0cdb10987b79fc3f3f3.asciidoc
@@ -1,0 +1,32 @@
+// search/request/sort.asciidoc:569
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line569 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L820-L869.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .Script(ss => ss
+            .Type("number")
+            .Script(sc => sc
+                .Source("doc['field_name'].value * params.factor")
+                .Lang("painless")
+                .Params(p => p
+                    .Add("factor", 1.1)
+                )
+            )
+            .Order(SortOrder.Ascending)
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/15dad5338065baaaa7d475abe85f4c22.asciidoc
+++ b/examples/Search/Request/SortPage/15dad5338065baaaa7d475abe85f4c22.asciidoc
@@ -1,0 +1,27 @@
+// search/request/sort.asciidoc:516
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line516 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L730-L770.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .GeoDistance(g => g
+            .Field("pin.location")
+            .Points(new GeoCoordinate(40, -70))
+            .Order(SortOrder.Ascending)
+            .Unit(DistanceUnit.Kilometers)
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/22334f4b24bb8977d3e1bf2ffdc29d3f.asciidoc
+++ b/examples/Search/Request/SortPage/22334f4b24bb8977d3e1bf2ffdc29d3f.asciidoc
@@ -1,0 +1,61 @@
+// search/request/sort.asciidoc:290
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line290 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L375-L476.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Nested(n => n
+            .Path("parent")
+            .Query(nq => nq
+                .LongRange(r => r
+                    .Field("parent.age")
+                    .GreaterThanOrEquals(21)
+                ) && +nq
+                .Nested(nn => nn
+                    .Path("parent.child")
+                    .Query(nnq => nnq
+                        .Match(m => m
+                            .Field("parent.child.name")
+                            .Query("matt")
+                        )
+                    )
+                )
+            )
+        )
+    )
+    .Sort(so => so
+        .Field(f => f
+            .Field("parent.child.age")
+            .Mode(SortMode.Min)
+            .Order(SortOrder.Ascending)
+            .Nested(ns => ns
+                .Path("parent")
+                .Filter(nf => nf
+                    .LongRange(tf => tf
+                        .Field("parent.age")
+                        .GreaterThanOrEquals(21)
+                    )
+                )
+                .Nested(nns => nns
+                    .Path("parent.child")
+                    .Filter(nnf => nnf
+                        .Match(m => m
+                            .Field("parent.child.name")
+                            .Query("matt")
+                        )
+                    )
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/2891aa10ee9d474780adf94d5607f2db.asciidoc
+++ b/examples/Search/Request/SortPage/2891aa10ee9d474780adf94d5607f2db.asciidoc
@@ -1,0 +1,22 @@
+// search/request/sort.asciidoc:154
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line154 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L209-L235.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .Index(new[] { "index_long", "index_double" })
+    .Sort(so => so
+        .Field(f => f
+            .Field("field")
+            .NumericType(NumericType.Double)
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/5f3549ac7fee94682ca0d7439eebdd2a.asciidoc
+++ b/examples/Search/Request/SortPage/5f3549ac7fee94682ca0d7439eebdd2a.asciidoc
@@ -1,0 +1,22 @@
+// search/request/sort.asciidoc:212
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line212 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L289-L315.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .Index(new[] { "index_long", "index_double" })
+    .Sort(so => so
+        .Field(f => f
+            .Field("field")
+            .NumericType(NumericType.DateNanos)
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/7477671958734843dd67cf0b8e6c7515.asciidoc
+++ b/examples/Search/Request/SortPage/7477671958734843dd67cf0b8e6c7515.asciidoc
@@ -1,0 +1,22 @@
+// search/request/sort.asciidoc:193
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line193 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L263-L287.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("index_long", c => c
+    .Map(m => m
+        .Properties(p => p
+            .DateNanos(n => n
+                .Name("field")
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/77243bbf92f2a55e0fca6c2a349a1c15.asciidoc
+++ b/examples/Search/Request/SortPage/77243bbf92f2a55e0fca6c2a349a1c15.asciidoc
@@ -1,0 +1,30 @@
+// search/request/sort.asciidoc:540
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line540 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L772-L818.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .GeoDistance(g => g
+            .Field("pin.location")
+            .Points(
+                new GeoCoordinate(40, -70),
+                new GeoCoordinate(42, -71)
+            )
+            .Order(SortOrder.Ascending)
+            .Unit(DistanceUnit.Kilometers)
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/899eef71a67a1b2aa11a2166ec7f48f1.asciidoc
+++ b/examples/Search/Request/SortPage/899eef71a67a1b2aa11a2166ec7f48f1.asciidoc
@@ -1,0 +1,25 @@
+// search/request/sort.asciidoc:370
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line370 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L514-L545.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .Field(f => f
+            .Field("price")
+            .UnmappedType(FieldType.Long)
+        )
+    )
+    .Query(q => q
+        .Term("product", "chocolate")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/979d25dff2d8987119410291ad47b0d1.asciidoc
+++ b/examples/Search/Request/SortPage/979d25dff2d8987119410291ad47b0d1.asciidoc
@@ -1,0 +1,27 @@
+// search/request/sort.asciidoc:445
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line445 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L599-L644.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .GeoDistance(g => g
+            .Field("pin.location")
+            .Points(new GeoLocation(40, -70))
+            .Order(SortOrder.Ascending)
+            .Unit(DistanceUnit.Kilometers)
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/abf329ebefaf58acd4ee30e685731499.asciidoc
+++ b/examples/Search/Request/SortPage/abf329ebefaf58acd4ee30e685731499.asciidoc
@@ -1,0 +1,23 @@
+// search/request/sort.asciidoc:123
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line123 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L155-L180.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("index_double", c => c
+    .Map(m => m
+        .Properties(p => p
+            .Number(n => n
+                .Name("field")
+                .Type(NumberType.Double)
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/ae9b5fbd42af2386ffbf56ad4a697e51.asciidoc
+++ b/examples/Search/Request/SortPage/ae9b5fbd42af2386ffbf56ad4a697e51.asciidoc
@@ -1,0 +1,29 @@
+// search/request/sort.asciidoc:30
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line30 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L55-L100.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<Tweet>(s => s
+    .Index("my_index")
+    .Sort(so => so
+        .Ascending(f => f.PostDate)
+        .Field(f => f.Field("user"))
+        .Descending(f => f.Name)
+        .Descending(f => f.Age)
+        .Field(f => f.Field("_score"))
+    )
+    .Query(q => q
+        .Term(t => t
+            .Field(f => f.User)
+            .Value("kimchy")
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/b997885974522ef439d5e345924cc5ba.asciidoc
+++ b/examples/Search/Request/SortPage/b997885974522ef439d5e345924cc5ba.asciidoc
@@ -1,0 +1,39 @@
+// search/request/sort.asciidoc:94
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line94 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L102-L153.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var indexResponse = client.Index(new
+{
+    product = "chocolate",
+    price = new[] { 20, 4 }
+}, i => i
+    .Index("my_index")
+    .Id(1)
+    .Refresh(Refresh.True)
+);
+
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Term(t => t
+            .Field("product")
+            .Value("chocolate")
+        )
+    )
+    .Sort(so => so
+        .Field(f => f
+            .Field("price")
+            .Order(SortOrder.Ascending)
+            .Mode(SortMode.Average)
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/d17269bb80fb63ec0bf37d219e003dcb.asciidoc
+++ b/examples/Search/Request/SortPage/d17269bb80fb63ec0bf37d219e003dcb.asciidoc
@@ -1,0 +1,30 @@
+// search/request/sort.asciidoc:392
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line392 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L547-L597.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .GeoDistance(g => g
+            .Field("pin.location")
+            .Points(new GeoCoordinate(40, -70))
+            .Order(SortOrder.Ascending)
+            .Unit(DistanceUnit.Kilometers)
+            .Mode(SortMode.Min)
+            .DistanceType(GeoDistanceType.Arc)
+            .IgnoreUnmapped()
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/d1b3b7d2bb2ab90d15fd10318abd24db.asciidoc
+++ b/examples/Search/Request/SortPage/d1b3b7d2bb2ab90d15fd10318abd24db.asciidoc
@@ -1,0 +1,32 @@
+// search/request/sort.asciidoc:11
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line11 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L12-L53.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("my_index", c => c
+    .Map<Tweet>(m => m
+        .Properties(p => p
+            .Date(d => d
+                .Name(n => n.PostDate)
+            )
+            .Keyword(k => k
+                .Name(n => n.User)
+            )
+            .Keyword(k => k
+                .Name(n => n.Name)
+            )
+            .Number(n => n
+                .Name(nn => nn.Age)
+                .Type(NumberType.Integer)
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/d50a3c64890f88af32c6d4ef4899d82a.asciidoc
+++ b/examples/Search/Request/SortPage/d50a3c64890f88af32c6d4ef4899d82a.asciidoc
@@ -1,0 +1,27 @@
+// search/request/sort.asciidoc:471
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line471 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L646-L686.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .GeoDistance(g => g
+            .Field("pin.location")
+            .Points(new GeoCoordinate(40, -70))
+            .Order(SortOrder.Ascending)
+            .Unit(DistanceUnit.Kilometers)
+        )
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/de139866a220124360e5e27d1a736ea4.asciidoc
+++ b/examples/Search/Request/SortPage/de139866a220124360e5e27d1a736ea4.asciidoc
@@ -1,0 +1,38 @@
+// search/request/sort.asciidoc:263
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line263 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L317-L373.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .Query(q => q
+        .Term(t => t
+            .Field("product")
+            .Value("chocolate")
+        )
+    )
+    .Sort(so => so
+        .Field(f => f
+            .Field("offer.price")
+            .Mode(SortMode.Average)
+            .Order(SortOrder.Ascending)
+            .Nested(ns => ns
+                .Path("offer")
+                .Filter(nf => nf
+                    .Term(tf => tf
+                        .Field("offer.color")
+                        .Value("blue")
+                    )
+                )
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/e8e451bc8c45bcf16df43804c4fc8329.asciidoc
+++ b/examples/Search/Request/SortPage/e8e451bc8c45bcf16df43804c4fc8329.asciidoc
@@ -1,0 +1,25 @@
+// search/request/sort.asciidoc:598
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line598 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L871-L907.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var searchResponse = client.Search<object>(s => s
+    .AllIndices()
+    .TrackScores()
+    .Sort(so => so
+        .Descending("post_date")
+        .Descending("name")
+        .Descending("age")
+    )
+    .Query(q => q
+        .Term("user", "kimchy")
+    )
+);
+----

--- a/examples/Search/Request/SortPage/ef0f4fa4272c47ff62fb7b422cf975e7.asciidoc
+++ b/examples/Search/Request/SortPage/ef0f4fa4272c47ff62fb7b422cf975e7.asciidoc
@@ -1,0 +1,28 @@
+// search/request/sort.asciidoc:346
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line346 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L478-L512.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var response0 = client.Search<object>(s => s
+    .AllIndices()
+    .Sort(so => so
+        .Field(f => f
+            .Field("price")
+            .MissingLast()
+        )
+    )
+    .Query(q => q
+        .Term(t => t
+            .Field("product")
+            .Value("chocolate")
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/f4a1008b3f9baa67bb03ce9ef5ab4cb4.asciidoc
+++ b/examples/Search/Request/SortPage/f4a1008b3f9baa67bb03ce9ef5ab4cb4.asciidoc
@@ -1,0 +1,22 @@
+// search/request/sort.asciidoc:181
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line181 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L237-L261.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("index_double", c => c
+    .Map(m => m
+        .Properties(p => p
+            .Date(n => n
+                .Name("field")
+            )
+        )
+    )
+);
+----

--- a/examples/Search/Request/SortPage/f6b5032bf27c2445d28845be0d413970.asciidoc
+++ b/examples/Search/Request/SortPage/f6b5032bf27c2445d28845be0d413970.asciidoc
@@ -1,0 +1,23 @@
+// search/request/sort.asciidoc:135
+
+////
+IMPORTANT NOTE
+==============
+This file is generated from method Line135 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/Request/SortPage.cs#L182-L207.
+If you wish to submit a PR to change this example, please change the source method above
+and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
+////
+
+[source, csharp]
+----
+var createIndexResponse = client.Indices.Create("index_long", c => c
+    .Map(m => m
+        .Properties(p => p
+            .Number(n => n
+                .Name("field")
+                .Type(NumberType.Long)
+            )
+        )
+    )
+);
+----

--- a/examples/Search/RequestBodyPage/0ce3606f1dba490eef83c4317b315b62.asciidoc
+++ b/examples/Search/RequestBodyPage/0ce3606f1dba490eef83c4317b315b62.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line7 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/RequestBodyPage.cs#L12-L37.
+This file is generated from method Line7 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/RequestBodyPage.cs#L12-L36.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/RequestBodyPage/bfcd65ab85d684d36a8550080032958d.asciidoc
+++ b/examples/Search/RequestBodyPage/bfcd65ab85d684d36a8550080032958d.asciidoc
@@ -3,7 +3,7 @@
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line156 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/RequestBodyPage.cs#L39-L60.
+This file is generated from method Line156 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/RequestBodyPage.cs#L38-L58.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/SearchPage/168bfdde773570cfc6dd3ab3574e413b.asciidoc
+++ b/examples/Search/SearchPage/168bfdde773570cfc6dd3ab3574e413b.asciidoc
@@ -1,9 +1,9 @@
-// search/search.asciidoc:400
+// search/search.asciidoc:404
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line400 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L53-L65.
+This file is generated from method Line404 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L53-L65.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/SearchPage/43682666e1abcb14770c99f02eb26a0d.asciidoc
+++ b/examples/Search/SearchPage/43682666e1abcb14770c99f02eb26a0d.asciidoc
@@ -1,9 +1,9 @@
-// search/search.asciidoc:415
+// search/search.asciidoc:419
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line415 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L81-L97.
+This file is generated from method Line419 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L81-L96.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/SearchPage/8022e6a690344035b6472a43a9d122e0.asciidoc
+++ b/examples/Search/SearchPage/8022e6a690344035b6472a43a9d122e0.asciidoc
@@ -1,9 +1,9 @@
-// search/search.asciidoc:409
+// search/search.asciidoc:413
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line409 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L67-L79.
+This file is generated from method Line413 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L67-L79.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/SearchPage/be49260e1b3496c4feac38c56ebb0669.asciidoc
+++ b/examples/Search/SearchPage/be49260e1b3496c4feac38c56ebb0669.asciidoc
@@ -1,9 +1,9 @@
-// search/search.asciidoc:342
+// search/search.asciidoc:346
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line342 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L25-L37.
+This file is generated from method Line346 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L25-L37.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Search/SearchPage/f5569945024b9d664828693705c27c1a.asciidoc
+++ b/examples/Search/SearchPage/f5569945024b9d664828693705c27c1a.asciidoc
@@ -1,9 +1,9 @@
-// search/search.asciidoc:388
+// search/search.asciidoc:392
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line388 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L39-L51.
+This file is generated from method Line392 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Search/SearchPage.cs#L39-L51.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/examples/Upgrade/RollingUpgradePage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
+++ b/examples/Upgrade/RollingUpgradePage/f8cc4b331a19ff4df8e4a490f906ee69.asciidoc
@@ -1,9 +1,9 @@
-// upgrade/rolling_upgrade.asciidoc:175
+// upgrade/rolling_upgrade.asciidoc:194
 
 ////
 IMPORTANT NOTE
 ==============
-This file is generated from method Line175 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Upgrade/RollingUpgradePage.cs#L96-L105.
+This file is generated from method Line194 in https://github.com/elastic/elasticsearch-net/tree/master/src/Examples/Examples/Upgrade/RollingUpgradePage.cs#L96-L105.
 If you wish to submit a PR to change this example, please change the source method above
 and run dotnet run -- asciidoc in the ExamplesGenerator project directory.
 ////

--- a/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Bucket/TermsAggregationPage.cs
@@ -122,7 +122,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
-				return e;
 			});
 		}
 
@@ -157,7 +156,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
-				return e;
 			});
 		}
 
@@ -200,7 +198,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
-				return e;
 			});
 		}
 
@@ -243,7 +240,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["genres"]["terms"]["order"].ToJArray(); });
-				return e;
 			});
 		}
 
@@ -302,7 +298,6 @@ namespace Examples.Aggregations.Bucket
 					b["aggs"]["countries"]["terms"]["order"].ToJArray();
 					b["aggs"]["countries"]["aggs"]["rock"]["filter"]["term"]["genre"].ToLongFormTermQuery();
 				});
-				return e;
 			});
 		}
 
@@ -358,7 +353,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["countries"]["aggs"]["rock"]["filter"]["term"]["genre"].ToLongFormTermQuery(); });
-				return e;
 			});
 		}
 
@@ -620,7 +614,6 @@ namespace Examples.Aggregations.Bucket
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aggs"]["expired_sessions"]["terms"]["order"].ToJArray(); });
-				return e;
 			});
 		}
 

--- a/tests/Examples/Aggregations/Metrics/ScriptedMetricAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/ScriptedMetricAggregationPage.cs
@@ -67,8 +67,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/scripted-metric-aggregation.asciidoc:147")]
-		public void Line147()
+		[Description("aggregations/metrics/scripted-metric-aggregation.asciidoc:150")]
+		public void Line150()
 		{
 			// tag::75e360d03fb416f0a65ca37c662c2e9c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Aggregations/Metrics/TTestAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TTestAggregationPage.cs
@@ -1,0 +1,102 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Aggregations.Metrics
+{
+	public class TTestAggregationPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("aggregations/metrics/t-test-aggregation.asciidoc:30")]
+		public void Line30()
+		{
+			// tag::9c071245643d02289b05d8163f207f74[]
+			var response0 = new SearchResponse<object>();
+			// end::9c071245643d02289b05d8163f207f74[]
+
+			response0.MatchesExample(@"GET node_upgrade/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""startup_time_ttest"" : {
+			            ""t_test"" : {
+			                ""a"" : {""field"": ""startup_time_before""}, <1>
+			                ""b"" : {""field"": ""startup_time_after""}, <2>
+			                ""type"": ""paired"" <3>
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("aggregations/metrics/t-test-aggregation.asciidoc:84")]
+		public void Line84()
+		{
+			// tag::a170b4aa968b32e40e288a97088cfc50[]
+			var response0 = new SearchResponse<object>();
+			// end::a170b4aa968b32e40e288a97088cfc50[]
+
+			response0.MatchesExample(@"GET node_upgrade/_search
+			{
+			    ""size"" : 0,
+			    ""aggs"" : {
+			        ""startup_time_ttest"" : {
+			            ""t_test"" : {
+			                ""a"" : {
+			                    ""field"" : ""startup_time_before"", <1>
+			                    ""filter"" : {
+			                        ""term"" : {
+			                            ""group"" : ""A""  <2>
+			                        }
+			                    }
+			                },
+			                ""b"" : {
+			                    ""field"" : ""startup_time_before"", <3>
+			                    ""filter"" : {
+			                        ""term"" : {
+			                            ""group"" : ""B"" <4>
+			                        }
+			                    }
+			                },
+			                ""type"" : ""heteroscedastic"" <5>
+			            }
+			        }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("aggregations/metrics/t-test-aggregation.asciidoc:146")]
+		public void Line146()
+		{
+			// tag::f114ff40e67771a24f796f458ab10838[]
+			var response0 = new SearchResponse<object>();
+			// end::f114ff40e67771a24f796f458ab10838[]
+
+			response0.MatchesExample(@"GET node_upgrade/_search
+			{
+			    ""size"": 0,
+			    ""aggs"" : {
+			        ""startup_time_ttest"" : {
+			            ""t_test"" : {
+			                ""a"": {
+			                    ""script"" : {
+			                        ""lang"": ""painless"",
+			                        ""source"": ""doc['startup_time_before'].value - params.adjustment"", <1>
+			                        ""params"" : {
+			                            ""adjustment"" : 10   <2>
+			                        }
+			                    }
+			                },
+			                ""b"": {
+			                    ""field"": ""startup_time_after"" <3>
+			                },
+			                ""type"": ""paired""
+			            }
+			        }
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TopMetricsAggregationPage.cs
@@ -7,29 +7,29 @@ namespace Examples.Aggregations.Metrics
 	public class TopMetricsAggregationPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:12")]
-		public void Line12()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:10")]
+		public void Line10()
 		{
-			// tag::d0321ef6bc9aae91b7fcfb76af085404[]
+			// tag::9d1fb129ac783355a20097effded1845[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::d0321ef6bc9aae91b7fcfb76af085404[]
+			// end::9d1fb129ac783355a20097effded1845[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {}}
-			{""s"": 1, ""v"": 3.1415}
+			{""s"": 1, ""m"": 3.1415}
 			{""index"": {}}
-			{""s"": 2, ""v"": 1.0}
+			{""s"": 2, ""m"": 1.0}
 			{""index"": {}}
-			{""s"": 3, ""v"": 2.71828}");
+			{""s"": 3, ""m"": 2.71828}");
 
 			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metrics"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""m""},
 			        ""sort"": {""s"": ""desc""}
 			      }
 			    }
@@ -38,31 +38,43 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:82")]
-		public void Line82()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:74")]
+		public void Line74()
 		{
-			// tag::ba2af8de92d3d197d809e2b9a9580ea5[]
+			// tag::73882fb729426f186221b5ebbd8f571f[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::ba2af8de92d3d197d809e2b9a9580ea5[]
 
-			response0.MatchesExample(@"POST /test/_bulk?refresh
-			{""index"": {}}
-			{""s"": 1, ""v"": 3.1415, ""m"": 1.9}
-			{""index"": {}}
-			{""s"": 2, ""v"": 1.0, ""m"": 6.7}
-			{""index"": {}}
-			{""s"": 3, ""v"": 2.71828, ""m"": -12.2}");
+			var response2 = new SearchResponse<object>();
+			// end::73882fb729426f186221b5ebbd8f571f[]
 
-			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
+			response0.MatchesExample(@"PUT /test
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""d"": {""type"": ""date""}
+			    }
+			  }
+			}");
+
+			response1.MatchesExample(@"POST /test/_bulk?refresh
+			{""index"": {}}
+			{""s"": 1, ""m"": 3.1415, ""i"": 1, ""d"": ""2020-01-01T00:12:12Z""}
+			{""index"": {}}
+			{""s"": 2, ""m"": 1.0, ""i"": 6, ""d"": ""2020-01-02T00:12:12Z""}
+			{""index"": {}}
+			{""s"": 3, ""m"": 2.71828, ""i"": -12, ""d"": ""2019-12-31T00:12:12Z""}");
+
+			response2.MatchesExample(@"POST /test/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
 			        ""metrics"": [
-			          {""field"": ""v""},
-			          {""field"": ""m""}
+			          {""field"": ""m""},
+			          {""field"": ""i""},
+			          {""field"": ""d""}
 			        ],
 			        ""sort"": {""s"": ""desc""}
 			      }
@@ -72,31 +84,31 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:132")]
-		public void Line132()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:133")]
+		public void Line133()
 		{
-			// tag::c4f657319298f90db11c954bb09403da[]
+			// tag::6013ed65d2058da5ce704b47a504b60a[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::c4f657319298f90db11c954bb09403da[]
+			// end::6013ed65d2058da5ce704b47a504b60a[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {}}
-			{""s"": 1, ""v"": 3.1415}
+			{""s"": 1, ""m"": 3.1415}
 			{""index"": {}}
-			{""s"": 2, ""v"": 1.0}
+			{""s"": 2, ""m"": 1.0}
 			{""index"": {}}
-			{""s"": 3, ""v"": 2.71828}");
+			{""s"": 3, ""m"": 2.71828}");
 
 			response1.MatchesExample(@"POST /test/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metrics"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""m""},
 			        ""sort"": {""s"": ""desc""},
-			        ""size"": 2
+			        ""size"": 3
 			      }
 			    }
 			  }
@@ -104,8 +116,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:180")]
-		public void Line180()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:183")]
+		public void Line183()
 		{
 			// tag::b63ce79ce4fa1bb9b99a789f4dcfef4e[]
 			var response0 = new SearchResponse<object>();
@@ -118,16 +130,16 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:200")]
-		public void Line200()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:202")]
+		public void Line202()
 		{
-			// tag::ed8c8e5006923f771aa4db0936184ac7[]
+			// tag::5b3384992c398ea8a3064d2e08725e2b[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
 
 			var response2 = new SearchResponse<object>();
-			// end::ed8c8e5006923f771aa4db0936184ac7[]
+			// end::5b3384992c398ea8a3064d2e08725e2b[]
 
 			response0.MatchesExample(@"PUT /node
 			{
@@ -141,11 +153,11 @@ namespace Examples.Aggregations.Metrics
 
 			response1.MatchesExample(@"POST /node/_bulk?refresh
 			{""index"": {}}
-			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T01:01:01"", ""v"": 1}
+			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T01:01:01"", ""m"": 1}
 			{""index"": {}}
-			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T02:01:01"", ""v"": 2}
+			{""ip"": ""192.168.0.1"", ""date"": ""2020-01-01T02:01:01"", ""m"": 2}
 			{""index"": {}}
-			{""ip"": ""192.168.0.2"", ""date"": ""2020-01-01T02:01:01"", ""v"": 3}");
+			{""ip"": ""192.168.0.2"", ""date"": ""2020-01-01T02:01:01"", ""m"": 3}");
 
 			response2.MatchesExample(@"POST /node/_search?filter_path=aggregations
 			{
@@ -157,7 +169,7 @@ namespace Examples.Aggregations.Metrics
 			      ""aggs"": {
 			        ""tm"": {
 			          ""top_metrics"": {
-			            ""metrics"": {""field"": ""v""},
+			            ""metrics"": {""field"": ""m""},
 			            ""sort"": {""date"": ""desc""}
 			          }
 			        }
@@ -168,12 +180,12 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:271")]
-		public void Line271()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:273")]
+		public void Line273()
 		{
-			// tag::8b1cc4f69975d3fcdaf8ef6d7d71cc81[]
+			// tag::4af15c4f26ddefb9c350e7a246a66a15[]
 			var response0 = new SearchResponse<object>();
-			// end::8b1cc4f69975d3fcdaf8ef6d7d71cc81[]
+			// end::4af15c4f26ddefb9c350e7a246a66a15[]
 
 			response0.MatchesExample(@"POST /node/_search?filter_path=aggregations
 			{
@@ -181,12 +193,12 @@ namespace Examples.Aggregations.Metrics
 			    ""ip"": {
 			      ""terms"": {
 			        ""field"": ""ip"",
-			        ""order"": {""tm.v"": ""desc""}
+			        ""order"": {""tm.m"": ""desc""}
 			      },
 			      ""aggs"": {
 			        ""tm"": {
 			          ""top_metrics"": {
-			            ""metrics"": {""field"": ""v""},
+			            ""metrics"": {""field"": ""m""},
 			            ""sort"": {""date"": ""desc""}
 			          }
 			        }
@@ -197,29 +209,29 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:332")]
-		public void Line332()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:334")]
+		public void Line334()
 		{
-			// tag::315cae9fbbb552bcdf84ae3af6689489[]
+			// tag::2d2f5ec97aa34ff7822a6a1ed08ef335[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::315cae9fbbb552bcdf84ae3af6689489[]
+			// end::2d2f5ec97aa34ff7822a6a1ed08ef335[]
 
 			response0.MatchesExample(@"POST /test/_bulk?refresh
 			{""index"": {""_index"": ""test1""}}
-			{""s"": 1, ""v"": 3.1415}
+			{""s"": 1, ""m"": 3.1415}
 			{""index"": {""_index"": ""test1""}}
-			{""s"": 2, ""v"": 1}
+			{""s"": 2, ""m"": 1}
 			{""index"": {""_index"": ""test2""}}
-			{""s"": 3.1, ""v"": 2.71828}");
+			{""s"": 3.1, ""m"": 2.71828}");
 
 			response1.MatchesExample(@"POST /test*/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metrics"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""m""},
 			        ""sort"": {""s"": ""asc""}
 			      }
 			    }
@@ -228,19 +240,19 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:372")]
-		public void Line372()
+		[Description("aggregations/metrics/top-metrics-aggregation.asciidoc:374")]
+		public void Line374()
 		{
-			// tag::035805d6f35a2ef517b9cd9ae037da05[]
+			// tag::56da9c55774f4c2e8eadde0579bdc60c[]
 			var response0 = new SearchResponse<object>();
-			// end::035805d6f35a2ef517b9cd9ae037da05[]
+			// end::56da9c55774f4c2e8eadde0579bdc60c[]
 
 			response0.MatchesExample(@"POST /test*/_search?filter_path=aggregations
 			{
 			  ""aggs"": {
 			    ""tm"": {
 			      ""top_metrics"": {
-			        ""metrics"": {""field"": ""v""},
+			        ""metrics"": {""field"": ""m""},
 			        ""sort"": {""s"": {""order"": ""asc"", ""numeric_type"": ""double""}}
 			      }
 			    }

--- a/tests/Examples/Aggregations/Metrics/TophitsAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/TophitsAggregationPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Aggregations.Metrics
 	public class TophitsAggregationPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/tophits-aggregation.asciidoc:36")]
-		public void Line36()
+		[Description("aggregations/metrics/tophits-aggregation.asciidoc:39")]
+		public void Line39()
 		{
 			// tag::12b4b34f9958ed157ac2d812d612cda6[]
 			var response0 = new SearchResponse<object>();
@@ -45,8 +45,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/tophits-aggregation.asciidoc:185")]
-		public void Line185()
+		[Description("aggregations/metrics/tophits-aggregation.asciidoc:188")]
+		public void Line188()
 		{
 			// tag::30db2702dd0071c72a090b8311d0db09[]
 			var response0 = new SearchResponse<object>();
@@ -85,8 +85,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/tophits-aggregation.asciidoc:238")]
-		public void Line238()
+		[Description("aggregations/metrics/tophits-aggregation.asciidoc:241")]
+		public void Line241()
 		{
 			// tag::2720c5e463876c415419c426697d15e4[]
 			var response0 = new SearchResponse<object>();
@@ -110,8 +110,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/tophits-aggregation.asciidoc:261")]
-		public void Line261()
+		[Description("aggregations/metrics/tophits-aggregation.asciidoc:264")]
+		public void Line264()
 		{
 			// tag::6ac67f7e30219d85fcc68b99459a39a4[]
 			var response0 = new SearchResponse<object>();
@@ -129,8 +129,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/tophits-aggregation.asciidoc:277")]
-		public void Line277()
+		[Description("aggregations/metrics/tophits-aggregation.asciidoc:280")]
+		public void Line280()
 		{
 			// tag::f1b8612151a660264fb62dc6c74b19be[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Aggregations/Metrics/ValuecountAggregationPage.cs
+++ b/tests/Examples/Aggregations/Metrics/ValuecountAggregationPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Aggregations.Metrics
 	public class ValuecountAggregationPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:10")]
-		public void Line10()
+		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:13")]
+		public void Line13()
 		{
 			// tag::5dd695679b5141d9142d3d30ba8d300a[]
 			var response0 = new SearchResponse<object>();
@@ -23,8 +23,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:43")]
-		public void Line43()
+		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:46")]
+		public void Line46()
 		{
 			// tag::3722cb3705b6bc7f486969deace3dd83[]
 			var response0 = new SearchResponse<object>();
@@ -45,8 +45,8 @@ namespace Examples.Aggregations.Metrics
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:62")]
-		public void Line62()
+		[Description("aggregations/metrics/valuecount-aggregation.asciidoc:65")]
+		public void Line65()
 		{
 			// tag::213ab768f1b6a895e09403a0880e259a[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/NormalizersPage.cs
+++ b/tests/Examples/Analysis/NormalizersPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Analysis
 	public class NormalizersPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/normalizers.asciidoc:25")]
-		public void Line25()
+		[Description("analysis/normalizers.asciidoc:27")]
+		public void Line27()
 		{
 			// tag::966ff3a4c5b61ed1a36d44c17ce06157[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/FlattenGraphTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/FlattenGraphTokenfilterPage.cs
@@ -1,0 +1,85 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class FlattenGraphTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/flatten-graph-tokenfilter.asciidoc:39")]
+		public void Line39()
+		{
+			// tag::2c27a8eb6528126f37a843d434cd88b6[]
+			var response0 = new SearchResponse<object>();
+			// end::2c27a8eb6528126f37a843d434cd88b6[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""synonym_graph"",
+			      ""synonyms"": [ ""dns, domain name system"" ]
+			    }
+			  ],
+			  ""text"": ""domain name system is fragile""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/flatten-graph-tokenfilter.asciidoc:118")]
+		public void Line118()
+		{
+			// tag::ef10e8d07d9fae945e035d5dee1e9754[]
+			var response0 = new SearchResponse<object>();
+			// end::ef10e8d07d9fae945e035d5dee1e9754[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""standard"",
+			  ""filter"": [
+			    {
+			      ""type"": ""synonym_graph"",
+			      ""synonyms"": [ ""dns, domain name system"" ]
+			    },
+			    ""flatten_graph""
+			  ],
+			  ""text"": ""domain name system is fragile""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/flatten-graph-tokenfilter.asciidoc:203")]
+		public void Line203()
+		{
+			// tag::4b6312348785cb57de3467f82ec252a5[]
+			var response0 = new SearchResponse<object>();
+			// end::4b6312348785cb57de3467f82ec252a5[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_custom_index_analyzer"": {
+			          ""type"": ""custom"",
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [
+			            ""my_custom_word_delimiter_graph_filter"",
+			            ""flatten_graph""
+			          ]
+			        }
+			      },
+			      ""filter"": {
+			        ""my_custom_word_delimiter_graph_filter"": {
+			          ""type"": ""word_delimiter_graph"",
+			          ""catenate_all"": true
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/KeywordMarkerTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeywordMarkerTokenfilterPage.cs
@@ -7,67 +7,97 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeywordMarkerTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:28")]
-		public void Line28()
+		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:35")]
+		public void Line35()
 		{
-			// tag::863c221b28ae5e58d39bd8f138291949[]
+			// tag::26f237f9bf14e8b972cc33ff6aebefa2[]
 			var response0 = new SearchResponse<object>();
-			// end::863c221b28ae5e58d39bd8f138291949[]
+			// end::26f237f9bf14e8b972cc33ff6aebefa2[]
 
-			response0.MatchesExample(@"PUT /keyword_marker_example
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [ ""stemmer"" ],
+			  ""text"": ""fox running and jumping""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:95")]
+		public void Line95()
+		{
+			// tag::5302f4f2bcc0f400ff71c791e6f68d7b[]
+			var response0 = new SearchResponse<object>();
+			// end::5302f4f2bcc0f400ff71c791e6f68d7b[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    {
+			      ""type"": ""keyword_marker"",
+			      ""keywords"": [ ""jumping"" ]
+			    },
+			    ""stemmer""
+			  ],
+			  ""text"": ""fox running and jumping""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:163")]
+		public void Line163()
+		{
+			// tag::059e04aaf093379401f665c33ac796dc[]
+			var response0 = new SearchResponse<object>();
+			// end::059e04aaf093379401f665c33ac796dc[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    {
+			      ""type"": ""keyword_marker"",
+			      ""keywords"": [ ""jumping"" ]
+			    },
+			    ""stemmer""
+			  ],
+			  ""text"": ""fox running and jumping"",
+			  ""explain"": true,
+			  ""attributes"": ""keyword""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:365")]
+		public void Line365()
+		{
+			// tag::f8c1fa91443573fcc0a5f2e22b7b4582[]
+			var response0 = new SearchResponse<object>();
+			// end::f8c1fa91443573fcc0a5f2e22b7b4582[]
+
+			response0.MatchesExample(@"PUT /my_index
 			{
 			  ""settings"": {
 			    ""analysis"": {
 			      ""analyzer"": {
-			        ""protect_cats"": {
+			        ""my_custom_analyzer"": {
 			          ""type"": ""custom"",
 			          ""tokenizer"": ""standard"",
-			          ""filter"": [""lowercase"", ""protect_cats"", ""porter_stem""]
-			        },
-			        ""normal"": {
-			          ""type"": ""custom"",
-			          ""tokenizer"": ""standard"",
-			          ""filter"": [""lowercase"", ""porter_stem""]
+			          ""filter"": [
+			            ""my_custom_keyword_marker_filter"",
+			            ""porter_stem""
+			          ]
 			        }
 			      },
 			      ""filter"": {
-			        ""protect_cats"": {
+			        ""my_custom_keyword_marker_filter"": {
 			          ""type"": ""keyword_marker"",
-			          ""keywords"": [""cats""]
+			          ""keywords"": ""analysis/example_word_list.txt""
 			        }
 			      }
 			    }
 			  }
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:59")]
-		public void Line59()
-		{
-			// tag::abcbf3c246c0d88831b875a601686e35[]
-			var response0 = new SearchResponse<object>();
-			// end::abcbf3c246c0d88831b875a601686e35[]
-
-			response0.MatchesExample(@"POST /keyword_marker_example/_analyze
-			{
-			  ""analyzer"" : ""protect_cats"",
-			  ""text"" : ""I like cats""
-			}");
-		}
-
-		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/keyword-marker-tokenfilter.asciidoc:102")]
-		public void Line102()
-		{
-			// tag::4ab8f55a8a45d53fb1676112379c212e[]
-			var response0 = new SearchResponse<object>();
-			// end::4ab8f55a8a45d53fb1676112379c212e[]
-
-			response0.MatchesExample(@"POST /keyword_marker_example/_analyze
-			{
-			  ""analyzer"" : ""normal"",
-			  ""text"" : ""I like cats""
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/KeywordRepeatTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/KeywordRepeatTokenfilterPage.cs
@@ -7,47 +7,92 @@ namespace Examples.Analysis.Tokenfilters
 	public class KeywordRepeatTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:19")]
-		public void Line19()
+		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:49")]
+		public void Line49()
 		{
-			// tag::9da83c9a2149bfc6fe215a612ae0a9aa[]
+			// tag::a037beb3d02296e1d36dd43ef5c935dd[]
 			var response0 = new SearchResponse<object>();
-			// end::9da83c9a2149bfc6fe215a612ae0a9aa[]
+			// end::a037beb3d02296e1d36dd43ef5c935dd[]
 
-			response0.MatchesExample(@"PUT /keyword_repeat_example
+			response0.MatchesExample(@"GET /_analyze
 			{
-			  ""settings"": {
-			    ""analysis"": {
-			      ""analyzer"": {
-			        ""stemmed_and_unstemmed"": {
-			          ""type"": ""custom"",
-			          ""tokenizer"": ""standard"",
-			          ""filter"": [""lowercase"", ""keyword_repeat"", ""porter_stem"", ""unique_stem""]
-			        }
-			      },
-			      ""filter"": {
-			        ""unique_stem"": {
-			          ""type"": ""unique"",
-			          ""only_on_same_position"": true
-			        }
-			      }
-			    }
-			  }
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    ""keyword_repeat""
+			  ],
+			  ""text"": ""fox running and jumping"",
+			  ""explain"": true,
+			  ""attributes"": ""keyword""
 			}");
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:45")]
-		public void Line45()
+		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:156")]
+		public void Line156()
 		{
-			// tag::757622a424b8445fee49746862a11b02[]
+			// tag::8cbf9b46ce3ccc966c4902d2e0c56317[]
 			var response0 = new SearchResponse<object>();
-			// end::757622a424b8445fee49746862a11b02[]
+			// end::8cbf9b46ce3ccc966c4902d2e0c56317[]
 
-			response0.MatchesExample(@"POST /keyword_repeat_example/_analyze
+			response0.MatchesExample(@"GET /_analyze
 			{
-			  ""analyzer"" : ""stemmed_and_unstemmed"",
-			  ""text"" : ""I like cats""
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    ""keyword_repeat"",
+			    ""stemmer""
+			  ],
+			  ""text"": ""fox running and jumping"",
+			  ""explain"": true,
+			  ""attributes"": ""keyword""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:274")]
+		public void Line274()
+		{
+			// tag::29783e5de3a5f3c985cbf11094cf49a0[]
+			var response0 = new SearchResponse<object>();
+			// end::29783e5de3a5f3c985cbf11094cf49a0[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    ""keyword_repeat"",
+			    ""stemmer"",
+			    ""remove_duplicates""
+			  ],
+			  ""text"": ""fox running and jumping"",
+			  ""explain"": true,
+			  ""attributes"": ""keyword""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/keyword-repeat-tokenfilter.asciidoc:384")]
+		public void Line384()
+		{
+			// tag::4710188da1085a6be9a1e0bdd66c4f26[]
+			var response0 = new SearchResponse<object>();
+			// end::4710188da1085a6be9a1e0bdd66c4f26[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_custom_analyzer"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [
+			            ""keyword_repeat"",
+			            ""porter_stem"",
+			            ""remove_duplicates""
+			          ]
+			        }
+			      }
+			    }
+			  }
 			}");
 		}
 	}

--- a/tests/Examples/Analysis/Tokenfilters/RemoveDuplicatesTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/RemoveDuplicatesTokenfilterPage.cs
@@ -1,0 +1,75 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class RemoveDuplicatesTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/remove-duplicates-tokenfilter.asciidoc:24")]
+		public void Line24()
+		{
+			// tag::15d948d593d2624ac5e2b155052048f0[]
+			var response0 = new SearchResponse<object>();
+			// end::15d948d593d2624ac5e2b155052048f0[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    ""keyword_repeat"",
+			    ""stemmer""
+			  ],
+			  ""text"": ""jumping dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/remove-duplicates-tokenfilter.asciidoc:79")]
+		public void Line79()
+		{
+			// tag::bab4c3b22c1768fcc7153345e4096dfb[]
+			var response0 = new SearchResponse<object>();
+			// end::bab4c3b22c1768fcc7153345e4096dfb[]
+
+			response0.MatchesExample(@"GET _analyze
+			{
+			  ""tokenizer"": ""whitespace"",
+			  ""filter"": [
+			    ""keyword_repeat"",
+			    ""stemmer"",
+			    ""remove_duplicates""
+			  ],
+			  ""text"": ""jumping dog""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/remove-duplicates-tokenfilter.asciidoc:136")]
+		public void Line136()
+		{
+			// tag::198d39435b00b938cc2fa8f98c92e135[]
+			var response0 = new SearchResponse<object>();
+			// end::198d39435b00b938cc2fa8f98c92e135[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_custom_analyzer"": {
+			          ""tokenizer"": ""standard"",
+			          ""filter"": [
+			            ""keyword_repeat"",
+			            ""stemmer"",
+			            ""remove_duplicates""
+			          ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/UppercaseTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/UppercaseTokenfilterPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Analysis.Tokenfilters
 	public class UppercaseTokenfilterPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/uppercase-tokenfilter.asciidoc:29")]
-		public void Line29()
+		[Description("analysis/tokenfilters/uppercase-tokenfilter.asciidoc:30")]
+		public void Line30()
 		{
 			// tag::9f7671119236423e0e40801ef6485af1[]
 			var response0 = new SearchResponse<object>();
@@ -23,8 +23,8 @@ namespace Examples.Analysis.Tokenfilters
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenfilters/uppercase-tokenfilter.asciidoc:91")]
-		public void Line91()
+		[Description("analysis/tokenfilters/uppercase-tokenfilter.asciidoc:92")]
+		public void Line92()
 		{
 			// tag::9db72fe811ee61ee3f7baa45916d20e0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenfilters/WordDelimiterGraphTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/WordDelimiterGraphTokenfilterPage.cs
@@ -1,0 +1,80 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class WordDelimiterGraphTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-graph-tokenfilter.asciidoc:47")]
+		public void Line47()
+		{
+			// tag::ffcf80e1094aa2d774f56f6b0bc54827[]
+			var response0 = new SearchResponse<object>();
+			// end::ffcf80e1094aa2d774f56f6b0bc54827[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""keyword"",
+			  ""filter"": [ ""word_delimiter_graph"" ],
+			  ""text"": ""Neil's-Super-Duper-XL500--42+AutoCoder""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-graph-tokenfilter.asciidoc:137")]
+		public void Line137()
+		{
+			// tag::4620e88aa70944db528af43fead2b9ab[]
+			var response0 = new SearchResponse<object>();
+			// end::4620e88aa70944db528af43fead2b9ab[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_analyzer"": {
+			          ""tokenizer"": ""keyword"",
+			          ""filter"": [ ""word_delimiter_graph"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-graph-tokenfilter.asciidoc:404")]
+		public void Line404()
+		{
+			// tag::aee2ef858cd6bcc75ef97563cbe5ca5f[]
+			var response0 = new SearchResponse<object>();
+			// end::aee2ef858cd6bcc75ef97563cbe5ca5f[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_analyzer"": {
+			          ""tokenizer"": ""keyword"",
+			          ""filter"": [ ""my_custom_word_delimiter_graph_filter"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""my_custom_word_delimiter_graph_filter"": {
+			          ""type"": ""word_delimiter_graph"",
+			          ""type_table"": [ ""- => ALPHA"" ],
+			          ""split_on_case_change"": false,
+			          ""split_on_numerics"": false,
+			          ""stem_english_possessive"": true
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenfilters/WordDelimiterTokenfilterPage.cs
+++ b/tests/Examples/Analysis/Tokenfilters/WordDelimiterTokenfilterPage.cs
@@ -1,0 +1,80 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Analysis.Tokenfilters
+{
+	public class WordDelimiterTokenfilterPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc:58")]
+		public void Line58()
+		{
+			// tag::c42bc6e74afc3d43cd032ec2bfd77385[]
+			var response0 = new SearchResponse<object>();
+			// end::c42bc6e74afc3d43cd032ec2bfd77385[]
+
+			response0.MatchesExample(@"GET /_analyze
+			{
+			  ""tokenizer"": ""keyword"",
+			  ""filter"": [ ""word_delimiter"" ],
+			  ""text"": ""Neil's-Super-Duper-XL500--42+AutoCoder""
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc:148")]
+		public void Line148()
+		{
+			// tag::0daa91e512cb2009925b5efb49e926f7[]
+			var response0 = new SearchResponse<object>();
+			// end::0daa91e512cb2009925b5efb49e926f7[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_analyzer"": {
+			          ""tokenizer"": ""keyword"",
+			          ""filter"": [ ""word_delimiter"" ]
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenfilters/word-delimiter-tokenfilter.asciidoc:359")]
+		public void Line359()
+		{
+			// tag::83a1cb2fd02a76f2766d7b186002859e[]
+			var response0 = new SearchResponse<object>();
+			// end::83a1cb2fd02a76f2766d7b186002859e[]
+
+			response0.MatchesExample(@"PUT /my_index
+			{
+			  ""settings"": {
+			    ""analysis"": {
+			      ""analyzer"": {
+			        ""my_analyzer"": {
+			          ""tokenizer"": ""keyword"",
+			          ""filter"": [ ""my_custom_word_delimiter_filter"" ]
+			        }
+			      },
+			      ""filter"": {
+			        ""my_custom_word_delimiter_filter"": {
+			          ""type"": ""word_delimiter"",
+			          ""type_table"": [ ""- => ALPHA"" ],
+			          ""split_on_case_change"": false,
+			          ""split_on_numerics"": false,
+			          ""stem_english_possessive"": true
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Analysis/Tokenizers/KeywordTokenizerPage.cs
+++ b/tests/Examples/Analysis/Tokenizers/KeywordTokenizerPage.cs
@@ -20,5 +20,21 @@ namespace Examples.Analysis.Tokenizers
 			  ""text"": ""New York""
 			}");
 		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("analysis/tokenizers/keyword-tokenizer.asciidoc:58")]
+		public void Line58()
+		{
+			// tag::c95d5317525c2ff625e6971c277247af[]
+			var response0 = new SearchResponse<object>();
+			// end::c95d5317525c2ff625e6971c277247af[]
+
+			response0.MatchesExample(@"POST _analyze
+			{
+			  ""tokenizer"": ""keyword"",
+			  ""filter"": [ ""lowercase"" ],
+			  ""text"": ""john.SMITH@example.COM""
+			}");
+		}
 	}
 }

--- a/tests/Examples/Analysis/Tokenizers/SimplepatternTokenizerPage.cs
+++ b/tests/Examples/Analysis/Tokenizers/SimplepatternTokenizerPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Analysis.Tokenizers
 	public class SimplepatternTokenizerPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenizers/simplepattern-tokenizer.asciidoc:38")]
-		public void Line38()
+		[Description("analysis/tokenizers/simplepattern-tokenizer.asciidoc:36")]
+		public void Line36()
 		{
 			// tag::9ffc049d5c5a570b90d913e92f910ee4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Analysis/Tokenizers/SimplepatternsplitTokenizerPage.cs
+++ b/tests/Examples/Analysis/Tokenizers/SimplepatternsplitTokenizerPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Analysis.Tokenizers
 	public class SimplepatternsplitTokenizerPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("analysis/tokenizers/simplepatternsplit-tokenizer.asciidoc:39")]
-		public void Line39()
+		[Description("analysis/tokenizers/simplepatternsplit-tokenizer.asciidoc:37")]
+		public void Line37()
 		{
 			// tag::5c28bb67716ed2bbe03c1d5d3733cb42[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Autoscaling/Apis/DeleteAutoscalingPolicyPage.cs
+++ b/tests/Examples/Autoscaling/Apis/DeleteAutoscalingPolicyPage.cs
@@ -1,0 +1,50 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Autoscaling.Apis
+{
+	public class DeleteAutoscalingPolicyPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/delete-autoscaling-policy.asciidoc:15")]
+		public void Line15()
+		{
+			// tag::e7e47d671e68046629a7969c55eed8b6[]
+			var response0 = new SearchResponse<object>();
+			// end::e7e47d671e68046629a7969c55eed8b6[]
+
+			response0.MatchesExample(@"PUT /_autoscaling/policy/my_autoscaling_policy
+			{
+			  ""policy"": {
+			    ""deciders"": {
+			      ""always"": {
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/delete-autoscaling-policy.asciidoc:29")]
+		public void Line29()
+		{
+			// tag::50a9623c153cabe64101efb633e10e6c[]
+			var response0 = new SearchResponse<object>();
+			// end::50a9623c153cabe64101efb633e10e6c[]
+
+			response0.MatchesExample(@"DELETE /_autoscaling/policy/<name>");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/delete-autoscaling-policy.asciidoc:52")]
+		public void Line52()
+		{
+			// tag::b620ef4400d2f660fe2c67835938442c[]
+			var response0 = new SearchResponse<object>();
+			// end::b620ef4400d2f660fe2c67835938442c[]
+
+			response0.MatchesExample(@"DELETE /_autoscaling/policy/my_autoscaling_policy");
+		}
+	}
+}

--- a/tests/Examples/Autoscaling/Apis/GetAutoscalingPolicyPage.cs
+++ b/tests/Examples/Autoscaling/Apis/GetAutoscalingPolicyPage.cs
@@ -1,0 +1,50 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Autoscaling.Apis
+{
+	public class GetAutoscalingPolicyPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/get-autoscaling-policy.asciidoc:15")]
+		public void Line15()
+		{
+			// tag::e7e47d671e68046629a7969c55eed8b6[]
+			var response0 = new SearchResponse<object>();
+			// end::e7e47d671e68046629a7969c55eed8b6[]
+
+			response0.MatchesExample(@"PUT /_autoscaling/policy/my_autoscaling_policy
+			{
+			  ""policy"": {
+			    ""deciders"": {
+			      ""always"": {
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/get-autoscaling-policy.asciidoc:29")]
+		public void Line29()
+		{
+			// tag::fb4799d2fe4011bf6084f89d97d9a4a5[]
+			var response0 = new SearchResponse<object>();
+			// end::fb4799d2fe4011bf6084f89d97d9a4a5[]
+
+			response0.MatchesExample(@"GET /_autoscaling/policy/<name>");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/get-autoscaling-policy.asciidoc:52")]
+		public void Line52()
+		{
+			// tag::0ea146b178561bc8b9002bed8a35641f[]
+			var response0 = new SearchResponse<object>();
+			// end::0ea146b178561bc8b9002bed8a35641f[]
+
+			response0.MatchesExample(@"GET /_autoscaling/policy/my_autoscaling_policy");
+		}
+	}
+}

--- a/tests/Examples/Autoscaling/Apis/PutAutoscalingPolicyPage.cs
+++ b/tests/Examples/Autoscaling/Apis/PutAutoscalingPolicyPage.cs
@@ -1,0 +1,47 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Autoscaling.Apis
+{
+	public class PutAutoscalingPolicyPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/put-autoscaling-policy.asciidoc:15")]
+		public void Line15()
+		{
+			// tag::4015b1eb9a15be7a3468bca965c52958[]
+			var response0 = new SearchResponse<object>();
+			// end::4015b1eb9a15be7a3468bca965c52958[]
+
+			response0.MatchesExample(@"PUT /_autoscaling/policy/<name>
+			{
+			  ""policy"": {
+			    ""deciders"": {
+			      ""always"": {
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("autoscaling/apis/put-autoscaling-policy.asciidoc:47")]
+		public void Line47()
+		{
+			// tag::e7e47d671e68046629a7969c55eed8b6[]
+			var response0 = new SearchResponse<object>();
+			// end::e7e47d671e68046629a7969c55eed8b6[]
+
+			response0.MatchesExample(@"PUT /_autoscaling/policy/my_autoscaling_policy
+			{
+			  ""policy"": {
+			    ""deciders"": {
+			      ""always"": {
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Cat/TasksPage.cs
+++ b/tests/Examples/Cat/TasksPage.cs
@@ -8,8 +8,8 @@ namespace Examples.Cat
 	{
 
 		[U(Skip = "Example not implemented")]
-		[Description("cat/tasks.asciidoc:67")]
-		public void Line67()
+		[Description("cat/tasks.asciidoc:57")]
+		public void Line57()
 		{
 			// tag::f3422381d36398fcb2612692b11b1e96[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cat/TransformsPage.cs
+++ b/tests/Examples/Cat/TransformsPage.cs
@@ -1,0 +1,20 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Cat
+{
+	public class TransformsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("cat/transforms.asciidoc:168")]
+		public void Line168()
+		{
+			// tag::da8c3c635ea1101d6a1a5eb1db2ffebd[]
+			var response0 = new SearchResponse<object>();
+			// end::da8c3c635ea1101d6a1a5eb1db2ffebd[]
+
+			response0.MatchesExample(@"GET /_cat/transforms?v&format=json");
+		}
+	}
+}

--- a/tests/Examples/Ccr/Apis/Follow/GetFollowInfoPage.cs
+++ b/tests/Examples/Ccr/Apis/Follow/GetFollowInfoPage.cs
@@ -18,8 +18,8 @@ namespace Examples.Ccr.Apis.Follow
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ccr/apis/follow/get-follow-info.asciidoc:138")]
-		public void Line138()
+		[Description("ccr/apis/follow/get-follow-info.asciidoc:145")]
+		public void Line145()
 		{
 			// tag::a520168c1c8b454a8f102d6a13027c73[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ccr/Apis/Follow/GetFollowStatsPage.cs
+++ b/tests/Examples/Ccr/Apis/Follow/GetFollowStatsPage.cs
@@ -18,8 +18,8 @@ namespace Examples.Ccr.Apis.Follow
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ccr/apis/follow/get-follow-stats.asciidoc:206")]
-		public void Line206()
+		[Description("ccr/apis/follow/get-follow-stats.asciidoc:211")]
+		public void Line211()
 		{
 			// tag::8e43bb5b7946143e69d397bb81d87df0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/NodesReloadSecureSettingsPage.cs
+++ b/tests/Examples/Cluster/NodesReloadSecureSettingsPage.cs
@@ -7,18 +7,24 @@ namespace Examples.Cluster
 	public class NodesReloadSecureSettingsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-reload-secure-settings.asciidoc:54")]
-		public void Line54()
+		[Description("cluster/nodes-reload-secure-settings.asciidoc:57")]
+		public void Line57()
 		{
-			// tag::72f20e645e118715b6197c2087b4db86[]
+			// tag::a28811aa25e10cfc38fe593c1615e1a1[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
-			// end::72f20e645e118715b6197c2087b4db86[]
+			// end::a28811aa25e10cfc38fe593c1615e1a1[]
 
-			response0.MatchesExample(@"POST _nodes/reload_secure_settings");
+			response0.MatchesExample(@"POST _nodes/reload_secure_settings
+			{
+			  ""secure_settings_password"":""s3cr3t""
+			}");
 
-			response1.MatchesExample(@"POST _nodes/nodeId1,nodeId2/reload_secure_settings");
+			response1.MatchesExample(@"POST _nodes/nodeId1,nodeId2/reload_secure_settings
+			{
+			  ""secure_settings_password"":""s3cr3t""
+			}");
 		}
 	}
 }

--- a/tests/Examples/Cluster/NodesStatsPage.cs
+++ b/tests/Examples/Cluster/NodesStatsPage.cs
@@ -8,8 +8,8 @@ namespace Examples.Cluster
 	{
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1363")]
-		public void Line1363()
+		[Description("cluster/nodes-stats.asciidoc:2140")]
+		public void Line2140()
 		{
 			// tag::5457c94f0039c6b95c7f9f305d0c6b58[]
 			var response0 = new SearchResponse<object>();
@@ -39,8 +39,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1381")]
-		public void Line1381()
+		[Description("cluster/nodes-stats.asciidoc:2158")]
+		public void Line2158()
 		{
 			// tag::150b5fee5678bf8cdf0932da73eada80[]
 			var response0 = new SearchResponse<object>();
@@ -78,8 +78,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1399")]
-		public void Line1399()
+		[Description("cluster/nodes-stats.asciidoc:2176")]
+		public void Line2176()
 		{
 			// tag::bd68666ca2e0be12f7624016317a62bc[]
 			var response0 = new SearchResponse<object>();
@@ -101,8 +101,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1415")]
-		public void Line1415()
+		[Description("cluster/nodes-stats.asciidoc:2192")]
+		public void Line2192()
 		{
 			// tag::09769561f082b50558fb7d8707719963[]
 			var response0 = new SearchResponse<object>();
@@ -112,8 +112,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1423")]
-		public void Line1423()
+		[Description("cluster/nodes-stats.asciidoc:2200")]
+		public void Line2200()
 		{
 			// tag::ef9c29759459904fef162acd223462c4[]
 			var response0 = new SearchResponse<object>();
@@ -123,8 +123,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/nodes-stats.asciidoc:1431")]
-		public void Line1431()
+		[Description("cluster/nodes-stats.asciidoc:2208")]
+		public void Line2208()
 		{
 			// tag::f160561efab38e40c2feebf5a2542ab5[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/ReroutePage.cs
+++ b/tests/Examples/Cluster/ReroutePage.cs
@@ -7,8 +7,8 @@ namespace Examples.Cluster
 	public class ReroutePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/reroute.asciidoc:180")]
-		public void Line180()
+		[Description("cluster/reroute.asciidoc:185")]
+		public void Line185()
 		{
 			// tag::c5488b3888749d3d5b9808ab28d384eb[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/StatsPage.cs
+++ b/tests/Examples/Cluster/StatsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Cluster
 	public class StatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/stats.asciidoc:347")]
-		public void Line347()
+		[Description("cluster/stats.asciidoc:1089")]
+		public void Line1089()
 		{
 			// tag::861f5f61409dc87f3671293b87839ff7[]
 			var response0 = new SearchResponse<object>();
@@ -18,8 +18,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/stats.asciidoc:591")]
-		public void Line591()
+		[Description("cluster/stats.asciidoc:1333")]
+		public void Line1333()
 		{
 			// tag::71c629c44bf3c542a0daacbfc253c4b0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/TasksPage.cs
+++ b/tests/Examples/Cluster/TasksPage.cs
@@ -92,8 +92,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/tasks.asciidoc:236")]
-		public void Line236()
+		[Description("cluster/tasks.asciidoc:241")]
+		public void Line241()
 		{
 			// tag::612c2e975f833de9815651135735eae5[]
 			var response0 = new SearchResponse<object>();
@@ -103,8 +103,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/tasks.asciidoc:247")]
-		public void Line247()
+		[Description("cluster/tasks.asciidoc:252")]
+		public void Line252()
 		{
 			// tag::bd3d710ec50a151453e141691163af72[]
 			var response0 = new SearchResponse<object>();
@@ -114,8 +114,8 @@ namespace Examples.Cluster
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/tasks.asciidoc:254")]
-		public void Line254()
+		[Description("cluster/tasks.asciidoc:259")]
+		public void Line259()
 		{
 			// tag::a3ce0cfe2176f3d8a36959a5916995f0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Cluster/VotingExclusionsPage.cs
+++ b/tests/Examples/Cluster/VotingExclusionsPage.cs
@@ -7,19 +7,19 @@ namespace Examples.Cluster
 	public class VotingExclusionsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/voting-exclusions.asciidoc:73")]
-		public void Line73()
+		[Description("cluster/voting-exclusions.asciidoc:81")]
+		public void Line81()
 		{
-			// tag::59681840e544bb5b3bd858c194972f23[]
+			// tag::f6ead39c5505045543b9225deca7367d[]
 			var response0 = new SearchResponse<object>();
-			// end::59681840e544bb5b3bd858c194972f23[]
+			// end::f6ead39c5505045543b9225deca7367d[]
 
-			response0.MatchesExample(@"POST /_cluster/voting_config_exclusions/nodeId1");
+			response0.MatchesExample(@"POST /_cluster/voting_config_exclusions?node_names=nodeName1,nodeName2");
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("cluster/voting-exclusions.asciidoc:82")]
-		public void Line82()
+		[Description("cluster/voting-exclusions.asciidoc:88")]
+		public void Line88()
 		{
 			// tag::25cb9e1da00dfd971065ce182467434d[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Docs/BulkPage.cs
+++ b/tests/Examples/Docs/BulkPage.cs
@@ -109,7 +109,6 @@ namespace Examples.Docs
 						objects[7].Add("_source", true);
 						(objects[8]["update"] as JObject).Add("_source", true);
 					});
-					return e;
 				});
 		}
 	}

--- a/tests/Examples/Docs/DeleteByQueryPage.cs
+++ b/tests/Examples/Docs/DeleteByQueryPage.cs
@@ -41,7 +41,6 @@ namespace Examples.Docs
 					var query = body["query"]["match"]["message"].Value<string>();
 					body["query"]["match"]["message"] = new JObject { { "query", query } };
 				});
-				return e;
 			});
 		}
 
@@ -117,7 +116,6 @@ namespace Examples.Docs
 				{
 					body["query"]["range"]["age"]["gte"] = 10d;
 				});
-				return e;
 			});
 		}
 
@@ -152,7 +150,6 @@ namespace Examples.Docs
 					var value = body["query"]["term"]["user"].Value<string>();
 					body["query"]["term"]["user"] = new JObject { { "value", value } };
 				});
-				return e;
 			});
 		}
 
@@ -210,7 +207,6 @@ namespace Examples.Docs
 				{
 					body["query"]["range"]["likes"]["lt"] = 10d;
 				});
-				return e;
 			});
 
 			deleteByQueryResponse2.MatchesExample(@"POST twitter/_delete_by_query
@@ -233,7 +229,6 @@ namespace Examples.Docs
 					// numeric ranges always use doubles
 					body["query"]["range"]["likes"]["lt"] = 10d;
 				});
-				return e;
 			});
 		}
 
@@ -261,7 +256,6 @@ namespace Examples.Docs
 			{
 				// refresh is always a POST with the client
 				e.Method = HttpMethod.POST;
-				return e;
 			});
 
 			searchResponse.MatchesExample(@"POST twitter/_search?size=0&filter_path=hits.total
@@ -283,7 +277,6 @@ namespace Examples.Docs
 					// numeric ranges always use doubles
 					body["query"]["range"]["likes"]["lt"] = 10d;
 				});
-				return e;
 			});
 		}
 
@@ -323,7 +316,6 @@ namespace Examples.Docs
 					// slices is defined in body
 					body["query"]["range"]["likes"]["lt"] = 10d;
 				});
-				return e;
 			});
 		}
 
@@ -363,7 +355,6 @@ namespace Examples.Docs
 					body["size"] = 0;
 					body["query"]["range"]["likes"]["lt"] = 10d;
 				});
-				return e;
 			});
 		}
 

--- a/tests/Examples/Docs/GetPage.cs
+++ b/tests/Examples/Docs/GetPage.cs
@@ -63,7 +63,6 @@ namespace Examples.Docs
 			{
 				// client does not support short hand _source for _source_includes
 				e.Uri.Query = e.Uri.Query.Replace("_source", "_source_includes");
-				return e;
 			});
 		}
 

--- a/tests/Examples/Docs/MultiGetPage.cs
+++ b/tests/Examples/Docs/MultiGetPage.cs
@@ -30,8 +30,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:128")]
-		public void Line128()
+		[Description("docs/multi-get.asciidoc:130")]
+		public void Line130()
 		{
 			// tag::53cf7d3731f50620b3277b80e2fbfd56[]
 			var response0 = new SearchResponse<object>();
@@ -51,8 +51,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:146")]
-		public void Line146()
+		[Description("docs/multi-get.asciidoc:148")]
+		public void Line148()
 		{
 			// tag::81095ba46e4d8c5da3623f5ea8c54a34[]
 			var response0 = new SearchResponse<object>();
@@ -65,8 +65,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:168")]
-		public void Line168()
+		[Description("docs/multi-get.asciidoc:170")]
+		public void Line170()
 		{
 			// tag::6b1ab3f273c6e425067cd5889b0c258f[]
 			var response0 = new SearchResponse<object>();
@@ -98,8 +98,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:206")]
-		public void Line206()
+		[Description("docs/multi-get.asciidoc:208")]
+		public void Line208()
 		{
 			// tag::c4272ba35b81125a805fb1a7292f3d25[]
 			var response0 = new SearchResponse<object>();
@@ -123,8 +123,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:229")]
-		public void Line229()
+		[Description("docs/multi-get.asciidoc:231")]
+		public void Line231()
 		{
 			// tag::27fac828d28ab065524dd1ce148840c0[]
 			var response0 = new SearchResponse<object>();
@@ -145,8 +145,8 @@ namespace Examples.Docs
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("docs/multi-get.asciidoc:252")]
-		public void Line252()
+		[Description("docs/multi-get.asciidoc:254")]
+		public void Line254()
 		{
 			// tag::1b37488d0a79d3c950029851b7cd623e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Docs/ReindexPage.cs
+++ b/tests/Examples/Docs/ReindexPage.cs
@@ -103,13 +103,11 @@ namespace Examples.Docs
 			refreshResponse.MatchesExample(@"GET _refresh", e =>
 			{
 				e.Method = HttpMethod.POST;
-				return e;
 			});
 
 			searchResponse.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total", e =>
 			{
 				e.MoveQueryStringToBody("size", 0);
-				return e;
 			});
 		}
 
@@ -148,7 +146,6 @@ namespace Examples.Docs
 			searchResponse.MatchesExample(@"POST new_twitter/_search?size=0&filter_path=hits.total", e =>
 			{
 				e.MoveQueryStringToBody("size", 0);
-				return e;
 			});
 		}
 
@@ -308,7 +305,6 @@ namespace Examples.Docs
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["source"]["index"] = b["source"]["index"].Flatten<string>(); });
-				return e;
 			});
 		}
 
@@ -351,7 +347,6 @@ namespace Examples.Docs
 			}", e =>
 			{
 				e.Method = HttpMethod.PUT;
-				return e;
 			});
 		}
 
@@ -438,7 +433,6 @@ namespace Examples.Docs
 			}", e =>
 			{
 				e.ApplyBodyChanges(o => ((JObject)o["script"]).Remove("lang"));
-				return e;
 			});
 		}
 
@@ -491,9 +485,7 @@ namespace Examples.Docs
 					((JObject)o["source"]["query"]["function_score"]).Remove("random_score");
 					var array = new JArray { JToken.FromObject(new { random_score = new object() }) };
 					((JObject)o["source"]["query"]["function_score"]).Add("functions", array);
-				}); ;
-
-				return e;
+				});
 			});
 		}
 
@@ -525,7 +517,6 @@ namespace Examples.Docs
 			}", e =>
 			{
 				e.ApplyBodyChanges(o => ((JObject)o["script"]).Remove("lang"));
-				return e;
 			});
 		}
 

--- a/tests/Examples/Docs/UpdateByQueryPage.cs
+++ b/tests/Examples/Docs/UpdateByQueryPage.cs
@@ -52,7 +52,6 @@ namespace Examples.Docs
 					var value = body["query"]["term"]["user"];
 					body["query"]["term"]["user"] = new JObject { ["value"] = value };
 				});
-				return e;
 			});
 		}
 
@@ -132,7 +131,6 @@ namespace Examples.Docs
 					var value = body["query"]["term"]["user"];
 					body["query"]["term"]["user"] = new JObject { ["value"] = value };
 				});
-				return e;
 			});
 		}
 
@@ -292,13 +290,11 @@ namespace Examples.Docs
 			refreshResponse.MatchesExample(@"GET _refresh", e =>
 			{
 				e.Method = HttpMethod.POST;
-				return e;
 			});
 
 			searchResponse.MatchesExample(@"POST twitter/_search?size=0&q=extra:test&filter_path=hits.total", e =>
 			{
 				e.MoveQueryStringToBody("size", 0);
-				return e;
 			});
 		}
 
@@ -341,7 +337,6 @@ namespace Examples.Docs
 			searchResponse.MatchesExample(@"POST twitter/_search?size=0&q=extra:test&filter_path=hits.total", e =>
 			{
 				e.MoveQueryStringToBody("size", 0);
-				return e;
 			});
 		}
 
@@ -445,7 +440,6 @@ namespace Examples.Docs
 				{
 					b["query"]["match"]["flag"].ToLongFormQuery();
 				});
-				return e;
 			});
 		}
 
@@ -487,7 +481,6 @@ namespace Examples.Docs
 				{
 					b["query"]["match"]["flag"].ToLongFormQuery();
 				});
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Docs/UpdatePage.cs
+++ b/tests/Examples/Docs/UpdatePage.cs
@@ -142,7 +142,6 @@ namespace Examples.Docs
 					var script = body["script"].Value<string>();
 					body["script"] = new JObject { { "source", script } };
 				});
-				return e;
 			});
 		}
 
@@ -170,7 +169,6 @@ namespace Examples.Docs
 					var script = body["script"].Value<string>();
 					body["script"] = new JObject { { "source", script } };
 				});
-				return e;
 			});
 		}
 

--- a/tests/Examples/Eql/SearchPage.cs
+++ b/tests/Examples/Eql/SearchPage.cs
@@ -28,8 +28,8 @@ namespace Examples.Eql
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("eql/search.asciidoc:39")]
-		public void Line39()
+		[Description("eql/search.asciidoc:48")]
+		public void Line48()
 		{
 			// tag::39e711af23a7eee61a1e13cf2ef7c360[]
 			var response0 = new SearchResponse<object>();
@@ -44,8 +44,8 @@ namespace Examples.Eql
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("eql/search.asciidoc:127")]
-		public void Line127()
+		[Description("eql/search.asciidoc:136")]
+		public void Line136()
 		{
 			// tag::6f915983b4c12bcd1a8ca1c9cf8feed1[]
 			var response0 = new SearchResponse<object>();
@@ -61,8 +61,8 @@ namespace Examples.Eql
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("eql/search.asciidoc:149")]
-		public void Line149()
+		[Description("eql/search.asciidoc:158")]
+		public void Line158()
 		{
 			// tag::382f6056cfbc3a113f675c0fbc59aaf3[]
 			var response0 = new SearchResponse<object>();
@@ -78,8 +78,8 @@ namespace Examples.Eql
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("eql/search.asciidoc:173")]
-		public void Line173()
+		[Description("eql/search.asciidoc:182")]
+		public void Line182()
 		{
 			// tag::bfdf5997fe6e1fc4e938a28fcd6c8683[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Graph/ExplorePage.cs
+++ b/tests/Examples/Graph/ExplorePage.cs
@@ -7,8 +7,8 @@ namespace Examples.Graph
 	public class ExplorePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("graph/explore.asciidoc:185")]
-		public void Line185()
+		[Description("graph/explore.asciidoc:201")]
+		public void Line201()
 		{
 			// tag::8bf5ac11eb42e652023a685af4a45ae2[]
 			var response0 = new SearchResponse<object>();
@@ -37,8 +37,8 @@ namespace Examples.Graph
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("graph/explore.asciidoc:290")]
-		public void Line290()
+		[Description("graph/explore.asciidoc:306")]
+		public void Line306()
 		{
 			// tag::6a1a238984d74771420d150dec47fd91[]
 			var response0 = new SearchResponse<object>();
@@ -95,8 +95,8 @@ namespace Examples.Graph
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("graph/explore.asciidoc:377")]
-		public void Line377()
+		[Description("graph/explore.asciidoc:393")]
+		public void Line393()
 		{
 			// tag::fa82d86a046d67366cfe9ce65535e433[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/HowTo/SearchSpeedPage.cs
+++ b/tests/Examples/HowTo/SearchSpeedPage.cs
@@ -124,8 +124,138 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:181")]
-		public void Line181()
+		[Description("how-to/search-speed.asciidoc:188")]
+		public void Line188()
+		{
+			// tag::34fff811cf60997f6df89928e5a41387[]
+			var response0 = new SearchResponse<object>();
+			// end::34fff811cf60997f6df89928e5a41387[]
+
+			response0.MatchesExample(@"GET /my_test_scores/_search
+			{
+			  ""query"": {
+			    ""term"": {
+			      ""grad_year"": ""2020""
+			    }
+			  },
+			  ""sort"": [
+			    {
+			      ""_script"": {
+			        ""type"": ""number"",
+			        ""script"": {
+			          ""source"": ""doc['math_score'].value + doc['verbal_score'].value""
+			        },
+			        ""order"": ""desc""
+			      }
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:219")]
+		public void Line219()
+		{
+			// tag::dda949d20d07a9edbe64cefc623df945[]
+			var response0 = new SearchResponse<object>();
+			// end::dda949d20d07a9edbe64cefc623df945[]
+
+			response0.MatchesExample(@"PUT /my_test_scores/_mapping
+			{
+			  ""properties"": {
+			    ""total_score"": {
+			      ""type"": ""long""
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:236")]
+		public void Line236()
+		{
+			// tag::295b3aaeb223612afdd991744dc9c873[]
+			var response0 = new SearchResponse<object>();
+			// end::295b3aaeb223612afdd991744dc9c873[]
+
+			response0.MatchesExample(@"PUT _ingest/pipeline/my_test_scores_pipeline
+			{
+			  ""description"": ""Calculates the total test score"",
+			  ""processors"": [
+			    {
+			      ""script"": {
+			        ""source"": ""ctx.total_score = (ctx.math_score + ctx.verbal_score)""
+			      }
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:255")]
+		public void Line255()
+		{
+			// tag::f70ff57c80cdbce3f1e7c63ee307c92d[]
+			var response0 = new SearchResponse<object>();
+			// end::f70ff57c80cdbce3f1e7c63ee307c92d[]
+
+			response0.MatchesExample(@"POST /_reindex
+			{
+			  ""source"": {
+			    ""index"": ""my_test_scores""
+			  },
+			  ""dest"": {
+			    ""index"": ""my_test_scores_2"",
+			    ""pipeline"": ""my_test_scores_pipeline""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:272")]
+		public void Line272()
+		{
+			// tag::161d6932c412a01a47ee0883b12056ca[]
+			var response0 = new SearchResponse<object>();
+			// end::161d6932c412a01a47ee0883b12056ca[]
+
+			response0.MatchesExample(@"POST /my_test_scores_2/_doc/?pipeline=my_test_scores_pipeline
+			{
+			  ""student"": ""kimchy"",
+			  ""grad_year"": ""2020"",
+			  ""math_score"": 800,
+			  ""verbal_score"": 800
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:288")]
+		public void Line288()
+		{
+			// tag::aab42564d36970fe9e2f6eab560470a0[]
+			var response0 = new SearchResponse<object>();
+			// end::aab42564d36970fe9e2f6eab560470a0[]
+
+			response0.MatchesExample(@"GET /my_test_scores_2/_search
+			{
+			  ""query"": {
+			    ""term"": {
+			      ""grad_year"": ""2020""
+			    }
+			  },
+			  ""sort"": [
+			    {
+			      ""total_score"": {
+			        ""order"": ""desc""
+			      }
+			    }
+			  ]
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("how-to/search-speed.asciidoc:337")]
+		public void Line337()
 		{
 			// tag::102c7de25d13c87cf28839ada9f63c95[]
 			var response0 = new SearchResponse<object>();
@@ -156,8 +286,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:207")]
-		public void Line207()
+		[Description("how-to/search-speed.asciidoc:363")]
+		public void Line363()
 		{
 			// tag::17dd67a66c49f7eb618dd17430e48dfa[]
 			var response0 = new SearchResponse<object>();
@@ -181,8 +311,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:240")]
-		public void Line240()
+		[Description("how-to/search-speed.asciidoc:396")]
+		public void Line396()
 		{
 			// tag::abc7a670a47516b58b6b07d7497b140c[]
 			var response0 = new SearchResponse<object>();
@@ -228,8 +358,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:312")]
-		public void Line312()
+		[Description("how-to/search-speed.asciidoc:468")]
+		public void Line468()
 		{
 			// tag::971c7a36ee79f2b3aa82c64ea338de70[]
 			var response0 = new SearchResponse<object>();
@@ -249,8 +379,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:443")]
-		public void Line443()
+		[Description("how-to/search-speed.asciidoc:599")]
+		public void Line599()
 		{
 			// tag::9559de0c2190f99fcc344887fc7b232a[]
 			var response0 = new SearchResponse<object>();
@@ -289,8 +419,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:481")]
-		public void Line481()
+		[Description("how-to/search-speed.asciidoc:637")]
+		public void Line637()
 		{
 			// tag::14936b96cfb8ff999a833f615ba75495[]
 			var response0 = new SearchResponse<object>();
@@ -316,8 +446,8 @@ namespace Examples.HowTo
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("how-to/search-speed.asciidoc:506")]
-		public void Line506()
+		[Description("how-to/search-speed.asciidoc:662")]
+		public void Line662()
 		{
 			// tag::9de10a59a5f56dd0906be627896cc789[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/GettingStartedIlmPage.cs
+++ b/tests/Examples/Ilm/GettingStartedIlmPage.cs
@@ -10,11 +10,11 @@ namespace Examples.Ilm
 		[Description("ilm/getting-started-ilm.asciidoc:46")]
 		public void Line46()
 		{
-			// tag::f2dc1a1a2a6ba3c7c4273ce41ada4207[]
+			// tag::080b3362db1fa14e1ca4e290d6e6447d[]
 			var response0 = new SearchResponse<object>();
-			// end::f2dc1a1a2a6ba3c7c4273ce41ada4207[]
+			// end::080b3362db1fa14e1ca4e290d6e6447d[]
 
-			response0.MatchesExample(@"PUT _ilm/policy/datastream_policy
+			response0.MatchesExample(@"PUT _ilm/policy/timeseries_policy
 			{
 			  ""policy"": {
 			    ""phases"": {
@@ -41,18 +41,18 @@ namespace Examples.Ilm
 		[Description("ilm/getting-started-ilm.asciidoc:93")]
 		public void Line93()
 		{
-			// tag::e3d7b19f993382750719cdfaad2fdd90[]
+			// tag::4d01c243f7406c98546311ec1ff6b7e6[]
 			var response0 = new SearchResponse<object>();
-			// end::e3d7b19f993382750719cdfaad2fdd90[]
+			// end::4d01c243f7406c98546311ec1ff6b7e6[]
 
-			response0.MatchesExample(@"PUT _template/datastream_template
+			response0.MatchesExample(@"PUT _template/timeseries_template
 			{
-			  ""index_patterns"": [""datastream-*""],                 \<1>
+			  ""index_patterns"": [""timeseries-*""],                 <1>
 			  ""settings"": {
 			    ""number_of_shards"": 1,
 			    ""number_of_replicas"": 1,
-			    ""index.lifecycle.name"": ""datastream_policy"",      \<2>
-			    ""index.lifecycle.rollover_alias"": ""datastream""    \<3>
+			    ""index.lifecycle.name"": ""timeseries_policy"",      <2>
+			    ""index.lifecycle.rollover_alias"": ""timeseries""    <3>
 			  }
 			}");
 		}
@@ -61,14 +61,14 @@ namespace Examples.Ilm
 		[Description("ilm/getting-started-ilm.asciidoc:135")]
 		public void Line135()
 		{
-			// tag::55ee835d7c28e933ad8fcb9e45af2bf2[]
+			// tag::7148c8512079d378af70302e65502dd2[]
 			var response0 = new SearchResponse<object>();
-			// end::55ee835d7c28e933ad8fcb9e45af2bf2[]
+			// end::7148c8512079d378af70302e65502dd2[]
 
-			response0.MatchesExample(@"PUT datastream-000001
+			response0.MatchesExample(@"PUT timeseries-000001
 			{
 			  ""aliases"": {
-			    ""datastream"": {
+			    ""timeseries"": {
 			      ""is_write_index"": true
 			    }
 			  }
@@ -79,11 +79,11 @@ namespace Examples.Ilm
 		[Description("ilm/getting-started-ilm.asciidoc:173")]
 		public void Line173()
 		{
-			// tag::a1dbaff15cf8166f74c443ca58258d7e[]
+			// tag::2ffa953b29ed0156c9e610daf66b8e48[]
 			var response0 = new SearchResponse<object>();
-			// end::a1dbaff15cf8166f74c443ca58258d7e[]
+			// end::2ffa953b29ed0156c9e610daf66b8e48[]
 
-			response0.MatchesExample(@"GET datastream-*/_ilm/explain");
+			response0.MatchesExample(@"GET timeseries-*/_ilm/explain");
 		}
 	}
 }

--- a/tests/Examples/Ilm/IlmWithExistingIndicesPage.cs
+++ b/tests/Examples/Ilm/IlmWithExistingIndicesPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ilm
 	public class IlmWithExistingIndicesPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:23")]
-		public void Line23()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:24")]
+		public void Line24()
 		{
 			// tag::4e2027438393cf93b9c9402b8511eab5[]
 			var response0 = new SearchResponse<object>();
@@ -37,8 +37,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:49")]
-		public void Line49()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:50")]
+		public void Line50()
 		{
 			// tag::8502a9281f5393a7160e4e46988da672[]
 			var response0 = new SearchResponse<object>();
@@ -52,8 +52,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:59")]
-		public void Line59()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:60")]
+		public void Line60()
 		{
 			// tag::7d51f0436e87dec4274133856866b07d[]
 			var response0 = new SearchResponse<object>();
@@ -67,8 +67,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:128")]
-		public void Line128()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:129")]
+		public void Line129()
 		{
 			// tag::75097f73665235b20df09739c820ad35[]
 			var response0 = new SearchResponse<object>();
@@ -111,8 +111,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:171")]
-		public void Line171()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:172")]
+		public void Line172()
 		{
 			// tag::3feab5c602192b8dc58435654b17d3fe[]
 			var response0 = new SearchResponse<object>();
@@ -148,8 +148,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:213")]
-		public void Line213()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:214")]
+		public void Line214()
 		{
 			// tag::ec195297eb804cba1cb19c9926773059[]
 			var response0 = new SearchResponse<object>();
@@ -166,8 +166,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:255")]
-		public void Line255()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:256")]
+		public void Line256()
 		{
 			// tag::8d39a0f0116702e981545d13371cd0eb[]
 			var response0 = new SearchResponse<object>();
@@ -191,8 +191,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:278")]
-		public void Line278()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:279")]
+		public void Line279()
 		{
 			// tag::bce0d86353e212cee466ccbc90bdc6e7[]
 			var response0 = new SearchResponse<object>();
@@ -227,8 +227,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:317")]
-		public void Line317()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:318")]
+		public void Line318()
 		{
 			// tag::89115f8d40d9a13b0b01dc7c33ffd1cc[]
 			var response0 = new SearchResponse<object>();
@@ -245,8 +245,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:356")]
-		public void Line356()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:357")]
+		public void Line357()
 		{
 			// tag::5df1ed33b5fcf3b9d85c20d100780d43[]
 			var response0 = new SearchResponse<object>();
@@ -261,8 +261,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:387")]
-		public void Line387()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:388")]
+		public void Line388()
 		{
 			// tag::41f211cc838f1bee7eac264784f905e2[]
 			var response0 = new SearchResponse<object>();
@@ -282,8 +282,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/ilm-with-existing-indices.asciidoc:417")]
-		public void Line417()
+		[Description("ilm/ilm-with-existing-indices.asciidoc:418")]
+		public void Line418()
 		{
 			// tag::227e19aecb349f31e74898384322ae01[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/PolicyDefinitionsPage.cs
+++ b/tests/Examples/Ilm/PolicyDefinitionsPage.cs
@@ -38,8 +38,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:166")]
-		public void Line166()
+		[Description("ilm/policy-definitions.asciidoc:167")]
+		public void Line167()
 		{
 			// tag::1116c769f39f0c7fe86ec2a4871efcd5[]
 			var response0 = new SearchResponse<object>();
@@ -62,8 +62,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:188")]
-		public void Line188()
+		[Description("ilm/policy-definitions.asciidoc:189")]
+		public void Line189()
 		{
 			// tag::0518c673094fb18ecb491a3b78af4695[]
 			var response0 = new SearchResponse<object>();
@@ -88,8 +88,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:213")]
-		public void Line213()
+		[Description("ilm/policy-definitions.asciidoc:216")]
+		public void Line216()
 		{
 			// tag::9d461ae140ddc018efd2650559800cd1[]
 			var response0 = new SearchResponse<object>();
@@ -115,8 +115,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:250")]
-		public void Line250()
+		[Description("ilm/policy-definitions.asciidoc:253")]
+		public void Line253()
 		{
 			// tag::83062a543163370328cf2e21a68c1bd3[]
 			var response0 = new SearchResponse<object>();
@@ -139,8 +139,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:277")]
-		public void Line277()
+		[Description("ilm/policy-definitions.asciidoc:288")]
+		public void Line288()
 		{
 			// tag::053497b6960f80fd7b005b7c6d54358f[]
 			var response0 = new SearchResponse<object>();
@@ -161,8 +161,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:324")]
-		public void Line324()
+		[Description("ilm/policy-definitions.asciidoc:338")]
+		public void Line338()
 		{
 			// tag::eb5486d2fe4283475bf9e0e09280be16[]
 			var response0 = new SearchResponse<object>();
@@ -185,8 +185,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:350")]
-		public void Line350()
+		[Description("ilm/policy-definitions.asciidoc:364")]
+		public void Line364()
 		{
 			// tag::0345fbd95c4516a89ac5ad261a16be8f[]
 			var response0 = new SearchResponse<object>();
@@ -207,8 +207,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:384")]
-		public void Line384()
+		[Description("ilm/policy-definitions.asciidoc:398")]
+		public void Line398()
 		{
 			// tag::fc9a1b1173690a911725cff3912e9755[]
 			var response0 = new SearchResponse<object>();
@@ -229,8 +229,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:422")]
-		public void Line422()
+		[Description("ilm/policy-definitions.asciidoc:436")]
+		public void Line436()
 		{
 			// tag::d7e7489b7d176aa854dfc785a12feab3[]
 			var response0 = new SearchResponse<object>();
@@ -251,8 +251,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:466")]
-		public void Line466()
+		[Description("ilm/policy-definitions.asciidoc:480")]
+		public void Line480()
 		{
 			// tag::19211ccf772f1dee7b500c21f4a9a805[]
 			var response0 = new SearchResponse<object>();
@@ -275,8 +275,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:489")]
-		public void Line489()
+		[Description("ilm/policy-definitions.asciidoc:503")]
+		public void Line503()
 		{
 			// tag::cfd4b34f35e531a20739a3b308d57134[]
 			var response0 = new SearchResponse<object>();
@@ -299,8 +299,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:512")]
-		public void Line512()
+		[Description("ilm/policy-definitions.asciidoc:526")]
+		public void Line526()
 		{
 			// tag::d4a41fb74b41b41a0ee114a2311f2815[]
 			var response0 = new SearchResponse<object>();
@@ -323,8 +323,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:536")]
-		public void Line536()
+		[Description("ilm/policy-definitions.asciidoc:550")]
+		public void Line550()
 		{
 			// tag::8940f2b911220acc9afef6360b6c13c4[]
 			var response0 = new SearchResponse<object>();
@@ -348,8 +348,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:561")]
-		public void Line561()
+		[Description("ilm/policy-definitions.asciidoc:575")]
+		public void Line575()
 		{
 			// tag::f6c79fa1c01bb4539d0cba0bd62c1ce0[]
 			var response0 = new SearchResponse<object>();
@@ -378,8 +378,32 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:612")]
-		public void Line612()
+		[Description("ilm/policy-definitions.asciidoc:623")]
+		public void Line623()
+		{
+			// tag::3f2e5132e35b9e8b3203a4a0541cf0d4[]
+			var response0 = new SearchResponse<object>();
+			// end::3f2e5132e35b9e8b3203a4a0541cf0d4[]
+
+			response0.MatchesExample(@"PUT _ilm/policy/my_policy
+			{
+			  ""policy"": {
+			    ""phases"": {
+			      ""cold"": {
+			        ""actions"": {
+			          ""searchable_snapshot"" : {
+			            ""snapshot_repository"" : ""backing_repo""
+			          }
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("ilm/policy-definitions.asciidoc:663")]
+		public void Line663()
 		{
 			// tag::149a0eea54cdf6ea3052af6dba2d2a63[]
 			var response0 = new SearchResponse<object>();
@@ -402,8 +426,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:664")]
-		public void Line664()
+		[Description("ilm/policy-definitions.asciidoc:715")]
+		public void Line715()
 		{
 			// tag::f3b4ddce8ff21fc1a76a7c0d9c36650e[]
 			var response0 = new SearchResponse<object>();
@@ -426,8 +450,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:721")]
-		public void Line721()
+		[Description("ilm/policy-definitions.asciidoc:772")]
+		public void Line772()
 		{
 			// tag::a5a58e8ad66afe831bc295500e3e8739[]
 			var response0 = new SearchResponse<object>();
@@ -448,8 +472,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/policy-definitions.asciidoc:746")]
-		public void Line746()
+		[Description("ilm/policy-definitions.asciidoc:797")]
+		public void Line797()
 		{
 			// tag::d14a2a6c2a8b084495b8a64708226650[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/SetUpLifecyclePolicyPage.cs
+++ b/tests/Examples/Ilm/SetUpLifecyclePolicyPage.cs
@@ -37,8 +37,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/set-up-lifecycle-policy.asciidoc:54")]
-		public void Line54()
+		[Description("ilm/set-up-lifecycle-policy.asciidoc:59")]
+		public void Line59()
 		{
 			// tag::3c9d99215a7020ab478bdf5c8287a14f[]
 			var response0 = new SearchResponse<object>();
@@ -57,8 +57,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/set-up-lifecycle-policy.asciidoc:85")]
-		public void Line85()
+		[Description("ilm/set-up-lifecycle-policy.asciidoc:90")]
+		public void Line90()
 		{
 			// tag::25737fd456fd317cc4cc2db76b6cf28e[]
 			var response0 = new SearchResponse<object>();
@@ -75,8 +75,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/set-up-lifecycle-policy.asciidoc:108")]
-		public void Line108()
+		[Description("ilm/set-up-lifecycle-policy.asciidoc:113")]
+		public void Line113()
 		{
 			// tag::160d259243d0800900b065c4b9d2b187[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ilm/UpdateLifecyclePolicyPage.cs
+++ b/tests/Examples/Ilm/UpdateLifecyclePolicyPage.cs
@@ -67,8 +67,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/update-lifecycle-policy.asciidoc:142")]
-		public void Line142()
+		[Description("ilm/update-lifecycle-policy.asciidoc:144")]
+		public void Line144()
 		{
 			// tag::fc541f5741c1fe052439ededa84ffe8a[]
 			var response0 = new SearchResponse<object>();
@@ -97,8 +97,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/update-lifecycle-policy.asciidoc:182")]
-		public void Line182()
+		[Description("ilm/update-lifecycle-policy.asciidoc:184")]
+		public void Line184()
 		{
 			// tag::0f6fa3a706a7c17858d3dbe329839ea6[]
 			var response0 = new SearchResponse<object>();
@@ -108,8 +108,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/update-lifecycle-policy.asciidoc:225")]
-		public void Line225()
+		[Description("ilm/update-lifecycle-policy.asciidoc:227")]
+		public void Line227()
 		{
 			// tag::f94601bc9cd640adb939af67116a40c8[]
 			var response0 = new SearchResponse<object>();
@@ -139,8 +139,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/update-lifecycle-policy.asciidoc:304")]
-		public void Line304()
+		[Description("ilm/update-lifecycle-policy.asciidoc:306")]
+		public void Line306()
 		{
 			// tag::416c65c55a53d0161426cc09ae999c72[]
 			var response0 = new SearchResponse<object>();
@@ -170,8 +170,8 @@ namespace Examples.Ilm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ilm/update-lifecycle-policy.asciidoc:494")]
-		public void Line494()
+		[Description("ilm/update-lifecycle-policy.asciidoc:496")]
+		public void Line496()
 		{
 			// tag::552b6761ef052efa1e83f8a3c30d6f78[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/CreateIndexPage.cs
+++ b/tests/Examples/Indices/CreateIndexPage.cs
@@ -49,8 +49,6 @@ namespace Examples.Indices
 						{ "index.number_of_replicas", 2 }
 					};
 				});
-
-				return e;
 			});
 		}
 
@@ -83,8 +81,6 @@ namespace Examples.Indices
 						{ "index.number_of_replicas", 2 },
 					};
 				});
-
-				return e;
 			});
 		}
 
@@ -126,8 +122,6 @@ namespace Examples.Indices
 						{ "index.number_of_shards", 1 },
 					};
 				});
-
-				return e;
 			});
 		}
 
@@ -163,7 +157,6 @@ namespace Examples.Indices
 			}", e =>
 			{
 				e.ApplyBodyChanges(b => { b["aliases"]["alias_2"]["filter"]["term"]["user"].ToLongFormTermQuery(); });
-				return e;
 			});
 		}
 
@@ -203,7 +196,6 @@ namespace Examples.Indices
 			{
 				e.Uri.Query = null;
 				e.ApplyBodyChanges(b => { b["settings"] = new JObject { { "index.write.wait_for_active_shards", "2" } }; });
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Indices/GetFieldMappingPage.cs
+++ b/tests/Examples/Indices/GetFieldMappingPage.cs
@@ -18,8 +18,8 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("indices/get-field-mapping.asciidoc:65")]
-		public void Line65()
+		[Description("indices/get-field-mapping.asciidoc:63")]
+		public void Line63()
 		{
 			// tag::f0f0f778e19134fbe3e4be98fc47bd34[]
 			var response0 = new SearchResponse<object>();
@@ -44,8 +44,8 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("indices/get-field-mapping.asciidoc:87")]
-		public void Line87()
+		[Description("indices/get-field-mapping.asciidoc:85")]
+		public void Line85()
 		{
 			// tag::299900fb08da80fe455cf3f1bb7d62ee[]
 			var response0 = new SearchResponse<object>();
@@ -55,8 +55,8 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("indices/get-field-mapping.asciidoc:120")]
-		public void Line120()
+		[Description("indices/get-field-mapping.asciidoc:118")]
+		public void Line118()
 		{
 			// tag::ed3bdf4d6799b43526851e92b6a60c55[]
 			var response0 = new SearchResponse<object>();
@@ -66,8 +66,8 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("indices/get-field-mapping.asciidoc:156")]
-		public void Line156()
+		[Description("indices/get-field-mapping.asciidoc:154")]
+		public void Line154()
 		{
 			// tag::b61afb7ca29a11243232ffcc8b5a43cf[]
 			var response0 = new SearchResponse<object>();
@@ -77,8 +77,8 @@ namespace Examples.Indices
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("indices/get-field-mapping.asciidoc:208")]
-		public void Line208()
+		[Description("indices/get-field-mapping.asciidoc:206")]
+		public void Line206()
 		{
 			// tag::9af393bb38bf098d65d00e7637824f44[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Indices/TemplatesPage.cs
+++ b/tests/Examples/Indices/TemplatesPage.cs
@@ -51,7 +51,6 @@ namespace Examples.Indices
 			}", e =>
 			{
 				e.AdjustIndexSettings();
-				return e;
 			});
 		}
 
@@ -98,7 +97,6 @@ namespace Examples.Indices
 			{
 				e.AdjustIndexSettings();
 				e.ApplyBodyChanges(o => o["aliases"]["alias2"]["filter"]["term"]["user"].ToLongFormTermQuery());
-				return e;
 			});
 		}
 
@@ -143,7 +141,6 @@ namespace Examples.Indices
 			}", e =>
 			{
 				e.AdjustIndexSettings();
-				return e;
 			});
 
 			putIndexTemplateResponse2.MatchesExample(@"PUT /_template/template_2
@@ -159,7 +156,6 @@ namespace Examples.Indices
 			}", e =>
 			{
 				e.AdjustIndexSettings();
-				return e;
 			});
 		}
 
@@ -189,7 +185,6 @@ namespace Examples.Indices
 			}", e =>
 			{
 				e.AdjustIndexSettings();
-				return e;
 			});
 		}
 

--- a/tests/Examples/Indices/TemplatesPage.cs
+++ b/tests/Examples/Indices/TemplatesPage.cs
@@ -56,8 +56,8 @@ namespace Examples.Indices
 		}
 
 		[U]
-		[Description("indices/templates.asciidoc:138")]
-		public void Line138()
+		[Description("indices/templates.asciidoc:136")]
+		public void Line136()
 		{
 			// tag::1b8caf0a6741126c6d0ad83b56fce290[]
 			var putIndexTemplateResponse = client.Indices.PutTemplate("template_1", t => t
@@ -103,8 +103,8 @@ namespace Examples.Indices
 		}
 
 		[U]
-		[Description("indices/templates.asciidoc:172")]
-		public void Line172()
+		[Description("indices/templates.asciidoc:170")]
+		public void Line170()
 		{
 			// tag::b5f95bc097a201b29c7200fc8d3d31c1[]
 			var putIndexTemplateResponse1 = client.Indices.PutTemplate("template_1", t => t
@@ -164,8 +164,8 @@ namespace Examples.Indices
 		}
 
 		[U]
-		[Description("indices/templates.asciidoc:223")]
-		public void Line223()
+		[Description("indices/templates.asciidoc:221")]
+		public void Line221()
 		{
 			// tag::9166cf38427d5cde5d2ec12a2012b669[]
 			var putIndexTemplateResponse1 = client.Indices.PutTemplate("template_1", t => t
@@ -194,8 +194,8 @@ namespace Examples.Indices
 		}
 
 		[U]
-		[Description("indices/templates.asciidoc:241")]
-		public void Line241()
+		[Description("indices/templates.asciidoc:239")]
+		public void Line239()
 		{
 			// tag::46658f00edc4865dfe472a392374cd0f[]
 			var getIndexTemplateResponse = client.Indices.GetTemplate("template_1", t => t.FilterPath(new[] { "*.version" }));

--- a/tests/Examples/Ingest/EnrichPage.cs
+++ b/tests/Examples/Ingest/EnrichPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ingest
 	public class EnrichPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:305")]
-		public void Line305()
+		[Description("ingest/enrich.asciidoc:321")]
+		public void Line321()
 		{
 			// tag::0c8bce944c1189a8551e8dbd99c365f2[]
 			var response0 = new SearchResponse<object>();
@@ -30,8 +30,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:324")]
-		public void Line324()
+		[Description("ingest/enrich.asciidoc:340")]
+		public void Line340()
 		{
 			// tag::497a51622ef123efc44e54ba2106385e[]
 			var response0 = new SearchResponse<object>();
@@ -48,8 +48,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:346")]
-		public void Line346()
+		[Description("ingest/enrich.asciidoc:362")]
+		public void Line362()
 		{
 			// tag::99da25a3d63f98c16df47f21acbf37e7[]
 			var response0 = new SearchResponse<object>();
@@ -66,8 +66,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:362")]
-		public void Line362()
+		[Description("ingest/enrich.asciidoc:378")]
+		public void Line378()
 		{
 			// tag::207c04ccbdce0e8a289070a3b0a79ecb[]
 			var response0 = new SearchResponse<object>();
@@ -77,8 +77,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:381")]
-		public void Line381()
+		[Description("ingest/enrich.asciidoc:397")]
+		public void Line397()
 		{
 			// tag::83b4a737514a047d31f12f110bed0b5e[]
 			var response0 = new SearchResponse<object>();
@@ -101,8 +101,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:403")]
-		public void Line403()
+		[Description("ingest/enrich.asciidoc:419")]
+		public void Line419()
 		{
 			// tag::ad3b9d676187bebdb62e0f1de9a202e0[]
 			var response0 = new SearchResponse<object>();
@@ -117,8 +117,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:417")]
-		public void Line417()
+		[Description("ingest/enrich.asciidoc:433")]
+		public void Line433()
 		{
 			// tag::a3f3c1f3f31dbd225da5fd14633bc4a0[]
 			var response0 = new SearchResponse<object>();
@@ -128,8 +128,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:478")]
-		public void Line478()
+		[Description("ingest/enrich.asciidoc:494")]
+		public void Line494()
 		{
 			// tag::927dd38daa489175a5008799452e870a[]
 			var response0 = new SearchResponse<object>();
@@ -149,8 +149,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:502")]
-		public void Line502()
+		[Description("ingest/enrich.asciidoc:518")]
+		public void Line518()
 		{
 			// tag::9ab4e8a564e13475cb3a0376be56bb8e[]
 			var response0 = new SearchResponse<object>();
@@ -167,8 +167,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:518")]
-		public void Line518()
+		[Description("ingest/enrich.asciidoc:534")]
+		public void Line534()
 		{
 			// tag::af4f82ce86672a9bafd834f334c8e1c9[]
 			var response0 = new SearchResponse<object>();
@@ -178,8 +178,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:535")]
-		public void Line535()
+		[Description("ingest/enrich.asciidoc:551")]
+		public void Line551()
 		{
 			// tag::958b661d89b2beeb0cfefe8edbe3e408[]
 			var response0 = new SearchResponse<object>();
@@ -202,8 +202,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:557")]
-		public void Line557()
+		[Description("ingest/enrich.asciidoc:573")]
+		public void Line573()
 		{
 			// tag::7495d7e8d99e4f5ac8034988b706e09d[]
 			var response0 = new SearchResponse<object>();
@@ -216,8 +216,8 @@ namespace Examples.Ingest
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ingest/enrich.asciidoc:569")]
-		public void Line569()
+		[Description("ingest/enrich.asciidoc:585")]
+		public void Line585()
 		{
 			// tag::ce20ab8067b6e4ad68e8ad7a5a0b73fd[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
+++ b/tests/Examples/Mapping/Dynamic/TemplatesPage.cs
@@ -194,7 +194,6 @@ namespace Examples.Mapping.Dynamic
 				{
 					body["mappings"]["dynamic_templates"][0]["full_name"]["mapping"]["copy_to"] = new JArray("full_name");
 				});
-				return e;
 			});
 
 			indexResponse.MatchesExample(@"PUT my_index/_doc/1

--- a/tests/Examples/Mapping/Params/AnalyzerPage.cs
+++ b/tests/Examples/Mapping/Params/AnalyzerPage.cs
@@ -6,51 +6,10 @@ namespace Examples.Mapping.Params
 {
 	public class AnalyzerPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
-		[Description("mapping/params/analyzer.asciidoc:43")]
-		public void Line43()
-		{
-			// tag::0ae23713026515ec5047c7bbcf9842f7[]
-			var response0 = new SearchResponse<object>();
-
-			var response1 = new SearchResponse<object>();
-
-			var response2 = new SearchResponse<object>();
-			// end::0ae23713026515ec5047c7bbcf9842f7[]
-
-			response0.MatchesExample(@"PUT /my_index
-			{
-			  ""mappings"": {
-			    ""properties"": {
-			      ""text"": { \<1>
-			        ""type"": ""text"",
-			        ""fields"": {
-			          ""english"": { \<2>
-			            ""type"":     ""text"",
-			            ""analyzer"": ""english""
-			          }
-			        }
-			      }
-			    }
-			  }
-			}");
-
-			response1.MatchesExample(@"GET my_index/_analyze \<3>
-			{
-			  ""field"": ""text"",
-			  ""text"": ""The quick Brown Foxes.""
-			}");
-
-			response2.MatchesExample(@"GET my_index/_analyze \<4>
-			{
-			  ""field"": ""text.english"",
-			  ""text"": ""The quick Brown Foxes.""
-			}");
-		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("mapping/params/analyzer.asciidoc:93")]
-		public void Line93()
+		[Description("mapping/params/analyzer.asciidoc:35")]
+		public void Line35()
 		{
 			// tag::5bf1e4194dce1e15eb7f48fd72b1fc6b[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Params/FormatPage.cs
+++ b/tests/Examples/Mapping/Params/FormatPage.cs
@@ -6,15 +6,24 @@ namespace Examples.Mapping.Params
 {
 	public class FormatPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("mapping/params/format.asciidoc:13")]
 		public void Line13()
 		{
 			// tag::7f465b7e8ed42df6c42251b4481e699e[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map<object>(m => m
+					.Properties(p => p
+						.Date(d => d
+							.Name("date")
+							.Format("yyyy-MM-dd")
+						)
+					)
+				)
+			);
 			// end::7f465b7e8ed42df6c42251b4481e699e[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""properties"": {

--- a/tests/Examples/Mapping/Params/NormalizerPage.cs
+++ b/tests/Examples/Mapping/Params/NormalizerPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Mapping.Params
 	public class NormalizerPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("mapping/params/normalizer.asciidoc:14")]
-		public void Line14()
+		[Description("mapping/params/normalizer.asciidoc:18")]
+		public void Line18()
 		{
 			// tag::4cd40113e0fc90c37976f28d7e4a2327[]
 			var response0 = new SearchResponse<object>();
@@ -86,8 +86,8 @@ namespace Examples.Mapping.Params
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("mapping/params/normalizer.asciidoc:121")]
-		public void Line121()
+		[Description("mapping/params/normalizer.asciidoc:125")]
+		public void Line125()
 		{
 			// tag::6f842819c50e8490080dd085e0c6aca3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/DateNanosPage.cs
+++ b/tests/Examples/Mapping/Types/DateNanosPage.cs
@@ -10,7 +10,7 @@ namespace Examples.Mapping.Types
 		[Description("mapping/types/date_nanos.asciidoc:32")]
 		public void Line32()
 		{
-			// tag::46dd5948cfc34adf1dfe024fc960bb01[]
+			// tag::5e11eb4d328005434b19bbb9b11a3685[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
@@ -24,7 +24,7 @@ namespace Examples.Mapping.Types
 			var response5 = new SearchResponse<object>();
 
 			var response6 = new SearchResponse<object>();
-			// end::46dd5948cfc34adf1dfe024fc960bb01[]
+			// end::5e11eb4d328005434b19bbb9b11a3685[]
 
 			response0.MatchesExample(@"PUT my_index
 			{
@@ -67,7 +67,7 @@ namespace Examples.Mapping.Types
 			{
 			  ""docvalue_fields"" : [
 			    {
-			      ""field"" : ""my_ip_field"",
+			      ""field"" : ""date"",
 			      ""format"": ""strict_date_time"" <7>
 			    }
 			  ]

--- a/tests/Examples/Mapping/Types/HistogramPage.cs
+++ b/tests/Examples/Mapping/Types/HistogramPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Mapping.Types
 	public class HistogramPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("mapping/types/histogram.asciidoc:74")]
-		public void Line74()
+		[Description("mapping/types/histogram.asciidoc:73")]
+		public void Line73()
 		{
 			// tag::7d6b1797b1178e96d287831a94bb9658[]
 			var response0 = new SearchResponse<object>();
@@ -30,8 +30,8 @@ namespace Examples.Mapping.Types
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("mapping/types/histogram.asciidoc:94")]
-		public void Line94()
+		[Description("mapping/types/histogram.asciidoc:93")]
+		public void Line93()
 		{
 			// tag::09774dd1a8613672844caadb2bc8dc1e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Mapping/Types/NestedPage.cs
+++ b/tests/Examples/Mapping/Types/NestedPage.cs
@@ -1,20 +1,32 @@
+using System.Collections.Generic;
 using Elastic.Xunit.XunitPlumbing;
-using Nest;
 using System.ComponentModel;
+using Examples.Models;
 
 namespace Examples.Mapping.Types
 {
 	public class NestedPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("mapping/types/nested.asciidoc:19")]
 		public void Line19()
 		{
 			// tag::8baccd8688a6bad1749b8935f9601ea4[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new GroupDoc
+			{
+				Group = "fans",
+				User = new List<User>
+					{
+						new User { First = "John", Last = "Smith" },
+						new User { First = "Alice", Last = "White" }
+					}
+			}, i => i
+			.Index("my_index")
+			.Id(1)
+			);
 			// end::8baccd8688a6bad1749b8935f9601ea4[]
 
-			response0.MatchesExample(@"PUT my_index/_doc/1
+			indexResponse.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""group"" : ""fans"",
 			  ""user"" : [ \<1>
@@ -30,15 +42,27 @@ namespace Examples.Mapping.Types
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("mapping/types/nested.asciidoc:55")]
 		public void Line55()
 		{
 			// tag::b214942b938e47f2c486e523546cb574[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<GroupDoc>(s => s
+				.Index("my_index")
+				.Query(q => q
+					.Match(m => m
+						.Field(f => f.User[0].First) // <1> An expression to build a path to the field `user.first` from the `GroupDoc` type.
+						.Query("Alice")
+					) && q
+					.Match(m => m
+						.Field(f => f.User[0].Last) // <2> An expression to build a path to the field `user.last` from the `GroupDoc` type.
+						.Query("Smith")
+					)
+				)
+			);
 			// end::b214942b938e47f2c486e523546cb574[]
 
-			response0.MatchesExample(@"GET my_index/_search
+			searchResponse.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""bool"": {
@@ -48,24 +72,88 @@ namespace Examples.Mapping.Types
 			      ]
 			    }
 			  }
-			}");
+			}", (example, body) =>
+			{
+				body["query"]["bool"]["must"][0]["match"]["user.first"].ToLongFormQuery();
+				body["query"]["bool"]["must"][1]["match"]["user.last"].ToLongFormQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("mapping/types/nested.asciidoc:80")]
 		public void Line80()
 		{
 			// tag::b919f88e6f47a40d5793479440a90ba6[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map<GroupDoc>(m => m
+					.Properties(p => p
+						.Nested<User>(n => n
+							.Name(nn => nn.User)
+						)
+					)
+				)
+			);
 
-			var response1 = new SearchResponse<object>();
+			var indexResponse = client.Index(new GroupDoc
+			{
+				Group = "fans",
+				User = new List<User>
+					{
+						new User { First = "John", Last = "Smith" },
+						new User { First = "Alice", Last = "White" }
+					}
+			}, i => i
+				.Index("my_index")
+				.Id(1)
+			);
 
-			var response2 = new SearchResponse<object>();
+			var searchResponse = client.Search<GroupDoc>(s => s
+				.Index("my_index")
+				.Query(q => q
+					.Nested(n => n
+						.Path(p => p.User)
+						.Query(nq => nq
+							.Match(m => m
+								.Field(f => f.User[0].First)
+								.Query("Alice")
+							) && nq
+							.Match(m => m
+								.Field(f => f.User[0].Last)
+								.Query("Smith")
+							)
+						)
+					)
+				)
+			);
 
-			var response3 = new SearchResponse<object>();
+			var searchResponse2 = client.Search<GroupDoc>(s => s
+				.Index("my_index")
+				.Query(q => q
+					.Nested(n => n
+						.Path(p => p.User)
+						.Query(nq => nq
+							.Match(m => m
+								.Field(f => f.User[0].First)
+								.Query("Alice")
+							) && nq
+							.Match(m => m
+								.Field(f => f.User[0].Last)
+								.Query("White")
+							)
+						)
+						.InnerHits(i => i
+							.Highlight(h => h
+								.Fields(hf => hf
+									.Field(f => f.User[0].First)
+								)
+							)
+						)
+					)
+				)
+			);
 			// end::b919f88e6f47a40d5793479440a90ba6[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			  ""mappings"": {
 			    ""properties"": {
@@ -76,7 +164,7 @@ namespace Examples.Mapping.Types
 			  }
 			}");
 
-			response1.MatchesExample(@"PUT my_index/_doc/1
+			indexResponse.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""group"" : ""fans"",
 			  ""user"" : [
@@ -91,7 +179,7 @@ namespace Examples.Mapping.Types
 			  ]
 			}");
 
-			response2.MatchesExample(@"GET my_index/_search
+			searchResponse.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""nested"": {
@@ -106,9 +194,13 @@ namespace Examples.Mapping.Types
 			      }
 			    }
 			  }
-			}");
+			}", (example, body) =>
+			{
+				body["query"]["nested"]["query"]["bool"]["must"][0]["match"]["user.first"].ToLongFormQuery();
+				body["query"]["nested"]["query"]["bool"]["must"][1]["match"]["user.last"].ToLongFormQuery();
+			});
 
-			response3.MatchesExample(@"GET my_index/_search
+			searchResponse2.MatchesExample(@"GET my_index/_search
 			{
 			  ""query"": {
 			    ""nested"": {
@@ -130,7 +222,11 @@ namespace Examples.Mapping.Types
 			      }
 			    }
 			  }
-			}");
+			}", (example, body) =>
+			{
+				body["query"]["nested"]["query"]["bool"]["must"][0]["match"]["user.first"].ToLongFormQuery();
+				body["query"]["nested"]["query"]["bool"]["must"][1]["match"]["user.last"].ToLongFormQuery();
+			});
 		}
 	}
 }

--- a/tests/Examples/Mapping/Types/SearchAsYouTypePage.cs
+++ b/tests/Examples/Mapping/Types/SearchAsYouTypePage.cs
@@ -61,7 +61,6 @@ namespace Examples.Mapping.Types
 			{
 				// query string params always need a value
 				e.Uri.Query = e.Uri.Query.Replace("refresh", "refresh=true");
-				return e;
 			});
 		}
 
@@ -133,7 +132,6 @@ namespace Examples.Mapping.Types
 					var value = body["query"]["match_phrase_prefix"]["my_field"];
 					body["query"]["match_phrase_prefix"]["my_field"] = new JObject { { "query", value } };
 				});
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Mapping/Types/WildcardPage.cs
+++ b/tests/Examples/Mapping/Types/WildcardPage.cs
@@ -1,0 +1,49 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Mapping.Types
+{
+	public class WildcardPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("mapping/types/wildcard.asciidoc:23")]
+		public void Line23()
+		{
+			// tag::4f272d2d69153037c3eba5864745b23e[]
+			var response0 = new SearchResponse<object>();
+
+			var response1 = new SearchResponse<object>();
+
+			var response2 = new SearchResponse<object>();
+
+			var response3 = new SearchResponse<object>();
+			// end::4f272d2d69153037c3eba5864745b23e[]
+
+			response0.MatchesExample(@"PUT my_index
+			{
+			  ""mappings"": {
+			    ""properties"": {
+			      ""my_wildcard"": {
+			        ""type"": ""wildcard""
+			      }
+			    }
+			  }
+			}");
+
+			response1.MatchesExample(@"PUT my_index/_doc/1
+			{
+			  ""my_wildcard"" : ""This string can be quite lengthy""
+			}");
+
+			response2.MatchesExample(@"POST my_index/_doc/_search
+			{
+			  ""query"": {
+			      ""wildcard"" : ""*quite*lengthy""
+			  }
+			}");
+
+			response3.MatchesExample(@"");
+		}
+	}
+}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/EstimateModelMemoryPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/EstimateModelMemoryPage.cs
@@ -1,0 +1,42 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Ml.AnomalyDetection.Apis
+{
+	public class EstimateModelMemoryPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("ml/anomaly-detection/apis/estimate-model-memory.asciidoc:60")]
+		public void Line60()
+		{
+			// tag::c4178795c108b4ed3daec4e69aa2acc6[]
+			var response0 = new SearchResponse<object>();
+			// end::c4178795c108b4ed3daec4e69aa2acc6[]
+
+			response0.MatchesExample(@"POST _ml/anomaly_detectors/_estimate_model_memory
+			{
+			    ""analysis_config"": {
+			        ""bucket_span"": ""5m"",
+			        ""detectors"": [
+			          {
+			            ""function"": ""sum"",
+			            ""field_name"": ""bytes"",
+			            ""by_field_name"": ""status"",
+			            ""partition_field_name"": ""app""
+			          }
+			        ],
+			        ""influencers"": [ ""source_ip"", ""dest_ip"" ]
+			    },
+			    ""overall_cardinality"": {
+			       ""status"": 10,
+			       ""app"": 50
+			    },
+			    ""max_bucket_cardinality"": {
+			       ""source_ip"": 300,
+			       ""dest_ip"": 30
+			    }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/FlushJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/FlushJobPage.cs
@@ -24,13 +24,13 @@ namespace Examples.Ml.AnomalyDetection.Apis
 		[Description("ml/anomaly-detection/apis/flush-job.asciidoc:98")]
 		public void Line98()
 		{
-			// tag::3033133e8675524fd8f969db0625b62e[]
+			// tag::7ebfb30b3ece855c1b783d9210939469[]
 			var response0 = new SearchResponse<object>();
-			// end::3033133e8675524fd8f969db0625b62e[]
+			// end::7ebfb30b3ece855c1b783d9210939469[]
 
 			response0.MatchesExample(@"POST _ml/anomaly_detectors/total-requests/_flush
 			{
-			  ""advance_time"": ""1514804400""
+			  ""advance_time"": ""1514804400000""
 			}");
 		}
 	}

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetBucketPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetBucketPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetBucketPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-bucket.asciidoc:174")]
-		public void Line174()
+		[Description("ml/anomaly-detection/apis/get-bucket.asciidoc:178")]
+		public void Line178()
 		{
 			// tag::f96d4614f2fc294339fef325b794355f[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetCategoryPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetCategoryPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetCategoryPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-category.asciidoc:100")]
-		public void Line100()
+		[Description("ml/anomaly-detection/apis/get-category.asciidoc:110")]
+		public void Line110()
 		{
 			// tag::e8f1c9ee003d115ec8f55e57990df6e4[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetDatafeedStatsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetDatafeedStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-datafeed-stats.asciidoc:135")]
-		public void Line135()
+		[Description("ml/anomaly-detection/apis/get-datafeed-stats.asciidoc:145")]
+		public void Line145()
 		{
 			// tag::f44d287c6937785eb09b91353c1deb1e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetJobStatsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetJobStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-job-stats.asciidoc:333")]
-		public void Line333()
+		[Description("ml/anomaly-detection/apis/get-job-stats.asciidoc:361")]
+		public void Line361()
 		{
 			// tag::9298aaf8232a819e79b3bf8471245e98[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/GetSnapshotPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/GetSnapshotPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class GetSnapshotPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/get-snapshot.asciidoc:193")]
-		public void Line193()
+		[Description("ml/anomaly-detection/apis/get-snapshot.asciidoc:200")]
+		public void Line200()
 		{
 			// tag::c873f9cd093e26515148f052e28c7805[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PostCalendarEventPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PostCalendarEventPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PostCalendarEventPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/post-calendar-event.asciidoc:63")]
-		public void Line63()
+		[Description("ml/anomaly-detection/apis/post-calendar-event.asciidoc:64")]
+		public void Line64()
 		{
 			// tag::c067182d385f59ce5952fb9a716fbf05[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PreviewDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PreviewDatafeedPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PreviewDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/preview-datafeed.asciidoc:51")]
-		public void Line51()
+		[Description("ml/anomaly-detection/apis/preview-datafeed.asciidoc:57")]
+		public void Line57()
 		{
 			// tag::38eed000de433b540116928681c520d3[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutDatafeedPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/put-datafeed.asciidoc:110")]
-		public void Line110()
+		[Description("ml/anomaly-detection/apis/put-datafeed.asciidoc:114")]
+		public void Line114()
 		{
 			// tag::23067c5e8da958fa4d914f3b5c9bf607[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/PutJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/PutJobPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class PutJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/put-job.asciidoc:239")]
-		public void Line239()
+		[Description("ml/anomaly-detection/apis/put-job.asciidoc:272")]
+		public void Line272()
 		{
 			// tag::9c11e238772d67dbc9d273776de9916c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateDatafeedPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateDatafeedPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateDatafeedPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/update-datafeed.asciidoc:112")]
-		public void Line112()
+		[Description("ml/anomaly-detection/apis/update-datafeed.asciidoc:119")]
+		public void Line119()
 		{
 			// tag::df6d5b5f8e1c8785503269ccb7b34763[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/AnomalyDetection/Apis/UpdateJobPage.cs
+++ b/tests/Examples/Ml/AnomalyDetection/Apis/UpdateJobPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.AnomalyDetection.Apis
 	public class UpdateJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/anomaly-detection/apis/update-job.asciidoc:172")]
-		public void Line172()
+		[Description("ml/anomaly-detection/apis/update-job.asciidoc:212")]
+		public void Line212()
 		{
 			// tag::421e68e2b9789f0e8c08760d9e685d1c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/ExplainDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/ExplainDfanalyticsPage.cs
@@ -7,23 +7,21 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class ExplainDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/explain-dfanalytics.asciidoc:88")]
-		public void Line88()
+		[Description("ml/df-analytics/apis/explain-dfanalytics.asciidoc:124")]
+		public void Line124()
 		{
-			// tag::1e75b0e71294527b43015cc333f9d9f7[]
+			// tag::8aa17bd25a3f2d634e5253b4b72fec4c[]
 			var response0 = new SearchResponse<object>();
-			// end::1e75b0e71294527b43015cc333f9d9f7[]
+			// end::8aa17bd25a3f2d634e5253b4b72fec4c[]
 
 			response0.MatchesExample(@"POST _ml/data_frame/analytics/_explain
 			{
-			  ""data_frame_analytics_config"": {
-			    ""source"": {
-			      ""index"": ""houses_sold_last_10_yrs""
-			    },
-			    ""analysis"": {
-			      ""regression"": {
-			        ""dependent_variable"": ""price""
-			      }
+			  ""source"": {
+			    ""index"": ""houses_sold_last_10_yrs""
+			  },
+			  ""analysis"": {
+			    ""regression"": {
+			      ""dependent_variable"": ""price""
 			    }
 			  }
 			}");

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class GetDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/get-dfanalytics.asciidoc:98")]
-		public void Line98()
+		[Description("ml/df-analytics/apis/get-dfanalytics.asciidoc:183")]
+		public void Line183()
 		{
 			// tag::5ccfd9f4698dcd7cdfbc6bad60081aab[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsStatsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetDfanalyticsStatsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class GetDfanalyticsStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/get-dfanalytics-stats.asciidoc:85")]
-		public void Line85()
+		[Description("ml/df-analytics/apis/get-dfanalytics-stats.asciidoc:84")]
+		public void Line84()
 		{
 			// tag::cfc52956b005d57111c49dfe1735634e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/GetInferenceTrainedModelPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class GetInferenceTrainedModelPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/get-inference-trained-model.asciidoc:108")]
-		public void Line108()
+		[Description("ml/df-analytics/apis/get-inference-trained-model.asciidoc:164")]
+		public void Line164()
 		{
 			// tag::f97c7791a0dd23aad5f96fd38ec7d12e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/PutDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/PutDfanalyticsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class PutDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:291")]
-		public void Line291()
+		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:414")]
+		public void Line414()
 		{
 			// tag::8c6f3bb8abae9ff1d21e776f16ad1c86[]
 			var response0 = new SearchResponse<object>();
@@ -56,8 +56,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:363")]
-		public void Line363()
+		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:486")]
+		public void Line486()
 		{
 			// tag::ce3c391c2b1915cfc44a2917bca71d19[]
 			var response0 = new SearchResponse<object>();
@@ -83,8 +83,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:426")]
-		public void Line426()
+		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:549")]
+		public void Line549()
 		{
 			// tag::e8211247c280a3fbbbdd32850b743b7b[]
 			var response0 = new SearchResponse<object>();
@@ -108,8 +108,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:483")]
-		public void Line483()
+		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:606")]
+		public void Line606()
 		{
 			// tag::ae82eb17c23cb8e5761cb6240a5ed0a6[]
 			var response0 = new SearchResponse<object>();
@@ -135,8 +135,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:517")]
-		public void Line517()
+		[Description("ml/df-analytics/apis/put-dfanalytics.asciidoc:640")]
+		public void Line640()
 		{
 			// tag::4fb0629146ca78b85e823edd405497bb[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Ml/DfAnalytics/Apis/StartDfanalyticsPage.cs
+++ b/tests/Examples/Ml/DfAnalytics/Apis/StartDfanalyticsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Ml.DfAnalytics.Apis
 	public class StartDfanalyticsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("ml/df-analytics/apis/start-dfanalytics.asciidoc:57")]
-		public void Line57()
+		[Description("ml/df-analytics/apis/start-dfanalytics.asciidoc:73")]
+		public void Line73()
 		{
 			// tag::1a3a4b8a4bfee4ab84ddd13d8835f560[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Models/GroupDoc.cs
+++ b/tests/Examples/Models/GroupDoc.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Examples.Models
+{
+	public class GroupDoc
+	{
+		public string Group { get; set; }
+		
+		public List<User> User { get; set; }
+	}
+}

--- a/tests/Examples/Models/Tweet.cs
+++ b/tests/Examples/Models/Tweet.cs
@@ -10,6 +10,8 @@ namespace Examples.Models
 
 		public int? Id { get; set; }
 
+		public string Name { get; set; }
+
 		public string Message { get; set; }
 
 		[DataMember(Name = "post_date")]

--- a/tests/Examples/Models/User.cs
+++ b/tests/Examples/Models/User.cs
@@ -1,0 +1,9 @@
+namespace Examples.Models
+{
+	public class User
+	{
+		public string First { get; set; }
+
+		public string Last { get; set; }
+	}
+}

--- a/tests/Examples/Modules/Discovery/AddingRemovingNodesPage.cs
+++ b/tests/Examples/Modules/Discovery/AddingRemovingNodesPage.cs
@@ -10,7 +10,7 @@ namespace Examples.Modules.Discovery
 		[Description("modules/discovery/adding-removing-nodes.asciidoc:64")]
 		public void Line64()
 		{
-			// tag::abcc9f98c6bbaf70aa0b1abf8011d2a4[]
+			// tag::4e1f02928ef243bf07fd425754b7642b[]
 			var response0 = new SearchResponse<object>();
 
 			var response1 = new SearchResponse<object>();
@@ -18,18 +18,18 @@ namespace Examples.Modules.Discovery
 			var response2 = new SearchResponse<object>();
 
 			var response3 = new SearchResponse<object>();
-			// end::abcc9f98c6bbaf70aa0b1abf8011d2a4[]
+			// end::4e1f02928ef243bf07fd425754b7642b[]
 
 			response0.MatchesExample(@"# Add node to voting configuration exclusions list and wait for the system
 			# to auto-reconfigure the node out of the voting configuration up to the
 			# default timeout of 30 seconds");
 
-			response1.MatchesExample(@"POST /_cluster/voting_config_exclusions/node_name");
+			response1.MatchesExample(@"POST /_cluster/voting_config_exclusions?node_names=node_name");
 
 			response2.MatchesExample(@"# Add node to voting configuration exclusions list and wait for
 			# auto-reconfiguration up to one minute");
 
-			response3.MatchesExample(@"POST /_cluster/voting_config_exclusions/node_name?timeout=1m");
+			response3.MatchesExample(@"POST /_cluster/voting_config_exclusions?node_names=node_name&timeout=1m");
 		}
 
 		[U(Skip = "Example not implemented")]

--- a/tests/Examples/Modules/RemoteClustersPage.cs
+++ b/tests/Examples/Modules/RemoteClustersPage.cs
@@ -7,12 +7,12 @@ namespace Examples.Modules
 	public class RemoteClustersPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("modules/remote-clusters.asciidoc:109")]
-		public void Line109()
+		[Description("modules/remote-clusters.asciidoc:133")]
+		public void Line133()
 		{
-			// tag::d4ce5a9672f85094e6d833d08debc018[]
+			// tag::318d8096ad47c1c939776c2ce12758f9[]
 			var response0 = new SearchResponse<object>();
-			// end::d4ce5a9672f85094e6d833d08debc018[]
+			// end::318d8096ad47c1c939776c2ce12758f9[]
 
 			response0.MatchesExample(@"PUT _cluster/settings
 			{
@@ -26,6 +26,7 @@ namespace Examples.Modules
 			          ""transport.ping_schedule"": ""30s""
 			        },
 			        ""cluster_two"": {
+			          ""mode"": ""sniff"",
 			          ""seeds"": [
 			            ""127.0.0.1:9301""
 			          ],
@@ -33,9 +34,8 @@ namespace Examples.Modules
 			          ""skip_unavailable"": true
 			        },
 			        ""cluster_three"": {
-			          ""seeds"": [
-			            ""127.0.0.1:9302""
-			          ]
+			          ""mode"": ""proxy"",
+			          ""proxy_address"": ""127.0.0.1:9302""
 			        }
 			      }
 			    }
@@ -44,12 +44,12 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("modules/remote-clusters.asciidoc:145")]
-		public void Line145()
+		[Description("modules/remote-clusters.asciidoc:170")]
+		public void Line170()
 		{
-			// tag::328b7b4d0de6fac3a91205251de6e9b5[]
+			// tag::0b1aad9e990ae831f392f816dfbd4528[]
 			var response0 = new SearchResponse<object>();
-			// end::328b7b4d0de6fac3a91205251de6e9b5[]
+			// end::0b1aad9e990ae831f392f816dfbd4528[]
 
 			response0.MatchesExample(@"PUT _cluster/settings
 			{
@@ -63,10 +63,16 @@ namespace Examples.Modules
 			          ""transport.ping_schedule"": ""60s""
 			        },
 			        ""cluster_two"": {
+			          ""mode"": ""sniff"",
 			          ""seeds"": [
 			            ""127.0.0.1:9301""
 			          ],
 			          ""transport.compress"": false
+			        },
+			        ""cluster_three"": {
+			          ""mode"": ""proxy"",
+			          ""proxy_address"": ""127.0.0.1:9302"",
+			          ""transport.compress"": true
 			        }
 			      }
 			    }
@@ -75,19 +81,20 @@ namespace Examples.Modules
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("modules/remote-clusters.asciidoc:177")]
-		public void Line177()
+		[Description("modules/remote-clusters.asciidoc:208")]
+		public void Line208()
 		{
-			// tag::2a0d451f9e13aca39467883b16270cc2[]
+			// tag::466bb2bc027f33a611e32fd7a9540eef[]
 			var response0 = new SearchResponse<object>();
-			// end::2a0d451f9e13aca39467883b16270cc2[]
+			// end::466bb2bc027f33a611e32fd7a9540eef[]
 
 			response0.MatchesExample(@"PUT _cluster/settings
 			{
 			  ""persistent"": {
 			    ""cluster"": {
 			      ""remote"": {
-			        ""cluster_two"": { \<1>
+			        ""cluster_two"": { <1>
+			          ""mode"": null,
 			          ""seeds"": null,
 			          ""skip_unavailable"": null,
 			          ""transport"": {

--- a/tests/Examples/QueryDsl/BoolQueryPage.cs
+++ b/tests/Examples/QueryDsl/BoolQueryPage.cs
@@ -79,7 +79,6 @@ namespace Examples.QueryDsl
 					ageQuery["gte"] = 10.0;
 					ageQuery["lte"] = 20.0;
 				});
-				return e;
 			});
 		}
 
@@ -112,7 +111,6 @@ namespace Examples.QueryDsl
 					var filter = b["query"]["bool"]["filter"].ToJArray();
 					filter[0]["term"]["status"].ToLongFormTermQuery();
 				});
-				return e;
 			});
 		}
 

--- a/tests/Examples/QueryDsl/ExistsQueryPage.cs
+++ b/tests/Examples/QueryDsl/ExistsQueryPage.cs
@@ -6,15 +6,22 @@ namespace Examples.QueryDsl
 {
 	public class ExistsQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/exists-query.asciidoc:20")]
 		public void Line20()
 		{
 			// tag::3342c69b2c2303247217532956fcce85[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Exists(e => e
+						.Field("user")
+					)
+				)
+			);
 			// end::3342c69b2c2303247217532956fcce85[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""exists"": {
@@ -24,15 +31,22 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/exists-query.asciidoc:56")]
 		public void Line56()
 		{
 			// tag::43af86de5e49aa06070092fffc138208[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => !q
+					.Exists(e => e
+						.Field("user")
+					)
+				)
+			);
 			// end::43af86de5e49aa06070092fffc138208[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""bool"": {
@@ -43,7 +57,10 @@ namespace Examples.QueryDsl
 			            }
 			        }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["bool"]["must_not"].ToJArray();
+			});
 		}
 	}
 }

--- a/tests/Examples/QueryDsl/MatchQueryPage.cs
+++ b/tests/Examples/QueryDsl/MatchQueryPage.cs
@@ -63,7 +63,6 @@ namespace Examples.QueryDsl
 				{
 					b["query"]["match"]["message"].ToLongFormQuery();
 				});
-				return e;
 			});
 		}
 

--- a/tests/Examples/QueryDsl/QueryFilterContextPage.cs
+++ b/tests/Examples/QueryDsl/QueryFilterContextPage.cs
@@ -51,7 +51,6 @@ namespace Examples.QueryDsl
 					must[1]["match"]["content"].ToLongFormQuery();
 					filter[0]["term"]["status"].ToLongFormTermQuery();
 				});
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/QueryDsl/QueryStringQueryPage.cs
+++ b/tests/Examples/QueryDsl/QueryStringQueryPage.cs
@@ -125,7 +125,6 @@ namespace Examples.QueryDsl
 				{
 					body["query"]["query_string"]["tie_breaker"] = 0d;
 				});
-				return e;
 			});
 		}
 

--- a/tests/Examples/QueryDsl/TermsQueryPage.cs
+++ b/tests/Examples/QueryDsl/TermsQueryPage.cs
@@ -6,15 +6,24 @@ namespace Examples.QueryDsl
 {
 	public class TermsQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/terms-query.asciidoc:19")]
 		public void Line19()
 		{
 			// tag::0c4ad860a485fe53d8140ad3ccd11dcf[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Terms(t => t
+						.Field("user")
+						.Terms("kimchy", "elasticsearch")
+						.Boost(1)
+					)
+				)
+			);
 			// end::0c4ad860a485fe53d8140ad3ccd11dcf[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"" : {
 			        ""terms"" : {
@@ -25,15 +34,23 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/terms-query.asciidoc:127")]
 		public void Line127()
 		{
 			// tag::9e56d79ad9a02b642c361f0b85dd95d7[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map<object>(p => p
+					.Properties(p => p
+						.Keyword(k => k
+							.Name("color")
+						)
+					)
+				)
+			);
 			// end::9e56d79ad9a02b642c361f0b85dd95d7[]
 
-			response0.MatchesExample(@"PUT my_index
+			createIndexResponse.MatchesExample(@"PUT my_index
 			{
 			    ""mappings"" : {
 			        ""properties"" : {
@@ -43,43 +60,68 @@ namespace Examples.QueryDsl
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/terms-query.asciidoc:145")]
 		public void Line145()
 		{
 			// tag::d3088d5fa59b3ab110f64fb4f9b0065c[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new
+			{
+				color = new[] { "blue", "green" }
+			}, i => i
+			.Index("my_index")
+			.Id(1)
+			);
 			// end::d3088d5fa59b3ab110f64fb4f9b0065c[]
 
-			response0.MatchesExample(@"PUT my_index/_doc/1
+			indexResponse.MatchesExample(@"PUT my_index/_doc/1
 			{
 			  ""color"":   [""blue"", ""green""]
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/terms-query.asciidoc:160")]
 		public void Line160()
 		{
 			// tag::8c5977410335d58217e0626618ce6641[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new
+			{
+				color = "blue"
+			}, i => i
+			.Index("my_index")
+			.Id(2)
+			);
 			// end::8c5977410335d58217e0626618ce6641[]
 
-			response0.MatchesExample(@"PUT my_index/_doc/2
+			indexResponse.MatchesExample(@"PUT my_index/_doc/2
 			{
 			  ""color"":   ""blue""
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/terms-query.asciidoc:186")]
 		public void Line186()
 		{
 			// tag::d1bcf2eb63a462bfdcf01a68e68d5b4a[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.Index("my_index")
+				.Pretty()
+				.Query(q => q
+					.Terms(t => t
+						.Field("color")
+						.TermsLookup<object>(l => l
+							.Index("my_index")
+							.Id("2")
+							.Path("color")
+						)
+					)
+				)
+			);
 			// end::d1bcf2eb63a462bfdcf01a68e68d5b4a[]
 
-			response0.MatchesExample(@"GET my_index/_search?pretty
+			searchResponse.MatchesExample(@"GET my_index/_search?pretty
 			{
 			  ""query"": {
 			    ""terms"": {

--- a/tests/Examples/QueryDsl/WildcardQueryPage.cs
+++ b/tests/Examples/QueryDsl/WildcardQueryPage.cs
@@ -6,15 +6,25 @@ namespace Examples.QueryDsl
 {
 	public class WildcardQueryPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("query-dsl/wildcard-query.asciidoc:21")]
 		public void Line21()
 		{
 			// tag::d31062ff8c015387889fed4ad86fd914[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Wildcard(w => w
+						.Field("user")
+						.Value("ki*y")
+						.Boost(1)
+						.Rewrite(MultiTermQueryRewrite.ConstantScore)
+					)
+				)
+			);
 			// end::d31062ff8c015387889fed4ad86fd914[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"": {
 			        ""wildcard"": {

--- a/tests/Examples/ResponseExtensions.cs
+++ b/tests/Examples/ResponseExtensions.cs
@@ -18,23 +18,21 @@ namespace Examples
 		private static readonly JsonSerializer Serializer = new JsonSerializer();
 
 		public static void MatchesExample(this IResponse response, string content, Action<Example, JObject> clientChanges) =>
-			response.MatchesExample(content, c =>
+			response.MatchesExample(content, e =>
 			{
-				c.ApplyBodyChanges(b=> clientChanges(c, b));
-				return c;
+				e.ApplyBodyChanges(b=> clientChanges(e, b));
 			});
 
 		/// <summary>
 		/// Asserts that the client generated request matches the example from the docs
 		/// </summary>
-		public static void MatchesExample(this IResponse response, string content, Func<Example, Example> clientChanges = null)
+		public static void MatchesExample(this IResponse response, string content, Action<Example> clientChanges = null)
 		{
 			var example = Example.Create(content);
 
 			// a specific example might use notation that is not supported by the client, because it only
 			// supports the long form. Allow a function to be passed to make modifications to suit.
-			if (clientChanges != null)
-				example = clientChanges(example);
+			clientChanges?.Invoke(example);
 
 			// apply global changes after local ones
 			example = Example.ApplyGlobalChanges(example);

--- a/tests/Examples/Rollup/Apis/GetJobPage.cs
+++ b/tests/Examples/Rollup/Apis/GetJobPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Rollup.Apis
 	public class GetJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("rollup/apis/get-job.asciidoc:83")]
-		public void Line83()
+		[Description("rollup/apis/get-job.asciidoc:89")]
+		public void Line89()
 		{
 			// tag::d095b422d9803c02b62c01adffc85376[]
 			var response0 = new SearchResponse<object>();
@@ -18,8 +18,8 @@ namespace Examples.Rollup.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("rollup/apis/get-job.asciidoc:156")]
-		public void Line156()
+		[Description("rollup/apis/get-job.asciidoc:164")]
+		public void Line164()
 		{
 			// tag::6d13e0721a7aac00adcdc5fe77198300[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Rollup/Apis/PutJobPage.cs
+++ b/tests/Examples/Rollup/Apis/PutJobPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Rollup.Apis
 	public class PutJobPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("rollup/apis/put-job.asciidoc:223")]
-		public void Line223()
+		[Description("rollup/apis/put-job.asciidoc:247")]
+		public void Line247()
 		{
 			// tag::2025834fab7efbb0542275c30d9d0bfe[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Root/ApiConventionsPage.cs
+++ b/tests/Examples/Root/ApiConventionsPage.cs
@@ -143,8 +143,8 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("api-conventions.asciidoc:404")]
-		public void Line404()
+		[Description("api-conventions.asciidoc:405")]
+		public void Line405()
 		{
 			// tag::5925c23a173a63bdb30b458248d1df76[]
 			var response0 = new SearchResponse<object>();
@@ -154,8 +154,8 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("api-conventions.asciidoc:568")]
-		public void Line568()
+		[Description("api-conventions.asciidoc:570")]
+		public void Line570()
 		{
 			// tag::a6f8636b03cc5f677b7d89e750328612[]
 			var response0 = new SearchResponse<object>();
@@ -165,8 +165,8 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("api-conventions.asciidoc:600")]
-		public void Line600()
+		[Description("api-conventions.asciidoc:602")]
+		public void Line602()
 		{
 			// tag::6d1e75312a28a5ba23837abf768f2510[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Root/FrozenIndicesPage.cs
+++ b/tests/Examples/Root/FrozenIndicesPage.cs
@@ -29,8 +29,8 @@ namespace Examples.Root
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("frozen-indices.asciidoc:106")]
-		public void Line106()
+		[Description("frozen-indices.asciidoc:97")]
+		public void Line97()
 		{
 			// tag::9ff10591660890ba9d00eb14168c3b67[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Root/GettingStartedPage.cs
+++ b/tests/Examples/Root/GettingStartedPage.cs
@@ -81,7 +81,6 @@ namespace Examples.Root
 					var asc = body["sort"][0]["account_number"];
 					body["sort"][0]["account_number"] = new JObject { { "order", asc } };
 				});
-				return e;
 			});
 		}
 
@@ -117,7 +116,6 @@ namespace Examples.Root
 					var sort = body["sort"][0]["account_number"].Value<string>();
 					body["sort"][0]["account_number"] = new JObject { { "order", sort } };
 				});
-				return e;
 			});
 		}
 
@@ -147,7 +145,6 @@ namespace Examples.Root
 				{
 					body["query"]["match"]["address"] = new JObject { { "query", "mill lane" } };
 				});
-				return e;
 			});
 		}
 
@@ -177,7 +174,6 @@ namespace Examples.Root
 				{
 					body["query"]["match_phrase"]["address"] = new JObject { { "query", "mill lane" } };
 				});
-				return e;
 			});
 		}
 
@@ -227,7 +223,6 @@ namespace Examples.Root
 					body["query"]["bool"]["must"][0]["match"]["age"] = new JObject { { "query", "40" } };
 					body["query"]["bool"]["must_not"][0]["match"]["state"] = new JObject { { "query", "ID" } };
 				});
-				return e;
 			});
 		}
 
@@ -282,7 +277,6 @@ namespace Examples.Root
 					filter["range"]["balance"]["lte"] = 30000d;
 					body["query"]["bool"]["filter"] = new JArray(filter);
 				});
-				return e;
 			});
 		}
 
@@ -408,7 +402,6 @@ namespace Examples.Root
 					var order = body["aggs"]["group_by_state"]["terms"]["order"];
 					body["aggs"]["group_by_state"]["terms"]["order"] = new JArray(order);
 				});
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Root/MappingPage.cs
+++ b/tests/Examples/Root/MappingPage.cs
@@ -9,8 +9,8 @@ namespace Examples.Root
 	public class MappingPage : ExampleBase
 	{
 		[U]
-		[Description("mapping.asciidoc:144")]
-		public void Line144()
+		[Description("mapping.asciidoc:137")]
+		public void Line137()
 		{
 			// tag::d8b2a88b5eca99d3691ad3cd40266736[]
 			var createIndexResponse = client.Indices.Create("my-index", c => c
@@ -37,8 +37,8 @@ namespace Examples.Root
 		}
 
 		[U]
-		[Description("mapping.asciidoc:173")]
-		public void Line173()
+		[Description("mapping.asciidoc:166")]
+		public void Line166()
 		{
 			// tag::71ba9033107882f61cdc3b32fc73568d[]
 			var mapResponse = client.Map<Employee>(m => m
@@ -64,8 +64,8 @@ namespace Examples.Root
 		}
 
 		[U]
-		[Description("mapping.asciidoc:211")]
-		public void Line211()
+		[Description("mapping.asciidoc:204")]
+		public void Line204()
 		{
 			// tag::609260ad1d5998be2ca09ff1fe237efa[]
 			var getMappingResponse = client.Indices.GetMapping<Employee>(m => m.Index("my-index"));
@@ -75,8 +75,8 @@ namespace Examples.Root
 		}
 
 		[U]
-		[Description("mapping.asciidoc:257")]
-		public void Line257()
+		[Description("mapping.asciidoc:250")]
+		public void Line250()
 		{
 			// tag::99a52be903945b17e734a1d02a57e958[]
 			var getMappingResponse = client.Indices.GetFieldMapping<Employee>(

--- a/tests/Examples/Root/SearchPage.cs
+++ b/tests/Examples/Root/SearchPage.cs
@@ -126,7 +126,6 @@ namespace Examples.Root
 				{
 					body.Remove("stats");
 				});
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Search/AsyncSearchPage.cs
+++ b/tests/Examples/Search/AsyncSearchPage.cs
@@ -1,0 +1,55 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Search
+{
+	public class AsyncSearchPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("search/async-search.asciidoc:17")]
+		public void Line17()
+		{
+			// tag::e50f9492af9e0174c7ecbe5ad7f09d74[]
+			var response0 = new SearchResponse<object>();
+			// end::e50f9492af9e0174c7ecbe5ad7f09d74[]
+
+			response0.MatchesExample(@"POST /sales*/_async_search?size=0
+			{
+			    ""sort"" : [
+			      { ""date"" : {""order"" : ""asc""} }
+			    ],
+			    ""aggs"" : {
+			        ""sale_date"" : {
+			             ""date_histogram"" : {
+			                 ""field"" : ""date"",
+			                 ""calendar_interval"": ""1d""
+			             }
+			         }
+			    }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("search/async-search.asciidoc:133")]
+		public void Line133()
+		{
+			// tag::14b81f96297952970b78a3216e059596[]
+			var response0 = new SearchResponse<object>();
+			// end::14b81f96297952970b78a3216e059596[]
+
+			response0.MatchesExample(@"GET /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("search/async-search.asciidoc:218")]
+		public void Line218()
+		{
+			// tag::7a3a7fbd81e5050b42e8c1eca26c7c1d[]
+			var response0 = new SearchResponse<object>();
+			// end::7a3a7fbd81e5050b42e8c1eca26c7c1d[]
+
+			response0.MatchesExample(@"DELETE /_async_search/FmRldE8zREVEUzA2ZVpUeGs2ejJFUFEaMkZ5QTVrSTZSaVN3WlNFVmtlWHJsdzoxMDc=");
+		}
+	}
+}

--- a/tests/Examples/Search/MultiSearchPage.cs
+++ b/tests/Examples/Search/MultiSearchPage.cs
@@ -22,8 +22,8 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/multi-search.asciidoc:282")]
-		public void Line282()
+		[Description("search/multi-search.asciidoc:288")]
+		public void Line288()
 		{
 			// tag::05af5eab63bf98d0078dfe661cd81124[]
 			var response0 = new SearchResponse<object>();
@@ -39,8 +39,8 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/multi-search.asciidoc:315")]
-		public void Line315()
+		[Description("search/multi-search.asciidoc:321")]
+		public void Line321()
 		{
 			// tag::a914be2ff7dd0cbdec0257f0ad50b625[]
 			var response0 = new SearchResponse<object>();
@@ -54,8 +54,8 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/multi-search.asciidoc:328")]
-		public void Line328()
+		[Description("search/multi-search.asciidoc:334")]
+		public void Line334()
 		{
 			// tag::28e66ff0ecdd71cb1426880115eab5dd[]
 			var response0 = new SearchResponse<object>();
@@ -77,8 +77,8 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/multi-search.asciidoc:347")]
-		public void Line347()
+		[Description("search/multi-search.asciidoc:353")]
+		public void Line353()
 		{
 			// tag::72e72cb3aa1b10b903d8cadcaddf7d10[]
 			var response0 = new SearchResponse<object>();
@@ -100,8 +100,8 @@ namespace Examples.Search
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/multi-search.asciidoc:367")]
-		public void Line367()
+		[Description("search/multi-search.asciidoc:373")]
+		public void Line373()
 		{
 			// tag::8b4c8f395c0a6f952a42051a0d357154[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/Request/IndexBoostPage.cs
+++ b/tests/Examples/Search/Request/IndexBoostPage.cs
@@ -10,16 +10,16 @@ namespace Examples.Search.Request
 		[Description("search/request/index-boost.asciidoc:11")]
 		public void Line11()
 		{
-			// tag::393c6b7a2e8c3381530c41ff2f7c4991[]
+			// tag::69dce2801f824f61e4f3ea9ee9371e31[]
 			var response0 = new SearchResponse<object>();
-			// end::393c6b7a2e8c3381530c41ff2f7c4991[]
+			// end::69dce2801f824f61e4f3ea9ee9371e31[]
 
 			response0.MatchesExample(@"GET /_search
 			{
-			    ""indices_boost"" : {
-			        ""index1"" : 1.4,
-			        ""index2"" : 1.3
-			    }
+			    ""indices_boost"" : [
+			        { ""index1"" : 1.4 },
+			        { ""index2"" : 1.3 }
+			    ]
 			}");
 		}
 

--- a/tests/Examples/Search/Request/SortPage.cs
+++ b/tests/Examples/Search/Request/SortPage.cs
@@ -1,20 +1,41 @@
 using Elastic.Xunit.XunitPlumbing;
 using Nest;
 using System.ComponentModel;
+using Elasticsearch.Net;
+using Examples.Models;
+using Newtonsoft.Json.Linq;
 
 namespace Examples.Search.Request
 {
 	public class SortPage : ExampleBase
 	{
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:11")]
 		public void Line11()
 		{
 			// tag::d1b3b7d2bb2ab90d15fd10318abd24db[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("my_index", c => c
+				.Map<Tweet>(m => m
+					.Properties(p => p
+						.Date(d => d
+							.Name(n => n.PostDate)
+						)
+						.Keyword(k => k
+							.Name(n => n.User)
+						)
+						.Keyword(k => k
+							.Name(n => n.Name)
+						)
+						.Number(n => n
+							.Name(nn => nn.Age)
+							.Type(NumberType.Integer)
+						)
+					)
+				)
+			);
 			// end::d1b3b7d2bb2ab90d15fd10318abd24db[]
 
-			response0.MatchesExample(@"PUT /my_index
+			createIndexResponse.MatchesExample(@"PUT /my_index
 			{
 			    ""mappings"": {
 			        ""properties"": {
@@ -31,15 +52,30 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:30")]
 		public void Line30()
 		{
 			// tag::ae9b5fbd42af2386ffbf56ad4a697e51[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<Tweet>(s => s
+				.Index("my_index")
+				.Sort(so => so
+					.Ascending(f => f.PostDate)
+					.Field(f => f.Field("user"))
+					.Descending(f => f.Name)
+					.Descending(f => f.Age)
+					.Field(f => f.Field("_score"))
+				)
+				.Query(q => q
+					.Term(t => t
+						.Field(f => f.User)
+						.Value("kimchy")
+					)
+				)
+			);
 			// end::ae9b5fbd42af2386ffbf56ad4a697e51[]
 
-			response0.MatchesExample(@"GET /my_index/_search
+			searchResponse.MatchesExample(@"GET /my_index/_search
 			{
 			    ""sort"" : [
 			        { ""post_date"" : {""order"" : ""asc""}},
@@ -51,26 +87,58 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+
+				// the client doesn't support many of the sort short forms
+				body["sort"][1] = new JObject { { "user", new JObject() } };
+				body["sort"][2] = new JObject { { "name", new JObject { { "order", "desc" } } } };
+				body["sort"][3] = new JObject { { "age", new JObject { { "order", "desc" } } } };
+				body["sort"][4] = new JObject { { "_score", new JObject() } };
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:94")]
 		public void Line94()
 		{
 			// tag::b997885974522ef439d5e345924cc5ba[]
-			var response0 = new SearchResponse<object>();
+			var indexResponse = client.Index(new
+			{
+				product = "chocolate",
+				price = new[] { 20, 4 }
+			}, i => i
+				.Index("my_index")
+				.Id(1)
+				.Refresh(Refresh.True)
+			);
 
-			var response1 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Term(t => t
+						.Field("product")
+						.Value("chocolate")
+					)
+				)
+				.Sort(so => so
+					.Field(f => f
+						.Field("price")
+						.Order(SortOrder.Ascending)
+						.Mode(SortMode.Average)
+					)
+				)
+			);
 			// end::b997885974522ef439d5e345924cc5ba[]
 
-			response0.MatchesExample(@"PUT /my_index/_doc/1?refresh
+			indexResponse.MatchesExample(@"PUT /my_index/_doc/1?refresh
 			{
 			   ""product"": ""chocolate"",
 			   ""price"": [20, 4]
 			}");
 
-			response1.MatchesExample(@"POST /_search
+			searchResponse.MatchesExample(@"POST /_search
 			{
 			   ""query"" : {
 			      ""term"" : { ""product"" : ""chocolate"" }
@@ -78,18 +146,30 @@ namespace Examples.Search.Request
 			   ""sort"" : [
 			      {""price"" : {""order"" : ""asc"", ""mode"" : ""avg""}}
 			   ]
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["product"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:123")]
 		public void Line123()
 		{
 			// tag::abf329ebefaf58acd4ee30e685731499[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("index_double", c => c
+				.Map(m => m
+					.Properties(p => p
+						.Number(n => n
+							.Name("field")
+							.Type(NumberType.Double)
+						)
+					)
+				)
+			);
 			// end::abf329ebefaf58acd4ee30e685731499[]
 
-			response0.MatchesExample(@"PUT /index_double
+			createIndexResponse.MatchesExample(@"PUT /index_double
 			{
 			    ""mappings"": {
 			        ""properties"": {
@@ -99,15 +179,24 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:135")]
 		public void Line135()
 		{
 			// tag::f6b5032bf27c2445d28845be0d413970[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("index_long", c => c
+				.Map(m => m
+					.Properties(p => p
+						.Number(n => n
+							.Name("field")
+							.Type(NumberType.Long)
+						)
+					)
+				)
+			);
 			// end::f6b5032bf27c2445d28845be0d413970[]
 
-			response0.MatchesExample(@"PUT /index_long
+			createIndexResponse.MatchesExample(@"PUT /index_long
 			{
 			    ""mappings"": {
 			        ""properties"": {
@@ -117,15 +206,23 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:154")]
 		public void Line154()
 		{
 			// tag::2891aa10ee9d474780adf94d5607f2db[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.Index(new[] { "index_long", "index_double" })
+				.Sort(so => so
+					.Field(f => f
+						.Field("field")
+						.NumericType(NumericType.Double)
+					)
+				)
+			);
 			// end::2891aa10ee9d474780adf94d5607f2db[]
 
-			response0.MatchesExample(@"POST /index_long,index_double/_search
+			searchResponse.MatchesExample(@"POST /index_long,index_double/_search
 			{
 			   ""sort"" : [
 			      {
@@ -137,15 +234,23 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:181")]
 		public void Line181()
 		{
 			// tag::f4a1008b3f9baa67bb03ce9ef5ab4cb4[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("index_double", c => c
+				.Map(m => m
+					.Properties(p => p
+						.Date(n => n
+							.Name("field")
+						)
+					)
+				)
+			);
 			// end::f4a1008b3f9baa67bb03ce9ef5ab4cb4[]
 
-			response0.MatchesExample(@"PUT /index_double
+			createIndexResponse.MatchesExample(@"PUT /index_double
 			{
 			    ""mappings"": {
 			        ""properties"": {
@@ -155,15 +260,23 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:193")]
 		public void Line193()
 		{
 			// tag::7477671958734843dd67cf0b8e6c7515[]
-			var response0 = new SearchResponse<object>();
+			var createIndexResponse = client.Indices.Create("index_long", c => c
+				.Map(m => m
+					.Properties(p => p
+						.DateNanos(n => n
+							.Name("field")
+						)
+					)
+				)
+			);
 			// end::7477671958734843dd67cf0b8e6c7515[]
 
-			response0.MatchesExample(@"PUT /index_long
+			createIndexResponse.MatchesExample(@"PUT /index_long
 			{
 			    ""mappings"": {
 			        ""properties"": {
@@ -173,15 +286,23 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:212")]
 		public void Line212()
 		{
 			// tag::5f3549ac7fee94682ca0d7439eebdd2a[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.Index(new[] { "index_long", "index_double" })
+				.Sort(so => so
+					.Field(f => f
+						.Field("field")
+						.NumericType(NumericType.DateNanos)
+					)
+				)
+			);
 			// end::5f3549ac7fee94682ca0d7439eebdd2a[]
 
-			response0.MatchesExample(@"POST /index_long,index_double/_search
+			searchResponse.MatchesExample(@"POST /index_long,index_double/_search
 			{
 			   ""sort"" : [
 			      {
@@ -193,15 +314,39 @@ namespace Examples.Search.Request
 			}");
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:263")]
 		public void Line263()
 		{
 			// tag::de139866a220124360e5e27d1a736ea4[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Term(t => t
+						.Field("product")
+						.Value("chocolate")
+					)
+				)
+				.Sort(so => so
+					.Field(f => f
+						.Field("offer.price")
+						.Mode(SortMode.Average)
+						.Order(SortOrder.Ascending)
+						.Nested(ns => ns
+							.Path("offer")
+							.Filter(nf => nf
+								.Term(tf => tf
+									.Field("offer.color")
+									.Value("blue")
+								)
+							)
+						)
+					)
+				)
+			);
 			// end::de139866a220124360e5e27d1a736ea4[]
 
-			response0.MatchesExample(@"POST /_search
+			searchResponse.MatchesExample(@"POST /_search
 			{
 			   ""query"" : {
 			      ""term"" : { ""product"" : ""chocolate"" }
@@ -220,18 +365,69 @@ namespace Examples.Search.Request
 			          }
 			       }
 			    ]
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["product"].ToLongFormTermQuery();
+				body["sort"][0]["offer.price"]["nested"]["filter"]["term"]["offer.color"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:290")]
 		public void Line290()
 		{
 			// tag::22334f4b24bb8977d3e1bf2ffdc29d3f[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Query(q => q
+					.Nested(n => n
+						.Path("parent")
+						.Query(nq => nq
+							.LongRange(r => r
+								.Field("parent.age")
+								.GreaterThanOrEquals(21)
+							) && +nq
+							.Nested(nn => nn
+								.Path("parent.child")
+								.Query(nnq => nnq
+									.Match(m => m
+										.Field("parent.child.name")
+										.Query("matt")
+									)
+								)
+							)
+						)
+					)
+				)
+				.Sort(so => so
+					.Field(f => f
+						.Field("parent.child.age")
+						.Mode(SortMode.Min)
+						.Order(SortOrder.Ascending)
+						.Nested(ns => ns
+							.Path("parent")
+							.Filter(nf => nf
+								.LongRange(tf => tf
+									.Field("parent.age")
+									.GreaterThanOrEquals(21)
+								)
+							)
+							.Nested(nns => nns
+								.Path("parent.child")
+								.Filter(nnf => nnf
+									.Match(m => m
+										.Field("parent.child.name")
+										.Query("matt")
+									)
+								)
+							)
+						)
+					)
+				)
+			);
 			// end::22334f4b24bb8977d3e1bf2ffdc29d3f[]
 
-			response0.MatchesExample(@"POST /_search
+			searchResponse.MatchesExample(@"POST /_search
 			{
 			   ""query"": {
 			      ""nested"": {
@@ -269,15 +465,36 @@ namespace Examples.Search.Request
 			         }
 			      }
 			   ]
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["nested"]["query"]["bool"].ToLongFormBoolQuery(b =>
+				{
+					b["filter"][0]["nested"]["query"]["match"]["parent.child.name"].ToLongFormQuery();
+				});
+				body["sort"][0]["parent.child.age"]["nested"]["nested"]["filter"]["match"]["parent.child.name"].ToLongFormQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:346")]
 		public void Line346()
 		{
 			// tag::ef0f4fa4272c47ff62fb7b422cf975e7[]
-			var response0 = new SearchResponse<object>();
+			var response0 = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.Field(f => f
+						.Field("price")
+						.MissingLast()
+					)
+				)
+				.Query(q => q
+					.Term(t => t
+						.Field("product")
+						.Value("chocolate")
+					)
+				)
+			);
 			// end::ef0f4fa4272c47ff62fb7b422cf975e7[]
 
 			response0.MatchesExample(@"GET /_search
@@ -288,18 +505,32 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""product"" : ""chocolate"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["product"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:370")]
 		public void Line370()
 		{
 			// tag::899eef71a67a1b2aa11a2166ec7f48f1[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.Field(f => f
+						.Field("price")
+						.UnmappedType(FieldType.Long)
+					)
+				)
+				.Query(q => q
+					.Term("product", "chocolate")
+				)
+			);
 			// end::899eef71a67a1b2aa11a2166ec7f48f1[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        { ""price"" : {""unmapped_type"" : ""long""} }
@@ -307,18 +538,37 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""product"" : ""chocolate"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["product"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:392")]
 		public void Line392()
 		{
 			// tag::d17269bb80fb63ec0bf37d219e003dcb[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(new GeoCoordinate(40, -70))
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+						.Mode(SortMode.Min)
+						.DistanceType(GeoDistanceType.Arc)
+						.IgnoreUnmapped()
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::d17269bb80fb63ec0bf37d219e003dcb[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -335,18 +585,39 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				var current = body["sort"][0]["_geo_distance"]["pin.location"];
+				body["sort"][0]["_geo_distance"]["pin.location"] = new JArray(new JObject {
+					{ "lat", current[1].Value<double>() },
+					{ "lon", current[0].Value<double>() },
+				});
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:445")]
 		public void Line445()
 		{
 			// tag::979d25dff2d8987119410291ad47b0d1[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(new GeoLocation(40, -70))
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::979d25dff2d8987119410291ad47b0d1[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -363,18 +634,37 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["sort"][0]["_geo_distance"]["pin.location"]["lat"] = 40d;
+				body["sort"][0]["_geo_distance"]["pin.location"]["lon"] = -70d;
+				body["sort"][0]["_geo_distance"]["pin.location"].ToJArray();
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:471")]
 		public void Line471()
 		{
 			// tag::d50a3c64890f88af32c6d4ef4899d82a[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(new GeoCoordinate(40, -70))
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::d50a3c64890f88af32c6d4ef4899d82a[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -388,18 +678,35 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["sort"][0]["_geo_distance"]["pin.location"] = new JArray(new JObject { { "lon", -70d }, { "lat", 40d } });
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U(Skip = "No representable with the client")]
 		[Description("search/request/sort.asciidoc:492")]
 		public void Line492()
 		{
 			// tag::a1db5c822745fe167e9ef854dca3d129[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(new GeoCoordinate(40, -70))
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::a1db5c822745fe167e9ef854dca3d129[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -413,18 +720,35 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["sort"][0]["_geo_distance"]["pin.location"] = new JArray(new JObject { { "lat", -70d }, { "lon", 40d } }); ;
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:516")]
 		public void Line516()
 		{
 			// tag::15dad5338065baaaa7d475abe85f4c22[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(new GeoCoordinate(40, -70))
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::15dad5338065baaaa7d475abe85f4c22[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -438,18 +762,38 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+				body["sort"][0]["_geo_distance"]["pin.location"] = new JArray(new JObject { { "lon", -70d }, { "lat", 40d } }); ;
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:540")]
 		public void Line540()
 		{
 			// tag::77243bbf92f2a55e0fca6c2a349a1c15[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.GeoDistance(g => g
+						.Field("pin.location")
+						.Points(
+							new GeoCoordinate(40, -70),
+							new GeoCoordinate(42, -71)
+						)
+						.Order(SortOrder.Ascending)
+						.Unit(DistanceUnit.Kilometers)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::77243bbf92f2a55e0fca6c2a349a1c15[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""sort"" : [
 			        {
@@ -463,18 +807,43 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+				body["sort"][0]["_geo_distance"]["pin.location"] = new JArray(
+					new JObject { { "lon", -70d }, { "lat", 40d } },
+					new JObject { { "lon", -71d }, { "lat", 42d } }
+				);
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:569")]
 		public void Line569()
 		{
 			// tag::04fe1e3a0047b0cdb10987b79fc3f3f3[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.Sort(so => so
+					.Script(ss => ss
+						.Type("number")
+						.Script(sc => sc
+							.Source("doc['field_name'].value * params.factor")
+							.Lang("painless")
+							.Params(p => p
+								.Add("factor", 1.1)
+							)
+						)
+						.Order(SortOrder.Ascending)
+					)
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::04fe1e3a0047b0cdb10987b79fc3f3f3[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
@@ -492,18 +861,33 @@ namespace Examples.Search.Request
 			            ""order"" : ""asc""
 			        }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+				body["sort"].ToJArray();
+			});
 		}
 
-		[U(Skip = "Example not implemented")]
+		[U]
 		[Description("search/request/sort.asciidoc:598")]
 		public void Line598()
 		{
 			// tag::e8e451bc8c45bcf16df43804c4fc8329[]
-			var response0 = new SearchResponse<object>();
+			var searchResponse = client.Search<object>(s => s
+				.AllIndices()
+				.TrackScores()
+				.Sort(so => so
+					.Descending("post_date")
+					.Descending("name")
+					.Descending("age")
+				)
+				.Query(q => q
+					.Term("user", "kimchy")
+				)
+			);
 			// end::e8e451bc8c45bcf16df43804c4fc8329[]
 
-			response0.MatchesExample(@"GET /_search
+			searchResponse.MatchesExample(@"GET /_search
 			{
 			    ""track_scores"": true,
 			    ""sort"" : [
@@ -514,7 +898,12 @@ namespace Examples.Search.Request
 			    ""query"" : {
 			        ""term"" : { ""user"" : ""kimchy"" }
 			    }
-			}");
+			}", (e, body) =>
+			{
+				body["query"]["term"]["user"].ToLongFormTermQuery();
+				body["sort"][1]["name"] = new JObject { { "order", "desc" } };
+				body["sort"][2]["age"] = new JObject { { "order", "desc" } };
+			});
 		}
 	}
 }

--- a/tests/Examples/Search/Request/StoredFieldsPage.cs
+++ b/tests/Examples/Search/Request/StoredFieldsPage.cs
@@ -41,8 +41,8 @@ namespace Examples.Search.Request
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("search/request/stored-fields.asciidoc:60")]
-		public void Line60()
+		[Description("search/request/stored-fields.asciidoc:55")]
+		public void Line55()
 		{
 			// tag::ccec437aed7a10d9111724ffd929fe00[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Search/RequestBodyPage.cs
+++ b/tests/Examples/Search/RequestBodyPage.cs
@@ -32,7 +32,6 @@ namespace Examples.Search
 					var value = b["query"]["term"]["user"];
 					b["query"]["term"]["user"] = new JObject { ["value"] = value };
 				});
-				return e;
 			});
 		}
 
@@ -55,7 +54,6 @@ namespace Examples.Search
 				e.Uri.Path = "/_all/_search";
 				e.MoveQueryStringToBody("size", 0);
 				e.MoveQueryStringToBody("terminate_after", 1);
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/Search/SearchPage.cs
+++ b/tests/Examples/Search/SearchPage.cs
@@ -23,8 +23,8 @@ namespace Examples.Search
 		}
 
 		[U]
-		[Description("search/search.asciidoc:342")]
-		public void Line342()
+		[Description("search/search.asciidoc:346")]
+		public void Line346()
 		{
 			// tag::be49260e1b3496c4feac38c56ebb0669[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -37,8 +37,8 @@ namespace Examples.Search
 		}
 
 		[U]
-		[Description("search/search.asciidoc:388")]
-		public void Line388()
+		[Description("search/search.asciidoc:392")]
+		public void Line392()
 		{
 			// tag::f5569945024b9d664828693705c27c1a[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -51,8 +51,8 @@ namespace Examples.Search
 		}
 
 		[U]
-		[Description("search/search.asciidoc:400")]
-		public void Line400()
+		[Description("search/search.asciidoc:404")]
+		public void Line404()
 		{
 			// tag::168bfdde773570cfc6dd3ab3574e413b[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -65,8 +65,8 @@ namespace Examples.Search
 		}
 
 		[U]
-		[Description("search/search.asciidoc:409")]
-		public void Line409()
+		[Description("search/search.asciidoc:413")]
+		public void Line413()
 		{
 			// tag::8022e6a690344035b6472a43a9d122e0[]
 			var searchResponse = client.Search<Tweet>(s => s
@@ -79,8 +79,8 @@ namespace Examples.Search
 		}
 
 		[U]
-		[Description("search/search.asciidoc:415")]
-		public void Line415()
+		[Description("search/search.asciidoc:419")]
+		public void Line419()
 		{
 			// tag::43682666e1abcb14770c99f02eb26a0d[]
 			var searchResponse = client.Search<Tweet>(s => s

--- a/tests/Examples/Search/SearchPage.cs
+++ b/tests/Examples/Search/SearchPage.cs
@@ -92,7 +92,6 @@ namespace Examples.Search
 			searchResponse.MatchesExample(@"GET /*/_search?q=user:kimchy", e =>
 			{
 				e.Uri.Path = "/_all/_search";
-				return e;
 			});
 		}
 	}

--- a/tests/Examples/SearchableSnapshots/Apis/ClearCachePage.cs
+++ b/tests/Examples/SearchableSnapshots/Apis/ClearCachePage.cs
@@ -1,0 +1,20 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.SearchableSnapshots.Apis
+{
+	public class ClearCachePage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("searchable-snapshots/apis/clear-cache.asciidoc:73")]
+		public void Line73()
+		{
+			// tag::69487bde55a1fc688a8cc5acf40b1555[]
+			var response0 = new SearchResponse<object>();
+			// end::69487bde55a1fc688a8cc5acf40b1555[]
+
+			response0.MatchesExample(@"POST /docs/_searchable_snapshots/cache/clear");
+		}
+	}
+}

--- a/tests/Examples/SearchableSnapshots/Apis/GetStatsPage.cs
+++ b/tests/Examples/SearchableSnapshots/Apis/GetStatsPage.cs
@@ -1,0 +1,20 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.SearchableSnapshots.Apis
+{
+	public class GetStatsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("searchable-snapshots/apis/get-stats.asciidoc:73")]
+		public void Line73()
+		{
+			// tag::806b19ef04f9b5acc99a59da73aff282[]
+			var response0 = new SearchResponse<object>();
+			// end::806b19ef04f9b5acc99a59da73aff282[]
+
+			response0.MatchesExample(@"GET /docs/_searchable_snapshots/stats");
+		}
+	}
+}

--- a/tests/Examples/SearchableSnapshots/Apis/MountSnapshotPage.cs
+++ b/tests/Examples/SearchableSnapshots/Apis/MountSnapshotPage.cs
@@ -1,0 +1,28 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.SearchableSnapshots.Apis
+{
+	public class MountSnapshotPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("searchable-snapshots/apis/mount-snapshot.asciidoc:110")]
+		public void Line110()
+		{
+			// tag::098820242e25a05d6a4d962ad4132d1b[]
+			var response0 = new SearchResponse<object>();
+			// end::098820242e25a05d6a4d962ad4132d1b[]
+
+			response0.MatchesExample(@"POST /_snapshot/my_repository/my_snapshot/_mount?wait_for_completion=true
+			{
+			  ""index"": ""my_docs"", <1>
+			  ""renamed_index"": ""docs"", <2>
+			  ""index_settings"": { <3>
+			    ""index.number_of_replicas"": 0
+			  },
+			  ""ignored_index_settings"": [ ""index.refresh_interval"" ] <4>
+			}");
+		}
+	}
+}

--- a/tests/Examples/SearchableSnapshots/Apis/RepositoryStatsPage.cs
+++ b/tests/Examples/SearchableSnapshots/Apis/RepositoryStatsPage.cs
@@ -1,0 +1,20 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.SearchableSnapshots.Apis
+{
+	public class RepositoryStatsPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("searchable-snapshots/apis/repository-stats.asciidoc:70")]
+		public void Line70()
+		{
+			// tag::ad607e070bd3191558e3e2cf2b5bc2ea[]
+			var response0 = new SearchResponse<object>();
+			// end::ad607e070bd3191558e3e2cf2b5bc2ea[]
+
+			response0.MatchesExample(@"GET /_snapshot/my_repository/_stats");
+		}
+	}
+}

--- a/tests/Examples/Setup/SecureSettingsPage.cs
+++ b/tests/Examples/Setup/SecureSettingsPage.cs
@@ -10,13 +10,13 @@ namespace Examples.Setup
 		[Description("setup/secure-settings.asciidoc:35")]
 		public void Line35()
 		{
-			// tag::32732207b66d0fd661e8e7638aef5176[]
+			// tag::eb7e3aaed0c8f3f8e3462bf3df9a7a5c[]
 			var response0 = new SearchResponse<object>();
-			// end::32732207b66d0fd661e8e7638aef5176[]
+			// end::eb7e3aaed0c8f3f8e3462bf3df9a7a5c[]
 
 			response0.MatchesExample(@"POST _nodes/reload_secure_settings
 			{
-			  ""reload_secure_settings"": ""s3cr3t"" <1>
+			  ""secure_settings_password"": ""s3cr3t"" <1>
 			}");
 		}
 	}

--- a/tests/Examples/Slm/Apis/SlmPutPage.cs
+++ b/tests/Examples/Slm/Apis/SlmPutPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Slm.Apis
 	public class SlmPutPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("slm/apis/slm-put.asciidoc:151")]
-		public void Line151()
+		[Description("slm/apis/slm-put.asciidoc:120")]
+		public void Line120()
 		{
 			// tag::aa7cf5df36b867aee5e3314ac4b4fa68[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Slm/IndexPage.cs
+++ b/tests/Examples/Slm/IndexPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Slm
 	public class IndexPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("slm/index.asciidoc:38")]
-		public void Line38()
+		[Description("slm/index.asciidoc:37")]
+		public void Line37()
 		{
 			// tag::1d7abeea98f6ed64cc8371794c90a921[]
 			var response0 = new SearchResponse<object>();
@@ -27,8 +27,8 @@ namespace Examples.Slm
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("slm/index.asciidoc:56")]
-		public void Line56()
+		[Description("slm/index.asciidoc:55")]
+		public void Line55()
 		{
 			// tag::ef76d0e4cdc2881c161a5557a98a3446[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/DeleteTransformPage.cs
+++ b/tests/Examples/Transform/Apis/DeleteTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class DeleteTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/delete-transform.asciidoc:47")]
-		public void Line47()
+		[Description("transform/apis/delete-transform.asciidoc:52")]
+		public void Line52()
 		{
 			// tag::70c736ecb3746dbe839af0e468712805[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/GetTransformPage.cs
+++ b/tests/Examples/Transform/Apis/GetTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class GetTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/get-transform.asciidoc:92")]
-		public void Line92()
+		[Description("transform/apis/get-transform.asciidoc:96")]
+		public void Line96()
 		{
 			// tag::c65b00a285f510dcd2865aa3539b4e03[]
 			var response0 = new SearchResponse<object>();
@@ -18,8 +18,8 @@ namespace Examples.Transform.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/get-transform.asciidoc:101")]
-		public void Line101()
+		[Description("transform/apis/get-transform.asciidoc:105")]
+		public void Line105()
 		{
 			// tag::c8ebbecc372bcfa5f4a6e7242395ab5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/GetTransformStatsPage.cs
+++ b/tests/Examples/Transform/Apis/GetTransformStatsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class GetTransformStatsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/get-transform-stats.asciidoc:191")]
-		public void Line191()
+		[Description("transform/apis/get-transform-stats.asciidoc:267")]
+		public void Line267()
 		{
 			// tag::53c6256295111524d5ff2885bdcb99a9[]
 			var response0 = new SearchResponse<object>();
@@ -18,14 +18,14 @@ namespace Examples.Transform.Apis
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/get-transform-stats.asciidoc:200")]
-		public void Line200()
+		[Description("transform/apis/get-transform-stats.asciidoc:275")]
+		public void Line275()
 		{
-			// tag::5db14291fd57c9cd780c969ae26dfaba[]
+			// tag::0755471d7dce4785d2e7ed0c10182ea3[]
 			var response0 = new SearchResponse<object>();
-			// end::5db14291fd57c9cd780c969ae26dfaba[]
+			// end::0755471d7dce4785d2e7ed0c10182ea3[]
 
-			response0.MatchesExample(@"GET _transform/ecommerce_transform/_stats");
+			response0.MatchesExample(@"GET _transform/ecommerce-customer-transform/_stats");
 		}
 	}
 }

--- a/tests/Examples/Transform/Apis/PreviewTransformPage.cs
+++ b/tests/Examples/Transform/Apis/PreviewTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class PreviewTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/preview-transform.asciidoc:114")]
-		public void Line114()
+		[Description("transform/apis/preview-transform.asciidoc:183")]
+		public void Line183()
 		{
 			// tag::a5ee3f40c34bd913a12e0069b6e42611[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/PutTransformPage.cs
+++ b/tests/Examples/Transform/Apis/PutTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class PutTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/put-transform.asciidoc:153")]
-		public void Line153()
+		[Description("transform/apis/put-transform.asciidoc:195")]
+		public void Line195()
 		{
 			// tag::23994a14e6b0681cd279b427324945db[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/StartTransformPage.cs
+++ b/tests/Examples/Transform/Apis/StartTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class StartTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/start-transform.asciidoc:60")]
-		public void Line60()
+		[Description("transform/apis/start-transform.asciidoc:64")]
+		public void Line64()
 		{
 			// tag::01bc0f2ed30eb3dd23511d01ce0ac6e1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/StopTransformPage.cs
+++ b/tests/Examples/Transform/Apis/StopTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class StopTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/stop-transform.asciidoc:91")]
-		public void Line91()
+		[Description("transform/apis/stop-transform.asciidoc:95")]
+		public void Line95()
 		{
 			// tag::654882f545eca8d7047695f867c63072[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/Apis/UpdateTransformPage.cs
+++ b/tests/Examples/Transform/Apis/UpdateTransformPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform.Apis
 	public class UpdateTransformPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/apis/update-transform.asciidoc:132")]
-		public void Line132()
+		[Description("transform/apis/update-transform.asciidoc:166")]
+		public void Line166()
 		{
 			// tag::27384266370152add76471dd0332a2f1[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/EcommerceTutorialPage.cs
+++ b/tests/Examples/Transform/EcommerceTutorialPage.cs
@@ -7,8 +7,8 @@ namespace Examples.Transform
 	public class EcommerceTutorialPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("transform/ecommerce-tutorial.asciidoc:88")]
-		public void Line88()
+		[Description("transform/ecommerce-tutorial.asciidoc:78")]
+		public void Line78()
 		{
 			// tag::8345d2615f43a934fe1871a5120eca1d[]
 			var response0 = new SearchResponse<object>();
@@ -61,8 +61,8 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/ecommerce-tutorial.asciidoc:164")]
-		public void Line164()
+		[Description("transform/ecommerce-tutorial.asciidoc:154")]
+		public void Line154()
 		{
 			// tag::c68404749f090ab191c0fd5f651635cf[]
 			var response0 = new SearchResponse<object>();
@@ -122,8 +122,8 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/ecommerce-tutorial.asciidoc:243")]
-		public void Line243()
+		[Description("transform/ecommerce-tutorial.asciidoc:233")]
+		public void Line233()
 		{
 			// tag::4ded8ad815ac0e83b1c21a6c18fd0763[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/ExamplesPage.cs
+++ b/tests/Examples/Transform/ExamplesPage.cs
@@ -84,12 +84,12 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/examples.asciidoc:207")]
-		public void Line207()
+		[Description("transform/examples.asciidoc:202")]
+		public void Line202()
 		{
-			// tag::0bad2211181281b6cc5df8e364bcc111[]
+			// tag::7bc36ea4a24937de6c009397861baf05[]
 			var response0 = new SearchResponse<object>();
-			// end::0bad2211181281b6cc5df8e364bcc111[]
+			// end::7bc36ea4a24937de6c009397861baf05[]
 
 			response0.MatchesExample(@"PUT _transform/suspicious_client_ips
 			{
@@ -116,30 +116,17 @@ namespace Examples.Transform
 			      ""agent_dc"": { ""cardinality"": { ""field"": ""agent.keyword"" }},
 			      ""geo.dest_dc"": { ""cardinality"": { ""field"": ""geo.dest"" }},
 			      ""responses.total"": { ""value_count"": { ""field"": ""timestamp"" }},
-			      ""responses.counts"": { <4>
-			        ""scripted_metric"": {
-			          ""init_script"": ""state.responses = ['error':0L,'success':0L,'other':0L]"",
-			          ""map_script"": """"""
-			            def code = doc['response.keyword'].value;
-			            if (code.startsWith('5') || code.startsWith('4')) {
-			              state.responses.error += 1 ;
-			            } else if(code.startsWith('2')) {
-			              state.responses.success += 1;
-			            } else {
-			              state.responses.other += 1;
-			            }
-			            """""",
-			          ""combine_script"": ""state.responses"",
-			          ""reduce_script"": """"""
-			            def counts = ['error': 0L, 'success': 0L, 'other': 0L];
-			            for (responses in states) {
-			              counts.error += responses['error'];
-			              counts.success += responses['success'];
-			              counts.other += responses['other'];
-			            }
-			            return counts;
-			            """"""
-			          }
+			      ""success"" : { <4>
+			         ""filter"": {
+			            ""term"": { ""response"" : ""200""}}
+			        },
+			      ""error404"" : {
+			         ""filter"": {
+			            ""term"": { ""response"" : ""404""}}
+			        },
+			      ""error503"" : {
+			         ""filter"": {
+			            ""term"": { ""response"" : ""503""}}
 			        },
 			      ""timestamp.min"": { ""min"": { ""field"": ""timestamp"" }},
 			      ""timestamp.max"": { ""max"": { ""field"": ""timestamp"" }},
@@ -158,8 +145,8 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/examples.asciidoc:288")]
-		public void Line288()
+		[Description("transform/examples.asciidoc:272")]
+		public void Line272()
 		{
 			// tag::4bd42e31ac4a5cf237777f1a0e97aba8[]
 			var response0 = new SearchResponse<object>();
@@ -169,8 +156,8 @@ namespace Examples.Transform
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("transform/examples.asciidoc:297")]
-		public void Line297()
+		[Description("transform/examples.asciidoc:282")]
+		public void Line282()
 		{
 			// tag::14f2dab0583c5a9fcc39931d33194872[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/Transform/PainlessExamplesPage.cs
+++ b/tests/Examples/Transform/PainlessExamplesPage.cs
@@ -1,0 +1,172 @@
+using Elastic.Xunit.XunitPlumbing;
+using System.ComponentModel;
+using Nest;
+
+namespace Examples.Transform
+{
+	public class PainlessExamplesPage : ExampleBase
+	{
+		[U(Skip = "Example not implemented")]
+		[Description("transform/painless-examples.asciidoc:160")]
+		public void Line160()
+		{
+			// tag::8ce484cceef334f0a8ad3a40570b3425[]
+			var response0 = new SearchResponse<object>();
+			// end::8ce484cceef334f0a8ad3a40570b3425[]
+
+			response0.MatchesExample(@"POST _transform/_preview
+			{
+			  ""source"": {
+			    ""index"": [ <1>
+			      ""kibana_sample_data_logs""
+			    ]
+			  },
+			  ""pivot"": {
+			    ""group_by"": {
+			      ""agent"": {
+			        ""terms"": {
+			          ""script"": { <2>
+			            ""source"": """"""String agent = doc['agent.keyword'].value;
+			            if (agent.contains(""MSIE"")) {
+			              return ""internet explorer"";
+			            } else if (agent.contains(""AppleWebKit"")) {
+			              return ""safari"";
+			            } else if (agent.contains('Firefox')) {
+			              return ""firefox"";
+			            } else { return agent }"""""",
+			            ""lang"": ""painless""
+			          }
+			        }
+			      }
+			    },
+			    ""aggregations"": { <3>
+			      ""200"": {
+			        ""filter"": {
+			          ""term"": {
+			            ""response"": ""200""
+			          }
+			        }
+			      },
+			      ""404"": {
+			        ""filter"": {
+			          ""term"": {
+			            ""response"": ""404""
+			          }
+			        }
+			      },
+			      ""503"": {
+			        ""filter"": {
+			          ""term"": {
+			            ""response"": ""503""
+			          }
+			        }
+			      }
+			    }
+			  },
+			  ""dest"": { <4>
+			    ""index"": ""pivot_logs""
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("transform/painless-examples.asciidoc:298")]
+		public void Line298()
+		{
+			// tag::d6e0be8357b50f7d5b9dd8dadf1567b1[]
+			var response0 = new SearchResponse<object>();
+			// end::d6e0be8357b50f7d5b9dd8dadf1567b1[]
+
+			response0.MatchesExample(@"PUT _data_frame/transforms/data_log
+			{
+			  ""source"": {
+			    ""index"": ""kibana_sample_data_logs""
+			  },
+			  ""dest"": {
+			    ""index"": ""data-logs-by-client""
+			  },
+			  ""pivot"": {
+			    ""group_by"": {
+			      ""machine.os"": {""terms"": {""field"": ""machine.os.keyword""}},
+			      ""machine.ip"": {""terms"": {""field"": ""clientip""}}
+			    },
+			    ""aggregations"": {
+			      ""time_frame.lte"": {
+			        ""max"": {
+			          ""field"": ""timestamp""
+			        }
+			      },
+			      ""time_frame.gte"": {
+			        ""min"": {
+			          ""field"": ""timestamp""
+			        }
+			      },
+			      ""time_length"": { <1>
+			        ""bucket_script"": {
+			          ""buckets_path"": { <2>
+			            ""min"": ""time_frame.gte.value"",
+			            ""max"": ""time_frame.lte.value""
+			          },
+			          ""script"": ""params.max - params.min"" <3>
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+
+		[U(Skip = "Example not implemented")]
+		[Description("transform/painless-examples.asciidoc:414")]
+		public void Line414()
+		{
+			// tag::22908e2f01460917d3145a53e3fb7546[]
+			var response0 = new SearchResponse<object>();
+			// end::22908e2f01460917d3145a53e3fb7546[]
+
+			response0.MatchesExample(@"POST _transform/_preview
+			{
+			  ""id"" : ""index_compare"",
+			  ""source"" : { <1>
+			    ""index"" : [
+			      ""index1"",
+			      ""index2""
+			    ],
+			    ""query"" : {
+			      ""match_all"" : { }
+			    }
+			  },
+			  ""dest"" : { <2>
+			    ""index"" : ""compare""
+			  },
+			  ""pivot"" : {
+			    ""group_by"" : {
+			      ""unique-id"" : {
+			        ""terms"" : {
+			          ""field"" : ""<unique-id-field>"" <3>
+			        }
+			      }
+			    },
+			    ""aggregations"" : {
+			      ""compare"" : { <4>
+			        ""scripted_metric"" : {
+			          ""init_script"" : """",
+			          ""map_script"" : ""state.doc = new HashMap(params['_source'])"", <5>
+			          ""combine_script"" : ""return state"", <6>
+			          ""reduce_script"" : """""" <7>
+			            if (states.size() != 2) {
+			              return ""count_mismatch""
+			            }
+			            if (states.get(0).equals(states.get(1))) {
+			              return ""match""
+			            } else {
+			              return ""mismatch""
+			            }
+			            """"""
+			        }
+			      }
+			    }
+			  }
+			}");
+		}
+	}
+}

--- a/tests/Examples/Upgrade/RollingUpgradePage.cs
+++ b/tests/Examples/Upgrade/RollingUpgradePage.cs
@@ -7,8 +7,8 @@ namespace Examples.Upgrade
 	public class RollingUpgradePage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:62")]
-		public void Line62()
+		[Description("upgrade/rolling_upgrade.asciidoc:65")]
+		public void Line65()
 		{
 			// tag::1cd3b9d65576a9212eef898eb3105758[]
 			var response0 = new SearchResponse<object>();
@@ -23,8 +23,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:63")]
-		public void Line63()
+		[Description("upgrade/rolling_upgrade.asciidoc:66")]
+		public void Line66()
 		{
 			// tag::f27c28ddbf4c266b5f42d14da837b8de[]
 			var response0 = new SearchResponse<object>();
@@ -34,8 +34,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:98")]
-		public void Line98()
+		[Description("upgrade/rolling_upgrade.asciidoc:101")]
+		public void Line101()
 		{
 			// tag::a21a7bf052b41f5b996dc58f7b69770f[]
 			var response0 = new SearchResponse<object>();
@@ -45,8 +45,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:113")]
-		public void Line113()
+		[Description("upgrade/rolling_upgrade.asciidoc:116")]
+		public void Line116()
 		{
 			// tag::7e49705769c42895fb7b1e2ca028ff47[]
 			var response0 = new SearchResponse<object>();
@@ -56,8 +56,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:126")]
-		public void Line126()
+		[Description("upgrade/rolling_upgrade.asciidoc:129")]
+		public void Line129()
 		{
 			// tag::45ef5156dbd2d3fd4fd22b8d99f7aad4[]
 			var response0 = new SearchResponse<object>();
@@ -72,8 +72,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:144")]
-		public void Line144()
+		[Description("upgrade/rolling_upgrade.asciidoc:147")]
+		public void Line147()
 		{
 			// tag::5c53944aec2ce3e55854e315f0482029[]
 			var response0 = new SearchResponse<object>();
@@ -83,8 +83,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:174")]
-		public void Line174()
+		[Description("upgrade/rolling_upgrade.asciidoc:177")]
+		public void Line177()
 		{
 			// tag::6b74ff6df5d7583add837b34a6c80a43[]
 			var response0 = new SearchResponse<object>();
@@ -94,8 +94,8 @@ namespace Examples.Upgrade
 		}
 
 		[U]
-		[Description("upgrade/rolling_upgrade.asciidoc:191")]
-		public void Line191()
+		[Description("upgrade/rolling_upgrade.asciidoc:194")]
+		public void Line194()
 		{
 			// tag::f8cc4b331a19ff4df8e4a490f906ee69[]
 			var catResponse = client.Cat.Health(h => h.Verbose());
@@ -105,8 +105,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:198")]
-		public void Line198()
+		[Description("upgrade/rolling_upgrade.asciidoc:201")]
+		public void Line201()
 		{
 			// tag::c4270d3851c76898fc8b112c6c597444[]
 			var response0 = new SearchResponse<object>();
@@ -116,8 +116,8 @@ namespace Examples.Upgrade
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("upgrade/rolling_upgrade.asciidoc:213")]
-		public void Line213()
+		[Description("upgrade/rolling_upgrade.asciidoc:216")]
+		public void Line216()
 		{
 			// tag::3c5d5a5c34a62724942329658c688f5e[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/RestApi/Security/CreateRoleMappingsPage.cs
+++ b/tests/Examples/XPack/Docs/En/RestApi/Security/CreateRoleMappingsPage.cs
@@ -7,8 +7,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 	public class CreateRoleMappingsPage : ExampleBase
 	{
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:112")]
-		public void Line112()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:113")]
+		public void Line113()
 		{
 			// tag::23b062c157235246d7c347b9047b2435[]
 			var response0 = new SearchResponse<object>();
@@ -28,8 +28,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:146")]
-		public void Line146()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:147")]
+		public void Line147()
 		{
 			// tag::b176e0d428726705298184ef39ad5cb2[]
 			var response0 = new SearchResponse<object>();
@@ -46,8 +46,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:159")]
-		public void Line159()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:160")]
+		public void Line160()
 		{
 			// tag::e60b7f75ca806f2c74927c3d9409a986[]
 			var response0 = new SearchResponse<object>();
@@ -64,8 +64,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:174")]
-		public void Line174()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:175")]
+		public void Line175()
 		{
 			// tag::7a23a385a63c87cab58fd494870450fd[]
 			var response0 = new SearchResponse<object>();
@@ -93,8 +93,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:216")]
-		public void Line216()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:217")]
+		public void Line217()
 		{
 			// tag::5ad365ed9e1a3c26093a0f09666c133a[]
 			var response0 = new SearchResponse<object>();
@@ -116,8 +116,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:239")]
-		public void Line239()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:240")]
+		public void Line240()
 		{
 			// tag::7e5faa551f2c95ffd627da352563d450[]
 			var response0 = new SearchResponse<object>();
@@ -134,8 +134,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:254")]
-		public void Line254()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:255")]
+		public void Line255()
 		{
 			// tag::b80e1f5b26bae4f3c2f8a604b7caaf17[]
 			var response0 = new SearchResponse<object>();
@@ -155,8 +155,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:278")]
-		public void Line278()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:279")]
+		public void Line279()
 		{
 			// tag::0d94d76b7f00d0459d1f8c962c144dcd[]
 			var response0 = new SearchResponse<object>();
@@ -200,8 +200,8 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:328")]
-		public void Line328()
+		[Description("../../x-pack/docs/en/rest-api/security/create-role-mappings.asciidoc:329")]
+		public void Line329()
 		{
 			// tag::50dc35d3d8705bd62aed20a15209476c[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/RestApi/Security/OidcAuthenticateApiPage.cs
+++ b/tests/Examples/XPack/Docs/En/RestApi/Security/OidcAuthenticateApiPage.cs
@@ -10,13 +10,13 @@ namespace Examples.XPack.Docs.En.RestApi.Security
 		[Description("../../x-pack/docs/en/rest-api/security/oidc-authenticate-api.asciidoc:65")]
 		public void Line65()
 		{
-			// tag::9e5d5a6c9adcba75b906e81c1496bd01[]
+			// tag::9c01db07c9ac395b6370e3b33965c21f[]
 			var response0 = new SearchResponse<object>();
-			// end::9e5d5a6c9adcba75b906e81c1496bd01[]
+			// end::9c01db07c9ac395b6370e3b33965c21f[]
 
 			response0.MatchesExample(@"POST /_security/oidc/authenticate
 			{
-			  ""redirect_uri"" : ""https://oidc-kibana.elastic.co:5603/api/security/v1/oidc?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
+			  ""redirect_uri"" : ""https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
 			  ""state"" : ""4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
 			  ""nonce"" : ""WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM"",
 			  ""realm"" : ""oidc1""

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/OidcGuidePage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/OidcGuidePage.cs
@@ -44,8 +44,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:604")]
-		public void Line604()
+		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:601")]
+		public void Line601()
 		{
 			// tag::a325f31e94fb1e8739258910593504a8[]
 			var response0 = new SearchResponse<object>();
@@ -58,8 +58,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:613")]
-		public void Line613()
+		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:610")]
+		public void Line610()
 		{
 			// tag::53e4ac5a4009fd21024f4b31e54aa83f[]
 			var response0 = new SearchResponse<object>();
@@ -73,8 +73,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:633")]
-		public void Line633()
+		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:630")]
+		public void Line630()
 		{
 			// tag::e3019fd5f23458ae49ad9854c97d321c[]
 			var response0 = new SearchResponse<object>();
@@ -87,16 +87,16 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:656")]
-		public void Line656()
+		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:653")]
+		public void Line653()
 		{
-			// tag::9e5d5a6c9adcba75b906e81c1496bd01[]
+			// tag::9c01db07c9ac395b6370e3b33965c21f[]
 			var response0 = new SearchResponse<object>();
-			// end::9e5d5a6c9adcba75b906e81c1496bd01[]
+			// end::9c01db07c9ac395b6370e3b33965c21f[]
 
 			response0.MatchesExample(@"POST /_security/oidc/authenticate
 			{
-			  ""redirect_uri"" : ""https://oidc-kibana.elastic.co:5603/api/security/v1/oidc?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
+			  ""redirect_uri"" : ""https://oidc-kibana.elastic.co:5603/api/security/oidc/callback?code=jtI3Ntt8v3_XvcLzCFGq&state=4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
 			  ""state"" : ""4dbrihtIAt3wBTwo6DxK-vdk-sSyDBV8Yf0AjdkdT5I"",
 			  ""nonce"" : ""WaBPH0KqPVdG5HHdSxPRjfoZbXMCicm5v1OiAj0DUFM"",
 			  ""realm"" : ""oidc1""
@@ -104,8 +104,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:674")]
-		public void Line674()
+		[Description("../../x-pack/docs/en/security/authentication/oidc-guide.asciidoc:671")]
+		public void Line671()
 		{
 			// tag::2a1eece9a59ac1773edcf0a932c26de0[]
 			var response0 = new SearchResponse<object>();

--- a/tests/Examples/XPack/Docs/En/Security/Authentication/SamlGuidePage.cs
+++ b/tests/Examples/XPack/Docs/En/Security/Authentication/SamlGuidePage.cs
@@ -44,8 +44,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:903")]
-		public void Line903()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:898")]
+		public void Line898()
 		{
 			// tag::49cb3f48a0097bfc597c52fa51c6d379[]
 			var response0 = new SearchResponse<object>();
@@ -58,8 +58,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:911")]
-		public void Line911()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:906")]
+		public void Line906()
 		{
 			// tag::b2b26f8568c5dba7649e79f09b859272[]
 			var response0 = new SearchResponse<object>();
@@ -73,8 +73,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:931")]
-		public void Line931()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:926")]
+		public void Line926()
 		{
 			// tag::a5dfcfd1cfb3558e7912456669c92eee[]
 			var response0 = new SearchResponse<object>();
@@ -87,8 +87,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:954")]
-		public void Line954()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:949")]
+		public void Line949()
 		{
 			// tag::8e208098a0156c4c92afe0a06960b230[]
 			var response0 = new SearchResponse<object>();
@@ -102,8 +102,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:983")]
-		public void Line983()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:978")]
+		public void Line978()
 		{
 			// tag::9eda9c39428b0c2c53cbd8ee7ae0f888[]
 			var response0 = new SearchResponse<object>();
@@ -117,8 +117,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:998")]
-		public void Line998()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:993")]
+		public void Line993()
 		{
 			// tag::553904c175a76d5ba83bc5d46fff7373[]
 			var response0 = new SearchResponse<object>();
@@ -132,8 +132,8 @@ namespace Examples.XPack.Docs.En.Security.Authentication
 		}
 
 		[U(Skip = "Example not implemented")]
-		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:1016")]
-		public void Line1016()
+		[Description("../../x-pack/docs/en/security/authentication/saml-guide.asciidoc:1011")]
+		public void Line1011()
 		{
 			// tag::a71154ea11a5214f409ecfd118e9b5e3[]
 			var response0 = new SearchResponse<object>();


### PR DESCRIPTION
This PR implements the client examples for April. Refactored `MatchesExample` to take `Action<Example>` instead of `Func<Example, Example>`.