### PR TITLE
Add Point property for mapping point datatype

### DIFF
--- a/src/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
+++ b/src/Nest.JsonNetSerializer/Converters/HandleNestTypesOnSourceJsonConverter.cs
@@ -22,7 +22,8 @@ namespace Nest.JsonNetSerializer.Converters
 			typeof(ILazyDocument),
 			typeof(LazyDocument),
 			typeof(GeoCoordinate),
-			typeof(GeoLocation)
+			typeof(GeoLocation),
+			typeof(CartesianPoint),
 		};
 
 		private readonly IElasticsearchSerializer _builtInSerializer;

--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -55,6 +55,10 @@ namespace Nest
 			selector?.Invoke(new ShapePropertyDescriptor<T>());
 
 		/// <inheritdoc />
+		public IProperty Point(Func<PointPropertyDescriptor<T>, IPointProperty> selector) =>
+			selector?.Invoke(new PointPropertyDescriptor<T>());
+
+		/// <inheritdoc />
 		public IProperty IntegerRange(Func<IntegerRangePropertyDescriptor<T>, IIntegerRangeProperty> selector) =>
 			selector?.Invoke(new IntegerRangePropertyDescriptor<T>());
 

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -152,5 +152,8 @@ namespace Nest
 
 		[EnumMember(Value = "wildcard")]
 		Wildcard,
+
+		[EnumMember(Value = "point")]
+		Point,
 	}
 }

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -5,7 +5,6 @@
 using System.Runtime.Serialization;
 using Elasticsearch.Net;
 
