### PR TITLE
update CatAllocationRecord

### DIFF
--- a/src/Nest/Cat/CatAllocation/CatAllocationRecord.cs
+++ b/src/Nest/Cat/CatAllocation/CatAllocationRecord.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Runtime.Serialization;
 
 namespace Nest
@@ -9,21 +10,57 @@ namespace Nest
 	[DataContract]
 	public class CatAllocationRecord : ICatRecord
 	{
-		[DataMember(Name ="diskAvail")]
+		/// <summary>
+		/// Amount of disk available
+		/// </summary>
+		[DataMember(Name ="disk.avail")]
 		public string DiskAvailable { get; set; }
 
-		[DataMember(Name ="diskRatio")]
-		public string DiskRatio { get; set; }
+		/// <summary>
+		/// Amount of disk used by Elasticsearch indices
+		/// </summary>
+		[DataMember(Name ="disk.indices")]
+		public string DiskIndices { get; set; }
 
-		[DataMember(Name ="diskUsed")]
+		/// <summary>
+		/// The percentage of disk used
+		/// </summary>
+		[DataMember(Name ="disk.percent")]
+		public string DiskPercent { get; set; }
+
+		/// <summary>
+		/// Total capacity of all volumes
+		/// </summary>
+		[DataMember(Name ="disk.total")]
+		public string DiskTotal { get; set; }
+
+		/// <summary>
+		/// Amount of disk used (total, not just Elasticsearch)
+		/// </summary>
+		[DataMember(Name ="disk.used")]
 		public string DiskUsed { get; set; }
 
+		/// <summary>
+		/// The host of the node
+		/// </summary>
+		[DataMember(Name ="host")]
+		public string Host { get; set; }
+
+		/// <summary>
+		/// The IP address of the node
+		/// </summary>
 		[DataMember(Name ="ip")]
 		public string Ip { get; set; }
 
+		/// <summary>
+		/// The name of the node
+		/// </summary>
 		[DataMember(Name ="node")]
 		public string Node { get; set; }
 
+		/// <summary>
+		/// Number of shards on the node
+		/// </summary>
 		[DataMember(Name ="shards")]
 		public string Shards { get; set; }
 	}

--- a/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
+++ b/tests/Tests/Cat/CatAllocation/CatAllocationApiTests.cs
@@ -2,7 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using Elasticsearch.Net;
+using System.Linq;
+using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
@@ -29,7 +30,22 @@ namespace Tests.Cat.CatAllocation
 			(client, r) => client.Cat.AllocationAsync(r)
 		);
 
-		protected override void ExpectResponse(CatResponse<CatAllocationRecord> response) =>
-			response.Records.Should().NotBeEmpty().And.Contain(a => !string.IsNullOrEmpty(a.Node));
+		protected override void ExpectResponse(CatResponse<CatAllocationRecord> response)
+		{
+			var records = response.Records;
+			records.Should().NotBeEmpty().And.Contain(a => !string.IsNullOrEmpty(a.Node));
+
+			foreach (var record in records.Where(r => !string.IsNullOrEmpty(r.Ip)))
+			{
+				record.Shards.Should().NotBeNullOrEmpty();
+				record.DiskIndices.Should().NotBeNullOrEmpty();
+				record.DiskUsed.Should().NotBeNullOrEmpty();
+				record.DiskAvailable.Should().NotBeNullOrEmpty();
+				record.DiskTotal.Should().NotBeNullOrEmpty();
+				record.DiskPercent.Should().NotBeNullOrEmpty();
+				record.Host.Should().NotBeNullOrEmpty();
+				record.Node.Should().NotBeNullOrEmpty();
+			}
+		}
 	}
 }


### PR DESCRIPTION
This commit updates the fields available on CatAllocationRecord
to match what is returned from Elasticsearch.

Fixes #4699