### PR TITLE
Fix script compilation settings

### DIFF
--- a/tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/Clusters/ClientTestClusterBase.cs
@@ -60,7 +60,8 @@ namespace Tests.Core.ManagedElasticsearch.Clusters
 			Add("node.remote_cluster_client", "true", ">=8.0.0-SNAPSHOT");
 
 			Add($"script.max_compilations_per_minute", "10000", "<6.0.0-rc1");
-			Add($"script.max_compilations_rate", "10000/1m", ">=6.0.0-rc1");
+			Add($"script.max_compilations_rate", "10000/1m", ">=6.0.0-rc1 <7.9.0-SNAPSHOT");
+			Add($"script.disable_max_compilations_rate", "true", ">=7.9.0-SNAPSHOT");
 
 			Add($"script.inline", "true", "<5.5.0");
 			Add($"script.stored", "true", ">5.0.0-alpha1 <5.5.0");


### PR DESCRIPTION
Relates: https://github.com/elastic/elasticsearch/pull/58283

This commit updates integration test cluster
settings to use disable_max_compilations_rate for
7.9.0-SNAPSHOT and above, and remove using
max_compilations_rate which is deprecated (and removed in 8.0.0-SNAPSHOT)