### PR TITLE
Fix Ids overloads on PinnedQuery

### DIFF
--- a/src/Nest/QueryDsl/Specialized/Pinned/PinnedQuery.cs
+++ b/src/Nest/QueryDsl/Specialized/Pinned/PinnedQuery.cs
@@ -10,21 +10,37 @@ using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
+	/// <summary>
+	/// Promotes selected documents to rank higher than those matching a given query. This feature is typically used to
+	/// guide searchers to curated documents that are promoted over and above any "organic" matches for a search.
+	/// The promoted or "pinned" documents are identified using the document IDs stored in the _id field.
+	/// <para />
+	/// Available in Elasticsearch 7.4.0+ with at least basic license level
+	/// </summary>
 	[InterfaceDataContract]
 	[ReadAs(typeof(PinnedQuery))]
 	public interface IPinnedQuery : IQuery
 	{
+		/// <summary>
+		/// An array of document IDs listed in the order they are to appear in results.
+		/// </summary>
 		[DataMember(Name = "ids")]
 		IEnumerable<Id> Ids { get; set; }
 
+		/// <summary>
+		/// Any choice of query used to rank documents which will be ranked below the "pinned" document ids.
+		/// </summary>
 		[DataMember(Name = "organic")]
 		QueryContainer Organic { get; set; }
 	}
 
+	/// <inheritdoc cref="IPinnedQuery"/>
 	public class PinnedQuery : QueryBase, IPinnedQuery
 	{
+		/// <inheritdoc />
 		public IEnumerable<Id> Ids { get; set; }
 
+		/// <inheritdoc />
 		public QueryContainer Organic { get; set; }
 
 		protected override bool Conditionless => IsConditionless(this);
@@ -34,6 +50,7 @@ namespace Nest
 		internal static bool IsConditionless(IPinnedQuery q) => !q.Ids.HasAny() && q.Organic.IsConditionless();
 	}
 
+	/// <inheritdoc cref="IPinnedQuery"/>
 	public class PinnedQueryDescriptor<T>
 		: QueryDescriptorBase<PinnedQueryDescriptor<T>, IPinnedQuery>
 			, IPinnedQuery
@@ -43,16 +60,27 @@ namespace Nest
 		IEnumerable<Id> IPinnedQuery.Ids { get; set; }
 		QueryContainer IPinnedQuery.Organic { get; set; }
 
-		public PinnedQueryDescriptor<T> Ids(params Id[] ids) => Assign(ids, (a, v) => a.Ids = v);
+		/// <inheritdoc cref="IPinnedQuery.Ids"/>
+		public PinnedQueryDescriptor<T> Ids(params Id[] ids) =>
+			Assign(ids, (a, v) => a.Ids = v);
 
-		public PinnedQueryDescriptor<T> Ids(IEnumerable<Id> ids) => Ids(ids?.ToArray());
+		/// <inheritdoc cref="IPinnedQuery.Ids"/>
+		public PinnedQueryDescriptor<T> Ids(IEnumerable<Id> ids) =>
+			Assign(ids, (a, v) => a.Ids = v);
 
-		public PinnedQueryDescriptor<T> Ids(IEnumerable<string> ids) => Ids(ids.ToArray());
+		/// <inheritdoc cref="IPinnedQuery.Ids"/>
+		public PinnedQueryDescriptor<T> Ids(IEnumerable<string> ids) =>
+			Assign(ids?.Select(i => (Id)i), (a, v) => a.Ids = v);
 
-		public PinnedQueryDescriptor<T> Ids(IEnumerable<long> ids) => Ids(ids.ToArray());
+		/// <inheritdoc cref="IPinnedQuery.Ids"/>
+		public PinnedQueryDescriptor<T> Ids(IEnumerable<long> ids) =>
+			Assign(ids?.Select(i => (Id)i), (a, v) => a.Ids = v);
 
-		public PinnedQueryDescriptor<T> Ids(IEnumerable<Guid> ids) => Ids(ids.ToArray());
+		/// <inheritdoc cref="IPinnedQuery.Ids"/>
+		public PinnedQueryDescriptor<T> Ids(IEnumerable<Guid> ids) =>
+			Assign(ids?.Select(i => (Id)i), (a, v) => a.Ids = v);
 
+		/// <inheritdoc cref="IPinnedQuery.Organic"/>
 		public PinnedQueryDescriptor<T> Organic(Func<QueryContainerDescriptor<T>, QueryContainer> selector) =>
 			Assign(selector, (a, v) => a.Organic = v?.Invoke(new QueryContainerDescriptor<T>()));
 	}

--- a/tests/Tests.Reproduce/GithubIssue4733.cs
+++ b/tests/Tests.Reproduce/GithubIssue4733.cs
@@ -1,0 +1,34 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4733
+	{
+		[U]
+		public void CanSerializeIdsQueryWithIEnumerableString()
+		{
+			var client = TestClient.DefaultInMemoryClient;
+
+			Func<ISearchResponse<object>> func = () => client.Search<object>(s => s
+				.From(0)
+				.Size(25)
+				.Source(s => s.Excludes(e => e.Field("events")))
+				.Query(q => q.Pinned(p => p
+						.Organic(o => o.MatchAll())
+						.Ids(new [] { "387c2c78-95b1-42f8-a965-e09a73f7cff6" })
+					)
+				)
+			);
+
+			func.Should().NotThrow();
+		}
+	}
+}


### PR DESCRIPTION
This commit fixes the Ids overloads on PinnedQuery by
performing the conversion to IEnumerable<Id> on each
overload and assigning to the Ids value.

Fixes #4733