### PR TITLE
Add Visit methods for derived IProperty types

### DIFF
--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -68,6 +68,12 @@ namespace Nest
 
 		void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
+		void Visit(ISearchAsYouTypeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
+		void Visit(IFieldAliasProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
+		void Visit(IWildcardProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
 		IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		bool SkipProperty(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -69,6 +69,12 @@ namespace Nest
 
 		public virtual void Visit(IConstantKeywordProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
+		public virtual void Visit(ISearchAsYouTypeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
+		public virtual void Visit(IFieldAliasProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
+		public virtual void Visit(IWildcardProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
 		public virtual IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => null;
 
 		public void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)

--- a/tests/Tests/CodeStandards/Parity/ParityTests.cs
+++ b/tests/Tests/CodeStandards/Parity/ParityTests.cs
@@ -37,7 +37,7 @@ namespace Tests.CodeStandards.Parity
 
 			var propertyTypes = interfaceType.Assembly
 				.GetTypes()
-				.Where(t => interfaceType.IsAssignableFrom(t) && t.IsInterface && !excludeInterfaceTypes.Contains(t));
+				.Where(t => t.IsInterface && interfaceType.IsAssignableFrom(t) && !excludeInterfaceTypes.Contains(t));
 
 			var visitMethodTypes = typeof(IPropertyVisitor).GetMethods()
 				.Where(m => m.ReturnType == typeof(void))


### PR DESCRIPTION
This commit adds missing Visit methods for IProperty types to IPropertyVisitor. Add unit test to ensure that visitor
contains a Visit method for derived IProperty types.