### PR TITLE
Correct grammar on MatchQuery CutoffFrequency

### DIFF
--- a/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
+++ b/src/Nest/QueryDsl/Abstractions/Container/QueryContainerDescriptor.cs
@@ -76,7 +76,7 @@ namespace Nest
 
 		/// <summary>
 		/// A fuzzy based query that uses similarity based on Levenshtein (edit distance) algorithm.
-		/// Warning: this query is not very scalable with its default prefix length of 0 � in this case,
+		/// Warning: this query is not very scalable with its default prefix length of 0. In this case,
 		/// every term will be enumerated and cause an edit score calculation or max_expansions is not set.
 		/// </summary>
 		public QueryContainer Fuzzy(Func<FuzzyQueryDescriptor<T>, IFuzzyQuery> selector) =>
@@ -160,7 +160,7 @@ namespace Nest
 			WrapInContainer(selector, (query, container) => container.Range = query);
 
 		/// <summary>
-		/// More like this query find documents that are �like� provided text by running it against one or more fields.
+		/// More like this query find documents that are like the provided text by running it against one or more fields.
 		/// </summary>
 		public QueryContainer MoreLikeThis(Func<MoreLikeThisQueryDescriptor<T>, IMoreLikeThisQuery> selector) =>
 			WrapInContainer(selector, (query, container) => container.MoreLikeThis = query);

--- a/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
+++ b/src/Nest/QueryDsl/FullText/Match/MatchQuery.cs
@@ -32,7 +32,7 @@ namespace Nest
 		/// or all of the low frequency terms in the case of an <see cref="Nest.Operator.And" /> match.
 		/// </summary>
 		[DataMember(Name = "cutoff_frequency")]
-		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skips blocks of documents efficiently if the total number of hits is not tracked.")]
+		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skip blocks of documents efficiently if the total number of hits is not tracked.")]
 		double? CutoffFrequency { get; set; }
 
 		/// <summary>
@@ -118,7 +118,7 @@ namespace Nest
 		public bool? AutoGenerateSynonymsPhraseQuery { get; set; }
 
 		/// <inheritdoc />
-		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skips blocks of documents efficiently if the total number of hits is not tracked.")]
+		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skip blocks of documents efficiently if the total number of hits is not tracked.")]
 		public double? CutoffFrequency { get; set; }
 
 		/// <inheritdoc />
@@ -168,7 +168,7 @@ namespace Nest
 		protected virtual string MatchQueryType => null;
 		string IMatchQuery.Analyzer { get; set; }
 		bool? IMatchQuery.AutoGenerateSynonymsPhraseQuery { get; set; }
-		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skips blocks of documents efficiently if the total number of hits is not tracked.")]
+		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skip blocks of documents efficiently if the total number of hits is not tracked.")]
 		double? IMatchQuery.CutoffFrequency { get; set; }
 		IFuzziness IMatchQuery.Fuzziness { get; set; }
 		MultiTermQueryRewrite IMatchQuery.FuzzyRewrite { get; set; }
@@ -198,7 +198,7 @@ namespace Nest
 			Assign(fuzzyTranspositions, (a, v) => a.FuzzyTranspositions = v);
 
 		/// <inheritdoc cref="IMatchQuery.CutoffFrequency" />
-		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skips blocks of documents efficiently if the total number of hits is not tracked.")]
+		[Obsolete("Deprecated in 7.3.0. This option can be omitted since MatchQuery can skip blocks of documents efficiently if the total number of hits is not tracked.")]
 		public MatchQueryDescriptor<T> CutoffFrequency(double? cutoffFrequency) => Assign(cutoffFrequency, (a, v) => a.CutoffFrequency = v);
 
 		/// <inheritdoc cref="IMatchQuery.FuzzyRewrite" />


### PR DESCRIPTION
Replace "can skips" with "can skip" in the four instances of the `MatchQuery.CutoffFrequency` Obsolete attributes in the MatchQuery class.

This is a documentation-only correction and there are **no** modifications to the code.

I also confirm that I have read, understood, and signed the CLA.