### PR TITLE
Deserialize enums in fallback Enum.Parse as case insensitive

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Formatters/EnumFormatter.cs
@@ -185,7 +185,7 @@ namespace Elasticsearch.Net.Utf8Json.Formatters
 				if (!nameValueMapping.TryGetValue(key, out value))
 				{
 					var str = StringEncoding.UTF8.GetString(key.Array, key.Offset, key.Count);
-					value = (T)Enum.Parse(typeof(T), str); // Enum.Parse is slow
+					value = (T)Enum.Parse(typeof(T), str, true); // Enum.Parse is slow
 				}
 				return value;
 			}

--- a/tests/Tests.Reproduce/GitHubIssue4817.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4817.cs
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4817
+	{
+		[U]
+		public void DeserializeCaseInsensitiveEnum()
+		{
+			var json = "{\"default_operator\":\"AND\",\"query\":\"Hans Mueller\"}";
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var elasticClient = new ElasticClient();
+
+			Func<QueryStringQuery> func = () => elasticClient.RequestResponseSerializer.Deserialize<QueryStringQuery>(new MemoryStream(bytes));
+
+			var query = func.Should().NotThrow().Subject;
+			query.DefaultOperator.Should().Be(Operator.And);
+		}
+	}
+}


### PR DESCRIPTION
This commit updates the EnumFormatter to parse case-insensitive
when falling back to the Enum.Parse method, which happens when
a value is not found in a mapping built from EnumMember/DataMember
value or field name.

Fixes #4817