### PR TITLE
Change default ModelSnapshotRetentionDays

### DIFF
--- a/tests/Tests/XPack/MachineLearning/GetJobs/GetJobsApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/GetJobs/GetJobsApiTests.cs
@@ -2,11 +2,12 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+using System;
 using System.Linq;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Core.Client;
 using Tests.Core.Extensions;
 using Tests.Framework.EndpointTests.TestState;
 
@@ -65,7 +66,9 @@ namespace Tests.XPack.MachineLearning.GetJobs
 			response.Jobs.First().DataDescription.TimeField.Name.Should().Be("@timestamp");
 			response.Jobs.First().DataDescription.TimeFormat.Should().Be("epoch_ms");
 
-			response.Jobs.First().ModelSnapshotRetentionDays.Should().Be(1);
+			response.Jobs.First().ModelSnapshotRetentionDays.Should().Be(TestClient.Configuration.InRange(">=7.8.0")
+				? 10
+				: 1);
 			response.Jobs.First().ResultsIndexName.Should().Be("shared");
 		}
 	}
@@ -123,7 +126,9 @@ namespace Tests.XPack.MachineLearning.GetJobs
 			response.Jobs.First().DataDescription.TimeField.Name.Should().Be("@timestamp");
 			response.Jobs.First().DataDescription.TimeFormat.Should().Be("epoch_ms");
 
-			response.Jobs.First().ModelSnapshotRetentionDays.Should().Be(1);
+			response.Jobs.First().ModelSnapshotRetentionDays.Should().Be(TestClient.Configuration.InRange(">=7.8.0")
+				? 10
+				: 1);
 			response.Jobs.First().ResultsIndexName.Should().Be("shared");
 		}
 	}

--- a/tests/Tests/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoApiTests.cs
@@ -2,10 +2,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+using System;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Core.Client;
 using Tests.Core.Extensions;
 using Tests.Framework.EndpointTests.TestState;
 
@@ -41,7 +42,10 @@ namespace Tests.XPack.MachineLearning.MachineLearningInfo
 			var anomalyDetectors = response.Defaults.AnomalyDetectors;
 			anomalyDetectors.ModelMemoryLimit.Should().Be("1gb");
 			anomalyDetectors.CategorizationExamplesLimit.Should().Be(4);
-			anomalyDetectors.ModelSnapshotRetentionDays.Should().Be(1);
+
+			anomalyDetectors.ModelSnapshotRetentionDays.Should().Be(TestClient.Configuration.InRange(">=7.8.0")
+				? 10
+				: 1);
 
 			response.Defaults.Datafeeds.ScrollSize.Should().Be(1000);
 

--- a/tests/Tests/XPack/MachineLearning/PutJob/PutJobApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/PutJob/PutJobApiTests.cs
@@ -2,13 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Core.Client;
 using Tests.Core.Extensions;
 using Tests.Domain;
 using Tests.Framework.EndpointTests.TestState;
@@ -122,7 +123,9 @@ namespace Tests.XPack.MachineLearning.PutJob
 			response.DataDescription.TimeField.Name.Should().Be("@timestamp");
 			response.DataDescription.TimeFormat.Should().Be("epoch_ms");
 
-			response.ModelSnapshotRetentionDays.Should().Be(1);
+			response.ModelSnapshotRetentionDays.Should().Be(TestClient.Configuration.InRange(">=7.8.0")
+				? 10
+				: 1);
 
 			// User-defined names are prepended with "custom-" by X-Pack ML
 			response.ResultsIndexName.Should().Be("custom-server-metrics");
@@ -205,6 +208,7 @@ namespace Tests.XPack.MachineLearning.PutJob
 		protected override Func<PutJobDescriptor<Metric>, IPutJobRequest> Fluent => f => f
 			.Description("Lab 1 - Simple example")
 			.ResultsIndexName("server-metrics")
+			.ModelSnapshotRetentionDays(1)
 			.AnalysisConfig(a => a
 				.BucketSpan("30m")
 				.Latency("0s")
@@ -247,6 +251,7 @@ namespace Tests.XPack.MachineLearning.PutJob
 			{
 				Description = "Lab 1 - Simple example",
 				ResultsIndexName = "server-metrics",
+				ModelSnapshotRetentionDays = 1,
 				AnalysisConfig = new AnalysisConfig
 				{
 					BucketSpan = "30m",


### PR DESCRIPTION
This commit fixes assertions on ModelSnapshotRetentionDays
as the default days has changed from 1 to 10.