### PR TITLE
Add special serialization handling for nullable ValueTuples

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Resolvers/DynamicGenericResolver.cs
@@ -229,6 +229,45 @@ namespace Elasticsearch.Net.Utf8Json.Resolvers
 
 					return CreateInstance(tupleFormatterType, ti.GenericTypeArguments);
 				}
+
+				// Nullable ValueTuple
+				else if (isNullable && nullableElementType.GetTypeInfo().IsConstructedGenericType() &&
+					nullableElementType.GetTypeInfo().FullName.StartsWith("System.ValueTuple"))
+				{
+					Type tupleFormatterType = null;
+					switch (nullableElementType.GenericTypeArguments.Length)
+					{
+						case 1:
+							tupleFormatterType = typeof(ValueTupleFormatter<>);
+							break;
+						case 2:
+							tupleFormatterType = typeof(ValueTupleFormatter<,>);
+							break;
+						case 3:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,>);
+							break;
+						case 4:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,,>);
+							break;
+						case 5:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,,,>);
+							break;
+						case 6:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,,,,>);
+							break;
+						case 7:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,,,,,>);
+							break;
+						case 8:
+							tupleFormatterType = typeof(ValueTupleFormatter<,,,,,,,>);
+							break;
+						default:
+							break;
+					}
+
+					var tupleFormatter = CreateInstance(tupleFormatterType, nullableElementType.GenericTypeArguments);
+					return CreateInstance(typeof(StaticNullableFormatter<>), new [] { nullableElementType }, tupleFormatter);
+				}
 #endif
 
 				// ArraySegement

--- a/tests/Tests.Reproduce/GithubIssue4703.cs
+++ b/tests/Tests.Reproduce/GithubIssue4703.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using Elastic.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4703
+	{
+		[U]
+		public void NullableValueTupleDoesNotThrow()
+		{
+			Func<IndexResponse> action = () =>
+				TestClient.DefaultInMemoryClient.Index(
+					new ExampleDoc
+					{
+						tupleNullable = ("somestring", 42),
+					}, i => i.Index("index"));
+
+			var a = action.Should().NotThrow();
+			var response = a.Subject;
+
+			var json = Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes);
+			json.Should().Be(@"{""tupleNullable"":{""item1"":""somestring"",""item2"":42}}");
+		}
+	}
+
+	public class ExampleDoc
+	{
+		public (string info, int number)? tupleNullable { get; set; }
+	}
+}

--- a/tests/Tests.Reproduce/GithubIssue4703.cs
+++ b/tests/Tests.Reproduce/GithubIssue4703.cs
@@ -27,7 +27,7 @@ namespace Tests.Reproduce
 			var response = a.Subject;
 
 			var json = Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes);
-			json.Should().Be(@"{""tupleNullable"":{""item1"":""somestring"",""item2"":42}}");
+			json.Should().Be(@"{""tupleNullable"":{""Item1"":""somestring"",""Item2"":42}}");
 		}
 	}
 

--- a/tests/Tests.Reproduce/GithubIssue4703.cs
+++ b/tests/Tests.Reproduce/GithubIssue4703.cs
@@ -4,7 +4,7 @@
 
 using System;
 using System.Text;
-using Elastic.Xunit.XunitPlumbing;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Client;


### PR DESCRIPTION
This PR adds special serialization handling for nullable `ValueTuple`s. Specialized handling is required as without, a nullable `ValueTuple` type ends up falling into `CustomDynamicObjectResolver` inside of
`NestFormatterResolver`, which will build a dynamic formatter using `MetaType` et.al, which enumerates interfaces and can cause a CLR error when calling `System.Runtime.CompilerServices.ITuple.get_Length()`.

Fixes #4703