### PR TITLE
Use SourceSerializer when deserializing Source API response

### DIFF
--- a/src/Elasticsearch.Net/Serialization/CustomResponseBuilderBase.cs
+++ b/src/Elasticsearch.Net/Serialization/CustomResponseBuilderBase.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 
 namespace Elasticsearch.Net
 {
-	// TODO: Pass both request/response serializer an source serializer in 8.0
+	// TODO: Pass both request/response serializer and source serializer in 8.0
 	public abstract class CustomResponseBuilderBase
 	{
 		public abstract object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream);

--- a/src/Elasticsearch.Net/Serialization/CustomResponseBuilderBase.cs
+++ b/src/Elasticsearch.Net/Serialization/CustomResponseBuilderBase.cs
@@ -8,6 +8,7 @@ using System.Threading.Tasks;
 
 namespace Elasticsearch.Net
 {
+	// TODO: Pass both request/response serializer an source serializer in 8.0
 	public abstract class CustomResponseBuilderBase
 	{
 		public abstract object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream);

--- a/src/Nest/Document/Single/Source/SourceRequestResponseBuilder.cs
+++ b/src/Nest/Document/Single/Source/SourceRequestResponseBuilder.cs
@@ -13,17 +13,44 @@ namespace Nest
 	{
 		public static SourceRequestResponseBuilder<TDocument> Instance { get; } = new SourceRequestResponseBuilder<TDocument>();
 
-		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream) =>
-			response.Success
-				? new SourceResponse<TDocument> { Body = builtInSerializer.Deserialize<TDocument>(stream) }
-				: new SourceResponse<TDocument>();
+		public override object DeserializeResponse(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream)
+		{
+			if (response.Success)
+			{
+				if (builtInSerializer is IInternalSerializer internalSerializer &&
+					internalSerializer.TryGetJsonFormatter(out var formatter))
+				{
+					var sourceSerializer = formatter.GetConnectionSettings().SourceSerializer;
+					return new SourceResponse<TDocument> { Body = sourceSerializer.Deserialize<TDocument>(stream) };
+				}
 
-		public override async Task<object> DeserializeResponseAsync(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default) =>
-			response.Success
-				? new SourceResponse<TDocument>
+				return new SourceResponse<TDocument> { Body = builtInSerializer.Deserialize<TDocument>(stream) };
+			}
+
+			return new SourceResponse<TDocument>();
+		}
+
+		public override async Task<object> DeserializeResponseAsync(IElasticsearchSerializer builtInSerializer, IApiCallDetails response, Stream stream, CancellationToken ctx = default)
+		{
+			if (response.Success)
+			{
+				if (builtInSerializer is IInternalSerializer internalSerializer &&
+					internalSerializer.TryGetJsonFormatter(out var formatter))
+				{
+					var sourceSerializer = formatter.GetConnectionSettings().SourceSerializer;
+					return new SourceResponse<TDocument>
+					{
+						Body = await sourceSerializer.DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
+					};
+				}
+
+				return new SourceResponse<TDocument>
 				{
 					Body = await builtInSerializer.DeserializeAsync<TDocument>(stream, ctx).ConfigureAwait(false)
-				}
-				: new SourceResponse<TDocument>();
+				};
+			}
+
+			return new SourceResponse<TDocument>();
+		}
 	}
 }

--- a/tests/Tests/Document/Single/Source/SourceApiTests.cs
+++ b/tests/Tests/Document/Single/Source/SourceApiTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Core.Xunit;
 using Tests.Domain;
 using Tests.Framework.DocumentationTests;
 
@@ -25,6 +26,18 @@ namespace Tests.Document.Single.Source
 			project.CuratedTags.Should().HaveCount(p.CuratedTags.Count());
 			project.LastActivity.Should().Be(p.LastActivity);
 			project.StartedOn.Should().Be(p.StartedOn);
+		}
+
+		[I]
+		[JsonNetSerializerOnly]
+		public void UseSourceSerializer()
+		{
+			var project = Client.Source<Project>(Project.Instance.Name, s => s.Routing(Project.Instance.Name)).Body;
+
+			var sourceOnly = project.SourceOnly;
+			sourceOnly.Should().NotBeNull();
+			sourceOnly.NotReadByDefaultSerializer.Should().Be("read");
+			sourceOnly.NotWrittenByDefaultSerializer.Should().Be("written");
 		}
 	}
 }


### PR DESCRIPTION
This commit uses the SourceSerializer to deserialize the source API response.

Fixes #4970