### PR TITLE
Serialize Epoch milliseconds as a string

### DIFF
--- a/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeOffsetEpochMillisecondsFormatter.cs
+++ b/src/Nest/CommonAbstractions/SerializationBehavior/JsonFormatters/DateTimeOffsetEpochMillisecondsFormatter.cs
@@ -11,8 +11,9 @@ namespace Nest
 	{
 		public override void Serialize(ref JsonWriter writer, DateTimeOffset value, IJsonFormatterResolver formatterResolver)
 		{
-			var dateTimeOffsetDifference = (value - DateTimeUtil.Epoch).TotalMilliseconds;
-			writer.WriteInt64((long)dateTimeOffsetDifference);
+			writer.WriteQuotation();
+			writer.WriteInt64(value.ToUnixTimeMilliseconds());
+			writer.WriteQuotation();
 		}
 	}
 
@@ -53,8 +54,9 @@ namespace Nest
 				return;
 			}
 
-			var dateTimeOffsetDifference = (value.Value - DateTimeUtil.Epoch).TotalMilliseconds;
-			writer.WriteInt64((long)dateTimeOffsetDifference);
+			writer.WriteQuotation();
+			writer.WriteInt64(value.Value.ToUnixTimeMilliseconds());
+			writer.WriteQuotation();
 		}
 	}
 }

--- a/tests/Tests/XPack/MachineLearning/GetAnomalyRecords/GetAnomalyRecordsApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/GetAnomalyRecords/GetAnomalyRecordsApiTests.cs
@@ -16,14 +16,24 @@ namespace Tests.XPack.MachineLearning.GetAnomalyRecords
 		: MachineLearningIntegrationTestBase<GetAnomalyRecordsResponse, IGetAnomalyRecordsRequest, GetAnomalyRecordsDescriptor,
 			GetAnomalyRecordsRequest>
 	{
+		private static readonly DateTimeOffset Timestamp = new DateTimeOffset(2016, 6, 2, 00, 00, 00, TimeSpan.Zero);
+
 		public GetAnomalyRecordsApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override bool ExpectIsValid => true;
 		protected override object ExpectJson => null;
 		protected override int ExpectStatusCode => 200;
-		protected override Func<GetAnomalyRecordsDescriptor, IGetAnomalyRecordsRequest> Fluent => f => f;
+		protected override Func<GetAnomalyRecordsDescriptor, IGetAnomalyRecordsRequest> Fluent => f => f
+			.Start(Timestamp.AddHours(-1))
+			.End(Timestamp.AddHours(1));
+
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
-		protected override GetAnomalyRecordsRequest Initializer => new GetAnomalyRecordsRequest(CallIsolatedValue);
+
+		protected override GetAnomalyRecordsRequest Initializer => new GetAnomalyRecordsRequest(CallIsolatedValue)
+		{
+			Start = Timestamp.AddHours(-1), End = Timestamp.AddHours(1)
+		};
+
 		protected override string UrlPath => $"/_ml/anomaly_detectors/{CallIsolatedValue}/results/records";
 
 		protected override GetAnomalyRecordsDescriptor NewDescriptor() => new GetAnomalyRecordsDescriptor(CallIsolatedValue);
@@ -33,7 +43,7 @@ namespace Tests.XPack.MachineLearning.GetAnomalyRecords
 			foreach (var callUniqueValue in values)
 			{
 				PutJob(client, callUniqueValue.Value);
-				IndexAnomalyRecord(client, callUniqueValue.Value, new DateTimeOffset(2016, 6, 2, 00, 00, 00, TimeSpan.Zero));
+				IndexAnomalyRecord(client, callUniqueValue.Value, Timestamp);
 			}
 		}
 

--- a/tests/Tests/XPack/MachineLearning/GetInfluencers/GetInfluencersApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/GetInfluencers/GetInfluencersApiTests.cs
@@ -22,10 +22,15 @@ namespace Tests.XPack.MachineLearning.GetInfluencers
 		protected override int ExpectStatusCode => 200;
 		protected override Func<GetInfluencersDescriptor, IGetInfluencersRequest> Fluent => f => f;
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
-		protected override GetInfluencersRequest Initializer => new GetInfluencersRequest(CallIsolatedValue);
+		protected override GetInfluencersRequest Initializer => new GetInfluencersRequest(CallIsolatedValue)
+		{
+			End = new DateTimeOffset(2016, 6, 2, 01, 00, 00, TimeSpan.Zero)
+		};
+
 		protected override string UrlPath => $"/_ml/anomaly_detectors/{CallIsolatedValue}/results/influencers";
 
-		protected override GetInfluencersDescriptor NewDescriptor() => new GetInfluencersDescriptor(CallIsolatedValue);
+		protected override GetInfluencersDescriptor NewDescriptor() => new GetInfluencersDescriptor(CallIsolatedValue)
+			.End(new DateTimeOffset(2016, 6, 2, 01, 00, 00, TimeSpan.Zero));
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{

--- a/tests/Tests/XPack/MachineLearning/StartDatafeed/StartDatafeedApiTests.cs
+++ b/tests/Tests/XPack/MachineLearning/StartDatafeed/StartDatafeedApiTests.cs
@@ -17,12 +17,23 @@ namespace Tests.XPack.MachineLearning.StartDatafeed
 	{
 		public StartDatafeedApiTests(MachineLearningCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		private DateTimeOffset Now => DateTimeOffset.Now;
+
 		protected override bool ExpectIsValid => true;
 		protected override object ExpectJson => null;
 		protected override int ExpectStatusCode => 200;
-		protected override Func<StartDatafeedDescriptor, IStartDatafeedRequest> Fluent => f => f;
+
+		protected override Func<StartDatafeedDescriptor, IStartDatafeedRequest> Fluent => f => f
+			.Start(Now)
+			.End(Now.AddSeconds(10));
+
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
-		protected override StartDatafeedRequest Initializer => new StartDatafeedRequest(CallIsolatedValue + "-datafeed");
+		protected override StartDatafeedRequest Initializer => new StartDatafeedRequest(CallIsolatedValue + "-datafeed")
+		{
+			Start = Now,
+			End = Now.AddSeconds(10)
+		};
+
 		protected override string UrlPath => $"_ml/datafeeds/{CallIsolatedValue}-datafeed/_start";
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)


### PR DESCRIPTION
This commit updates the DateTimeOffsetEpochMillisecondsFormatter
and NullableDateTimeOffsetEpochMillisecondsFormatter to serialize
epoch milliseconds as a string instead of a number. Add additional
parameters to integration tests to assert the change is valid
where used.