### PR TITLE
Allow HttpClient instances to be refreshed periodically

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 #if DOTNETCORE
 using System.Net.Http;
 using System.Runtime.InteropServices;
@@ -24,8 +25,8 @@ namespace Elasticsearch.Net
 	public class ConnectionConfiguration : ConnectionConfiguration<ConnectionConfiguration>
 	{
 		/// <summary>
-		/// Detects whether we are running on .NET Core with CurlHandler.
-		/// If this is true, we will set a very restrictive <see cref="DefaultConnectionLimit"/>
+		/// Detects whether we are running on .NET Core without SocketsHttpHandler existing or being enabled
+		/// If this is true we will set a very restrictive <see cref="DefaultConnectionLimit"/>
 		/// As the old curl based handler is known to bleed TCP connections:
 		/// <para>https://github.com/dotnet/runtime/issues/22366</para>
 		/// </summary>

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -1,11 +1,10 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-using System.Net;
 #if DOTNETCORE
 using System.Net.Http;
 using System.Runtime.InteropServices;

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -24,8 +24,8 @@ namespace Elasticsearch.Net
 	public class ConnectionConfiguration : ConnectionConfiguration<ConnectionConfiguration>
 	{
 		/// <summary>
-		/// Detects whether we are running on .NET Core without SocketsHttpHandler existing or being enabled
-		/// If this is true we will set a very restrictive <see cref="DefaultConnectionLimit"/>
+		/// Detects whether we are running on .NET Core with CurlHandler.
+		/// If this is true, we will set a very restrictive <see cref="DefaultConnectionLimit"/>
 		/// As the old curl based handler is known to bleed TCP connections:
 		/// <para>https://github.com/dotnet/runtime/issues/22366</para>
 		/// </summary>

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -249,5 +249,15 @@ namespace Elasticsearch.Net
 		/// Whether the request should be sent with chunked Transfer-Encoding.
 		/// </summary>
 		bool TransferEncodingChunked { get; }
+
+		/// <summary>
+		/// DnsRefreshTimeout for the connections. Defaults to 5 minutes.
+		#if DOTNETCORE
+		/// <para>Will create new instances of <see cref="System.Net.Http.HttpClient"/> after this timeout to force DNS updates</para>
+		#else
+		/// <para>Will set <see cref="System.Net.ServicePointManager.ConnectionLeaseTimeout "/>
+		#endif
+		/// </summary>
+		TimeSpan DnsRefreshTimeout { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
@@ -9,8 +9,11 @@ using System.Threading;
 
 namespace Elasticsearch.Net
 {
-    // Thread-safety: We treat this class as immutable except for the timer. Creating a new object
-    // for the 'expiry' pool simplifies the threading requirements significantly.
+	/// <summary>
+    /// Thread-safety: We treat this class as immutable except for the timer. Creating a new object
+	/// for the 'expiry' pool simplifies the threading requirements significantly.
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/ActiveHandlerTrackingEntry.cs</para>
+	/// </summary>
     internal class ActiveHandlerTrackingEntry
     {
         private static readonly TimerCallback TimerCallback = (s) => ((ActiveHandlerTrackingEntry)s).Timer_Tick();

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
@@ -1,0 +1,81 @@
+﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+    // Thread-safety: We treat this class as immutable except for the timer. Creating a new object
+    // for the 'expiry' pool simplifies the threading requirements significantly.
+    internal class ActiveHandlerTrackingEntry
+    {
+        private static readonly TimerCallback TimerCallback = (s) => ((ActiveHandlerTrackingEntry)s).Timer_Tick();
+        private readonly object _lock;
+        private bool _timerInitialized;
+        private Timer _timer;
+        private TimerCallback _callback;
+
+        public ActiveHandlerTrackingEntry(
+            int key,
+            LifetimeTrackingHttpMessageHandler handler,
+            TimeSpan lifetime)
+        {
+            Key = key;
+            Handler = handler;
+            Lifetime = lifetime;
+
+            _lock = new object();
+        }
+
+        public LifetimeTrackingHttpMessageHandler Handler { get; private set; }
+
+        public TimeSpan Lifetime { get; }
+
+        public int Key { get; }
+
+        public void StartExpiryTimer(TimerCallback callback)
+        {
+            if (Lifetime == Timeout.InfiniteTimeSpan) return;
+
+            if (Volatile.Read(ref _timerInitialized)) return;
+
+            StartExpiryTimerSlow(callback);
+        }
+
+        private void StartExpiryTimerSlow(TimerCallback callback)
+        {
+            Debug.Assert(Lifetime != Timeout.InfiniteTimeSpan);
+
+            lock (_lock)
+            {
+                if (Volatile.Read(ref _timerInitialized))
+                    return;
+
+                _callback = callback;
+                _timer = NonCapturingTimer.Create(TimerCallback, this, Lifetime, Timeout.InfiniteTimeSpan);
+                _timerInitialized = true;
+            }
+        }
+
+        private void Timer_Tick()
+        {
+            Debug.Assert(_callback != null);
+            Debug.Assert(_timer != null);
+
+            lock (_lock)
+			{
+				if (_timer == null) return;
+
+				_timer.Dispose();
+				_timer = null;
+
+				_callback(this);
+			}
+        }
+    }
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
@@ -1,0 +1,33 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Net.Http;
+
+namespace Elasticsearch.Net
+{
+	// Thread-safety: This class is immutable
+	internal class ExpiredHandlerTrackingEntry
+	{
+		private readonly WeakReference _livenessTracker;
+
+		// IMPORTANT: don't cache a reference to `other` or `other.Handler` here.
+		// We need to allow it to be GC'ed.
+		public ExpiredHandlerTrackingEntry(ActiveHandlerTrackingEntry other)
+		{
+			Key = other.Key;
+
+			_livenessTracker = new WeakReference(other.Handler);
+			InnerHandler = other.Handler.InnerHandler;
+		}
+
+		public bool CanDispose => !_livenessTracker.IsAlive;
+
+		public HttpMessageHandler InnerHandler { get; }
+
+		public int Key { get; }
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
@@ -8,7 +8,10 @@ using System.Net.Http;
 
 namespace Elasticsearch.Net
 {
-	// Thread-safety: This class is immutable
+	/// <summary>
+	/// Thread-safety: This class is immutable
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/ExpiredHandlerTrackingEntry.cs</para>
+	/// </summary>
 	internal class ExpiredHandlerTrackingEntry
 	{
 		private readonly WeakReference _livenessTracker;

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
@@ -7,9 +7,12 @@ using System.Net.Http;
 
 namespace Elasticsearch.Net
 {
-	// This a marker used to check if the underlying handler should be disposed. HttpClients
-	// share a reference to an instance of this class, and when it goes out of scope the inner handler
-	// is eligible to be disposed.
+	/// <summary>
+	/// This a marker used to check if the underlying handler should be disposed. HttpClients
+	/// share a reference to an instance of this class, and when it goes out of scope the inner handler
+	/// is eligible to be disposed.
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/LifetimeTrackingHttpMessageHandler.cs</para>
+	/// </summary>
 	internal class LifetimeTrackingHttpMessageHandler : DelegatingHandler
 	{
 		public LifetimeTrackingHttpMessageHandler(HttpMessageHandler innerHandler)

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
@@ -1,0 +1,24 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System.Net.Http;
+
+namespace Elasticsearch.Net
+{
+	// This a marker used to check if the underlying handler should be disposed. HttpClients
+	// share a reference to an instance of this class, and when it goes out of scope the inner handler
+	// is eligible to be disposed.
+	internal class LifetimeTrackingHttpMessageHandler : DelegatingHandler
+	{
+		public LifetimeTrackingHttpMessageHandler(HttpMessageHandler innerHandler)
+			: base(innerHandler) { }
+
+		protected override void Dispose(bool disposing)
+		{
+			// The lifetime of this is tracked separately by ActiveHandlerTrackingEntry
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -1,0 +1,253 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Xml;
+using Elasticsearch.Net;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Heavily modified version of DefaultHttpClientFactory, repurposed for RequestData
+	/// </summary>
+	internal class RequestDataHttpClientFactory : IDisposable
+	{
+		private readonly Func<RequestData, HttpMessageHandler> _createHttpClientHandler;
+		private static readonly TimerCallback CleanupCallback = (s) => ((RequestDataHttpClientFactory)s).CleanupTimer_Tick();
+		private readonly Func<int, RequestData, Lazy<ActiveHandlerTrackingEntry>> _entryFactory;
+
+		// Default time of 10s for cleanup seems reasonable.
+		// Quick math:
+		// 10 distinct named clients * expiry time >= 1s = approximate cleanup queue of 100 items
+		//
+		// This seems frequent enough. We also rely on GC occurring to actually trigger disposal.
+		private readonly TimeSpan _defaultCleanupInterval = TimeSpan.FromSeconds(10);
+
+		// We use a new timer for each regular cleanup cycle, protected with a lock. Note that this scheme
+		// doesn't give us anything to dispose, as the timer is started/stopped as needed.
+		//
+		// There's no need for the factory itself to be disposable. If you stop using it, eventually everything will
+		// get reclaimed.
+		private Timer _cleanupTimer;
+		private readonly object _cleanupTimerLock;
+		private readonly object _cleanupActiveLock;
+
+		// Collection of 'active' handlers.
+		//
+		// Using lazy for synchronization to ensure that only one instance of HttpMessageHandler is created
+		// for each name.
+		//
+		private readonly ConcurrentDictionary<int, Lazy<ActiveHandlerTrackingEntry>> _activeHandlers;
+
+		public int InUseHandlers => _activeHandlers.Count;
+		private int _removedHandlers = 0;
+		public int RemovedHandlers => _activeHandlers.Count;
+
+		// Collection of 'expired' but not yet disposed handlers.
+		//
+		// Used when we're rotating handlers so that we can dispose HttpMessageHandler instances once they
+		// are eligible for garbage collection.
+		//
+		private readonly ConcurrentQueue<ExpiredHandlerTrackingEntry> _expiredHandlers;
+		private readonly TimerCallback _expiryCallback;
+
+		public RequestDataHttpClientFactory(Func<RequestData, HttpMessageHandler> createHttpClientHandler)
+		{
+			_createHttpClientHandler = createHttpClientHandler;
+			// case-sensitive because named options is.
+			_activeHandlers = new ConcurrentDictionary<int, Lazy<ActiveHandlerTrackingEntry>>();
+			_entryFactory = (key, requestData) =>
+			{
+				return new Lazy<ActiveHandlerTrackingEntry>(() => CreateHandlerEntry(key, requestData),
+					LazyThreadSafetyMode.ExecutionAndPublication);
+			};
+
+			_expiredHandlers = new ConcurrentQueue<ExpiredHandlerTrackingEntry>();
+			_expiryCallback = ExpiryTimer_Tick;
+
+			_cleanupTimerLock = new object();
+			_cleanupActiveLock = new object();
+		}
+
+		public HttpClient CreateClient(RequestData requestData)
+		{
+			if (requestData == null) throw new ArgumentNullException(nameof(requestData));
+
+			var key = HttpConnection.GetClientKey(requestData);
+			var handler = CreateHandler(key, requestData);
+			var client = new HttpClient(handler, disposeHandler: false);
+			return client;
+		}
+
+		private HttpMessageHandler CreateHandler(int key, RequestData requestData)
+		{
+			if (requestData == null) throw new ArgumentNullException(nameof(requestData));
+
+			#if NETSTANDARD2_1
+			var entry = _activeHandlers.GetOrAdd(key, (k, r) => _entryFactory(k, r), requestData).Value;
+			#else
+			var entry = _activeHandlers.GetOrAdd(key, (k) => _entryFactory(k, requestData)).Value;
+			#endif
+
+			StartHandlerEntryTimer(entry);
+
+			return entry.Handler;
+		}
+
+		private ActiveHandlerTrackingEntry CreateHandlerEntry(int key, RequestData requestData)
+		{
+			// Wrap the handler so we can ensure the inner handler outlives the outer handler.
+			var handler = new LifetimeTrackingHttpMessageHandler(CreateHandler(key, requestData));
+
+			// Note that we can't start the timer here. That would introduce a very very subtle race condition
+			// with very short expiry times. We need to wait until we've actually handed out the handler once
+			// to start the timer.
+			//
+			// Otherwise it would be possible that we start the timer here, immediately expire it (very short
+			// timer) and then dispose it without ever creating a client. That would be bad. It's unlikely
+			// this would happen, but we want to be sure.
+			return new ActiveHandlerTrackingEntry(key, handler, TimeSpan.FromMinutes(1));
+		}
+
+		private void ExpiryTimer_Tick(object state)
+		{
+			var active = (ActiveHandlerTrackingEntry)state;
+
+			// The timer callback should be the only one removing from the active collection. If we can't find
+			// our entry in the collection, then this is a bug.
+			var removed = _activeHandlers.TryRemove(active.Key, out var found);
+			if (removed) Interlocked.Increment(ref _removedHandlers);
+			Debug.Assert(removed, "Entry not found. We should always be able to remove the entry");
+			Debug.Assert(object.ReferenceEquals(active, found.Value), "Different entry found. The entry should not have been replaced");
+
+			// At this point the handler is no longer 'active' and will not be handed out to any new clients.
+			// However we haven't dropped our strong reference to the handler, so we can't yet determine if
+			// there are still any other outstanding references (we know there is at least one).
+			//
+			// We use a different state object to track expired handlers. This allows any other thread that acquired
+			// the 'active' entry to use it without safety problems.
+			var expired = new ExpiredHandlerTrackingEntry(active);
+			_expiredHandlers.Enqueue(expired);
+
+			StartCleanupTimer();
+		}
+
+		protected virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry) => entry.StartExpiryTimer(_expiryCallback);
+
+		protected virtual void StartCleanupTimer()
+		{
+			lock (_cleanupTimerLock)
+				_cleanupTimer ??= NonCapturingTimer.Create(CleanupCallback, this, _defaultCleanupInterval, Timeout.InfiniteTimeSpan);
+		}
+
+		protected virtual void StopCleanupTimer()
+		{
+			lock (_cleanupTimerLock)
+			{
+				_cleanupTimer.Dispose();
+				_cleanupTimer = null;
+			}
+		}
+
+		private void CleanupTimer_Tick()
+		{
+			// Stop any pending timers, we'll restart the timer if there's anything left to process after cleanup.
+			//
+			// With the scheme we're using it's possible we could end up with some redundant cleanup operations.
+			// This is expected and fine.
+			//
+			// An alternative would be to take a lock during the whole cleanup process. This isn't ideal because it
+			// would result in threads executing ExpiryTimer_Tick as they would need to block on cleanup to figure out
+			// whether we need to start the timer.
+			StopCleanupTimer();
+
+			if (!Monitor.TryEnter(_cleanupActiveLock))
+			{
+				// We don't want to run a concurrent cleanup cycle. This can happen if the cleanup cycle takes
+				// a long time for some reason. Since we're running user code inside Dispose, it's definitely
+				// possible.
+				//
+				// If we end up in that position, just make sure the timer gets started again. It should be cheap
+				// to run a 'no-op' cleanup.
+				StartCleanupTimer();
+				return;
+			}
+
+			try
+			{
+				var initialCount = _expiredHandlers.Count;
+
+				for (var i = 0; i < initialCount; i++)
+				{
+					// Since we're the only one removing from _expired, TryDequeue must always succeed.
+					_expiredHandlers.TryDequeue(out var entry);
+					Debug.Assert(entry != null, "Entry was null, we should always get an entry back from TryDequeue");
+
+					if (entry.CanDispose)
+					{
+						try
+						{
+							entry.InnerHandler.Dispose();
+						}
+						catch (Exception)
+						{
+							// ignored (ignored in HttpClientFactory too)
+						}
+					}
+					else
+					{
+						// If the entry is still live, put it back in the queue so we can process it
+						// during the next cleanup cycle.
+						_expiredHandlers.Enqueue(entry);
+					}
+				}
+			}
+			finally
+			{
+				Monitor.Exit(_cleanupActiveLock);
+			}
+
+			// We didn't totally empty the cleanup queue, try again later.
+			if (_expiredHandlers.Count > 0) StartCleanupTimer();
+		}
+
+		public void Dispose()
+		{
+			//try to cleanup nicely
+			CleanupTimer_Tick();
+			_cleanupTimer?.Dispose();
+
+			//CleanupTimer might not cleanup everything because it will only dispose if the WeakReference allows it.
+			// here we forcefully dispose a Client -> ConnectionSettings -> Connection -> RequestDataHttpClientFactory
+			var attempts = 0;
+			do
+			{
+				attempts++;
+				var initialCount = _expiredHandlers.Count;
+				for (var i = 0; i < initialCount; i++)
+				{
+					// Since we're the only one removing from _expired, TryDequeue must always succeed.
+					_expiredHandlers.TryDequeue(out var entry);
+					try
+					{
+						entry?.InnerHandler.Dispose();
+					}
+					catch (Exception)
+					{
+						// ignored (ignored in HttpClientFactory too)
+					}
+				}
+			} while (attempts < 5 && _expiredHandlers.Count > 0);
+
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -16,7 +16,7 @@ using Elasticsearch.Net;
 namespace Elasticsearch.Net
 {
 	/// <summary>
-	/// Heavily modified version of DefaultHttpClientFactory, repurposed for RequestData
+	/// Heavily modified version of DefaultHttpClientFactory, re-purposed for RequestData
 	/// </summary>
 	internal class RequestDataHttpClientFactory : IDisposable
 	{
@@ -48,7 +48,7 @@ namespace Elasticsearch.Net
 		private readonly ConcurrentDictionary<int, Lazy<ActiveHandlerTrackingEntry>> _activeHandlers;
 
 		public int InUseHandlers => _activeHandlers.Count;
-		private int _removedHandlers = 0;
+		private int _removedHandlers;
 		public int RemovedHandlers => _removedHandlers;
 
 		// Collection of 'expired' but not yet disposed handlers.

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -17,6 +17,7 @@ namespace Elasticsearch.Net
 {
 	/// <summary>
 	/// Heavily modified version of DefaultHttpClientFactory, re-purposed for RequestData
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs</para>
 	/// </summary>
 	internal class RequestDataHttpClientFactory : IDisposable
 	{

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
@@ -1,0 +1,40 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+	// A convenience API for interacting with System.Threading.Timer in a way
+	// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+	// everywhere we use timers to avoid rooting any values stored in asynclocals.
+	internal static class NonCapturingTimer
+	{
+		public static Timer Create(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+		{
+			if (callback == null) throw new ArgumentNullException(nameof(callback));
+
+			// Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+			var restoreFlow = false;
+			try
+			{
+				if (ExecutionContext.IsFlowSuppressed()) return new Timer(callback, state, dueTime, period);
+
+				ExecutionContext.SuppressFlow();
+				restoreFlow = true;
+
+				return new Timer(callback, state, dueTime, period);
+			}
+			finally
+			{
+				// Restore the current ExecutionContext
+				if (restoreFlow) ExecutionContext.RestoreFlow();
+			}
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
@@ -9,9 +9,12 @@ using System.Threading;
 
 namespace Elasticsearch.Net
 {
-	// A convenience API for interacting with System.Threading.Timer in a way
-	// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
-	// everywhere we use timers to avoid rooting any values stored in asynclocals.
+	/// <summary>
+	/// A convenience API for interacting with System.Threading.Timer in a way
+	/// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+	/// everywhere we use timers to avoid rooting any values stored in asynclocals.
+	/// <para> https://github.com/dotnet/runtime/blob/master/src/libraries/Common/src/Extensions/ValueStopwatch/ValueStopwatch.cs </para>
+	/// </summary>
 	internal static class NonCapturingTimer
 	{
 		public static Timer Create(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)

--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -219,6 +219,7 @@ namespace Elasticsearch.Net
 		{
 			requestServicePoint.UseNagleAlgorithm = false;
 			requestServicePoint.Expect100Continue = false;
+			requestServicePoint.ConnectionLeaseTimeout = (int)requestData.DnsRefreshTimeout.TotalMilliseconds;
 			if (requestData.ConnectionSettings.ConnectionLimit > 0)
 				requestServicePoint.ConnectionLimit = requestData.ConnectionSettings.ConnectionLimit;
 			//looking at http://referencesource.microsoft.com/#System/net/System/Net/ServicePoint.cs

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -73,6 +73,7 @@ namespace Elasticsearch.Net
 
 			KeepAliveInterval = (int)(global.KeepAliveInterval?.TotalMilliseconds ?? 2000);
 			KeepAliveTime = (int)(global.KeepAliveTime?.TotalMilliseconds ?? 2000);
+			DnsRefreshTimeout = global.DnsRefreshTimeout;
 
 			ProxyAddress = global.ProxyAddress;
 			ProxyUsername = global.ProxyUsername;
@@ -130,6 +131,7 @@ namespace Elasticsearch.Net
 		public bool TransferEncodingChunked { get; }
 
 		public Uri Uri => Node != null ? new Uri(Node.Uri, PathAndQuery) : null;
+		public TimeSpan DnsRefreshTimeout { get; }
 
 		public override string ToString() => $"{Method.GetStringValue()} {_path}";
 

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype

--- a/tests/Tests.ScratchPad/Program.cs
+++ b/tests/Tests.ScratchPad/Program.cs
@@ -24,6 +24,14 @@ namespace Tests.ScratchPad
 
 			public void OnNext(DiagnosticListener value)
 			{
+
+				var client = new ElasticClient();
+
+				client.Search<Project>();
+
+				client.LowLevel.Search<SearchResponse<Project>>(PostData.Serializable(new SearchRequest()));
+
+
 				void WriteToConsole<T>(string eventName, T data)
 				{
 					var a = Activity.Current;

--- a/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -26,12 +26,34 @@ namespace Tests.ClientConcepts.Connection
 
 			connection.CallCount.Should().Be(1);
 			connection.InUseHandlers.Should().Be(1);
+			connection.RemovedHandlers.Should().Be(0);
 
 			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
 
 			connection.CallCount.Should().Be(2);
 			connection.InUseHandlers.Should().Be(1);
 		}
+
+		[I] public async Task RespectsDnsRefreshTimeout()
+		{
+			var connection = new TestableHttpConnection();
+			connection.RemovedHandlers.Should().Be(0);
+			var requestData = CreateRequestData(dnsRefreshTimeout: TimeSpan.FromSeconds(1));
+			connection.Request<StringResponse>(requestData);
+			await Task.Delay(TimeSpan.FromSeconds(2));
+			connection.Request<StringResponse>(requestData);
+
+			connection.CallCount.Should().Be(2);
+			connection.InUseHandlers.Should().Be(1);
+			connection.RemovedHandlers.Should().Be(1);
+
+			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
+
+			connection.CallCount.Should().Be(3);
+			connection.InUseHandlers.Should().Be(1);
+			connection.RemovedHandlers.Should().Be(1);
+		}
+
 
 		[I] public async Task MultipleInstancesOfHttpClientWhenRequestTimeoutChanges() =>
 			await MultipleInstancesOfHttpClientWhen(() => CreateRequestData(TimeSpan.FromSeconds(30)));
@@ -54,16 +76,19 @@ namespace Tests.ClientConcepts.Connection
 
 			connection.CallCount.Should().Be(1);
 			connection.InUseHandlers.Should().Be(1);
+			connection.RemovedHandlers.Should().Be(0);
 
 			requestData = differentRequestData();
 			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
 
 			connection.CallCount.Should().Be(2);
 			connection.InUseHandlers.Should().Be(2);
+			connection.RemovedHandlers.Should().Be(0);
 		}
 
 		private RequestData CreateRequestData(
 			TimeSpan requestTimeout = default,
+			TimeSpan? dnsRefreshTimeout = default,
 			Uri proxyAddress = null,
 			bool disableAutomaticProxyDetection = false,
 			bool httpCompression = false,
@@ -75,6 +100,7 @@ namespace Tests.ClientConcepts.Connection
 			var node = Client.ConnectionSettings.ConnectionPool.Nodes.First();
 			var connectionSettings = new ConnectionSettings(node.Uri)
 				.RequestTimeout(requestTimeout)
+				.DnsRefreshTimeout(dnsRefreshTimeout ?? ConnectionConfiguration.DefaultDnsRefreshTimeout)
 				.DisableAutomaticProxyDetection(disableAutomaticProxyDetection)
 				.TransferEncodingChunked(transferEncodingChunked)
 				.EnableHttpCompression(httpCompression);

--- a/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
+++ b/tests/Tests/ClientConcepts/Connection/HttpConnectionTests.cs
@@ -25,12 +25,12 @@ namespace Tests.ClientConcepts.Connection
 			connection.Request<StringResponse>(requestData);
 
 			connection.CallCount.Should().Be(1);
-			connection.ClientCount.Should().Be(1);
+			connection.InUseHandlers.Should().Be(1);
 
 			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
 
 			connection.CallCount.Should().Be(2);
-			connection.ClientCount.Should().Be(1);
+			connection.InUseHandlers.Should().Be(1);
 		}
 
 		[I] public async Task MultipleInstancesOfHttpClientWhenRequestTimeoutChanges() =>
@@ -53,13 +53,13 @@ namespace Tests.ClientConcepts.Connection
 			connection.Request<StringResponse>(requestData);
 
 			connection.CallCount.Should().Be(1);
-			connection.ClientCount.Should().Be(1);
+			connection.InUseHandlers.Should().Be(1);
 
 			requestData = differentRequestData();
 			await connection.RequestAsync<StringResponse>(requestData, CancellationToken.None).ConfigureAwait(false);
 
 			connection.CallCount.Should().Be(2);
-			connection.ClientCount.Should().Be(2);
+			connection.InUseHandlers.Should().Be(2);
 		}
 
 		private RequestData CreateRequestData(
@@ -157,7 +157,6 @@ namespace Tests.ClientConcepts.Connection
 			private readonly Action<HttpResponseMessage> _response;
 			private TestableClientHandler _handler;
 			public int CallCount { get; private set; }
-			public int ClientCount => Clients.Count;
 			public HttpClientHandler LastHttpClientHandler => (HttpClientHandler)_handler.InnerHandler;
 
 			public TestableHttpConnection(Action<HttpResponseMessage> response) => _response = response;

--- a/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
@@ -48,11 +48,8 @@ namespace Tests.Framework.EndpointTests
 
 		[I] public virtual async Task ReturnsExpectedResponse() => await AssertOnAllResponses(ExpectResponse);
 
-		protected override Task AssertOnAllResponses(Action<TResponse> assert)
-		{
-			if (!ExpectIsValid) return base.AssertOnAllResponses(assert);
-
-			return base.AssertOnAllResponses((r) =>
+		protected override Task AssertOnAllResponses(Action<TResponse> assert) =>
+			base.AssertOnAllResponses((r) =>
 			{
 				if (TestClient.Configuration.RunIntegrationTests && !r.IsValid && r.ApiCall.OriginalException != null
 					&& !(r.ApiCall.OriginalException is ElasticsearchClientException))
@@ -71,7 +68,6 @@ namespace Tests.Framework.EndpointTests
 					throw new ResponseAssertionException(ex.SourceException, r).Demystify();
 				}
 			});
-		}
 	}
 
 	public class ResponseAssertionException : Exception

--- a/tests/Tests/Search/Search/InvalidSearchApiTests.cs
+++ b/tests/Tests/Search/Search/InvalidSearchApiTests.cs
@@ -38,7 +38,7 @@ namespace Tests.Search.Search
 			}
 		};
 
-		protected override int ExpectStatusCode => 500;
+		protected override int ExpectStatusCode => 400;
 
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
 			.From(10)
@@ -67,9 +67,10 @@ namespace Tests.Search.Search
 			response.ShouldNotBeValid();
 			var serverError = response.ServerError;
 			serverError.Should().NotBeNull();
-			serverError.Status.Should().Be(ExpectStatusCode);
-			serverError.Error.Reason.Should().Be("all shards failed");
-			serverError.Error.RootCause.First().Reason.Should().Contain("value source config is invalid");
+			serverError.Status.Should().Be(ExpectStatusCode, "{0}", response.DebugInformation);
+
+			serverError.Error.Type.Should().Be("illegal_argument_exception");
+			serverError.Error.RootCause.First().Reason.Should().Contain("Required one of fields");
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes a longstanding wish to be able to recycle `HttpClient` instances periodically. We reuse HttpClient/HttpMessageHandler's to prevent TCP leakage but  [infamously this does not take DNS changes into account](https://github.com/dotnet/runtime/issues/18348).

`IHttpClientFactory` from [Microsoft.Extensions.Http](https://www.nuget.org/packages/Microsoft.Extensions.Http/) solves this but the nuget package depends on too many things we don't want to depend on OOTB like Dependency Injection.  This copies parts of this code (now MIT licensed as of February) so we can reuse the same strategy in the client. 


Starting with `netstandard2.1` `SocketsHttpHander` also supports `PooledConnectionLifetime` this however has a bug in corrolation with [`MaxConnectionsPerServer`](https://github.com/dotnet/corefx/pull/29822). This is fixed in `netcoreapp3.0` and up. 

The goal is to ship this new `RequestDataHttpClientFactory` introduced here in all TFM's. 

In a follow up commit we'll introduce `netcoreapp3.0` and `netcoreapp3.1` TFM's that will only use `RequestDataHttpClientFactory` to create `HttpClient` instances but won't use its recycling capabilities since that's now handled by `PooledConectionLifetime`.


