### PR TITLE
Elasticsearch always returns a 400 now for our invalid search

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
       es77:
         esVersion: '7.7.0'
       es78:
-        esVersion: '7.8-SNAPSHOT'
+        esVersion: '7.8.0-SNAPSHOT'
       latest7:
         esVersion: 'latest-7'
   steps:
@@ -136,7 +136,7 @@ jobs:
         es77:
           esVersion: '7.7.0'
         es78:
-          esVersion: '7.8-SNAPSHOT'
+          esVersion: '7.8.0-SNAPSHOT'
         latest7:
           esVersion: 'latest-7'
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,6 +93,10 @@ jobs:
         esVersion: '7.5.0'
       es76:
         esVersion: '7.6.0'
+      es77:
+        esVersion: '7.7.0'
+      es78:
+        esVersion: '7.8-SNAPSHOT'
       latest7:
         esVersion: 'latest-7'
   steps:
@@ -129,6 +133,10 @@ jobs:
           esVersion: '7.5.0'
         es76:
           esVersion: '7.6.0'
+        es77:
+          esVersion: '7.7.0'
+        es78:
+          esVersion: '7.8-SNAPSHOT'
         latest7:
           esVersion: 'latest-7'
   steps:

--- a/tests/Tests/Search/Search/InvalidSearchApiTests.cs
+++ b/tests/Tests/Search/Search/InvalidSearchApiTests.cs
@@ -17,8 +17,6 @@ namespace Tests.Search.Search
 {
 	public class InvalidSearchApiTests : SearchApiTests
 	{
-		private bool isAtLeast78 = TestConfiguration.Instance.InRange(">=7.8.0");
-
 		public InvalidSearchApiTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		/// <summary> This is rather noisy on the console out, we only need to test 1 of our overloads randomly really. </summary>
@@ -45,7 +43,7 @@ namespace Tests.Search.Search
 			}
 		};
 
-		protected override int ExpectStatusCode => isAtLeast78 ? 500 : 400;
+		protected override int ExpectStatusCode => 400;
 
 		protected override Func<SearchDescriptor<Project>, ISearchRequest> Fluent => s => s
 			.From(10)
@@ -75,19 +73,10 @@ namespace Tests.Search.Search
 			var serverError = response.ServerError;
 			serverError.Should().NotBeNull();
 
-			if (isAtLeast78)
-			{
-				serverError.Status.Should().Be(500 );
-				serverError.Error.Reason.Should().Be("all shards failed");
-				serverError.Error.RootCause.First().Reason.Should().Contain("value source config is invalid");
-			}
-			else
-			{
-				serverError.Status.Should().Be(400);
-				serverError.Error.Reason.Should().Be("all shards failed");
-				serverError.Error.RootCause.First().Reason.Should().Contain("[-1m]");
-			}
-
+			serverError.Status.Should().Be(ExpectStatusCode);
+			serverError.Error.Reason.Should().Be("all shards failed");
+			serverError.Error.RootCause.First().Reason.Should()
+				.NotBeNullOrWhiteSpace();
 
 		}
 	}

--- a/tests/Tests/Search/Search/InvalidSearchApiTests.cs
+++ b/tests/Tests/Search/Search/InvalidSearchApiTests.cs
@@ -74,7 +74,7 @@ namespace Tests.Search.Search
 			serverError.Should().NotBeNull();
 
 			serverError.Status.Should().Be(ExpectStatusCode);
-			serverError.Error.Reason.Should().Be("all shards failed");
+			serverError.Error.Reason.Should().NotBeNullOrWhiteSpace();
 			serverError.Error.RootCause.First().Reason.Should()
 				.NotBeNullOrWhiteSpace();
 


### PR DESCRIPTION
This simplifies our assertions and broadens them to hopefully fail less.


Added 7.8.0 SNAPSHOT and `7.7.0` to the test matrix now that `latest-7` resolves to `7.9.0-SNAPSHOT`