### PR TITLE
AutoDateHistogramAggregate Interval should be DateMathTime

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -665,7 +665,7 @@ namespace Nest
 				reader.ReadNext();
 				propertyName = reader.ReadPropertyNameSegmentRaw();
 				if (propertyName.EqualsBytes(JsonWriter.GetEncodedPropertyNameWithoutQuotation("interval")))
-					bucket.Interval = formatterResolver.GetFormatter<Time>().Deserialize(ref reader, formatterResolver);
+					bucket.Interval = formatterResolver.GetFormatter<DateMathTime>().Deserialize(ref reader, formatterResolver);
 				else
 					// skip for now
 					reader.ReadNextBlock();

--- a/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramBucket.cs
+++ b/src/Nest/Aggregations/Bucket/AutoDateHistogram/AutoDateHistogramBucket.cs
@@ -6,6 +6,6 @@
 {
 	public class AutoDateHistogramAggregate : MultiBucketAggregate<DateHistogramBucket>
 	{
-		public Time Interval { get; internal set; }
+		public DateMathTime Interval { get; internal set; }
 	}
 }

--- a/src/Nest/Aggregations/Bucket/BucketAggregate.cs
+++ b/src/Nest/Aggregations/Bucket/BucketAggregate.cs
@@ -68,6 +68,6 @@ namespace Nest
 		public IReadOnlyCollection<IBucket> Items { get; set; } = EmptyReadOnly<IBucket>.Collection;
 		public IReadOnlyDictionary<string, object> Meta { get; set; } = EmptyReadOnly<string, object>.Dictionary;
 		public long? SumOtherDocCount { get; set; }
-		public Time Interval { get; set; }
+		public DateMathTime Interval { get; set; }
 	}
 }

--- a/tests/Tests.Reproduce/GitHubIssue4333.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4333.cs
@@ -1,0 +1,95 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4333
+	{
+		[U]
+		public void CanDeserializeYearIntervalUnit()
+		{
+			var json = @"{
+			""took"" : 162,
+			""timed_out"" : false,
+			""_shards"" : {
+				""total"" : 3,
+				""successful"" : 3,
+				""skipped"" : 0,
+				""failed"" : 0
+			},
+			""hits"" : {
+				""total"" : 4089559,
+				""max_score"" : 0.0,
+				""hits"" : [ ]
+			},
+			""aggregations"" : {
+				""modDate"" : {
+					""buckets"" : [
+					{
+						""key_as_string"" : ""2013-01-01T00:00:00.000Z"",
+						""key"" : 1356998400000,
+						""doc_count"" : 32
+					},
+					{
+						""key_as_string"" : ""2014-01-01T00:00:00.000Z"",
+						""key"" : 1388534400000,
+						""doc_count"" : 617
+					},
+					{
+						""key_as_string"" : ""2015-01-01T00:00:00.000Z"",
+						""key"" : 1420070400000,
+						""doc_count"" : 183
+					},
+					{
+						""key_as_string"" : ""2016-01-01T00:00:00.000Z"",
+						""key"" : 1451606400000,
+						""doc_count"" : 3479
+					},
+					{
+						""key_as_string"" : ""2017-01-01T00:00:00.000Z"",
+						""key"" : 1483228800000,
+						""doc_count"" : 1948427
+					},
+					{
+						""key_as_string"" : ""2018-01-01T00:00:00.000Z"",
+						""key"" : 1514764800000,
+						""doc_count"" : 555748
+					},
+					{
+						""key_as_string"" : ""2019-01-01T00:00:00.000Z"",
+						""key"" : 1546300800000,
+						""doc_count"" : 1268034
+					},
+					{
+						""key_as_string"" : ""2020-01-01T00:00:00.000Z"",
+						""key"" : 1577836800000,
+						""doc_count"" : 313039
+					}
+					],
+					""interval"" : ""1y""
+				}
+			}
+		}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var pool = new SingleNodeConnectionPool(new Uri("http://localhost:9200"));
+			var connectionSettings = new ConnectionSettings(pool, new InMemoryConnection(bytes)).DefaultIndex("default_index");
+			var client = new ElasticClient(connectionSettings);
+
+			var response = client.Search<object>();
+
+			Func<AutoDateHistogramAggregate> func = () => response.Aggregations.AutoDateHistogram("modDate");
+
+			var agg = func.Should().NotThrow().Subject;
+			agg.Interval.Should().Be("1y");
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes a bug with AutoDateHistogramAggregate Interval
property that uses the Time type to represent valid intervals. The Time
type however does not support Months and Years, which are valid units
for the AutoDateHistogram interval.

Fixes #4333