### PR TITLE
Consistent file string comparison across Windows and Linux

### DIFF
--- a/docs/aggregations.asciidoc
+++ b/docs/aggregations.asciidoc
@@ -64,11 +64,11 @@ The values are typically extracted from the fields of the document (using the fi
 
 * <<sum-aggregation-usage,Sum Aggregation Usage>>
 
+* <<t-test-aggregation-usage,T Test Aggregation Usage>>
+
 * <<top-hits-aggregation-usage,Top Hits Aggregation Usage>>
 
 * <<top-metrics-aggregation-usage,Top Metrics Aggregation Usage>>
-
-* <<t-test-aggregation-usage,T Test Aggregation Usage>>
 
 * <<value-count-aggregation-usage,Value Count Aggregation Usage>>
 
@@ -108,11 +108,11 @@ include::aggregations/metric/string-stats/string-stats-aggregation-usage.asciido
 
 include::aggregations/metric/sum/sum-aggregation-usage.asciidoc[]
 
+include::aggregations/metric/t-test/t-test-aggregation-usage.asciidoc[]
+
 include::aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc[]
 
 include::aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc[]
-
-include::aggregations/metric/t-test/t-test-aggregation-usage.asciidoc[]
 
 include::aggregations/metric/value-count/value-count-aggregation-usage.asciidoc[]
 

--- a/docs/query-dsl.asciidoc
+++ b/docs/query-dsl.asciidoc
@@ -49,13 +49,13 @@ NEST exposes all of the full text queries available in Elasticsearch
 
 * <<intervals-usage,Intervals Usage>>
 
-* <<match-usage,Match Usage>>
-
 * <<match-bool-prefix-usage,Match Bool Prefix Usage>>
+
+* <<match-phrase-prefix-usage,Match Phrase Prefix Usage>>
 
 * <<match-phrase-usage,Match Phrase Usage>>
 
-* <<match-phrase-prefix-usage,Match Phrase Prefix Usage>>
+* <<match-usage,Match Usage>>
 
 * <<multi-match-usage,Multi Match Usage>>
 
@@ -71,13 +71,13 @@ include::query-dsl/full-text/common-terms/common-terms-usage.asciidoc[]
 
 include::query-dsl/full-text/intervals/intervals-usage.asciidoc[]
 
-include::query-dsl/full-text/match/match-usage.asciidoc[]
-
 include::query-dsl/full-text/match-bool-prefix/match-bool-prefix-usage.asciidoc[]
+
+include::query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc[]
 
 include::query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc[]
 
-include::query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc[]
+include::query-dsl/full-text/match/match-usage.asciidoc[]
 
 include::query-dsl/full-text/multi-match/multi-match-usage.asciidoc[]
 
@@ -122,13 +122,13 @@ NEST exposes all of the term queries available in Elasticsearch
 
 * <<term-query-usage,Term Query Usage>>
 
+* <<terms-set-query-usage,Terms Set Query Usage>>
+
 * <<terms-list-query-usage,Terms List Query Usage>>
 
 * <<terms-lookup-query-usage,Terms Lookup Query Usage>>
 
 * <<terms-query-usage,Terms Query Usage>>
-
-* <<terms-set-query-usage,Terms Set Query Usage>>
 
 * <<wildcard-query-usage,Wildcard Query Usage>>
 
@@ -160,13 +160,13 @@ include::query-dsl/term-level/regexp/regexp-query-usage.asciidoc[]
 
 include::query-dsl/term-level/term/term-query-usage.asciidoc[]
 
+include::query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc[]
+
 include::query-dsl/term-level/terms/terms-list-query-usage.asciidoc[]
 
 include::query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc[]
 
 include::query-dsl/term-level/terms/terms-query-usage.asciidoc[]
-
-include::query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc[]
 
 include::query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc[]
 
@@ -283,9 +283,9 @@ Specialized types of queries that do not fit into other groups
 
 * <<rank-feature-query-usage,Rank Feature Query Usage>>
 
-* <<script-query-usage,Script Query Usage>>
-
 * <<script-score-query-usage,Script Score Query Usage>>
+
+* <<script-query-usage,Script Query Usage>>
 
 * <<shape-query-usage,Shape Query Usage>>
 
@@ -305,9 +305,9 @@ include::query-dsl/specialized/pinned/pinned-query-usage.asciidoc[]
 
 include::query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc[]
 
-include::query-dsl/specialized/script/script-query-usage.asciidoc[]
-
 include::query-dsl/specialized/script-score/script-score-query-usage.asciidoc[]
+
+include::query-dsl/specialized/script/script-query-usage.asciidoc[]
 
 include::query-dsl/specialized/shape/shape-query-usage.asciidoc[]
 

--- a/src/DocGenerator/Program.cs
+++ b/src/DocGenerator/Program.cs
@@ -3,7 +3,8 @@
 // See the LICENSE file in the project root for more information
 
 ﻿using System;
-using System.IO;
+ using System.Globalization;
+ using System.IO;
 using System.Linq;
 using CommandLine;
 using Newtonsoft.Json.Linq;
@@ -14,6 +15,7 @@ namespace DocGenerator
 	{
 		static Program()
 		{
+			CultureInfo.DefaultThreadCurrentCulture = new CultureInfo("en-us");
 			var root = new DirectoryInfo(Directory.GetCurrentDirectory());
 
 			do

--- a/src/DocGenerator/StringExtensions.cs
+++ b/src/DocGenerator/StringExtensions.cs
@@ -224,7 +224,8 @@ namespace DocGenerator
 		{
 			json = null;
 
-			foreach (var substitution in Substitutions) anonymousTypeString = anonymousTypeString.Replace(substitution.Key, substitution.Value);
+			foreach (var substitution in Substitutions)
+				anonymousTypeString = anonymousTypeString.Replace(substitution.Key, substitution.Value);
 
 			var text =
 				$@"

--- a/src/DocGenerator/SyntaxNodeExtensions.cs
+++ b/src/DocGenerator/SyntaxNodeExtensions.cs
@@ -39,7 +39,7 @@ namespace DocGenerator
 		/// </summary>
 		public static bool ShouldBeConvertedToJson(this SyntaxNode node, SyntaxTriviaList leadingTrivia)
 		{
-			if (leadingTrivia == default(SyntaxTriviaList))
+			if (leadingTrivia == default)
 				return false;
 
 			var singleLineCommentIndex = leadingTrivia.IndexOf(SyntaxKind.SingleLineCommentTrivia);
@@ -77,7 +77,10 @@ namespace DocGenerator
 
 			// find the first anonymous object or new object expression
 			var syntax = node.DescendantNodes()
-				.FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax || n is ObjectCreationExpressionSyntax || n is LiteralExpressionSyntax);
+				.FirstOrDefault(n =>
+					n is AnonymousObjectCreationExpressionSyntax ||
+					n is ObjectCreationExpressionSyntax ||
+					n is LiteralExpressionSyntax);
 
 			return syntax != null && syntax.ToFullString().TryGetJsonForExpressionSyntax(out json);
 		}
@@ -107,7 +110,7 @@ namespace DocGenerator
 		public static string ToFullStringWithoutPragmaWarningDirectiveTrivia(this SyntaxNode node)
 		{
 			var pragma = node.DescendantTrivia(s => true, true).Where(t => t.IsKind(SyntaxKind.PragmaWarningDirectiveTrivia));
-			return node.ReplaceTrivia(pragma, (s, r) => default(SyntaxTrivia)).ToFullString();
+			return node.ReplaceTrivia(pragma, (s, r) => default).ToFullString();
 		}
 	}
 }


### PR DESCRIPTION
This commit fixes a difference in the default string comparison
on .NET core across Windows and Linux which was causing the
Stale docs github action to fail on CI because generated documentation
was ordering asciidoc includes and list items in a different order.

This fix sets a specific culture to use and uses ordinal string
comparison. Tested on Windows and Ubuntu 18.04 WSL 2.