### PR TITLE
Add addition settings to s3 repository

### DIFF
--- a/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
+++ b/src/Nest/Modules/SnapshotAndRestore/Repositories/S3Repository.cs
@@ -118,6 +118,25 @@ namespace Nest
 		[DataMember(Name = "disable_chunked_encoding")]
 		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
 		bool? DisableChunkedEncoding { get; set; }
+
+		/// <summary>
+		/// Make the repository readonly. Defaults to false.
+		/// </summary>
+		[DataMember(Name = "readonly")]
+		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
+		bool? ReadOnly { get; set; }
+
+		/// <summary>
+		/// Throttles per node restore rate. Defaults to 40mb per second.
+		/// </summary>
+		[DataMember(Name = "max_restore_bytes_per_sec")]
+		string MaxRestoreBytesPerSecond { get; set; }
+
+		/// <summary>
+		/// Throttles per node snapshot rate. Defaults to 40mb per second.
+		/// </summary>
+		[DataMember(Name = "max_snapshot_bytes_per_sec")]
+		string MaxSnapshotBytesPerSecond { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -159,6 +178,15 @@ namespace Nest
 
 		/// <inheritdoc />
 		public bool? DisableChunkedEncoding { get; set; }
+
+		/// <inheritdoc />
+		public bool? ReadOnly { get; set; }
+
+		/// <inheritdoc />
+		public string MaxRestoreBytesPerSecond { get; set; }
+
+		/// <inheritdoc />
+		public string MaxSnapshotBytesPerSecond { get; set; }
 	}
 
 	/// <inheritdoc cref="IS3RepositorySettings"/>
@@ -178,6 +206,9 @@ namespace Nest
 		string IS3RepositorySettings.StorageClass { get; set; }
 		bool? IS3RepositorySettings.PathStyleAccess { get; set; }
 		bool? IS3RepositorySettings.DisableChunkedEncoding { get; set; }
+		bool? IS3RepositorySettings.ReadOnly { get; set; }
+		string IS3RepositorySettings.MaxRestoreBytesPerSecond { get; set; }
+		string IS3RepositorySettings.MaxSnapshotBytesPerSecond { get; set; }
 
 		/// <inheritdoc cref="IS3RepositorySettings.Bucket" />
 		public S3RepositorySettingsDescriptor Bucket(string bucket) => Assign(bucket, (a, v) => a.Bucket = v);
@@ -214,6 +245,18 @@ namespace Nest
 		/// <inheritdoc cref="IS3RepositorySettings.DisableChunkedEncoding" />
 		public S3RepositorySettingsDescriptor DisableChunkedEncoding(bool? disableChunkedEncoding = true) =>
 			Assign(disableChunkedEncoding, (a, v) => a.DisableChunkedEncoding = v);
+
+		/// <inheritdoc cref="IS3RepositorySettings.ReadOnly" />
+		public S3RepositorySettingsDescriptor ReadOnly(bool? readOnly = true) =>
+			Assign(readOnly, (a, v) => a.ReadOnly = v);
+
+		/// <inheritdoc cref="IS3RepositorySettings.MaxRestoreBytesPerSecond" />
+		public S3RepositorySettingsDescriptor MaxRestoreBytesPerSecond(string maxRestoreBytesPerSecond) =>
+			Assign(maxRestoreBytesPerSecond, (a, v) => a.MaxRestoreBytesPerSecond = v);
+
+		/// <inheritdoc cref="IS3RepositorySettings.MaxSnapshotBytesPerSecond" />
+		public S3RepositorySettingsDescriptor MaxSnapshotBytesPerSecond(string maxSnapshotBytesPerSecond) =>
+			Assign(maxSnapshotBytesPerSecond, (a, v) => a.MaxSnapshotBytesPerSecond = v);
 	}
 
 	/// <inheritdoc cref="IS3Repository"/>

--- a/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Repositories/CreateRepository/CreateRepositoryApiTests.cs
@@ -321,7 +321,9 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 				server_side_encryption = true,
 				buffer_size = "100mb",
 				canned_acl = "authenticated-read",
-				storage_class = "standard"
+				storage_class = "standard",
+				max_restore_bytes_per_sec = "40mb",
+				max_snapshot_bytes_per_sec = "40mb",
 			}
 		};
 
@@ -336,6 +338,8 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 					.BufferSize("100mb")
 					.CannedAcl("authenticated-read")
 					.StorageClass("standard")
+					.MaxRestoreBytesPerSecond("40mb")
+					.MaxSnapshotBytesPerSecond("40mb")
 				)
 			);
 
@@ -352,7 +356,9 @@ namespace Tests.Modules.SnapshotAndRestore.Repositories.CreateRepository
 				ServerSideEncryption = true,
 				BufferSize = "100mb",
 				CannedAcl = "authenticated-read",
-				StorageClass = "standard"
+				StorageClass = "standard",
+				MaxRestoreBytesPerSecond = "40mb",
+				MaxSnapshotBytesPerSecond = "40mb"
 			})
 		};
 


### PR DESCRIPTION
This commit adds additional settings to s3 repository
settings:

- max_restore_bytes_per_sec
- max_snapshot_bytes_per_sec
- readonly

Closes #4889