### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+* text=auto
+
+*.sh text eol=lf
+.ci/run-tests text eol=lf


### PR DESCRIPTION
This commit adds a .gitattributes file to treat all shell scripts and .ci/run-tests as LF eol