### PR TITLE
More lenient extended_stats deserialization

### DIFF
--- a/src/Nest/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
+++ b/src/Nest/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregate.cs
@@ -2,7 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿namespace Nest
+using System.Runtime.Serialization;
+
+namespace Nest
 {
 	public class ExtendedStatsAggregate : StatsAggregate
 	{
@@ -12,9 +14,13 @@
 		public double? Variance { get; set; }
 	}
 
+	[DataContract]
 	public class StandardDeviationBounds
 	{
+		[DataMember(Name = "lower")]
 		public double? Lower { get; set; }
+
+		[DataMember(Name = "upper")]
 		public double? Upper { get; set; }
 	}
 }


### PR DESCRIPTION
This commit updates the deserialization of
ExtendedStatsAggregate to make it more lenient to
the introduction of new fields.

Closes #4773