### PR TITLE
Mark all Visit methods virtual on NoopPropertyVisitor

### DIFF
--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -6,7 +6,6 @@ using System.Reflection;
 
 namespace Nest
 {
-	// TODO: Make all methods virtual
 	public class NoopPropertyVisitor : IPropertyVisitor
 	{
 		public virtual bool SkipProperty(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => false;
@@ -27,21 +26,21 @@ namespace Nest
 
 		public virtual void Visit(ITokenCountProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IPercolatorProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IPercolatorProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IIntegerRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IIntegerRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IFloatRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IFloatRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(ILongRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(ILongRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IDoubleRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IDoubleRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IDateRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IDateRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IIpRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IIpRangeProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
-		public void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+		public virtual void Visit(IJoinProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
 		public virtual void Visit(IRankFeatureProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
@@ -77,7 +76,7 @@ namespace Nest
 
 		public virtual IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => null;
 
-		public void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
+		public virtual void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
 		{
 			switch (type)
 			{

--- a/tests/Tests/CodeStandards/Parity/ParityTests.cs
+++ b/tests/Tests/CodeStandards/Parity/ParityTests.cs
@@ -40,10 +40,18 @@ namespace Tests.CodeStandards.Parity
 				.Where(t => t.IsInterface && interfaceType.IsAssignableFrom(t) && !excludeInterfaceTypes.Contains(t));
 
 			var visitMethodTypes = typeof(IPropertyVisitor).GetMethods()
-				.Where(m => m.ReturnType == typeof(void))
+				.Where(m => m.Name == nameof(IPropertyVisitor.Visit) && m.ReturnType == typeof(void))
 				.Select(m => m.GetParameters()[0].ParameterType);
 
 			propertyTypes.Except(visitMethodTypes).Should().BeEmpty();
+		}
+
+		[U]
+		public void NoopPropertyVisitorVisitMethodsAreAllVirtual()
+		{
+			var methods = typeof(NoopPropertyVisitor).GetMethods()
+				.Where(m => m.Name == nameof(NoopPropertyVisitor.Visit));
+			methods.Should().OnlyContain(m => m.IsVirtual);
 		}
 	}
 }


### PR DESCRIPTION
This commit marks all  Visit methods virtual on `NoopPropertyVisitor` to allow overriding only specific methods.

Add unit test to verify that methods are virtual, now and in the future.