### PR TITLE
Remove ILRepack

### DIFF
--- a/build/scripts/Building.fs
+++ b/build/scripts/Building.fs
@@ -118,20 +118,11 @@ module Build =
                [mainDll]
                |> Seq.append depAssemblies
                |> Seq.map (fun dll ->
-                   sprintf @"-i ""%s"" -o ""%s"" " dll (renamedDll dll)
+                   sprintf @"-i ""%s"" -o ""%s"" -k ""%s""" dll (renamedDll dll) keyFile
                )
            
             ReposTooling.Rewriter dlls
            
-            let rewrittenDll = renamedDll mainDll 
-            let ilMergeArgs = [
-                "/internalize"; 
-                (sprintf "/lib:%s" (Paths.InplaceBuildOutput project tfm)); 
-                (sprintf "/keyfile:%s" keyFile); 
-                (sprintf "/out:%s" rewrittenDll)
-            ]
-                
-            Tooling.ILRepack.Exec (ilMergeArgs |> List.append [rewrittenDll])
             Shell.rm mainDll
             let mainPdb = sprintf "%s.pdb" (Path.Combine(fullPath, project))
             if File.exists mainPdb then Shell.rm mainPdb

--- a/build/scripts/Tooling.fs
+++ b/build/scripts/Tooling.fs
@@ -62,7 +62,6 @@ module Tooling =
         member this.ExecIn workingDirectory arguments = this.ExecInWithTimeout workingDirectory arguments timeout
         member this.Exec arguments = this.ExecWithTimeout arguments timeout
 
-    let ILRepack = BuildTooling(None, "build/scripts/bin/Release/netcoreapp3.0/ILRepack.exe")
     let DotNet = BuildTooling(None, "dotnet")
 
     

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -46,14 +46,9 @@
     <PackageReference Include="Fake.IO.Zip" Version="5.15.0" />
     <PackageReference Include="Fake.Tools.Git" Version="5.15.0" />
     
-    <PackageReference Include="ILRepack" Version="2.1.0-beta1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
 
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Proc" Version="0.6.1" />
   </ItemGroup>
-  <Target Name="CopyToolPackages" AfterTargets="Build">
-    <Copy SourceFiles="$(PkgILRepack)\tools\ILRepack.exe" DestinationFolder="$(OutDir)" />
-  </Target>
-
 </Project>

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "assembly-rewriter": {
-      "version": "0.10.0",
+      "version": "0.11.0",
       "commands": [
         "assembly-rewriter"
       ]


### PR DESCRIPTION
This commit removes ILRepack from the build. ILRepack is used in
the 6.x branch to internalize Json.NET into the Nest assembly, and
was being used in 7.x and master branch **only** to sign the versioned
canary packages. Since assembly-rewriter can now sign a rewritten
assembly (works cross-platform) in nullean/assembly-rewriter#7,
there is no need for ILRepack at all.