### PR TITLE
PrimitiveObjectFormatter eagerly reads integer where double could be preferred.

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/PrimitiveObjectFormatter.cs
@@ -158,6 +158,9 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
                 case JsonToken.Number:
 					var numberSegment = reader.ReadNumberSegment();
 					// conditional operator here would cast both to double, so don't use.
+					// Check for IsDouble first, IsDouble && IsLong can both return true, prefer precision
+					if (numberSegment.IsDouble())
+						return NumberConverter.ReadDouble(numberSegment.Array, numberSegment.Offset, out _);
 					if (numberSegment.IsLong())
 						return NumberConverter.ReadInt64(numberSegment.Array, numberSegment.Offset, out _);
 

--- a/tests/Tests.YamlRunner/Commands.fs
+++ b/tests/Tests.YamlRunner/Commands.fs
@@ -12,10 +12,16 @@ let private barOptions =
        ForegroundColor = ConsoleColor.Cyan,
        ForegroundColorDone = Nullable ConsoleColor.DarkGreen,
        BackgroundColor = Nullable ConsoleColor.DarkGray,
-       ProgressCharacter = '─'
+       ProgressCharacter = '─',
+       CollapseWhenFinished = true
     )
 let private subBarOptions = 
-    ProgressBarOptions(ForegroundColor = ConsoleColor.Yellow, ForegroundColorDone = Nullable ConsoleColor.DarkGreen, ProgressCharacter = '─')
+    ProgressBarOptions(
+        ForegroundColor = ConsoleColor.Yellow,
+        ForegroundColorDone = Nullable ConsoleColor.DarkGreen,
+        ProgressCharacter = '─',
+        CollapseWhenFinished = true
+    )
 
 let LocateTests namedSuite revision directoryFilter fileFilter = async {
     let! folders = TestsLocator.ListFolders namedSuite revision directoryFilter 


### PR DESCRIPTION
A bug in `PrimitiveObjectFormatter` which is used when deserializing
`object` was eagerly reading doubles as integers. This was flagged in
failing yaml test reproduce:


> ./build.sh rest-spec-tests xpack -f analytics -t t_test.yml -s "heteroscedastic t-test"


Scrollbars now also collapse when running the yaml tests now that
ShellProgressbar properly scrolls children into view this got to be a
tad excessive