### PR TITLE
Add missing priority property

### DIFF
--- a/src/Nest/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
+++ b/src/Nest/Indices/IndexSettings/IndexTemplates/GetIndexTemplate/TemplateMapping.cs
@@ -27,6 +27,9 @@ namespace Nest
 
 		[DataMember(Name ="version")]
 		int? Version { get; set; }
+
+		[DataMember(Name ="priority")]
+		int? Priority { get; set; }
 	}
 
 	public class TemplateMapping : ITemplateMapping
@@ -41,5 +44,7 @@ namespace Nest
 		public IIndexSettings Settings { get; set; }
 
 		public int? Version { get; set; }
+
+		public int? Priority { get; set; }
 	}
 }

--- a/src/Nest/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateRequest.cs
+++ b/src/Nest/Indices/IndexSettings/IndexTemplates/PutIndexTemplate/PutIndexTemplateRequest.cs
@@ -23,6 +23,8 @@ namespace Nest
 		public IIndexSettings Settings { get; set; }
 
 		public int? Version { get; set; }
+
+		public int? Priority { get; set; }
 	}
 
 	public partial class PutIndexTemplateDescriptor
@@ -38,9 +40,13 @@ namespace Nest
 
 		int? ITemplateMapping.Version { get; set; }
 
+		int? ITemplateMapping.Priority { get; set; }
+
 		public PutIndexTemplateDescriptor Order(int? order) => Assign(order, (a, v) => a.Order = v);
 
 		public PutIndexTemplateDescriptor Version(int? version) => Assign(version, (a, v) => a.Version = v);
+
+		public PutIndexTemplateDescriptor Priority(int? priority) => Assign(priority, (a, p) => a.Priority = p);
 
 		public PutIndexTemplateDescriptor IndexPatterns(params string[] patterns) => Assign(patterns, (a, v) => a.IndexPatterns = v);
 


### PR DESCRIPTION
Allow setting the `priority` when creating index templates.

https://www.elastic.co/guide/en/elasticsearch/reference/current/index-templates.html