### PR TITLE
Add support for the new `data_*` roles.

### DIFF
--- a/src/Nest/Cluster/NodesInfo/NodeRole.cs
+++ b/src/Nest/Cluster/NodesInfo/NodeRole.cs
@@ -17,6 +17,18 @@ namespace Nest
 		[EnumMember(Value = "data")]
 		Data,
 
+		[EnumMember(Value = "data_cold")]
+		DataCold,
+
+		[EnumMember(Value = "data_content")]
+		DataContent,
+
+		[EnumMember(Value = "data_hot")]
+		DataHot,
+
+		[EnumMember(Value = "data_warm")]
+		DataWarm,
+
 		[EnumMember(Value = "client")]
 		Client,
 


### PR DESCRIPTION
Our integration tests were failing calling the `nodes.info` API because
it could not map `data_cold` to this enum.