### PR TITLE
Fix #4298 be less strict about `Operations` on `IBulkRequest`

### DIFF
--- a/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkOperationsCollection.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkOperation/BulkOperationsCollection.cs
@@ -20,11 +20,8 @@ namespace Nest
 
 		public BulkOperationsCollection() => Items = new List<TOperation>();
 
-		public BulkOperationsCollection(IEnumerable<TOperation> operations)
-		{
-			Items = new List<TOperation>();
-			Items.AddRange(operations);
-		}
+		public BulkOperationsCollection(IEnumerable<TOperation> operations) =>
+			Items = new List<TOperation>(operations);
 
 		public int Count
 		{

--- a/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
@@ -25,7 +25,7 @@ namespace Nest
 		IList<IBulkOperation> IBulkRequest.Operations
 		{
 			get => _operations;
-			set { }
+			set => throw new NotImplementedException($"{nameof(BulkDescriptor)} does not allow {nameof(IBulkRequest)}.{nameof(IBulkRequest.Operations)} to be set directly");
 		}
 
 		public BulkDescriptor Create<T>(Func<BulkCreateDescriptor<T>, IBulkCreateOperation<T>> bulkCreateSelector)

--- a/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
+++ b/src/Nest/Document/Multiple/Bulk/BulkRequest.cs
@@ -10,17 +10,23 @@ namespace Nest
 	public partial interface IBulkRequest
 	{
 		[IgnoreDataMember]
-		BulkOperationsCollection<IBulkOperation> Operations { get; set; }
+		IList<IBulkOperation> Operations { get; set; }
 	}
 
 	public partial class BulkRequest
 	{
-		public BulkOperationsCollection<IBulkOperation> Operations { get; set; }
+		public IList<IBulkOperation> Operations { get; set; }
 	}
 
 	public partial class BulkDescriptor
 	{
-		BulkOperationsCollection<IBulkOperation> IBulkRequest.Operations { get; set; } = new BulkOperationsCollection<IBulkOperation>();
+		private readonly BulkOperationsCollection<IBulkOperation> _operations = new BulkOperationsCollection<IBulkOperation>();
+
+		IList<IBulkOperation> IBulkRequest.Operations
+		{
+			get => _operations;
+			set { }
+		}
 
 		public BulkDescriptor Create<T>(Func<BulkCreateDescriptor<T>, IBulkCreateOperation<T>> bulkCreateSelector)
 			where T : class =>
@@ -148,7 +154,8 @@ namespace Nest
 				var op = bulkIndexSelector.InvokeOrDefault(defaultSelector(o), o);
 				if (op != null) operations.Add(op);
 			}
-			return Assign(operations, (a, v) => a.Operations.AddRange(v));
+			_operations.AddRange(operations);
+			return this;
 		}
 
 	}

