### PR TITLE
Use format that null_value conforms to

### DIFF
--- a/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
@@ -16,7 +16,7 @@ namespace Tests.Mapping.Types.Core.Date
 			Index = false,
 			Boost = 1.2,
 			IgnoreMalformed = true,
-			Format = "MM/dd/yyyy")]
+			Format = "yyyy-MM-dd'T'HH:mm[:ss][.S]")]
 		public DateTime Full { get; set; }
 
 		public DateTime Inferred { get; set; }
@@ -42,7 +42,7 @@ namespace Tests.Mapping.Types.Core.Date
 					index = false,
 					boost = 1.2,
 					ignore_malformed = true,
-					format = "MM/dd/yyyy"
+					format = "yyyy-MM-dd'T'HH:mm[:ss][.S]"
 				},
 				minimal = new
 				{

--- a/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
@@ -27,7 +27,7 @@ namespace Tests.Mapping.Types.Core.Date
 					index = false,
 					boost = 1.2,
 					ignore_malformed = true,
-					format = "MM/dd/yyyy",
+					format = "yyyy-MM-dd'T'HH:mm[:ss][.S]",
 					null_value = DateTime.MinValue
 				}
 			}
@@ -42,7 +42,7 @@ namespace Tests.Mapping.Types.Core.Date
 				.Index(false)
 				.Boost(1.2)
 				.IgnoreMalformed()
-				.Format("MM/dd/yyyy")
+				.Format("yyyy-MM-dd'T'HH:mm[:ss][.S]")
 				.NullValue(DateTime.MinValue)
 			);
 
@@ -57,7 +57,7 @@ namespace Tests.Mapping.Types.Core.Date
 					Index = false,
 					Boost = 1.2,
 					IgnoreMalformed = true,
-					Format = "MM/dd/yyyy",
+					Format = "yyyy-MM-dd'T'HH:mm[:ss][.S]",
 					NullValue = DateTime.MinValue
 				}
 			}

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
@@ -16,7 +16,7 @@ namespace Tests.Mapping.Types.Core.DateNanos
 			Index = false,
 			Boost = 1.2,
 			IgnoreMalformed = true,
-			Format = "MM/dd/yyyy")]
+			Format = "yyyy-MM-dd'T'HH:mm[:ss][.S]")]
 		public DateTime Full { get; set; }
 
 		[DateNanos]
@@ -38,7 +38,7 @@ namespace Tests.Mapping.Types.Core.DateNanos
 					index = false,
 					boost = 1.2,
 					ignore_malformed = true,
-					format = "MM/dd/yyyy"
+					format = "yyyy-MM-dd'T'HH:mm[:ss][.S]"
 				},
 				minimal = new
 				{

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+ using System;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -27,7 +27,7 @@ namespace Tests.Mapping.Types.Core.DateNanos
 					index = false,
 					boost = 1.2,
 					ignore_malformed = true,
-					format = "MM/dd/yyyy",
+					format = "yyyy-MM-dd'T'HH:mm[:ss][.S]",
 					null_value = DateTime.MinValue
 				}
 			}
@@ -42,7 +42,7 @@ namespace Tests.Mapping.Types.Core.DateNanos
 				.Index(false)
 				.Boost(1.2)
 				.IgnoreMalformed()
-				.Format("MM/dd/yyyy")
+				.Format("yyyy-MM-dd'T'HH:mm[:ss][.S]")
 				.NullValue(DateTime.MinValue)
 			);
 
@@ -57,7 +57,7 @@ namespace Tests.Mapping.Types.Core.DateNanos
 					Index = false,
 					Boost = 1.2,
 					IgnoreMalformed = true,
-					Format = "MM/dd/yyyy",
+					Format = "yyyy-MM-dd'T'HH:mm[:ss][.S]",
 					NullValue = DateTime.MinValue
 				}
 			}


### PR DESCRIPTION
This commit updates the Format used in Date[Nanos]PropertyTests
to one that can be used to parse the null_value.

Closes #4781