### PR TITLE
Don't sanitize the keys for Filters aggregation named buckets

### DIFF
--- a/src/Nest/Aggregations/Bucket/Filters/FiltersAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/Filters/FiltersAggregate.cs
@@ -28,6 +28,9 @@ namespace Nest
 
 		public FiltersAggregate(IReadOnlyDictionary<string, IAggregate> aggregations) : base(aggregations) { }
 
+		// Don't sanitize the keys as these are the keys for named buckets
+		protected override string Sanitize(string key) => key;
+
 		public IReadOnlyCollection<FiltersBucketItem> Buckets { get; set; } = EmptyReadOnly<FiltersBucketItem>.Collection;
 
 		public SingleBucketAggregate NamedBucket(string key) => Global(key);

--- a/tests/Tests.Reproduce/GithubIssue4582.cs
+++ b/tests/Tests.Reproduce/GithubIssue4582.cs
@@ -1,0 +1,54 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+using Tests.Core.Extensions;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4582
+	{
+		[U]
+		public void DeserializeBucketKeyWithHash()
+		{
+			var json = @"
+{
+  ""hits"": {
+  },
+  ""aggregations"":
+  {
+    ""some_agg"" : {
+      ""buckets"" : {
+        ""value1"" : {
+          ""doc_count"" : 0
+        },
+        ""value2"" : {
+          ""doc_count"" : 0
+        },
+        ""value3#something else"" : {
+          ""doc_count"" : 0
+        }
+      }
+    }
+  }
+}
+";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var client = TestClient.FixedInMemoryClient(bytes);
+			var response = client.Search<object>();
+
+			var filters = response.Aggregations
+				.Filters("some_agg")
+				.Select(x => x.Key)
+				.ToList();
+
+			filters[2].Should().Be("value3#something else");
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes a bug where the keys in the dictionary passed
to filters aggregation are sanitized when copying to the backing
dictionary. Keys in this scenario are the keys for named buckets
which should never be sanitized.

Fixes #4582