### PR TITLE
Check _cleanupTimer is not null when disposing

### DIFF
--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -154,7 +154,7 @@ namespace Elasticsearch.Net
 		{
 			lock (_cleanupTimerLock)
 			{
-				_cleanupTimer.Dispose();
+				_cleanupTimer?.Dispose();
 				_cleanupTimer = null;
 			}
 		}

--- a/tests/Tests.Reproduce/GitHubIssue4818.cs
+++ b/tests/Tests.Reproduce/GitHubIssue4818.cs
@@ -1,0 +1,22 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue4818
+	{
+		[U]
+		public void ConnectionSettingsDoesNotThrowNullReferenceException()
+		{
+			IDisposable settings = new ConnectionSettings();
+			Action func = () => settings.Dispose();
+			func.Should().NotThrow<NullReferenceException>();
+		}
+	}
+}


### PR DESCRIPTION
This commit checks that _cleanupTimer is not null
when disposing, which it may be if no requests have
been made.

Fixes #4818