### PR TITLE
[Backport 6.x] Reimplement #4673 manually

### DIFF
--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -8,12 +8,6 @@
         "assembly-rewriter"
       ]
     },
-    "dotnet-assembly-differ": {
-      "version": "1.0.0-ci20190926135713",
-      "commands": [
-        "assembly-differ"
-      ]
-    },
     "assembly-differ": {
       "version": "0.9.0",
       "commands": [

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -77,6 +77,12 @@ namespace Elasticsearch.Net
 		public static readonly TimeSpan DefaultTimeout = TimeSpan.FromMinutes(1);
 
 		/// <summary>
+		/// The default timeout before a TCP connection is forcefully recycled so that DNS updates come through
+		/// Defaults to 5 minutes.
+		/// </summary>
+		public static readonly TimeSpan DefaultDnsRefreshTimeout = TimeSpan.FromMinutes(5);
+
+		/// <summary>
 		/// The default connection limit for both Elasticsearch.Net and Nest. Defaults to <c>80</c>
 #if DOTNETCORE
 		/// <para>Except for <see cref="HttpClientHandler"/> implementations based on curl, which defaults to <see cref="Environment.ProcessorCount"/></para>
@@ -185,6 +191,7 @@ namespace Elasticsearch.Net
 		private string _proxyPassword;
 		private string _proxyUsername;
 		private TimeSpan _requestTimeout;
+		private TimeSpan _dnsRefreshTimeout;
 		private Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> _serverCertificateValidationCallback;
 		private IReadOnlyCollection<int> _skipDeserializationForStatusCodes = new ReadOnlyCollection<int>(new int[] { });
 		private TimeSpan? _sniffLifeSpan;
@@ -202,6 +209,7 @@ namespace Elasticsearch.Net
 
 			_connectionLimit = ConnectionConfiguration.DefaultConnectionLimit;
 			_requestTimeout = ConnectionConfiguration.DefaultTimeout;
+			_dnsRefreshTimeout = ConnectionConfiguration.DefaultDnsRefreshTimeout;
 			_sniffOnConnectionFault = true;
 			_sniffOnStartup = true;
 			_sniffLifeSpan = TimeSpan.FromHours(1);
@@ -249,6 +257,7 @@ namespace Elasticsearch.Net
 		NameValueCollection IConnectionConfigurationValues.QueryStringParameters => _queryString;
 		IElasticsearchSerializer IConnectionConfigurationValues.RequestResponseSerializer => UseThisRequestResponseSerializer;
 		TimeSpan IConnectionConfigurationValues.RequestTimeout => _requestTimeout;
+		TimeSpan IConnectionConfigurationValues.DnsRefreshTimeout => _dnsRefreshTimeout;
 
 		Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> IConnectionConfigurationValues.ServerCertificateValidationCallback =>
 			_serverCertificateValidationCallback;
@@ -418,6 +427,16 @@ namespace Elasticsearch.Net
 		/// </para>
 		/// </summary>
 		public T MaxRetryTimeout(TimeSpan maxRetryTimeout) => Assign(maxRetryTimeout, (a, v) => a._maxRetryTimeout = v);
+
+		/// <summary>
+		/// DnsRefreshTimeout for the connections. Defaults to 5 minutes.
+		#if DOTNETCORE
+		/// <para>Will create new instances of <see cref="System.Net.Http.HttpClient"/> after this timeout to force DNS updates</para>
+		#else
+		/// <para>Will set both <see cref="System.Net.ServicePointManager.DnsRefreshTimeout"/> and <see cref="System.Net.ServicePointManager.ConnectionLeaseTimeout "/>
+		#endif
+		/// </summary>
+		public T DnsRefreshTimeout(TimeSpan timeout) => Assign(timeout, (a, v) => a._dnsRefreshTimeout = v);
 
 		/// <summary>
 		/// If your connection has to go through proxy, use this method to specify the proxy url

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -219,5 +219,15 @@ namespace Elasticsearch.Net
 		/// versions that initiate requests to Elasticsearch
 		/// </summary>
 		string UserAgent { get; }
+
+		/// <summary>
+		/// DnsRefreshTimeout for the connections. Defaults to 5 minutes.
+		#if DOTNETCORE
+		/// <para>Will create new instances of <see cref="System.Net.Http.HttpClient"/> after this timeout to force DNS updates</para>
+		#else
+		/// <para>Will set <see cref="System.Net.ServicePointManager.ConnectionLeaseTimeout "/>
+		#endif
+		/// </summary>
+		TimeSpan DnsRefreshTimeout { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ActiveHandlerTrackingEntry.cs
@@ -1,0 +1,84 @@
+﻿﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+    /// Thread-safety: We treat this class as immutable except for the timer. Creating a new object
+	/// for the 'expiry' pool simplifies the threading requirements significantly.
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/ActiveHandlerTrackingEntry.cs</para>
+	/// </summary>
+    internal class ActiveHandlerTrackingEntry
+    {
+        private static readonly TimerCallback TimerCallback = (s) => ((ActiveHandlerTrackingEntry)s).Timer_Tick();
+        private readonly object _lock;
+        private bool _timerInitialized;
+        private Timer _timer;
+        private TimerCallback _callback;
+
+        public ActiveHandlerTrackingEntry(
+            int key,
+            LifetimeTrackingHttpMessageHandler handler,
+            TimeSpan lifetime)
+        {
+            Key = key;
+            Handler = handler;
+            Lifetime = lifetime;
+
+            _lock = new object();
+        }
+
+        public LifetimeTrackingHttpMessageHandler Handler { get; private set; }
+
+        public TimeSpan Lifetime { get; }
+
+        public int Key { get; }
+
+        public void StartExpiryTimer(TimerCallback callback)
+        {
+            if (Lifetime == Timeout.InfiniteTimeSpan) return;
+
+            if (Volatile.Read(ref _timerInitialized)) return;
+
+            StartExpiryTimerSlow(callback);
+        }
+
+        private void StartExpiryTimerSlow(TimerCallback callback)
+        {
+            Debug.Assert(Lifetime != Timeout.InfiniteTimeSpan);
+
+            lock (_lock)
+            {
+                if (Volatile.Read(ref _timerInitialized))
+                    return;
+
+                _callback = callback;
+                _timer = NonCapturingTimer.Create(TimerCallback, this, Lifetime, Timeout.InfiniteTimeSpan);
+                _timerInitialized = true;
+            }
+        }
+
+        private void Timer_Tick()
+        {
+            Debug.Assert(_callback != null);
+            Debug.Assert(_timer != null);
+
+            lock (_lock)
+			{
+				if (_timer == null) return;
+
+				_timer.Dispose();
+				_timer = null;
+
+				_callback(this);
+			}
+        }
+    }
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ExpiredHandlerTrackingEntry.cs
@@ -1,0 +1,36 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Net.Http;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Thread-safety: This class is immutable
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/ExpiredHandlerTrackingEntry.cs</para>
+	/// </summary>
+	internal class ExpiredHandlerTrackingEntry
+	{
+		private readonly WeakReference _livenessTracker;
+
+		// IMPORTANT: don't cache a reference to `other` or `other.Handler` here.
+		// We need to allow it to be GC'ed.
+		public ExpiredHandlerTrackingEntry(ActiveHandlerTrackingEntry other)
+		{
+			Key = other.Key;
+
+			_livenessTracker = new WeakReference(other.Handler);
+			InnerHandler = other.Handler.InnerHandler;
+		}
+
+		public bool CanDispose => !_livenessTracker.IsAlive;
+
+		public HttpMessageHandler InnerHandler { get; }
+
+		public int Key { get; }
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/LifetimeTrackingHttpMessageHandler.cs
@@ -1,0 +1,27 @@
+﻿// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System.Net.Http;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// This a marker used to check if the underlying handler should be disposed. HttpClients
+	/// share a reference to an instance of this class, and when it goes out of scope the inner handler
+	/// is eligible to be disposed.
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/LifetimeTrackingHttpMessageHandler.cs</para>
+	/// </summary>
+	internal class LifetimeTrackingHttpMessageHandler : DelegatingHandler
+	{
+		public LifetimeTrackingHttpMessageHandler(HttpMessageHandler innerHandler)
+			: base(innerHandler) { }
+
+		protected override void Dispose(bool disposing)
+		{
+			// The lifetime of this is tracked separately by ActiveHandlerTrackingEntry
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -1,0 +1,255 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Xml;
+using Elasticsearch.Net;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// Heavily modified version of DefaultHttpClientFactory, re-purposed for RequestData
+	/// <para>https://github.com/dotnet/runtime/blob/master/src/libraries/Microsoft.Extensions.Http/src/DefaultHttpClientFactory.cs</para>
+	/// </summary>
+	internal class RequestDataHttpClientFactory : IDisposable
+	{
+		private readonly Func<RequestData, HttpMessageHandler> _createHttpClientHandler;
+		private static readonly TimerCallback CleanupCallback = (s) => ((RequestDataHttpClientFactory)s).CleanupTimer_Tick();
+		private readonly Func<int, RequestData, Lazy<ActiveHandlerTrackingEntry>> _entryFactory;
+
+		// Default time of 10s for cleanup seems reasonable.
+		// Quick math:
+		// 10 distinct named clients * expiry time >= 1s = approximate cleanup queue of 100 items
+		//
+		// This seems frequent enough. We also rely on GC occurring to actually trigger disposal.
+		private readonly TimeSpan _defaultCleanupInterval = TimeSpan.FromSeconds(10);
+
+		// We use a new timer for each regular cleanup cycle, protected with a lock. Note that this scheme
+		// doesn't give us anything to dispose, as the timer is started/stopped as needed.
+		//
+		// There's no need for the factory itself to be disposable. If you stop using it, eventually everything will
+		// get reclaimed.
+		private Timer _cleanupTimer;
+		private readonly object _cleanupTimerLock;
+		private readonly object _cleanupActiveLock;
+
+		// Collection of 'active' handlers.
+		//
+		// Using lazy for synchronization to ensure that only one instance of HttpMessageHandler is created
+		// for each name.
+		//
+		private readonly ConcurrentDictionary<int, Lazy<ActiveHandlerTrackingEntry>> _activeHandlers;
+
+		public int InUseHandlers => _activeHandlers.Count;
+		private int _removedHandlers;
+		public int RemovedHandlers => _removedHandlers;
+
+		// Collection of 'expired' but not yet disposed handlers.
+		//
+		// Used when we're rotating handlers so that we can dispose HttpMessageHandler instances once they
+		// are eligible for garbage collection.
+		//
+		private readonly ConcurrentQueue<ExpiredHandlerTrackingEntry> _expiredHandlers;
+		private readonly TimerCallback _expiryCallback;
+
+		public RequestDataHttpClientFactory(Func<RequestData, HttpMessageHandler> createHttpClientHandler)
+		{
+			_createHttpClientHandler = createHttpClientHandler;
+			// case-sensitive because named options is.
+			_activeHandlers = new ConcurrentDictionary<int, Lazy<ActiveHandlerTrackingEntry>>();
+			_entryFactory = (key, requestData) =>
+			{
+				return new Lazy<ActiveHandlerTrackingEntry>(() => CreateHandlerEntry(key, requestData),
+					LazyThreadSafetyMode.ExecutionAndPublication);
+			};
+
+			_expiredHandlers = new ConcurrentQueue<ExpiredHandlerTrackingEntry>();
+			_expiryCallback = ExpiryTimer_Tick;
+
+			_cleanupTimerLock = new object();
+			_cleanupActiveLock = new object();
+		}
+
+		public HttpClient CreateClient(RequestData requestData)
+		{
+			if (requestData == null) throw new ArgumentNullException(nameof(requestData));
+
+			var key = HttpConnection.GetClientKey(requestData);
+			var handler = CreateHandler(key, requestData);
+			var client = new HttpClient(handler, disposeHandler: false);
+			return client;
+		}
+
+		private HttpMessageHandler CreateHandler(int key, RequestData requestData)
+		{
+			if (requestData == null) throw new ArgumentNullException(nameof(requestData));
+
+			#if NETSTANDARD2_1
+			var entry = _activeHandlers.GetOrAdd(key, (k, r) => _entryFactory(k, r), requestData).Value;
+			#else
+			var entry = _activeHandlers.GetOrAdd(key, (k) => _entryFactory(k, requestData)).Value;
+			#endif
+
+			StartHandlerEntryTimer(entry);
+
+			return entry.Handler;
+		}
+
+		private ActiveHandlerTrackingEntry CreateHandlerEntry(int key, RequestData requestData)
+		{
+			// Wrap the handler so we can ensure the inner handler outlives the outer handler.
+			var handler = new LifetimeTrackingHttpMessageHandler(_createHttpClientHandler(requestData));
+
+			// Note that we can't start the timer here. That would introduce a very very subtle race condition
+			// with very short expiry times. We need to wait until we've actually handed out the handler once
+			// to start the timer.
+			//
+			// Otherwise it would be possible that we start the timer here, immediately expire it (very short
+			// timer) and then dispose it without ever creating a client. That would be bad. It's unlikely
+			// this would happen, but we want to be sure.
+			return new ActiveHandlerTrackingEntry(key, handler, requestData.DnsRefreshTimeout);
+		}
+
+		private void ExpiryTimer_Tick(object state)
+		{
+			var active = (ActiveHandlerTrackingEntry)state;
+
+			// The timer callback should be the only one removing from the active collection. If we can't find
+			// our entry in the collection, then this is a bug.
+			var removed = _activeHandlers.TryRemove(active.Key, out var found);
+			if (removed)
+				Interlocked.Increment(ref _removedHandlers);
+			Debug.Assert(removed, "Entry not found. We should always be able to remove the entry");
+			Debug.Assert(object.ReferenceEquals(active, found.Value), "Different entry found. The entry should not have been replaced");
+
+			// At this point the handler is no longer 'active' and will not be handed out to any new clients.
+			// However we haven't dropped our strong reference to the handler, so we can't yet determine if
+			// there are still any other outstanding references (we know there is at least one).
+			//
+			// We use a different state object to track expired handlers. This allows any other thread that acquired
+			// the 'active' entry to use it without safety problems.
+			var expired = new ExpiredHandlerTrackingEntry(active);
+			_expiredHandlers.Enqueue(expired);
+
+			StartCleanupTimer();
+		}
+
+		protected virtual void StartHandlerEntryTimer(ActiveHandlerTrackingEntry entry) => entry.StartExpiryTimer(_expiryCallback);
+
+		protected virtual void StartCleanupTimer()
+		{
+			lock (_cleanupTimerLock)
+				_cleanupTimer ??= NonCapturingTimer.Create(CleanupCallback, this, _defaultCleanupInterval, Timeout.InfiniteTimeSpan);
+		}
+
+		protected virtual void StopCleanupTimer()
+		{
+			lock (_cleanupTimerLock)
+			{
+				_cleanupTimer.Dispose();
+				_cleanupTimer = null;
+			}
+		}
+
+		private void CleanupTimer_Tick()
+		{
+			// Stop any pending timers, we'll restart the timer if there's anything left to process after cleanup.
+			//
+			// With the scheme we're using it's possible we could end up with some redundant cleanup operations.
+			// This is expected and fine.
+			//
+			// An alternative would be to take a lock during the whole cleanup process. This isn't ideal because it
+			// would result in threads executing ExpiryTimer_Tick as they would need to block on cleanup to figure out
+			// whether we need to start the timer.
+			StopCleanupTimer();
+
+			if (!Monitor.TryEnter(_cleanupActiveLock))
+			{
+				// We don't want to run a concurrent cleanup cycle. This can happen if the cleanup cycle takes
+				// a long time for some reason. Since we're running user code inside Dispose, it's definitely
+				// possible.
+				//
+				// If we end up in that position, just make sure the timer gets started again. It should be cheap
+				// to run a 'no-op' cleanup.
+				StartCleanupTimer();
+				return;
+			}
+
+			try
+			{
+				var initialCount = _expiredHandlers.Count;
+
+				for (var i = 0; i < initialCount; i++)
+				{
+					// Since we're the only one removing from _expired, TryDequeue must always succeed.
+					_expiredHandlers.TryDequeue(out var entry);
+					Debug.Assert(entry != null, "Entry was null, we should always get an entry back from TryDequeue");
+
+					if (entry.CanDispose)
+					{
+						try
+						{
+							entry.InnerHandler.Dispose();
+						}
+						catch (Exception)
+						{
+							// ignored (ignored in HttpClientFactory too)
+						}
+					}
+					else
+					{
+						// If the entry is still live, put it back in the queue so we can process it
+						// during the next cleanup cycle.
+						_expiredHandlers.Enqueue(entry);
+					}
+				}
+			}
+			finally
+			{
+				Monitor.Exit(_cleanupActiveLock);
+			}
+
+			// We didn't totally empty the cleanup queue, try again later.
+			if (_expiredHandlers.Count > 0) StartCleanupTimer();
+		}
+
+		public void Dispose()
+		{
+			//try to cleanup nicely
+			CleanupTimer_Tick();
+			_cleanupTimer?.Dispose();
+
+			//CleanupTimer might not cleanup everything because it will only dispose if the WeakReference allows it.
+			// here we forcefully dispose a Client -> ConnectionSettings -> Connection -> RequestDataHttpClientFactory
+			var attempts = 0;
+			do
+			{
+				attempts++;
+				var initialCount = _expiredHandlers.Count;
+				for (var i = 0; i < initialCount; i++)
+				{
+					// Since we're the only one removing from _expired, TryDequeue must always succeed.
+					_expiredHandlers.TryDequeue(out var entry);
+					try
+					{
+						entry?.InnerHandler.Dispose();
+					}
+					catch (Exception)
+					{
+						// ignored (ignored in HttpClientFactory too)
+					}
+				}
+			} while (attempts < 5 && _expiredHandlers.Count > 0);
+
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/ValueStopWatch.cs
@@ -1,0 +1,43 @@
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information.
+
+#if DOTNETCORE
+using System;
+using System.Diagnostics;
+using System.Threading;
+
+namespace Elasticsearch.Net
+{
+	/// <summary>
+	/// A convenience API for interacting with System.Threading.Timer in a way
+	/// that doesn't capture the ExecutionContext. We should be using this (or equivalent)
+	/// everywhere we use timers to avoid rooting any values stored in asynclocals.
+	/// <para> https://github.com/dotnet/runtime/blob/master/src/libraries/Common/src/Extensions/ValueStopwatch/ValueStopwatch.cs </para>
+	/// </summary>
+	internal static class NonCapturingTimer
+	{
+		public static Timer Create(TimerCallback callback, object state, TimeSpan dueTime, TimeSpan period)
+		{
+			if (callback == null) throw new ArgumentNullException(nameof(callback));
+
+			// Don't capture the current ExecutionContext and its AsyncLocals onto the timer
+			var restoreFlow = false;
+			try
+			{
+				if (ExecutionContext.IsFlowSuppressed()) return new Timer(callback, state, dueTime, period);
+
+				ExecutionContext.SuppressFlow();
+				restoreFlow = true;
+
+				return new Timer(callback, state, dueTime, period);
+			}
+			finally
+			{
+				// Restore the current ExecutionContext
+				if (restoreFlow) ExecutionContext.RestoreFlow();
+			}
+		}
+	}
+}
+#endif

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -59,6 +59,7 @@ namespace Elasticsearch.Net
 
 			KeepAliveInterval = (int)(global.KeepAliveInterval?.TotalMilliseconds ?? 2000);
 			KeepAliveTime = (int)(global.KeepAliveTime?.TotalMilliseconds ?? 2000);
+			DnsRefreshTimeout = global.DnsRefreshTimeout;
 
 			ProxyAddress = global.ProxyAddress;
 			ProxyUsername = global.ProxyUsername;
@@ -108,6 +109,7 @@ namespace Elasticsearch.Net
 		public string UserAgent { get; }
 
 		public Uri Uri => Node != null ? new Uri(Node.Uri, PathAndQuery) : null;
+		public TimeSpan DnsRefreshTimeout { get; }
 
 		private string CreatePathWithQueryStrings(string path, IConnectionConfigurationValues global, IRequestParameters request)
 		{


### PR DESCRIPTION
6.x does not follow the new layout so a cherry-pick is too involved.

Manually reimplemented the same logic that introduces
`RequestDataHttpClientFactory` to periodically recycle HttpClient
instances.