### PR TITLE
Do not wrap null ISourceFilter in Union

### DIFF
--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -298,7 +298,9 @@ namespace Nest
 
 		/// <inheritdoc cref="ISearchRequest.Source" />
 		public SearchDescriptor<TInferDocument> Source(Func<SourceFilterDescriptor<TInferDocument>, ISourceFilter> selector) =>
-			Assign(selector, (a, v) => a.Source = new Union<bool, ISourceFilter>(v?.Invoke(new SourceFilterDescriptor<TInferDocument>())));
+			Assign(selector?.Invoke(new SourceFilterDescriptor<TInferDocument>()), (a, v) => a.Source = v is null
+				? null
+				: new Union<bool,ISourceFilter>(v));
 
 		/// <inheritdoc cref="ISearchRequest.Size" />
 		public SearchDescriptor<TInferDocument> Size(int? size) => Assign(size, (a, v) => a.Size = v);

--- a/tests/Tests.Reproduce/GithubIssue4787.cs
+++ b/tests/Tests.Reproduce/GithubIssue4787.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GithubIssue4787
+	{
+		[U]
+		public void DoNotSerializeNullSourceFilter()
+		{
+			var connectionSettings = new ConnectionSettings(new InMemoryConnection()).DisableDirectStreaming();
+			var client = new ElasticClient(connectionSettings);
+
+			Func<ISearchResponse<object>> action = () =>
+				client.Search<object>(s => s
+					.Query(q => q
+						.MatchAll()
+					)
+					.Index("index")
+					.Source(sfd => null)
+				);
+
+			var response = action.Should().NotThrow().Subject;
+
+			var json = Encoding.UTF8.GetString(response.ApiCall.RequestBodyInBytes);
+			json.Should().Be(@"{""query"":{""match_all"":{}}}");
+		}
+	}
+}


### PR DESCRIPTION
This commit updates the .Source() method
to not wrap a null ISourceFilter in Union<bool,ISourceFilter>, so
that it is not serialized in the request.

Fixes #4787