### PR TITLE
Fix field value factor serialization

### DIFF
--- a/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
+++ b/src/Nest/QueryDsl/Compound/FunctionScore/Functions/ScoreFunctionJsonFormatter.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elasticsearch.Net;
 using Elasticsearch.Net.Utf8Json;
 using Elasticsearch.Net.Utf8Json.Internal;
 
@@ -195,8 +196,35 @@ namespace Nest
 		private static void WriteFieldValueFactor(ref JsonWriter writer, IFieldValueFactorFunction value, IJsonFormatterResolver formatterResolver)
 		{
 			writer.WritePropertyName("field_value_factor");
-			var formatter = formatterResolver.GetFormatter<IFieldValueFactorFunction>();
-			formatter.Serialize(ref writer, value, formatterResolver);
+
+			writer.WriteBeginObject();
+
+			writer.WritePropertyName("field");
+			writer.WriteString(formatterResolver.GetConnectionSettings().Inferrer.Field(value.Field));
+
+			if (value.Factor.HasValue)
+			{
+				writer.WriteValueSeparator();
+				writer.WritePropertyName("factor");
+				writer.WriteDouble(value.Factor.Value);
+			}
+
+			if (value.Modifier.HasValue)
+			{
+				writer.WriteValueSeparator();
+				writer.WritePropertyName("modifier");
+				formatterResolver.GetFormatter<FieldValueFactorModifier>()
+					.Serialize(ref writer, value.Modifier.Value, formatterResolver);
+			}
+
+			if (value.Missing.HasValue)
+			{
+				writer.WriteValueSeparator();
+				writer.WritePropertyName("missing");
+				writer.WriteDouble(value.Missing.Value);
+			}
+
+			writer.WriteEndObject();
 		}
 
 		private void WriteDecay(ref JsonWriter writer, IDecayFunction decay, IJsonFormatterResolver formatterResolver)

--- a/tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/Compound/FunctionScore/FunctionScoreQueryUsageTests.cs
@@ -63,7 +63,16 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 				},
 				new FieldValueFactorFunction
 				{
-					Field = Field<Project>(p => p.NumberOfContributors), Factor = 1.1, Missing = 0.1, Modifier = FieldValueFactorModifier.Square
+					Field = Field<Project>(p => p.NumberOfContributors),
+					Factor = 1.1,
+					Missing = 0.1,
+					Modifier = FieldValueFactorModifier.Square,
+					Weight = 3,
+					Filter = new TermQuery
+					{
+						Field = Field<Project>(p => p.Branches),
+						Value = "dev"
+					}
 				},
 				new RandomScoreFunction { Seed = 1337, Field = "_seq_no" },
 				new RandomScoreFunction { Seed = "randomstring", Field = "_seq_no" },
@@ -134,13 +143,24 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 					},
 					new
 					{
+						filter = new
+						{
+							term = new
+							{
+								branches = new
+								{
+									value = "dev"
+								}
+							}
+						},
 						field_value_factor = new
 						{
 							field = "numberOfContributors",
 							factor = 1.1,
 							missing = 0.1,
 							modifier = "square"
-						}
+						},
+						weight = 3.0
 					},
 					new { random_score = new { seed = 1337, field = "_seq_no" } },
 					new { random_score = new { seed = "randomstring", field = "_seq_no" } },
@@ -197,7 +217,19 @@ namespace Tests.QueryDsl.Compound.FunctionScore
 						.Scale(Distance.Miles(1))
 						.MultiValueMode(MultiValueMode.Average)
 					)
-					.FieldValueFactor(b => b.Field(p => p.NumberOfContributors).Factor(1.1).Missing(0.1).Modifier(FieldValueFactorModifier.Square))
+					.FieldValueFactor(b => b
+						.Field(p => p.NumberOfContributors)
+						.Factor(1.1)
+						.Missing(0.1)
+						.Modifier(FieldValueFactorModifier.Square)
+						.Weight(3)
+						.Filter(fi => fi
+							.Term(t => t
+								.Field(p => p.Branches)
+								.Value("dev")
+							)
+						)
+					)
 					.RandomScore(r => r.Seed(1337).Field("_seq_no"))
 					.RandomScore(r => r.Seed("randomstring").Field("_seq_no"))
 					.Weight(1.0)


### PR DESCRIPTION
Relates: https://stackoverflow.com/questions/63502401/elasticsearch-nest-incorrect-function-score-json-generation

This commit fixes the serialization of IFieldValueFactorFunction whereby
filter and weight were being serialized twice, once inside of
field_value_factor and once outside.