### PR TITLE
NameValueCollection.ToQueryString performance optimisation

### DIFF
--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -23,6 +23,8 @@
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
     <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
+
+    <PackageReference Condition="'$(TargetFramework)' != 'netstandard2.1'" Include="System.Memory" Version="4.5.0" />
       
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />

--- a/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
+++ b/src/Elasticsearch.Net/Extensions/NameValueCollectionExtensions.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Buffers;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -12,28 +13,56 @@ namespace Elasticsearch.Net.Extensions
 {
 	internal static class NameValueCollectionExtensions
 	{
+		private const int MaxCharsOnStack = 256; // 512 bytes
+
 		internal static string ToQueryString(this NameValueCollection nv)
 		{
 			if (nv == null || nv.AllKeys.Length == 0) return string.Empty;
 
-			// initialize with capacity for number of key/values with length 5 each
-			var builder = new StringBuilder("?", nv.AllKeys.Length * 2 * 5);
-			for (var i = 0; i < nv.AllKeys.Length; i++)
+			var maxLength = 1 + nv.AllKeys.Length - 1; // account for '?', and any required '&' chars
+			foreach (var key in nv.AllKeys)
 			{
-				if (i != 0)
-					builder.Append("&");
-
-				var key = nv.AllKeys[i];
-				builder.Append(Uri.EscapeDataString(key));
-				var value = nv[key];
-				if (!value.IsNullOrEmpty())
-				{
-					builder.Append("=");
-					builder.Append(Uri.EscapeDataString(nv[key]));
-				}
+				maxLength += 1 + (key.Length + nv[key]?.Length ?? 0) * 3; // '=' char + worst case assume all key/value chars are escaped
 			}
 
-			return builder.ToString();
+			// prefer stack allocated array for short lengths
+			// note: renting for larger lengths is slightly more efficient since no zeroing occurs
+			char[] rentedFromPool = null;
+			var buffer = maxLength > MaxCharsOnStack
+				? rentedFromPool = ArrayPool<char>.Shared.Rent(maxLength)
+				: stackalloc char[MaxCharsOnStack];
+
+			try
+			{
+				var position = 0;
+				buffer[position++] = '?';
+
+				foreach (var key in nv.AllKeys)
+				{
+					if (position != 1)
+						buffer[position++] = '&';
+
+					var escapedKey = Uri.EscapeDataString(key);
+					escapedKey.AsSpan().CopyTo(buffer.Slice(position));
+					position += escapedKey.Length;
+
+					var value = nv[key];
+
+					if (value.IsNullOrEmpty()) continue;
+
+					buffer[position++] = '=';
+					var escapedValue = Uri.EscapeDataString(value);
+					escapedValue.AsSpan().CopyTo(buffer.Slice(position));
+					position += escapedValue.Length;
+				}
+
+				return buffer.Slice(0, position).ToString();
+			}
+			finally
+			{
+				if (rentedFromPool is object)
+					ArrayPool<char>.Shared.Return(rentedFromPool, clearArray: false);
+			}
 		}
 
 		internal static void UpdateFromDictionary(this NameValueCollection queryString, Dictionary<string, object> queryStringUpdates,

--- a/tests/Tests/Extensions/NameValueCollectionExtensionsTests.cs
+++ b/tests/Tests/Extensions/NameValueCollectionExtensionsTests.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using Elasticsearch.Net.Extensions;
+using FluentAssertions;
+using Xunit;
+
+namespace Tests.Extensions
+{
+	public class NameValueCollectionExtensionsTests
+	{
+		[Theory]
+		[MemberData(nameof(QueryStringTestData))]
+		public void ToQueryString_ReturnsExpectedString(NameValueCollection nvc, string expected) => nvc.ToQueryString().Should().Be(expected);
+
+		public static IEnumerable<object[]> QueryStringTestData =>
+			new List<object[]>
+			{
+				new object[] { new NameValueCollection
+				{
+					{ "q", "title:\"The Right Way\" AND mod_date:[20020101 TO 20030101]" },
+					{ "from", "10000" },
+					{ "request_cache", bool.TrueString },
+					{ "size", "100" }
+				}, "?q=title%3A%22The%20Right%20Way%22%20AND%20mod_date%3A%5B20020101%20TO%2020030101%5D&from=10000&request_cache=True&size=100" },
+
+				new object[] { new NameValueCollection
+				{
+					{ "q", "name:john~1 AND (age:[30 TO 40} OR surname:K*) AND -city" },
+				}, "?q=name%3Ajohn~1%20AND%20%28age%3A%5B30%20TO%2040%7D%20OR%20surname%3AK%2A%29%20AND%20-city" },
+
+				new object[] { new NameValueCollection
+				{
+					{ "q", null },
+				}, "?q" }
+			};
+	}
+}

--- a/tests/Tests/Extensions/NameValueCollectionExtensionsTests.cs
+++ b/tests/Tests/Extensions/NameValueCollectionExtensionsTests.cs
@@ -31,7 +31,17 @@ namespace Tests.Extensions
 				new object[] { new NameValueCollection
 				{
 					{ "q", null },
-				}, "?q" }
+				}, "?q" },
+
+				new object[] { new NameValueCollection
+				{
+					{ "emoji", "😅"}
+				}, "?emoji=%F0%9F%98%85" },
+
+				new object[] { new NameValueCollection
+				{
+					{ "€", "€"}
+				}, "?%E2%82%AC=%E2%82%AC" }
 			};
 	}
 }


### PR DESCRIPTION
This commit optimises the internal `ToQueryString` extension method on the `NameValueCollection` type. It avoids some intermediate string allocations by using a zero-alloc buffer to format the final query string.

- Adds a test for the extension method to validate existing behaviour is unaffected by the change of implementation.
- Adds the `System.Memory` package to support `Span<T>` usage across all target frameworks. This is registered conditionally for targets before NetStandard 2.1. I had some downgrade errors when using the latest package version, so I've aligned with the existing `System.Buffers` version for the time being.

I've opened this against master although it may be valuable to back port to existing supported versions?

The exact performance improvement varies based on the underlying collection, but in all cases resulted in less allocations and executes equal to or faster than the original code.

## .NET Core 2.1 Benchmark Results

```c#
private NameValueCollection _nvc = new NameValueCollection
{
    { "q", "title:\"The Right Way\" AND mod_date:[20020101 TO 20030101]" },
    { "from", "10000" },
    { "request_cache", bool.TrueString },
    { "size", "100" }
};
```

```
|   Method |     Mean |     Error |    StdDev | Ratio | RatioSD |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|--------- |---------:|----------:|----------:|------:|--------:|-------:|------:|------:|----------:|
| Original | 4.105 us | 0.0901 us | 0.2614 us |  1.00 |    0.00 | 0.3052 |     - |     - |    1288 B |
|      New | 3.652 us | 0.0730 us | 0.1898 us |  0.89 |    0.07 | 0.1755 |     - |     - |     736 B |
```

- Allocations reduced by 42.9%
- 11% faster

For smaller collections and key/value lengths, the allocation improvement can be greater. I've seen up to 77% on some test cases where no URI encoding need occur.

Closes #4951