### PR TITLE
Mute CsvProcessor tests

### DIFF
--- a/tests/Tests/Ingest/ProcessorAssertions.cs
+++ b/tests/Tests/Ingest/ProcessorAssertions.cs
@@ -5,6 +5,7 @@ using System.Reflection;
 using Elastic.Xunit.XunitPlumbing;
 using Nest;
 using Tests.Core.Client;
+using Tests.Core.Xunit;
 using Tests.Domain;
 
 namespace Tests.Ingest
@@ -70,7 +71,7 @@ namespace Tests.Ingest
 			public override string Key => "append";
 		}
 
-		[SkipVersion("<7.7.0", "Empty Value introduced in Elasticsearch 7.7.0+, CSV introduced in 7.6.0+")]
+		[BlockedByIssue("https://github.com/elastic/elasticsearch/issues/55643")]
 		public class Csv : ProcessorAssertion
 		{
 			public override Func<ProcessorsDescriptor, IPromise<IList<IProcessor>>> Fluent => d => d

--- a/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
+++ b/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
@@ -5,12 +5,14 @@ using Nest;
 using Tests.Configuration;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Core.Xunit;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
 
 namespace Tests.Ingest.PutPipeline
 {
+	[BlockedByIssue("https://github.com/elastic/elasticsearch/issues/55643")]
 	public class PutPipelineApiTests
 		: ApiIntegrationTestBase<XPackCluster, PutPipelineResponse, IPutPipelineRequest, PutPipelineDescriptor, PutPipelineRequest>
 	{


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/issues/55643

Mute CsvProcessor tests, until upstream bug is fixed.