### PR TITLE
Ignore ContainsMetadata field when automapping Attachment

### DIFF
--- a/src/Nest/Mapping/Types/Specialized/Attachment/Attachment.cs
+++ b/src/Nest/Mapping/Types/Specialized/Attachment/Attachment.cs
@@ -29,6 +29,7 @@ namespace Nest
 		/// attachment.
 		/// </summary>
 		[IgnoreDataMember]
+		[Ignore]
 		public bool ContainsMetadata =>
 			!Author.IsNullOrEmpty() ||
 			ContentLength.HasValue ||

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -6,6 +6,7 @@
 
 namespace Nest
 {
+	// TODO: Make all methods virtual
 	public class NoopPropertyVisitor : IPropertyVisitor
 	{
 		public virtual bool SkipProperty(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => false;


### PR DESCRIPTION
This commit adds `[Ignore]` attribute to the `ContainsMetadata`
field to ignore the field when automapping an Attachment.

`[IgnoreDataMember]` ignores the value when serializing an
instance of Attachment, but `NoopPropertyVisitor` does not
take into account `[IgnoreDataMember]` when mapping properties.