### PR TITLE
Short circuit in ToUrl to remove allocations when possible.

### DIFF
--- a/src/Nest/CommonAbstractions/Request/UrlLookup.cs
+++ b/src/Nest/CommonAbstractions/Request/UrlLookup.cs
@@ -41,6 +41,9 @@ namespace Nest
 
 		public string ToUrl(ResolvedRouteValues values)
 		{
+			if (values.Count == 0 && _tokenized.Length == 1 && _tokenized[0][0] != '@')
+				return _tokenized[0];
+
 			var sb = new StringBuilder(_length);
 			var i = 0;
 			for (var index = 0; index < _tokenized.Length; index++)


### PR DESCRIPTION
In the process of going through the code, I spotted a fairly trivial change which can reduce allocations during URL generation for endpoints where no route values need to be applied.

`UrlLookup.ToUrl` can short-circuit in such cases to avoid duplicating the string and allocating a StringBuilder. For requests where no index is supplied, the allocations can be entirely removed and an 87% reduction in execution time can be achieved.

The examples below test with the cluster health endpoints.

**Before:**

```
|      Method |     Mean |    Error |   StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |---------:|---------:|---------:|-------:|------:|------:|----------:|
|      Health | 41.60 ns | 0.637 ns | 0.596 ns | 0.0381 |     - |     - |     160 B |
| HealthIndex | 85.60 ns | 0.851 ns | 0.796 ns | 0.0457 |     - |     - |     192 B |
```

**After:**

```
|      Method |      Mean |     Error |    StdDev |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|------------ |----------:|----------:|----------:|-------:|------:|------:|----------:|
|      Health |  5.352 ns | 0.0611 ns | 0.0510 ns |      - |     - |     - |         - |
| HealthIndex | 84.470 ns | 0.5005 ns | 0.4437 ns | 0.0457 |     - |     - |     192 B |
```