### PR TITLE
Add script to add file license headers

### DIFF
--- a/build/add-headers.sh
+++ b/build/add-headers.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+script_path=$(dirname $(realpath -s $0))/../
+
+
+(find "$script_path" -name "*.fs" | grep -v "/bin/" | grep -v "/obj/")|while read fname; do
+    line=$(head -n 1 "$fname")
+    if [[ "$line" =~ ^/ ]] || [[ "$line" =~ ^# ]] ; then 
+      echo "Skipped already starts with / or #: $fname"
+    else 
+      cat "${script_path}build/file-header.txt" "$fname" > "${fname}.new"
+      mv "${fname}.new" "$fname"
+    fi
+done
+
+(find "$script_path" -name "*.cs" | grep -v "/bin/" | grep -v "/obj/")|while read fname; do
+    line=$(head -n 1 "$fname")
+    if [[ "$line" =~ ^/ ]] || [[ "$line" =~ ^# ]] ; then 
+      echo "Skipped already starts with / or #: $fname"
+    else 
+      cat "${script_path}build/file-header.txt" "$fname" > "${fname}.new"
+      mv "${fname}.new" "$fname"
+    fi
+done

--- a/build/file-header.txt
+++ b/build/file-header.txt
@@ -1,0 +1,4 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+


### PR DESCRIPTION
`master` and `7.x` now set `$HEADER` properly in `.DotSettings` so new files will always have the license. Its also part of the silent code cleanup.

Experimented with a new code clean up profile that just does adding file headers but it needs code clean up too so would be even noisier. Doing this through code clean up is also wayy to slow. 

This PR therefor adds a one-off script to inject the license to all `cs` and `fs` files.

It does a quick check to see if the file does not already start with `/` or `#`. It's easier to fix up false negative then true positives after running the tool. 

Adding this PR in isolation but will run the tool on the branches itself directly. Nothing worse then having a 4000 file PR pending 😸 

cc @russcam 