### PR TITLE
Remove Boost from IpProperty

### DIFF
--- a/src/Nest/Mapping/Types/Specialized/Ip/IpAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/Ip/IpAttribute.cs
@@ -2,17 +2,11 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-﻿namespace Nest
+namespace Nest
 {
 	public class IpAttribute : ElasticsearchDocValuesPropertyAttributeBase, IIpProperty
 	{
 		public IpAttribute() : base(FieldType.Ip) { }
-
-		public double Boost
-		{
-			get => Self.Boost.GetValueOrDefault();
-			set => Self.Boost = value;
-		}
 
 		public bool Index
 		{
@@ -26,7 +20,6 @@
 			set => Self.NullValue = value;
 		}
 
-		double? IIpProperty.Boost { get; set; }
 		bool? IIpProperty.Index { get; set; }
 		string IIpProperty.NullValue { get; set; }
 		private IIpProperty Self => this;

--- a/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
@@ -14,9 +14,6 @@ namespace Nest
 	[InterfaceDataContract]
 	public interface IIpProperty : IDocValuesProperty
 	{
-		[DataMember(Name ="boost")]
-		double? Boost { get; set; }
-
 		[DataMember(Name ="index")]
 		bool? Index { get; set; }
 
@@ -30,7 +27,6 @@ namespace Nest
 	{
 		public IpProperty() : base(FieldType.Ip) { }
 
-		public double? Boost { get; set; }
 		public bool? Index { get; set; }
 		public string NullValue { get; set; }
 	}
@@ -43,13 +39,10 @@ namespace Nest
 	{
 		public IpPropertyDescriptor() : base(FieldType.Ip) { }
 
-		double? IIpProperty.Boost { get; set; }
 		bool? IIpProperty.Index { get; set; }
 		string IIpProperty.NullValue { get; set; }
 
 		public IpPropertyDescriptor<T> Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
-
-		public IpPropertyDescriptor<T> Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
 		public IpPropertyDescriptor<T> NullValue(string nullValue) => Assign(nullValue, (a, v) => a.NullValue = v);
 	}

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
@@ -132,7 +132,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 		public void MappingProperties()
 		{
 			var nested = new NestedProperty() { Name = "hello" };
-			var ip = new IpPropertyDescriptor<Project>().Name("field").Boost(2);
+			var ip = new IpPropertyDescriptor<Project>().Name("field");
 
 			DebugFor(nested).Should().StartWith("Type: nested");
 			DebugFor(ip).Should().StartWith("Type: ip");

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
@@ -10,7 +10,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 	{
 		[Ip(
 			Index = false,
-			Boost = 1.3,
 			NullValue = "127.0.0.1")]
 		public string Full { get; set; }
 
@@ -28,7 +27,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				{
 					type = "ip",
 					index = false,
-					boost = 1.3,
 					null_value = "127.0.0.1"
 				},
 				minimal = new

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
@@ -22,7 +22,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				{
 					type = "ip",
 					index = false,
-					boost = 1.3,
 					null_value = "127.0.0.1",
 					doc_values = true,
 					store = true,
@@ -34,7 +33,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 			.Ip(s => s
 				.Name(p => p.Name)
 				.Index(false)
-				.Boost(1.3)
 				.NullValue("127.0.0.1")
 				.DocValues()
 				.Store()
@@ -47,7 +45,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				"name", new IpProperty
 				{
 					Index = false,
-					Boost = 1.3,
 					NullValue = "127.0.0.1",
 					DocValues = true,
 					Store = true,


### PR DESCRIPTION
This commit removes the Boost property from Ip field mappings.

Fixes #4957