### PR TITLE
Selective inclusion of new API's in the high level code generator

### DIFF
--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -31,7 +31,10 @@ namespace ApiGenerator.Configuration
 			// To be removed
 			"indices.upgrade.json",
 			"indices.get_upgrade.json",
-			"indices.exists_type.json",
+
+			// already removed in the client.
+			"indices.exists_type.json"
+
 		};
 
 		private static string[] IgnoredApisHighLevel { get; } =
@@ -114,13 +117,14 @@ namespace ApiGenerator.Configuration
 		public static bool IsNewHighLevelApi(string apiFileName) =>
 			// if its explicitly ignored we know about it.
 			!IgnoredApis.Contains(apiFileName)
+			&& !IgnoredApisHighLevel.Contains(apiFileName)
 			// no requests with [MapsApi("filename.json")] found
 			&& !HighLevelApiNameMapping.ContainsKey(apiFileName.Replace(".json", ""));
 
 		public static bool IgnoreHighLevelApi(string apiFileName)
 		{
 			//explicitly ignored
-			if (IgnoredApisHighLevel.Contains(apiFileName)) return true;
+			if (IgnoredApis.Contains(apiFileName) || IgnoredApisHighLevel.Contains(apiFileName)) return true;
 
 			//always generate already mapped requests
 			if (!IsNewHighLevelApi(apiFileName)) return false;

--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -127,7 +127,8 @@ namespace ApiGenerator.Configuration
 			if (IgnoredApis.Contains(apiFileName) || IgnoredApisHighLevel.Contains(apiFileName)) return true;
 
 			//always generate already mapped requests
-			if (!IsNewHighLevelApi(apiFileName)) return false;
+
+			if (HighLevelApiNameMapping.ContainsKey(apiFileName.Replace(".json", ""))) return false;
 
 			return !EnableHighLevelCodeGen.Contains(apiFileName);
 		}

--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -34,7 +34,7 @@ namespace ApiGenerator.Configuration
 			"indices.exists_type.json",
 		};
 
-		public static string[] IgnoredApisHighLevel { get; } =
+		private static string[] IgnoredApisHighLevel { get; } =
 		{
 			"autoscaling.get_autoscaling_decision.json", // 7.7 experimental
 			"autoscaling.delete_autoscaling_decision.json", // experimental
@@ -108,6 +108,21 @@ namespace ApiGenerator.Configuration
 				select new { Value = f.Name.Replace("Request", ""), Key = c.Replace(".json", "") })
 			.DistinctBy(v => v.Key)
 			.ToDictionary(k => k.Key, v => v.Value.Replace(".cs", ""));
+
+		public static readonly HashSet<string> EnableHighLevelCodeGen = new HashSet<string>();
+
+		public static bool IsNewHighLevelApi(string apiFileName) => !HighLevelApiNameMapping.ContainsKey(apiFileName.Replace(".json", ""));
+
+		public static bool IgnoreHighLevelApi(string apiFileName)
+		{
+			//explicitly ignored
+			if (IgnoredApisHighLevel.Contains(apiFileName)) return true;
+
+			//always generate already mapped requests
+			if (!IsNewHighLevelApi(apiFileName)) return false;
+
+			return !EnableHighLevelCodeGen.Contains(apiFileName);
+		}
 
 		private static Dictionary<string, string> _apiNameMapping;
 

--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -111,7 +111,11 @@ namespace ApiGenerator.Configuration
 
 		public static readonly HashSet<string> EnableHighLevelCodeGen = new HashSet<string>();
 
