### PR TITLE
Add FixedInterval and CalendarInterval to IDateHistogramCompositeAggr…

### DIFF
--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -41,7 +41,7 @@ a => a
         )
         .DateHistogram("started", d => d
             .Field(f => f.StartedOn)
-            .Interval(DateInterval.Month)
+            .CalendarInterval(DateInterval.Month)
         )
         .Histogram("branch_count", h => h
             .Field(f => f.RequiredBranches)
@@ -78,7 +78,7 @@ new CompositeAggregation("my_buckets")
         new DateHistogramCompositeAggregationSource("started")
         {
             Field = Field<Project>(f => f.StartedOn),
-            Interval = DateInterval.Month
+            CalendarInterval = DateInterval.Month
         },
         new HistogramCompositeAggregationSource("branch_count")
         {
@@ -120,7 +120,7 @@ new CompositeAggregation("my_buckets")
           "started": {
             "date_histogram": {
               "field": "startedOn",
-              "interval": "month"
+              "calendar_interval": "month"
             }
           }
         },

--- a/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
+++ b/src/Nest/Aggregations/Bucket/Composite/DateHistogramCompositeAggregationSource.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Runtime.Serialization;
 
 namespace Nest
@@ -21,10 +22,23 @@ namespace Nest
 		string Format { get; set; }
 
 		/// <summary>
-		/// 	The interval to use when bucketing documents
+		/// The interval to use when bucketing documents
 		/// </summary>
 		[DataMember(Name ="interval")]
+		[Obsolete("Use FixedInterval or CalendarInterval")]
 		Union<DateInterval?, Time> Interval { get; set; }
+
+		/// <summary>
+		/// The calendar interval to use when bucketing documents
+		/// </summary>
+		[DataMember(Name ="calendar_interval")]
+		public Union<DateInterval?, DateMathTime> CalendarInterval { get; set; }
+
+		/// <summary>
+		/// The fixed interval to use when bucketing documents
+		/// </summary>
+		[DataMember(Name ="fixed_interval")]
+		public Time FixedInterval { get; set; }
 
 		/// <summary>
 		/// Used to indicate that bucketing should use a different time zone.
@@ -44,7 +58,14 @@ namespace Nest
 		public string Format { get; set; }
 
 		/// <inheritdoc />
+		[Obsolete("Use FixedInterval or CalendarInterval")]
 		public Union<DateInterval?, Time> Interval { get; set; }
+
+		/// <inheritdoc />
+		public Union<DateInterval?, DateMathTime> CalendarInterval { get; set; }
+
+		/// <inheritdoc />
+		public Time FixedInterval { get; set; }
 
 		/// <inheritdoc />
 		public string TimeZone { get; set; }
@@ -62,15 +83,31 @@ namespace Nest
 
 		string IDateHistogramCompositeAggregationSource.Format { get; set; }
 		Union<DateInterval?, Time> IDateHistogramCompositeAggregationSource.Interval { get; set; }
+		Union<DateInterval?, DateMathTime> IDateHistogramCompositeAggregationSource.CalendarInterval { get; set; }
+		Time IDateHistogramCompositeAggregationSource.FixedInterval { get; set; }
 		string IDateHistogramCompositeAggregationSource.TimeZone { get; set; }
 
 		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Interval" />
+		[Obsolete("Use FixedInterval or CalendarInterval")]
 		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(DateInterval? interval) =>
 			Assign(interval, (a, v) => a.Interval = v);
 
 		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.Interval" />
+		[Obsolete("Use FixedInterval or CalendarInterval")]
 		public DateHistogramCompositeAggregationSourceDescriptor<T> Interval(Time interval) =>
 			Assign(interval, (a, v) => a.Interval = v);
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.CalendarInterval" />
+		public DateHistogramCompositeAggregationSourceDescriptor<T> CalendarInterval(DateInterval? interval) =>
+			Assign(interval, (a, v) => a.CalendarInterval = v);
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.CalendarInterval" />
+		public DateHistogramCompositeAggregationSourceDescriptor<T> CalendarInterval(DateMathTime interval) =>
+			Assign(interval, (a, v) => a.CalendarInterval = v);
+
+		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.FixedInterval" />
+		public DateHistogramCompositeAggregationSourceDescriptor<T> FixedInterval(Time interval) =>
+			Assign(interval, (a, v) => a.FixedInterval = v);
 
 		/// <inheritdoc cref="IDateHistogramCompositeAggregationSource.TimeZone" />
 		public DateHistogramCompositeAggregationSourceDescriptor<T> TimeZone(string timezone) => Assign(timezone, (a, v) => a.TimeZone = v);

--- a/tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Composite/CompositeAggregationUsageTests.cs
@@ -62,7 +62,7 @@ namespace Tests.Aggregations.Bucket.Composite
 								date_histogram = new
 								{
 									field = "startedOn",
-									interval = "month"
+									calendar_interval = "month"
 								}
 							}
 						},
@@ -118,7 +118,7 @@ namespace Tests.Aggregations.Bucket.Composite
 					)
 					.DateHistogram("started", d => d
 						.Field(f => f.StartedOn)
-						.Interval(DateInterval.Month)
+						.CalendarInterval(DateInterval.Month)
 					)
 					.Histogram("branch_count", h => h
 						.Field(f => f.RequiredBranches)
@@ -151,7 +151,7 @@ namespace Tests.Aggregations.Bucket.Composite
 					new DateHistogramCompositeAggregationSource("started")
 					{
 						Field = Field<Project>(f => f.StartedOn),
-						Interval = DateInterval.Month
+						CalendarInterval = DateInterval.Month
 					},
 					new HistogramCompositeAggregationSource("branch_count")
 					{
@@ -344,7 +344,7 @@ namespace Tests.Aggregations.Bucket.Composite
 	}
 
 	//hide
-	[SkipVersion("<6.3.0", "Date histogram source only supports format starting from Elasticsearch 6.3.0+")]
+	[SkipVersion("<7.2.0", "Date histogram source only supports fixed_interval starting from Elasticsearch 7.2.0+")]
 	public class DateFormatCompositeAggregationUsageTests : ProjectsOnlyAggregationUsageTestBase
 	{
 		public DateFormatCompositeAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
@@ -364,7 +364,7 @@ namespace Tests.Aggregations.Bucket.Composite
 								date_histogram = new
 								{
 									field = "startedOn",
-									interval = "month",
+									fixed_interval = "30d",
 									format = "yyyy-MM-dd"
 								}
 							}
@@ -396,7 +396,7 @@ namespace Tests.Aggregations.Bucket.Composite
 				.Sources(s => s
 					.DateHistogram("started", d => d
 						.Field(f => f.StartedOn)
-						.Interval(DateInterval.Month)
+						.FixedInterval("30d")
 						.Format("yyyy-MM-dd")
 					)
 				)
@@ -418,7 +418,7 @@ namespace Tests.Aggregations.Bucket.Composite
 					new DateHistogramCompositeAggregationSource("started")
 					{
 						Field = Field<Project>(f => f.StartedOn),
-						Interval = DateInterval.Month,
+						FixedInterval = new Time(30, TimeUnit.Day),
 						Format = "yyyy-MM-dd"
 					},
 				},


### PR DESCRIPTION
…egationSource

This commit adds FixedInterval and CalendarInterval to
IDateHistogramCompositeAggregationSource and deprecates
Interval.

FixedInterval uses Time type as units must be specified and the largest unit
supported is Day.

CalendarInterval can specify either a DateInterval or a DateMathTime
with a fixed unit of 1.

Closes #4695.