--- a/tests/Tests.Benchmarking/BulkCreationBenchmarkTests.cs
+++ b/tests/Tests.Benchmarking/BulkCreationBenchmarkTests.cs
@@ -10,7 +10,7 @@ using Tests.Domain;
 namespace Tests.Benchmarking
 {
 	[BenchmarkConfig(10)]
-	public class BulkSerializationBenchmarkTests
+	public class BulkCreationBenchmarkTests
 	{
 		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
 		private static readonly byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
@@ -23,6 +23,9 @@ namespace Tests.Benchmarking
 
 		[GlobalSetup]
 		public void Setup() { }
+
+		[Benchmark(Description = "Descriptors.V8")]
+		public Nest8.BulkDescriptor CreateUsingDecriptorsV8() => new Nest8.BulkDescriptor().IndexMany(Projects);
 
 		[Benchmark(Description = "Descriptors")]
 		public BulkDescriptor CreateUsingDecriptors() => new BulkDescriptor().IndexMany(Projects);

--- a/tests/Tests.Benchmarking/BulkSerializationBenchmarkTests.cs
+++ b/tests/Tests.Benchmarking/BulkSerializationBenchmarkTests.cs
@@ -1,0 +1,89 @@
+using System.Collections.Generic;
+using System.Linq;
+using BenchmarkDotNet.Attributes;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Benchmarking.Framework;
+using Tests.Core.Client;
+using Tests.Domain;
+
+namespace Tests.Benchmarking
+{
+	[BenchmarkConfig(10)]
+	public class BulkSerializationBenchmarkTests
+	{
+		private static readonly IList<Project> Projects = Project.Generator.Clone().Generate(10000);
+		private static readonly byte[] Response = TestClient.DefaultInMemoryClient.ConnectionSettings.RequestResponseSerializer.SerializeToBytes(ReturnBulkResponse(Projects));
+
+		private static readonly IElasticClient Client =
+			new ElasticClient(new ConnectionSettings(new InMemoryConnection(Response, 200, null, null))
+				.DefaultIndex("index")
+				.EnableHttpCompression(false)
+			);
+
+		[GlobalSetup]
+		public void Setup() { }
+
+		[Benchmark(Description = "Descriptors")]
+		public BulkDescriptor CreateUsingDecriptors() => new BulkDescriptor().IndexMany(Projects);
+
+		[Benchmark(Description = "BulkCollection.AddRange")]
+		public BulkRequest SynchronizedCollection()
+		{
+			var ops = new BulkOperationsCollection<IBulkOperation>();
+			ops.AddRange(Projects.Select(p=> new BulkCreateOperation<Project>(p)));
+			return new BulkRequest
+			{
+				Operations = ops
+			};
+		}
+
+		[Benchmark(Description = "BulkCollection.const")]
+		public BulkRequest SynchronizedCollectionConstructor()
+		{
+			var ops = new BulkOperationsCollection<IBulkOperation>(
+				Projects.Select(p=> new BulkCreateOperation<Project>(p))
+			);
+			return new BulkRequest
+			{
+				Operations = ops
+			};
+		}
+
+		[Benchmark(Description = "new List")]
+		public BulkRequest NewList() =>
+			new BulkRequest
+			{
+				Operations = new List<IBulkOperation>(
+					Projects.Select(p=> new BulkCreateOperation<Project>(p))
+				)
+			};
+
+		private static object BulkItemResponse(Project project) => new
+		{
+			index = new
+			{
+				_index = "nest-52cfd7aa",
+				_id = project.Name,
+				_version = 1,
+				_shards = new
+				{
+					total = 2,
+					successful = 1,
+					failed = 0
+				},
+				created = true,
+				status = 201
+			}
+		};
+
+		private static object ReturnBulkResponse(IList<Project> projects) => new
+		{
+			took = 276,
+			errors = false,
+			items = projects
+				.Select(p => BulkItemResponse(p))
+				.ToArray()
+		};
+	}
+}


### PR DESCRIPTION
`IBulkRequest` dictated that operations should be implemented using `BulkOperationsCollection` which effectively is a `SynchronizedCollection`. We did this back in 2013 because concurrent producers calling `.IndexMany()` were expected to be threadsafe. 

Since then we also introduced the object inititalizer syntax. Here we can push back on this requirement. This PR fixes that so that users using that syntax are not forced to use the `BulkOperationsCollection`.

Some performance numbers attached:


|                  Method |     Mean |     Error |    StdDev | Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------------------ |---------:|----------:|----------:|------:|------:|------:|----------:|
|          Descriptors.V8 | 2.581 ms | 0.0529 ms | 0.1383 ms |     - |     - |     - |    1.7 MB |
|             Descriptors | 2.722 ms | 0.0818 ms | 0.2308 ms |     - |     - |     - |    1.7 MB |
| BulkCollection.AddRange | 1.173 ms | 0.0317 ms | 0.0936 ms |     - |     - |     - |   1.09 MB |
|    BulkCollection.const | 1.096 ms | 0.0217 ms | 0.0583 ms |     - |     - |     - |   1.09 MB |
|              'new List' | 1.061 ms | 0.0209 ms | 0.0468 ms |     - |     - |     - |   1.09 MB |