### PR TITLE
Unmute CsvProcessor

### DIFF
--- a/tests/Tests/Ingest/ProcessorAssertions.cs
+++ b/tests/Tests/Ingest/ProcessorAssertions.cs
@@ -75,7 +75,7 @@ namespace Tests.Ingest
 			public override string Key => "append";
 		}
 
-		[BlockedByIssue("https://github.com/elastic/elasticsearch/issues/55643")]
+		[SkipVersion("<7.8.0", "Empty Value bug in versions less than Elasticsearch 7.8.0")]
 		public class Csv : ProcessorAssertion
 		{
 			public override Func<ProcessorsDescriptor, IPromise<IList<IProcessor>>> Fluent => d => d

--- a/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
+++ b/tests/Tests/Ingest/PutPipeline/PutPipelineApiTests.cs
@@ -2,21 +2,21 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
 using Tests.Configuration;
 using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
-using Tests.Core.Xunit;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
 
 namespace Tests.Ingest.PutPipeline
 {
-	[BlockedByIssue("https://github.com/elastic/elasticsearch/issues/55643")]
+	[SkipVersion("<7.8.0", "Empty Value bug in versions less than Elasticsearch 7.8.0")]
 	public class PutPipelineApiTests
 		: ApiIntegrationTestBase<XPackCluster, PutPipelineResponse, IPutPipelineRequest, PutPipelineDescriptor, PutPipelineRequest>
 	{


### PR DESCRIPTION
Relates: #4718.
Unmute CsvProcessot tests for 7.8.0 now that empty_value is fixed.