### PR TITLE
Remove increment inside loop when validating intermediate CA

### DIFF
--- a/src/Elasticsearch.Net/Connection/CertificateValidations.cs
+++ b/src/Elasticsearch.Net/Connection/CertificateValidations.cs
@@ -119,12 +119,10 @@ namespace Elasticsearch.Net
 			{
 				var c = chain.ChainElements[i].Certificate.Thumbprint;
 				var cPrivate = privateChain.ChainElements[i].Certificate.Thumbprint;
-				if (c == ca.Thumbprint) found = true;
+				if (!found && c == ca.Thumbprint) found = true;
 
 				//mis aligned certificate chain, return false so we do not accept this certificate
 				if (c != cPrivate) return false;
-
-				i++;
 			}
 			return found;
 		}


### PR DESCRIPTION
This commit fixes a bug when validating an intermediate CA
to remove the increment inside of the loop, since it
is incremented outside the loop already.

Don't check the certificate thumbprint against
the CA thumbprint if it's already been found.

Fixes #4717