### PR TITLE
Fixing BulkAll indefinitely hanging when failing

### DIFF
--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -204,7 +204,7 @@ namespace Nest
 
 			void ThrowOnExhaustedRetries()
 			{
-				if (_partitionedBulkRequest.ContinueAfterDroppedDocuments || backOffRetries < _backOffRetries) return;
+				if (backOffRetries < _backOffRetries) return;
 
 				throw ThrowOnBadBulk(response,
 					$"{nameof(BulkAll)} halted after {nameof(PipelineFailure)}.{reason} from _bulk and exhausting retries ({backOffRetries})"


### PR DESCRIPTION
Ensure BulkAll() is aborted properly if the whole bulk request keeps returning a bad statuscode and ContinueOnDroppedDocuments is true. This was introduced in #4014 when trying to address a similar issue with backOffTries being ignored.