-		public static bool IsNewHighLevelApi(string apiFileName) => !HighLevelApiNameMapping.ContainsKey(apiFileName.Replace(".json", ""));
+		public static bool IsNewHighLevelApi(string apiFileName) =>
+			// if its explicitly ignored we know about it.
+			!IgnoredApis.Contains(apiFileName)
+			// no requests with [MapsApi("filename.json")] found
+			&& !HighLevelApiNameMapping.ContainsKey(apiFileName.Replace(".json", ""));
 
 		public static bool IgnoreHighLevelApi(string apiFileName)
 		{

--- a/src/ApiGenerator/Domain/RestApiSpec.cs
+++ b/src/ApiGenerator/Domain/RestApiSpec.cs
@@ -31,9 +31,10 @@ namespace ApiGenerator.Domain
 
 		public ImmutableSortedDictionary<string, ReadOnlyCollection<ApiEndpoint>> EndpointsPerNamespaceHighLevel =>
 			Endpoints.Values
-				.Where(v => !CodeConfiguration.IgnoredApisHighLevel.Contains(v.FileName))
+				.Where(v => !CodeConfiguration.IgnoreHighLevelApi(v.FileName))
 				.GroupBy(e => e.CsharpNames.Namespace)
 				.ToImmutableSortedDictionary(kv => kv.Key, kv => kv.ToList().AsReadOnly());
+
 
 		private IEnumerable<EnumDescription> _enumDescriptions;
 		public IEnumerable<EnumDescription> EnumsInTheSpec

--- a/src/ApiGenerator/Generator/ApiGenerator.cs
+++ b/src/ApiGenerator/Generator/ApiGenerator.cs
@@ -18,9 +18,9 @@ namespace ApiGenerator.Generator
 {
 	public class ApiGenerator
 	{
-		public static List<string> Warnings { get; private set; }
+		public static List<string> Warnings { get; private set; } = new List<string>();
 
-		public static async Task Generate(string downloadBranch, bool lowLevelOnly, params string[] folders)
+		public static async Task Generate(string downloadBranch, bool lowLevelOnly, RestApiSpec spec)
 		{
 			async Task Generate(IList<RazorGeneratorBase> generators, RestApiSpec restApiSpec, bool highLevel)
 			{
@@ -35,8 +35,7 @@ namespace ApiGenerator.Generator
 				}
 			}
 
-			Warnings = new List<string>();
-			var spec = CreateRestApiSpecModel(downloadBranch, folders);
+
 			var lowLevelGenerators = new List<RazorGeneratorBase>
 			{
 				//low level client
@@ -77,7 +76,7 @@ namespace ApiGenerator.Generator
 			Console.ResetColor();
 		}
 
-		private static RestApiSpec CreateRestApiSpecModel(string downloadBranch, string[] folders)
+		public static RestApiSpec CreateRestApiSpecModel(string downloadBranch, params string[] folders)
 		{
 			var directories = Directory.GetDirectories(GeneratorLocations.RestSpecificationFolder, "*", SearchOption.AllDirectories)
 				.Where(f => folders == null || folders.Length == 0 || folders.Contains(new DirectoryInfo(f).Name))

--- a/src/ApiGenerator/Generator/ApiGenerator.cs
+++ b/src/ApiGenerator/Generator/ApiGenerator.cs
@@ -43,6 +43,7 @@ namespace ApiGenerator.Generator
 				new LowLevelClientImplementationGenerator(),
 				new RequestParametersGenerator(),
 				new EnumsGenerator(),
+				new ApiUrlsLookupsGenerator(),
 			};
 
 			var highLevelGenerators = new List<RazorGeneratorBase>
@@ -52,7 +53,6 @@ namespace ApiGenerator.Generator
 				new HighLevelClientImplementationGenerator(),
 				new DescriptorsGenerator(),
 				new RequestsGenerator(),
-				new ApiUrlsLookupsGenerator(),
 			};
 
 			await Generate(lowLevelGenerators, spec, highLevel: false);

--- a/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
+++ b/src/ApiGenerator/Views/HighLevel/Requests/ApiUrlsLookup.cshtml
@@ -13,7 +13,7 @@ namespace Nest
 	{
 @foreach (var endpoint in m.Endpoints.Values)
 {
-	if (CodeConfiguration.IgnoredApisHighLevel.Contains(endpoint.FileName))
+	if (CodeConfiguration.IgnoreHighLevelApi(endpoint.Name))
 	{
 		continue;
 	}

--- a/src/Nest/Cluster/Ping/PingRequest.cs
+++ b/src/Nest/Cluster/Ping/PingRequest.cs
@@ -4,6 +4,7 @@
 
 namespace Nest
 {
+	[MapsApi("ping.json")]
 	public partial interface IPingRequest { }
 
 	public partial class PingRequest { }

--- a/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
@@ -11,6 +11,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[JsonFormatter(typeof(BulkRequestFormatter))]
+	[MapsApi("bulk.json")]
 	public partial interface IBulkRequest
 	{
 		[IgnoreDataMember]

--- a/src/Nest/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
+++ b/src/Nest/Document/Multiple/DeleteByQuery/DeleteByQueryRequest.cs
@@ -10,6 +10,7 @@ namespace Nest
 	/// <summary>
 	/// Delete documents that match a given query
 	/// </summary>
+	[MapsApi("delete_by_query.json")]
 	public partial interface IDeleteByQueryRequest
 	{
 		/// <summary>

--- a/src/Nest/Document/Multiple/ReindexRethrottle/ReindexRethrottleRequest.cs
+++ b/src/Nest/Document/Multiple/ReindexRethrottle/ReindexRethrottleRequest.cs
@@ -4,6 +4,7 @@
 
 namespace Nest
 {
+	[MapsApi("reindex_rethrottle.json")]
 	public partial interface IReindexRethrottleRequest { }
 
 	public partial class ReindexRethrottleRequest : IReindexRethrottleRequest { }

--- a/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
+++ b/src/Nest/Document/Multiple/UpdateByQuery/UpdateByQueryRequest.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	[MapsApi("update_by_query.json")]
 	public partial interface IUpdateByQueryRequest
 	{
 		/// <summary>

--- a/src/Nest/Document/Single/Get/GetRequest.cs
+++ b/src/Nest/Document/Single/Get/GetRequest.cs
@@ -4,6 +4,7 @@
 
 namespace Nest
 {
+	[MapsApi("get.json")]
 	public partial interface IGetRequest { }
 
 	// ReSharper disable once UnusedTypeParameter

--- a/src/Nest/Document/Single/Index/IndexRequest.cs
+++ b/src/Nest/Document/Single/Index/IndexRequest.cs
@@ -9,6 +9,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[JsonFormatter(typeof(IndexRequestFormatter<>))]
+	[MapsApi("index.json")]
 	public partial interface IIndexRequest<TDocument> : IProxyRequest, IDocumentRequest where TDocument : class
 	{
 		TDocument Document { get; set; }

--- a/src/Nest/Document/Single/Update/UpdateRequest.cs
+++ b/src/Nest/Document/Single/Update/UpdateRequest.cs
@@ -8,7 +8,8 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
-	public partial interface IUpdateRequest<TDocument, TPartialDocument> 
+	[MapsApi("update.json")]
+	public partial interface IUpdateRequest<TDocument, TPartialDocument>
 		where TDocument : class
 		where TPartialDocument : class
 	{

--- a/src/Nest/Search/Scroll/Scroll/ScrollRequest.cs
+++ b/src/Nest/Search/Scroll/Scroll/ScrollRequest.cs
@@ -7,6 +7,7 @@ using System.Runtime.Serialization;
 
 namespace Nest
 {
+	[MapsApi("scroll.json")]
 	public partial interface IScrollRequest : ITypedSearchRequest
 	{
 		[DataMember(Name ="scroll")]

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -11,6 +11,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[ReadAs(typeof(SearchRequest))]
+	[MapsApi("search.json")]
 	public partial interface ISearchRequest : ITypedSearchRequest
 	{
 		/// <summary>

--- a/src/Nest/Search/SearchShards/SearchShardsRequest.cs
+++ b/src/Nest/Search/SearchShards/SearchShardsRequest.cs
@@ -4,6 +4,7 @@
 
 namespace Nest
 {
+	[MapsApi("search_shards.json")]
 	public partial interface ISearchShardsRequest { }
 
 	// ReSharper disable once UnusedTypeParameter

--- a/src/Nest/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
+++ b/src/Nest/Search/SearchTemplate/RenderSearchTemplate/RenderSearchTemplateRequest.cs
@@ -9,6 +9,7 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
+	[MapsApi("render_search_template.json")]
 	public partial interface IRenderSearchTemplateRequest
 	{
 		[DataMember(Name = "file")]

--- a/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
+++ b/src/Nest/Search/SearchTemplate/SearchTemplateRequest.cs
@@ -10,6 +10,7 @@ using Elasticsearch.Net;
 namespace Nest
 {
 	[ReadAs(typeof(SearchTemplateRequest))]
+	[MapsApi("search_template.json")]
 	public partial interface ISearchTemplateRequest : ITypedSearchRequest
 	{
 		[DataMember(Name ="id")]


### PR DESCRIPTION
Updates the high level codegeneration so that new API's, those not mapped and not explicitly ignored, require confirmation before generating. 


![gated-gen](https://user-images.githubusercontent.com/245275/79864092-24659380-83d9-11ea-855e-cd81f0aa6597.gif)

