### PR TITLE
Fix ScriptCacheStats

### DIFF
--- a/src/Nest/Cluster/NodesStats/NodeStats.cs
+++ b/src/Nest/Cluster/NodesStats/NodeStats.cs
@@ -66,8 +66,7 @@ namespace Nest
 		/// Available in Elasticsearch 7.8.0+
 		/// </summary>
 		[DataMember(Name = "script_cache")]
-		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ScriptStats>))]
-		public IReadOnlyDictionary<string, ScriptStats> ScriptCache { get; internal set; }
+		public ScriptCacheStats ScriptCache { get; internal set; }
 
 		[DataMember(Name = "thread_pool")]
 		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, ThreadCountStats>))]
@@ -83,6 +82,22 @@ namespace Nest
 		public string TransportAddress { get; internal set; }
 	}
 
+	[DataContract]
+	public class ScriptCacheStats
+	{
+		[DataMember(Name = "sum")]
+		public ScriptStats Sum { get; internal set; }
+
+		[DataMember(Name = "contexts")]
+		public IReadOnlyCollection<ContextScriptStats> Contexts { get; internal set; }
+	}
+
+	[DataContract]
+	public class ContextScriptStats : ScriptStats
+	{
+		[DataMember(Name = "context")]
+		public string Context { get; internal set; }
+	}
 
 	[DataContract]
 	public class ScriptStats

--- a/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -189,8 +189,11 @@ namespace Tests.Cluster.NodesStats
 
 		protected void Assert(ScriptStats script) => script.Should().NotBeNull();
 
-		protected void Assert(IReadOnlyDictionary<string, ScriptStats> scriptCache) =>
+		protected void Assert(ScriptCacheStats scriptCache)
+		{
 			scriptCache.Should().NotBeNull();
+			scriptCache.Sum.Should().NotBeNull();
+		}
 
 		protected void Assert(TransportStats transport) => transport.Should().NotBeNull();
 


### PR DESCRIPTION
This commit fixes the response type for node stats script_cache
to a type with "sum" and "contexts" fields, to match the shape of returned JSON