### PR TITLE
Remove MapsApi from DeleteExpiredData overload

### DIFF
--- a/src/Elasticsearch.Net/Patch.ElasticLowLevelClient.MachineLearning.cs
+++ b/src/Elasticsearch.Net/Patch.ElasticLowLevelClient.MachineLearning.cs
@@ -17,7 +17,6 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(DELETE, "_ml/_delete_expired_data", null, RequestParams(requestParameters));
 		///<summary>DELETE on /_ml/_delete_expired_data <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-delete-expired-data.html</para></summary>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
-		[MapsApi("ml.delete_expired_data")]
 		public Task<TResponse> DeleteExpiredDataAsync<TResponse>(DeleteExpiredDataRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(DELETE, "_ml/_delete_expired_data", ctx, null, RequestParams(requestParameters));
 	}


### PR DESCRIPTION
This commit removes the MapsApiAttribute from the DeleteExpiredData overloads, so that the overload with a body are used for yaml tests