### PR TITLE
Add RequestParams overload without optional content type

### DIFF
--- a/src/Elasticsearch.Net/ElasticLowLevelClient.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.cs
@@ -75,10 +75,10 @@ namespace Elasticsearch.Net
 		protected internal TRequestParams RequestParams<TRequestParams>(TRequestParams requestParams, string contentType = null, string accept = null)
 			where TRequestParams : class, IRequestParameters, new()
 		{
-			if (contentType.IsNullOrEmpty()) return requestParams;
+			if (contentType.IsNullOrEmpty() && accept.IsNullOrEmpty()) return requestParams;
 
 			requestParams ??= new TRequestParams();
-			if (requestParams.RequestConfiguration == null) requestParams.RequestConfiguration = new RequestConfiguration();
+			requestParams.RequestConfiguration ??= new RequestConfiguration();
 			if (!contentType.IsNullOrEmpty() && requestParams.RequestConfiguration.ContentType.IsNullOrEmpty())
 				requestParams.RequestConfiguration.ContentType = contentType;
 			if (!accept.IsNullOrEmpty() && requestParams.RequestConfiguration.Accept.IsNullOrEmpty())

--- a/src/Elasticsearch.Net/NamespacedClientProxy.cs
+++ b/src/Elasticsearch.Net/NamespacedClientProxy.cs
@@ -20,9 +20,13 @@ namespace Elasticsearch.Net
 
 		protected string Url(FormattableString formattable) => _client.Url(formattable);
 
-		protected TRequestParams RequestParams<TRequestParams>(TRequestParams requestParams, string contentType = null)
+		protected TRequestParams RequestParams<TRequestParams>(TRequestParams requestParams, string contentType)
 			where TRequestParams : class, IRequestParameters, new()
 			=> _client.RequestParams(requestParams, contentType ?? ContentType, contentType ?? ContentType);
+
+		protected TRequestParams RequestParams<TRequestParams>(TRequestParams requestParams)
+			where TRequestParams : class, IRequestParameters, new()
+			=> _client.RequestParams(requestParams, ContentType, ContentType);
 
 		// ReSharper disable once UnassignedGetOnlyAutoProperty intended to be overridden
 		protected virtual string ContentType { get; }


### PR DESCRIPTION
This commit adds back a RequestParams overload on NamespacedClientProxy
in Elasticsearch.Net that does not accept a content type
optional parameter, and removes the optional part
of the parameter on the other overload, for backwards
binary compatibility.