### PR TITLE
[DOCS] Fixes broken link to sliced scroll

### DIFF
--- a/docs/search/scrolling-documents.asciidoc
+++ b/docs/search/scrolling-documents.asciidoc
@@ -73,7 +73,7 @@ scrollAllObservable.Wait(TimeSpan.FromMinutes(10), response => <3>
     ProcessResponse(response.SearchResponse); <4>
 });
 ----
-<1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
+<1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html[sliced scroll] documentation for choosing an appropriate number of slices.
 <2> Number of concurrent sliced scroll requests. Usually want to set this to the same value as the number of slices
 <3> Total overall time for scrolling **all** documents. Ensure this is a sufficient value to scroll all documents
 <4> do something with the response

--- a/docs/search/scrolling-documents.asciidoc
+++ b/docs/search/scrolling-documents.asciidoc
@@ -73,7 +73,7 @@ scrollAllObservable.Wait(TimeSpan.FromMinutes(10), response => <3>
     ProcessResponse(response.SearchResponse); <4>
 });
 ----
-<1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
+<1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
 <2> Number of concurrent sliced scroll requests. Usually want to set this to the same value as the number of slices
 <3> Total overall time for scrolling **all** documents. Ensure this is a sufficient value to scroll all documents
 <4> do something with the response

--- a/tests/Tests/Search/ScrollingDocuments.doc.cs
+++ b/tests/Tests/Search/ScrollingDocuments.doc.cs
@@ -64,7 +64,7 @@ namespace Tests.Search
 		[I]
 		public void SimpleScrollAllObservable()
 		{
-			int numberOfSlices = Environment.ProcessorCount; // <1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-body.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
+			int numberOfSlices = Environment.ProcessorCount; // <1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
 
 			var scrollAllObservable = Client.ScrollAll<Project>("10s", numberOfSlices, sc => sc
 				.MaxDegreeOfParallelism(numberOfSlices) // <2> Number of concurrent sliced scroll requests. Usually want to set this to the same value as the number of slices

--- a/tests/Tests/Search/ScrollingDocuments.doc.cs
+++ b/tests/Tests/Search/ScrollingDocuments.doc.cs
@@ -64,7 +64,7 @@ namespace Tests.Search
 		[I]
 		public void SimpleScrollAllObservable()
 		{
-			int numberOfSlices = Environment.ProcessorCount; // <1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html#sliced-scroll[sliced scroll] documentation for choosing an appropriate number of slices.
+			int numberOfSlices = Environment.ProcessorCount; // <1> See https://www.elastic.co/guide/en/elasticsearch/reference/current/paginate-search-results.html[sliced scroll] documentation for choosing an appropriate number of slices.
 
 			var scrollAllObservable = Client.ScrollAll<Project>("10s", numberOfSlices, sc => sc
 				.MaxDegreeOfParallelism(numberOfSlices) // <2> Number of concurrent sliced scroll requests. Usually want to set this to the same value as the number of slices


### PR DESCRIPTION
Related to https://github.com/elastic/docs/pull/1932

This PR fixes the following links that will break when the "current" documentation branch becomes 7.9:

````
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/net-api/7.x/scrolling-documents.html:
13:54:52 INFO:build_docs:   - en/elasticsearch/reference/current/search-request-body.html#sliced-scroll
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/net-api/current/scrolling-documents.html:
13:54:52 INFO:build_docs:   - en/elasticsearch/reference/current/search-request-body.html#sliced-scroll
13:54:52 INFO:build_docs:  /tmp/docsbuild/target_repo/html/en/elasticsearch/client/net-api/master/scrolling-documents.html:
13:54:52 INFO:build_docs:   - en/elasticsearch/reference/current/search-request-body.html#sliced-scroll
````

NOTE: This fixes changes the link to https://www.elastic.co/guide/en/elasticsearch/reference/7.9/paginate-search-results.html. It does not change the link to https://www.elastic.co/guide/en/elasticsearch/reference/7.9/paginate-search-results.html#slice-scroll since that section ID does not exist until current=7.9.  If necessary, we can update the URL again after 7.9 is released.
