### PR TITLE
Fix check for agressive connectionlimit

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 #if DOTNETCORE
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -23,11 +24,33 @@ namespace Elasticsearch.Net
 	/// </summary>
 	public class ConnectionConfiguration : ConnectionConfiguration<ConnectionConfiguration>
 	{
-#if DOTNETCORE
-		private static bool IsCurlHandler { get; } = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.CurlHandler") != null;
+		/// <summary>
+		/// Detects whether we are running on .NET Core without SocketsHttpHandler existing or being enabled
+		/// If this is true we will set a very restrictive <see cref="DefaultConnectionLimit"/>
+		/// As the old curl based handler is known to bleed TCP connections:
+		/// <para>https://github.com/dotnet/runtime/issues/22366</para>
+		/// </summary>
+        private static bool OnDotNetCoreWithNoSocketsHttpHandlerEnabled
+        {
+            get
+            {
+#if !DOTNETCORE
+					return false;
 #else
-		private static bool IsCurlHandler { get; } = false;
+                var exists = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.SocketsHttpHandler") != null;
+                if (!exists) return false;
+
+				if (AppContext.TryGetSwitch("System.Net.Http.UseSocketsHttpHandler", out var isEnabled))
+                    return isEnabled;
+                var environmentVariable =
+                    Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER");
+                return environmentVariable == null ||
+                       !environmentVariable.Equals("false", StringComparison.OrdinalIgnoreCase) &&
+                       !environmentVariable.Equals("0");
 #endif
+
+            }
+        }
 
 		/// <summary>
 		/// The default ping timeout. Defaults to 2 seconds
@@ -52,7 +75,7 @@ namespace Elasticsearch.Net
 		/// <para>Except for <see cref="HttpClientHandler"/> implementations based on curl, which defaults to <see cref="Environment.ProcessorCount"/></para>
 #endif
 		/// </summary>
-		public static readonly int DefaultConnectionLimit = IsCurlHandler ? Environment.ProcessorCount : 80;
+		public static readonly int DefaultConnectionLimit = !OnDotNetCoreWithNoSocketsHttpHandlerEnabled ? Environment.ProcessorCount : 80;
 
 		/// <summary>
 		/// The default user agent for Elasticsearch.Net

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -5,7 +5,6 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 #if DOTNETCORE
 using System.Net.Http;
 using System.Runtime.InteropServices;

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -24,32 +24,41 @@ namespace Elasticsearch.Net
 	public class ConnectionConfiguration : ConnectionConfiguration<ConnectionConfiguration>
 	{
 		/// <summary>
-		/// Detects whether we are running on .NET Core without SocketsHttpHandler existing or being enabled
-		/// If this is true we will set a very restrictive <see cref="DefaultConnectionLimit"/>
+		/// Detects whether we are running on .NET Core with CurlHandler.
+		/// If this is true, we will set a very restrictive <see cref="DefaultConnectionLimit"/>
 		/// As the old curl based handler is known to bleed TCP connections:
 		/// <para>https://github.com/dotnet/runtime/issues/22366</para>
 		/// </summary>
-        private static bool OnDotNetCoreWithNoSocketsHttpHandlerEnabled
-        {
-            get
-            {
+        private static bool UsingCurlHandler
+		{
+			get
+			{
 #if !DOTNETCORE
-					return false;
+				return false;
 #else
-                var exists = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.SocketsHttpHandler") != null;
-                if (!exists) return false;
+				var curlHandlerExists = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.CurlHandler") != null;
+				if (!curlHandlerExists) return false;
+
+				var socketsHandlerExists = typeof(HttpClientHandler).Assembly.GetType("System.Net.Http.SocketsHttpHandler") != null;
+				// running on a .NET core version with CurlHandler, before the existence of SocketsHttpHandler.
+				// Must be using CurlHandler.
+				if (!socketsHandlerExists) return true;
 
 				if (AppContext.TryGetSwitch("System.Net.Http.UseSocketsHttpHandler", out var isEnabled))
-                    return isEnabled;
-                var environmentVariable =
-                    Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER");
-                return environmentVariable == null ||
-                       !environmentVariable.Equals("false", StringComparison.OrdinalIgnoreCase) &&
-                       !environmentVariable.Equals("0");
-#endif
+					return !isEnabled;
 
-            }
-        }
+				var environmentVariable =
+					Environment.GetEnvironmentVariable("DOTNET_SYSTEM_NET_HTTP_USESOCKETSHTTPHANDLER");
+
+				// SocketsHandler exists and no environment variable exists to disable it.
+				// Must be using SocketsHandler and not CurlHandler
+				if (environmentVariable == null) return false;
+
+				return environmentVariable.Equals("false", StringComparison.OrdinalIgnoreCase) ||
+					environmentVariable.Equals("0");
+#endif
+			}
+		}
 
 		/// <summary>
 		/// The default ping timeout. Defaults to 2 seconds
@@ -74,7 +83,7 @@ namespace Elasticsearch.Net
 		/// <para>Except for <see cref="HttpClientHandler"/> implementations based on curl, which defaults to <see cref="Environment.ProcessorCount"/></para>
 #endif
 		/// </summary>
-		public static readonly int DefaultConnectionLimit = !OnDotNetCoreWithNoSocketsHttpHandlerEnabled ? Environment.ProcessorCount : 80;
+		public static readonly int DefaultConnectionLimit = UsingCurlHandler ? Environment.ProcessorCount : 80;
 
 		/// <summary>
 		/// The default user agent for Elasticsearch.Net


### PR DESCRIPTION
In https://github.com/dotnet/runtime/issues/22366 we found that if
HttpClient is using the curl handler it will lead to TCP connections
bleeding. Our DefaultConnectionLimit is very restrictive if this is
true. Our check however is too lenient and will default to true always
on .NET core since netcoreapp still ships with CurlHandler as recent as
`3.1.x`