### PR TITLE
[DOCS] Correct docs links for boxplot and top metrics aggs

### DIFF
--- a/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.5
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.x
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.5
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/7.x
 
 :github: https://github.com/elastic/elasticsearch-net
 


### PR DESCRIPTION
a415e6ad896c7e2c0c35bc4d6ea9f4f50d1b1848 updated the docs link branch
from `master` to `7.5` for the boxplot and top metrics aggregations.

However, those aggregations are only available in 7.7 and later
branches.

This updates the docs to use the `7.x` branch for links.