### PR TITLE
Add script_cache to Node Stats API

### DIFF
--- a/src/Nest/Cluster/NodesStats/NodeStats.cs
+++ b/src/Nest/Cluster/NodesStats/NodeStats.cs
@@ -62,6 +62,13 @@ namespace Nest
 		[DataMember(Name = "script")]
 		public ScriptStats Script { get; internal set; }
 
+		/// <summary>
+		/// Available in Elasticsearch 7.8.0+
+		/// </summary>
+		[DataMember(Name = "script_cache")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ScriptStats>))]
+		public IReadOnlyDictionary<string, ScriptStats> ScriptCache { get; internal set; }
+
 		[DataMember(Name = "thread_pool")]
 		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ThreadCountStats>))]
 		public IReadOnlyDictionary<string, ThreadCountStats> ThreadPool { get; internal set; }
@@ -85,6 +92,9 @@ namespace Nest
 
 		[DataMember(Name = "compilations")]
 		public long Compilations { get; internal set; }
+
+		[DataMember(Name = "compilation_limit_triggered")]
+		public long CompilationLimitTriggered { get; internal set; }
 	}
 
 	[DataContract]

--- a/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -73,6 +73,11 @@ namespace Tests.Cluster.NodesStats
 			Assert(node.Jvm);
 			Assert(node.AdaptiveSelection);
 			Assert(node.Ingest);
+
+			if (TestClient.Configuration.InRange(">=7.8.0"))
+			{
+				Assert(node.ScriptCache);
+			}
 		}
 
 		protected void Assert(NodeIngestStats nodeIngestStats)
@@ -94,9 +99,6 @@ namespace Tests.Cluster.NodesStats
 
 			processorStats.Type.Should().Be("set");
 			processorStats.Statistics.Should().NotBeNull();
-
-
-
 		}
 
 		protected void Assert(IReadOnlyDictionary<string, AdaptiveSelectionStats> adaptiveSelectionStats) =>
@@ -186,6 +188,9 @@ namespace Tests.Cluster.NodesStats
 		}
 
 		protected void Assert(ScriptStats script) => script.Should().NotBeNull();
+
+		protected void Assert(IReadOnlyDictionary<string, ScriptStats> scriptCache) =>
+			scriptCache.Should().NotBeNull();
 
 		protected void Assert(TransportStats transport) => transport.Should().NotBeNull();
 


### PR DESCRIPTION
Relates: #4718

This commit adds the script_cache to node stats
API response.