### PR TITLE
Remove similarity from Date property integration tests

### DIFF
--- a/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DateAttributeTests.cs
@@ -11,7 +11,6 @@ namespace Tests.Mapping.Types.Core.Date
 	{
 		[Date(
 			DocValues = true,
-			Similarity = "classic",
 			Store = true,
 			Index = false,
 			Boost = 1.2,
@@ -37,7 +36,6 @@ namespace Tests.Mapping.Types.Core.Date
 				{
 					type = "date",
 					doc_values = true,
-					similarity = "classic",
 					store = true,
 					index = false,
 					boost = 1.2,

--- a/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Date/DatePropertyTests.cs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿using System;
+using System;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -22,7 +22,6 @@ namespace Tests.Mapping.Types.Core.Date
 				{
 					type = "date",
 					doc_values = false,
-					similarity = "BM25",
 					store = true,
 					index = false,
 					boost = 1.2,
@@ -37,7 +36,6 @@ namespace Tests.Mapping.Types.Core.Date
 			.Date(b => b
 				.Name(p => p.LastActivity)
 				.DocValues(false)
-				.Similarity("BM25")
 				.Store()
 				.Index(false)
 				.Boost(1.2)
@@ -52,7 +50,6 @@ namespace Tests.Mapping.Types.Core.Date
 				"lastActivity", new DateProperty
 				{
 					DocValues = false,
-					Similarity = "BM25",
 					Store = true,
 					Index = false,
 					Boost = 1.2,

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosAttributeTests.cs
@@ -11,7 +11,6 @@ namespace Tests.Mapping.Types.Core.DateNanos
 	{
 		[DateNanos(
 			DocValues = true,
-			Similarity = "classic",
 			Store = true,
 			Index = false,
 			Boost = 1.2,
@@ -33,7 +32,6 @@ namespace Tests.Mapping.Types.Core.DateNanos
 				{
 					type = "date_nanos",
 					doc_values = true,
-					similarity = "classic",
 					store = true,
 					index = false,
 					boost = 1.2,

--- a/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/DateNanos/DateNanosPropertyTests.cs
@@ -2,7 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
- using System;
+using System;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -22,7 +22,6 @@ namespace Tests.Mapping.Types.Core.DateNanos
 				{
 					type = "date_nanos",
 					doc_values = false,
-					similarity = "BM25",
 					store = true,
 					index = false,
 					boost = 1.2,
@@ -37,7 +36,6 @@ namespace Tests.Mapping.Types.Core.DateNanos
 			.DateNanos(b => b
 				.Name(p => p.LastActivity)
 				.DocValues(false)
-				.Similarity("BM25")
 				.Store()
 				.Index(false)
 				.Boost(1.2)
@@ -52,7 +50,6 @@ namespace Tests.Mapping.Types.Core.DateNanos
 				"lastActivity", new DateNanosProperty
 				{
 					DocValues = false,
-					Similarity = "BM25",
 					Store = true,
 					Index = false,
 					Boost = 1.2,


### PR DESCRIPTION
This commit removes the Similarity property usage from the
Date and DateNanos property integration tests.

Similarity is not a valid property and should be
removed as part of #3145