### PR TITLE
[DOCS] Adds shared/attributes.asciidoc to index

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -11,6 +11,8 @@ If you wish to submit a PR for any spelling mistakes, typos or grammatical error
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 include::introduction.asciidoc[]
 
 include::installation.asciidoc[]

--- a/tests/Tests/index.asciidoc
+++ b/tests/Tests/index.asciidoc
@@ -3,6 +3,8 @@
 [[elasticsearch-net-reference]]
 = Elasticsearch.Net and NEST: the .NET clients
 
+include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
+
 include::introduction.asciidoc[]
 
 include::installation.asciidoc[]


### PR DESCRIPTION
## Overview

This PR adds the reference of the shared/attribute.asciidoc file to the index.asciidoc, so abbreviations in the attributes file can be used across the .NET documentation.