### PR TITLE
Add effective max model memory limit to ML info

### DIFF
--- a/src/Nest/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoResponse.cs
+++ b/src/Nest/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoResponse.cs
@@ -62,5 +62,11 @@ namespace Nest
 	{
 		[DataMember(Name = "max_model_memory_limit")]
 		public string MaxModelMemoryLimit { get; internal set; }
+
+		/// <summary>
+		/// Available in Elasticsearch 7.8.0+
+		/// </summary>
+		[DataMember(Name = "effective_max_model_memory_limit")]
+		public string EffectiveMaxModelMemoryLimit { get; internal set; }
 	}
 }

--- a/tests/Tests/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/MachineLearningInfo/MachineLearningInfoApiTests.cs
@@ -56,6 +56,9 @@ namespace Tests.XPack.MachineLearning.MachineLearningInfo
 				analyzer.Tokenizer.Should().Be("ml_classic");
 				analyzer.Filter.Should().NotBeNullOrEmpty();
 			}
+
+			if (TestClient.Configuration.InRange(">=7.8.0"))
+				response.Limits.EffectiveMaxModelMemoryLimit.Should().NotBeNullOrEmpty();
 		}
 	}
 }


### PR DESCRIPTION
Relates: elastic/elasticsearch#55529, #4803