-
 namespace Nest
 {
 	/// <summary>

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -95,6 +95,9 @@ namespace Nest
 		/// <inheritdoc cref="IShapeProperty"/>
 		TReturnType Shape(Func<ShapePropertyDescriptor<T>, IShapeProperty> selector);
 
+		/// <inheritdoc cref="IPointProperty"/>
+		TReturnType Point(Func<PointPropertyDescriptor<T>, IPointProperty> selector);
+
 		/// <inheritdoc cref="ICompletionProperty"/>
 		TReturnType Completion(Func<CompletionPropertyDescriptor<T>, ICompletionProperty> selector);
 
@@ -156,42 +159,64 @@ namespace Nest
 
 		public PropertiesDescriptor(IProperties properties) : base(properties ?? new Properties<T>()) { }
 
+		/// <inheritdoc cref="IBinaryProperty"/>
 		public PropertiesDescriptor<T> Binary(Func<BinaryPropertyDescriptor<T>, IBinaryProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IBooleanProperty"/>
 		public PropertiesDescriptor<T> Boolean(Func<BooleanPropertyDescriptor<T>, IBooleanProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="ICompletionProperty"/>
 		public PropertiesDescriptor<T> Completion(Func<CompletionPropertyDescriptor<T>, ICompletionProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IDateProperty"/>
 		public PropertiesDescriptor<T> Date(Func<DatePropertyDescriptor<T>, IDateProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IDateNanosProperty"/>
 		public PropertiesDescriptor<T> DateNanos(Func<DateNanosPropertyDescriptor<T>, IDateNanosProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IDateRangeProperty"/>
 		public PropertiesDescriptor<T> DateRange(Func<DateRangePropertyDescriptor<T>, IDateRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IDoubleRangeProperty"/>
 		public PropertiesDescriptor<T> DoubleRange(Func<DoubleRangePropertyDescriptor<T>, IDoubleRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IFloatRangeProperty"/>
 		public PropertiesDescriptor<T> FloatRange(Func<FloatRangePropertyDescriptor<T>, IFloatRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IGeoPointProperty"/>
 		public PropertiesDescriptor<T> GeoPoint(Func<GeoPointPropertyDescriptor<T>, IGeoPointProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IGeoShapeProperty"/>
 		public PropertiesDescriptor<T> GeoShape(Func<GeoShapePropertyDescriptor<T>, IGeoShapeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IShapeProperty"/>
 		public PropertiesDescriptor<T> Shape(Func<ShapePropertyDescriptor<T>, IShapeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IPointProperty"/>
+		public PropertiesDescriptor<T> Point(Func<PointPropertyDescriptor<T>, IPointProperty> selector) => SetProperty(selector);
+
+		/// <inheritdoc cref="IIntegerRangeProperty"/>
 		public PropertiesDescriptor<T> IntegerRange(Func<IntegerRangePropertyDescriptor<T>, IIntegerRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IIpProperty"/>
 		public PropertiesDescriptor<T> Ip(Func<IpPropertyDescriptor<T>, IIpProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IIpRangeProperty"/>
 		public PropertiesDescriptor<T> IpRange(Func<IpRangePropertyDescriptor<T>, IIpRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IJoinProperty"/>
 		public PropertiesDescriptor<T> Join(Func<JoinPropertyDescriptor<T>, IJoinProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IKeywordProperty"/>
 		public PropertiesDescriptor<T> Keyword(Func<KeywordPropertyDescriptor<T>, IKeywordProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="ILongRangeProperty"/>
 		public PropertiesDescriptor<T> LongRange(Func<LongRangePropertyDescriptor<T>, ILongRangeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IMurmur3HashProperty"/>
 		public PropertiesDescriptor<T> Murmur3Hash(Func<Murmur3HashPropertyDescriptor<T>, IMurmur3HashProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="INestedProperty"/>
 		public PropertiesDescriptor<T> Nested<TChild>(Func<NestedPropertyDescriptor<T, TChild>, INestedProperty> selector)
 			where TChild : class => SetProperty(selector);
 
@@ -202,18 +227,23 @@ namespace Nest
 		/// </summary>
 		public PropertiesDescriptor<T> Number(Func<NumberPropertyDescriptor<T>, INumberProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IObjectProperty"/>
 		public PropertiesDescriptor<T> Object<TChild>(Func<ObjectTypeDescriptor<T, TChild>, IObjectProperty> selector)
 			where TChild : class => SetProperty(selector);
 
+		/// <inheritdoc cref="IPercolatorProperty"/>
 		public PropertiesDescriptor<T> Percolator(Func<PercolatorPropertyDescriptor<T>, IPercolatorProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="ITextProperty"/>
 		public PropertiesDescriptor<T> Text(Func<TextPropertyDescriptor<T>, ITextProperty> selector) => SetProperty(selector);
 
 		/// <inheritdoc cref="ISearchAsYouTypeProperty"/>
 		public PropertiesDescriptor<T> SearchAsYouType(Func<SearchAsYouTypePropertyDescriptor<T>, ISearchAsYouTypeProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="ITokenCountProperty"/>
 		public PropertiesDescriptor<T> TokenCount(Func<TokenCountPropertyDescriptor<T>, ITokenCountProperty> selector) => SetProperty(selector);
 
+		/// <inheritdoc cref="IFieldAliasProperty"/>
 		public PropertiesDescriptor<T> FieldAlias(Func<FieldAliasPropertyDescriptor<T>, IFieldAliasProperty> selector) => SetProperty(selector);
 
 		/// <inheritdoc cref="IRankFeatureProperty"/>
@@ -236,6 +266,9 @@ namespace Nest
 		public PropertiesDescriptor<T> Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) =>
 			SetProperty(selector);
 
+		/// <summary>
+		/// Map a custom property.
+		/// </summary>
 		public PropertiesDescriptor<T> Custom(IProperty customType) => SetProperty(customType);
 
 		private PropertiesDescriptor<T> SetProperty<TDescriptor, TInterface>(Func<TDescriptor, TInterface> selector)

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -81,6 +81,7 @@ namespace Nest
 				case FieldType.GeoPoint: return Deserialize<GeoPointProperty>(ref segmentReader, formatterResolver);
 				case FieldType.GeoShape: return Deserialize<GeoShapeProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Shape: return Deserialize<ShapeProperty>(ref segmentReader, formatterResolver);
+				case FieldType.Point: return Deserialize<PointProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Completion: return Deserialize<CompletionProperty>(ref segmentReader, formatterResolver);
 				case FieldType.TokenCount: return Deserialize<TokenCountProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Murmur3Hash: return Deserialize<Murmur3HashProperty>(ref segmentReader, formatterResolver);
@@ -158,6 +159,9 @@ namespace Nest
 					break;
 				case IShapeProperty shapeProperty:
 					Serialize(ref writer, shapeProperty, formatterResolver);
+					break;
+				case IPointProperty pointProperty:
+					Serialize(ref writer, pointProperty, formatterResolver);
 					break;
 				case ICompletionProperty completionProperty:
 					Serialize(ref writer, completionProperty, formatterResolver);

--- a/src/Nest/Mapping/Types/Specialized/Point/PointAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/Point/PointAttribute.cs
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+ namespace Nest
+{
+	/// <inheritdoc cref="IPointProperty" />
+	public class PointAttribute : ElasticsearchPropertyAttributeBase, IPointProperty
+	{
+		public PointAttribute() : base(FieldType.Point) { }
+
+		bool? IPointProperty.IgnoreMalformed { get; set; }
+		bool? IPointProperty.IgnoreZValue { get; set; }
+		CartesianPoint IPointProperty.NullValue { get; set; }
+
+		private IPointProperty Self => this;
+
+		/// <inheritdoc cref="IPointProperty.IgnoreMalformed" />
+		public bool IgnoreMalformed
+		{
+			get => Self.IgnoreMalformed.GetValueOrDefault(false);
+			set => Self.IgnoreMalformed = value;
+		}
+
+		/// <inheritdoc cref="IPointProperty.IgnoreZValue" />
+		public bool IgnoreZValue
+		{
+			get => Self.IgnoreZValue.GetValueOrDefault(true);
+			set => Self.IgnoreZValue = value;
+		}
+
+		/// <inheritdoc cref="IPointProperty.NullValue" />
+		public CartesianPoint NullValue
+		{
+			get => Self.NullValue;
+			set => Self.NullValue = value;
+		}
+	}
+}

--- a/src/Nest/Mapping/Types/Specialized/Point/PointProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Point/PointProperty.cs
@@ -1,0 +1,87 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// The point datatype facilitates the indexing of and searching
+	/// arbitrary `x, y` pairs that fall in a 2-dimensional planar
+	/// coordinate system.
+	/// <para />
+	/// You can query documents using this type using <see cref="IShapeQuery"/>.
+	/// <para />
+	/// Available in Elasticsearch 7.8.0+ with at least basic license level
+	/// </summary>
+	[InterfaceDataContract]
+	public interface IPointProperty : IProperty
+	{
+		/// <summary>
+		/// If <c>true</c>, malformed geojson shapes are ignored. If false (default),
+		/// malformed geojson shapes throw an exception and reject the whole document.
+		/// </summary>
+		[DataMember(Name ="ignore_malformed")]
+		bool? IgnoreMalformed { get; set; }
+
+		/// <summary>
+		/// If true (default) three dimension points will be accepted (stored in source) but
+		/// only x and y values will be indexed; the third dimension is ignored. If false,
+		/// geo-points containing any more than x and y (two dimensions) values throw
+		/// an exception and reject the whole document.
+		/// </summary>
+		[DataMember(Name ="ignore_z_value")]
+		bool? IgnoreZValue { get; set; }
+
+		/// <summary>
+		/// Accepts an point value which is substituted for any explicit `null` values.
+		/// Defaults to `null`, which means the field is treated as missing.
+		/// </summary>
+		[DataMember(Name = "null_value")]
+		CartesianPoint NullValue { get; set; }
+	}
+
+	/// <inheritdoc cref="IPointProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class PointProperty : PropertyBase, IPointProperty
+	{
+		public PointProperty() : base(FieldType.Point) { }
+
+		/// <inheritdoc />
+		public bool? IgnoreMalformed { get; set; }
+
+		/// <inheritdoc />
+		public bool? IgnoreZValue { get; set; }
+
+		/// <inheritdoc />
+		public CartesianPoint NullValue { get; set; }
+	}
+
+	/// <inheritdoc cref="IPointProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class PointPropertyDescriptor<T>
+		: PropertyDescriptorBase<PointPropertyDescriptor<T>, IPointProperty, T>, IPointProperty
+		where T : class
+	{
+		public PointPropertyDescriptor() : base(FieldType.Point) { }
+
+		bool? IPointProperty.IgnoreMalformed { get; set; }
+		bool? IPointProperty.IgnoreZValue { get; set; }
+		CartesianPoint IPointProperty.NullValue { get; set; }
+
+		/// <inheritdoc cref="IPointProperty.IgnoreMalformed" />
+		public PointPropertyDescriptor<T> IgnoreMalformed(bool? ignoreMalformed = true) =>
+			Assign(ignoreMalformed, (a, v) => a.IgnoreMalformed = v);
+
+		/// <inheritdoc cref="IPointProperty.IgnoreZValue" />
+		public PointPropertyDescriptor<T> IgnoreZValue(bool? ignoreZValue = true) =>
+			Assign(ignoreZValue, (a, v) => a.IgnoreZValue = v);
+
+		/// <inheritdoc cref="IPointProperty.NullValue" />
+		public PointPropertyDescriptor<T> NullValue(CartesianPoint nullValue) =>
+			Assign(nullValue, (a, v) => a.NullValue = v);
+	}
+}

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -34,6 +34,8 @@ namespace Nest
 
 		void Visit(IShapeProperty property);
 
+		void Visit(IPointProperty property);
+
 		void Visit(INumberProperty property);
 
 		void Visit(ICompletionProperty property);
@@ -88,6 +90,8 @@ namespace Nest
 		public virtual void Visit(IBooleanProperty property) { }
 
 		public virtual void Visit(IBinaryProperty property) { }
+
+		public virtual void Visit(IPointProperty property) { }
 
 		public virtual void Visit(INumberProperty property) { }
 

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -32,6 +32,8 @@ namespace Nest
 
 		void Visit(IShapeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
+		void Visit(IPointProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
 		void Visit(ICompletionProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		void Visit(IIpProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -165,6 +165,12 @@ namespace Nest
 							Accept(t.Fields);
 						});
 						break;
+					case FieldType.Point:
+						Visit<IPointProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+						});
+						break;
 					case FieldType.Completion:
 						Visit<ICompletionProperty>(field, t =>
 						{

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -21,6 +21,8 @@ namespace Nest
 
 		public virtual void Visit(IShapeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
+		public virtual void Visit(IPointProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
 		public virtual void Visit(ICompletionProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual void Visit(IMurmur3HashProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -167,6 +167,9 @@ namespace Nest
 				case IConstantKeywordProperty constantKeyword:
 					Visit(constantKeyword, propertyInfo, attribute);
 					break;
+				case IPointProperty point:
+					Visit(point, propertyInfo, attribute);
+					break;
 			}
 		}
 	}

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -24,8 +24,7 @@ namespace Nest
 	internal enum GeoFormat
 	{
 		GeoJson,
-		WellKnownText,
-		String,
+		WellKnownText
 	}
 
 	// TODO: Rename to ShapeType in 8.x

--- a/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
+++ b/src/Nest/QueryDsl/Geo/Shape/GeoShapeBase.cs
@@ -24,9 +24,11 @@ namespace Nest
 	internal enum GeoFormat
 	{
 		GeoJson,
-		WellKnownText
+		WellKnownText,
+		String,
 	}
 
+	// TODO: Rename to ShapeType in 8.x
 	internal static class GeoShapeType
 	{
 		// WKT uses BBOX for envelope geo shape

--- a/src/Nest/QueryDsl/Geo/WKT/GeoWKTException.cs
+++ b/src/Nest/QueryDsl/Geo/WKT/GeoWKTException.cs
@@ -6,8 +6,9 @@ using System;
 
 namespace Nest
 {
+	// TODO: Change to WKTException in 8.x
 	/// <summary>
-	/// An exception when handling <see cref="IGeoShape" /> in Well-Known Text format
+	/// An exception when handling shapes in Well-Known Text (WKT) format
 	/// </summary>
 	public class GeoWKTException : Exception
 	{

--- a/src/Nest/QueryDsl/Geo/WKT/GeoWKTReader.cs
+++ b/src/Nest/QueryDsl/Geo/WKT/GeoWKTReader.cs
@@ -279,7 +279,7 @@ namespace Nest
 				$"Expected number but found: {tokenizer.TokenString()}", tokenizer.LineNumber, tokenizer.Position);
 		}
 
-		private static bool IsNumberNext(WellKnownTextTokenizer tokenizer)
+		internal static bool IsNumberNext(WellKnownTextTokenizer tokenizer)
 		{
 			var token = tokenizer.PeekToken();
 			return token == TokenType.Word;

--- a/src/Nest/QueryDsl/Specialized/Shape/CartesianPoint.cs
+++ b/src/Nest/QueryDsl/Specialized/Shape/CartesianPoint.cs
@@ -173,12 +173,12 @@ namespace Nest
 				case ShapeFormat.WellKnownText:
 					writer.WriteQuotation();
 					writer.WriteRaw(Encoding.UTF8.GetBytes(GeoShapeType.Point));
-					writer.WriteByte((byte)' ');
-					writer.WriteByte((byte)'(');
+					writer.WriteRaw((byte)' ');
+					writer.WriteRaw((byte)'(');
 					writer.WriteSingle(value.X);
-					writer.WriteByte((byte)' ');
+					writer.WriteRaw((byte)' ');
 					writer.WriteSingle(value.Y);
-					writer.WriteByte((byte)')');
+					writer.WriteRaw((byte)')');
 					writer.WriteQuotation();
 					break;
 				case ShapeFormat.String:

--- a/src/Nest/QueryDsl/Specialized/Shape/CartesianPoint.cs
+++ b/src/Nest/QueryDsl/Specialized/Shape/CartesianPoint.cs
@@ -1,0 +1,263 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Text;
+using Elasticsearch.Net.Utf8Json;
+using Elasticsearch.Net.Utf8Json.Internal;
+using Nest;
+
+namespace Nest
+{
+	internal enum ShapeFormat
+	{
+		Object,
+		Array,
+		WellKnownText,
+		String,
+	}
+
+	/// <summary>
+	/// Represents a point in the cartesian plane.
+	/// </summary>
+	[JsonFormatter(typeof(CartesianPointFormatter))]
+	public class CartesianPoint : IEquatable<CartesianPoint>
+	{
+		internal ShapeFormat Format = ShapeFormat.Object;
+
+		public float X { get; set; }
+		public float Y { get; set; }
+
+		public CartesianPoint()
+		{
+		}
+
+		public CartesianPoint(float x, float y)
+		{
+			X = x;
+			Y = y;
+		}
+
+		public bool Equals(CartesianPoint other)
+		{
+			if (ReferenceEquals(null, other)) return false;
+			if (ReferenceEquals(this, other)) return true;
+
+			return X.Equals(other.X) && Y.Equals(other.Y);
+		}
+
+		public override bool Equals(object obj)
+		{
+			if (ReferenceEquals(null, obj)) return false;
+			if (ReferenceEquals(this, obj)) return true;
+			if (obj.GetType() != GetType()) return false;
+
+			return Equals((CartesianPoint)obj);
+		}
+
+		public override int GetHashCode()
+		{
+			unchecked
+			{
+				return (X.GetHashCode() * 397) ^ Y.GetHashCode();
+			}
+		}
+
+		public static CartesianPoint FromCoordinates(string coordinates)
+		{
+			var values = coordinates.Split(',');
+			if (values.Length > 3 || values.Length < 2)
+				throw new InvalidOperationException(
+					$"failed to parse {coordinates}, expected 2 or 3 coordinates but found: {values.Length}");
+
+			var s = values[0].Trim();
+			if (!float.TryParse(s, out var x))
+				throw new InvalidOperationException($"failed to parse float for x from {s}");
+
+			s = values[1].Trim();
+			if (!float.TryParse(s, out var y))
+				throw new InvalidOperationException($"failed to parse float for y from {s}");
+
+			if (values.Length > 2)
+			{
+				s = values[2].Trim();
+				if (!float.TryParse(s, out var _))
+					throw new InvalidOperationException($"failed to parse float for z from {s}");
+			}
+
+			return new CartesianPoint(x, y) { Format = ShapeFormat.String };
+		}
+
+		public static CartesianPoint FromWellKnownText(string wkt)
+		{
+			using var tokenizer = new WellKnownTextTokenizer(new StringReader(wkt));
+			var token = tokenizer.NextToken();
+
+			if (token != TokenType.Word)
+				throw new GeoWKTException(
+					$"Expected word but found {tokenizer.TokenString()}", tokenizer.LineNumber, tokenizer.Position);
+
+			var type = tokenizer.TokenValue.ToUpperInvariant();
+			if (type != GeoShapeType.Point)
+				throw new GeoWKTException(
+					$"Expected {GeoShapeType.Point} but found {type}", tokenizer.LineNumber, tokenizer.Position);
+
+			if (GeoWKTReader.NextEmptyOrOpen(tokenizer) == TokenType.Word)
+				return null;
+
+			var x = Convert.ToSingle(GeoWKTReader.NextNumber(tokenizer));
+			var y = Convert.ToSingle(GeoWKTReader.NextNumber(tokenizer));
+
+			// ignore any z value for now
+			if (GeoWKTReader.IsNumberNext(tokenizer))
+				GeoWKTReader.NextNumber(tokenizer);
+
+			var point = new CartesianPoint(x, y) { Format = ShapeFormat.WellKnownText };
+			GeoWKTReader.NextCloser(tokenizer);
+
+			return point;
+		}
+
+		public static implicit operator CartesianPoint(string value)
+		{
+			try
+			{
+				return value.IndexOf(",", StringComparison.InvariantCultureIgnoreCase) > -1
+					? FromCoordinates(value)
+					: FromWellKnownText(value);
+			}
+			catch
+			{
+				// implicit conversions should never fail
+				return null;
+			}
+		}
+
+		public static bool operator ==(CartesianPoint left, CartesianPoint right) => Equals(left, right);
+
+		public static bool operator !=(CartesianPoint left, CartesianPoint right) => !Equals(left, right);
+	}
+
+	internal class CartesianPointFormatter : IJsonFormatter<CartesianPoint>
+	{
+		private static readonly AutomataDictionary Fields = new AutomataDictionary { { "x", 0 }, { "y", 1 }, { "z", 2 } };
+
+		public void Serialize(ref JsonWriter writer, CartesianPoint value, IJsonFormatterResolver formatterResolver)
+		{
+			if (value is null)
+			{
+				writer.WriteNull();
+				return;
+			}
+
+			switch (value.Format)
+			{
+				case ShapeFormat.Object:
+					writer.WriteBeginObject();
+					writer.WritePropertyName("x");
+					writer.WriteSingle(value.X);
+					writer.WriteValueSeparator();
+					writer.WritePropertyName("y");
+					writer.WriteSingle(value.Y);
+					writer.WriteEndObject();
+					break;
+				case ShapeFormat.Array:
+					writer.WriteBeginArray();
+					writer.WriteSingle(value.X);
+					writer.WriteValueSeparator();
+					writer.WriteSingle(value.Y);
+					writer.WriteEndArray();
+					break;
+				case ShapeFormat.WellKnownText:
+					writer.WriteQuotation();
+					writer.WriteRaw(Encoding.UTF8.GetBytes(GeoShapeType.Point));
+					writer.WriteByte((byte)' ');
+					writer.WriteByte((byte)'(');
+					writer.WriteSingle(value.X);
+					writer.WriteByte((byte)' ');
+					writer.WriteSingle(value.Y);
+					writer.WriteByte((byte)')');
+					writer.WriteQuotation();
+					break;
+				case ShapeFormat.String:
+					writer.WriteQuotation();
+					writer.WriteSingle(value.X);
+					writer.WriteValueSeparator();
+					writer.WriteSingle(value.Y);
+					writer.WriteQuotation();
+					break;
+			}
+		}
+
+		public CartesianPoint Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
+		{
+			var token = reader.GetCurrentJsonToken();
+			switch (token)
+			{
+				case JsonToken.BeginObject:
+				{
+					var count = 0;
+					var point = new CartesianPoint { Format = ShapeFormat.Object };
+					while (reader.ReadIsInObject(ref count))
+					{
+						var property = reader.ReadPropertyNameSegmentRaw();
+						if (Fields.TryGetValue(property, out var value))
+						{
+							switch (value)
+							{
+								case 0:
+									point.X = reader.ReadSingle();
+									break;
+								case 1:
+									point.Y = reader.ReadSingle();
+									break;
+								case 2:
+									reader.ReadSingle();
+									break;
+							}
+						}
+						else
+							throw new JsonParsingException($"Unknown property {property.Utf8String()} when parsing {nameof(CartesianPoint)}");
+					}
+
+					return point;
+				}
+				case JsonToken.BeginArray:
+				{
+					var count = 0;
+					var point = new CartesianPoint { Format = ShapeFormat.Array };
+					while (reader.ReadIsInArray(ref count))
+					{
+						switch (count)
+						{
+							case 1:
+								point.X = reader.ReadSingle();
+								break;
+							case 2:
+								point.Y = reader.ReadSingle();
+								break;
+							case 3:
+								reader.ReadSingle();
+								break;
+							default:
+								throw new JsonParsingException($"Expected 2 or 3 coordinates but found {count}");
+						}
+					}
+
+					return point;
+				}
+				case JsonToken.String:
+				{
+					var value = reader.ReadString();
+					return value.IndexOf(",", StringComparison.InvariantCultureIgnoreCase) > -1
+						? CartesianPoint.FromCoordinates(value)
+						: CartesianPoint.FromWellKnownText(value);
+				}
+				default:
+					throw new JsonParsingException($"Unexpected token type {token} when parsing {nameof(CartesianPoint)}");
+			}
+		}
+	}
+}

--- a/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -203,6 +203,8 @@ namespace Tests.Indices.MappingManagement.GetMapping
 
 		public void Visit(IShapeProperty mapping) => Increment("shape");
 
+		public void Visit(IPointProperty mapping) => Increment("point");
+
 		public void Visit(IIpProperty mapping) => Increment("ip");
 
 		public void Visit(IObjectProperty mapping) => Increment("object");

--- a/tests/Tests/Mapping/Types/Specialized/Point/CartesianPointSerializationTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Point/CartesianPointSerializationTests.cs
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+using Tests.Core.Extensions;
+using Tests.Core.Serialization;
+
+namespace Tests.Mapping.Types.Specialized.Point
+{
+	public class CartesianPointSerializationTests
+	{
+		[U]
+		public void CanSerializeCartesianPointFromCoordinates()
+		{
+			var point = new PointDocument { Point = CartesianPoint.FromCoordinates("90.0,-90.0") };
+			SerializationTester.Default.AssertRoundTrip(point, new { point = "90.0,-90.0" });
+		}
+
+		[U]
+		public void CanSerializeCartesianPointFromWellKnownText()
+		{
+			var point = new PointDocument { Point = CartesianPoint.FromWellKnownText("POINT (90.0 -90.0)") };
+			SerializationTester.Default.AssertRoundTrip(point, new { point = "POINT (90.0 -90.0)" });
+		}
+
+		[U]
+		public void CanSerializeCartesianPoint()
+		{
+			var point = new PointDocument { Point = new CartesianPoint(90, -90) };
+			SerializationTester.Default.AssertRoundTrip(point, new { point = new { x = 90f, y = -90f } });
+		}
+
+		[U]
+		public void CanDeserializeCartesianPointFromArray()
+		{
+			var point = new CartesianPoint(90, -90);
+
+			CartesianPoint deserialized = null;
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("[90, -90]")))
+				deserialized = TestClient.DefaultInMemoryClient.SourceSerializer.Deserialize<CartesianPoint>(stream);
+
+			deserialized.Should().Be(point);
+		}
+
+		private class PointDocument
+		{
+			public CartesianPoint Point { get; set; }
+		}
+	}
+}

--- a/tests/Tests/Mapping/Types/Specialized/Point/CartesianPointSerializationTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Point/CartesianPointSerializationTests.cs
@@ -48,6 +48,18 @@ namespace Tests.Mapping.Types.Specialized.Point
 			deserialized.Should().Be(point);
 		}
 
+		[U]
+		public void CanDeserializeCartesianPointFromObject()
+		{
+			var point = new CartesianPoint(90, -90);
+
+			CartesianPoint deserialized = null;
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes("{ \"x\": 90, \"y\": -90 }")))
+				deserialized = TestClient.DefaultInMemoryClient.SourceSerializer.Deserialize<CartesianPoint>(stream);
+
+			deserialized.Should().Be(point);
+		}
+
 		private class PointDocument
 		{
 			public CartesianPoint Point { get; set; }

--- a/tests/Tests/Mapping/Types/Specialized/Point/PointAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Point/PointAttributeTests.cs
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+ using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+
+namespace Tests.Mapping.Types.Specialized.Point
+{
+	public class PointTest
+	{
+		[Point(IgnoreMalformed = true, IgnoreZValue = true)]
+		public object Full { get; set; }
+
+		[Point]
+		public object Minimal { get; set; }
+	}
+
+	[SkipVersion("<7.8.0", "Points introduced in 7.8.0+")]
+	public class PointAttributeTests : AttributeTestsBase<PointTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				full = new
+				{
+					type = "point",
+					ignore_z_value = true,
+					ignore_malformed = true
+
+				},
+				minimal = new
+				{
+					type = "point"
+				}
+			}
+		};
+	}
+}

--- a/tests/Tests/Mapping/Types/Specialized/Point/PointPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Point/PointPropertyTests.cs
@@ -1,0 +1,48 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+ using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Specialized.Point
+{
+	[SkipVersion("<7.8.0", "Points introduced in 7.8.0+")]
+	public class PointPropertyTests : PropertyTestsBase
+	{
+		public PointPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				arbitraryPoint = new
+				{
+					type = "point",
+					ignore_z_value = true
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.Point(p => p
+				.Name("arbitraryPoint")
+				.IgnoreZValue()
+			);
+
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"arbitraryPoint", new PointProperty
+				{
+					IgnoreZValue = true
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
Relates: #4718, elastic/elasticsearch#53804

This commit adds a Point property to map the new point data type.
A CartesianPoint type is introduced to model points.