### PR TITLE
Remove performance counters from RecyclableMemoryStream

### DIFF
--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager-Events.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager-Events.cs
@@ -60,62 +60,6 @@ namespace Elasticsearch.Net
 	internal sealed partial class RecyclableMemoryStreamManager
 	{
 		public static readonly Events EventsWriter = new Events();
-		private Counters Counter { get; }
-
-		public sealed class Counters : IDisposable
-		{
-			private ReadOnlyCollection<PollingCounter> Polls { get;}
-
-			public Counters(RecyclableMemoryStreamManager instance)
-			{
-				// ReSharper disable once UnusedParameter.Local
-				PollingCounter Create(string name, Func<double> poll, string description) =>
-					new PollingCounter(name, EventsWriter, poll)
-					// ReSharper disable once RedundantEmptyObjectOrCollectionInitializer
-					{
-#if NETSTANDARD2_1
-						DisplayName = description
-#endif
-					};
-
-
-				var polls = new List<PollingCounter>()
-				{
-					{ Create("blocks", () => _blocks, "Pooled blocks active")},
-					{ Create("large-buffers", () => _largeBuffers, "Large buffers active")},
-					{ Create("large-buffers-free", () => instance.LargeBuffersFree, "Large buffers free")},
-					{ Create("large-pool-inuse", () => instance.LargePoolInUseSize, "Large pool in use size")},
-					{ Create("small-pool-free", () => instance.SmallBlocksFree, "Small pool free blocks")},
-					{ Create("small-pool-inuse", () => instance.SmallPoolInUseSize, "Small pool in use size")},
-					{ Create("small-pool-free", () => instance.SmallPoolFreeSize, "Small pool free size")},
-					{ Create("small-pool-max", () => instance.MaximumFreeSmallPoolBytes, "Small pool max size")},
-					{ Create("memory-streams", () => _memoryStreams, "Active memory streams")},
-				};
-				Polls = new ReadOnlyCollection<PollingCounter>(polls);
-
-
-			}
-
-			private long _blocks;
-			internal void ReportBlockCreated() => Interlocked.Increment(ref _blocks);
-
-			internal void ReportBlockDiscarded() => Interlocked.Decrement(ref _blocks);
-
-			private long _largeBuffers;
-			internal void ReportLargeBufferCreated() => Interlocked.Increment(ref _largeBuffers);
-
-			internal void ReportLargeBufferDiscarded() => Interlocked.Decrement(ref _largeBuffers);
-
-			private long _memoryStreams;
-			internal void ReportStreamCreated() => Interlocked.Increment(ref _memoryStreams);
-
-			internal void ReportStreamDisposed() => Interlocked.Decrement(ref _memoryStreams);
-
-			public void Dispose()
-			{
-				foreach(var p in Polls) p.Dispose();
-			}
-		}
 
 		[EventSource(Name = "Elasticsearch-Net-RecyclableMemoryStream", Guid = "{AD44FDAC-D3FC-460A-9EBE-E55A3569A8F6}")]
 		public sealed class Events : EventSource

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -513,9 +513,6 @@ namespace Elasticsearch.Net
 			private readonly RecyclableMemoryStreamManager _instance;
 
 			public ReportingMemoryStream(byte[] bytes, RecyclableMemoryStreamManager instance) : base(bytes) => _instance = instance;
-
-			//NOTE DisposeAsync calls Dispose as well
-			protected override void Dispose(bool disposing) => base.Dispose();
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamManager.cs
@@ -162,7 +162,6 @@ namespace Elasticsearch.Net
 
 			for (var i = 0; i < _largePools.Length; ++i) _largePools[i] = new ConcurrentStack<byte[]>();
 
-			Counter = new Counters(this);
 			EventsWriter.MemoryStreamManagerInitialized(blockSize, largeBufferMultiple, maximumBufferSize);
 		}
 
@@ -480,41 +479,17 @@ namespace Elasticsearch.Net
 				LargePoolFreeSize);
 		}
 
-		internal void ReportBlockCreated()
-		{
-			Counter.ReportBlockCreated();
-			BlockCreated?.Invoke();
-		}
+		internal void ReportBlockCreated() => BlockCreated?.Invoke();
 
-		internal void ReportBlockDiscarded()
-		{
-			Counter.ReportBlockDiscarded();
-			BlockDiscarded?.Invoke();
-		}
+		internal void ReportBlockDiscarded() => BlockDiscarded?.Invoke();
 
-		internal void ReportLargeBufferCreated()
-		{
-			Counter.ReportLargeBufferCreated();
-			LargeBufferCreated?.Invoke();
-		}
+		internal void ReportLargeBufferCreated() => LargeBufferCreated?.Invoke();
 
-		internal void ReportLargeBufferDiscarded(Events.MemoryStreamDiscardReason reason)
-		{
-			Counter.ReportLargeBufferDiscarded();
-			LargeBufferDiscarded?.Invoke(reason);
-		}
+		internal void ReportLargeBufferDiscarded(Events.MemoryStreamDiscardReason reason) => LargeBufferDiscarded?.Invoke(reason);
 
-		internal void ReportStreamCreated()
-		{
-			Counter.ReportStreamCreated();
-			StreamCreated?.Invoke();
-		}
+		internal void ReportStreamCreated() => StreamCreated?.Invoke();
 
-		internal void ReportStreamDisposed()
-		{
-			Counter.ReportStreamDisposed();
-			StreamDisposed?.Invoke();
-		}
+		internal void ReportStreamDisposed() => StreamDisposed?.Invoke();
 
 		internal void ReportStreamFinalized() => StreamFinalized?.Invoke();
 
@@ -537,14 +512,10 @@ namespace Elasticsearch.Net
 		{
 			private readonly RecyclableMemoryStreamManager _instance;
 
-			public ReportingMemoryStream(byte[] bytes, RecyclableMemoryStreamManager instance) : base(bytes)
-			{
-				_instance = instance;
-				_instance.Counter.ReportStreamCreated();
-			}
+			public ReportingMemoryStream(byte[] bytes, RecyclableMemoryStreamManager instance) : base(bytes) => _instance = instance;
 
 			//NOTE DisposeAsync calls Dispose as well
-			protected override void Dispose(bool disposing) => _instance.Counter.ReportStreamDisposed();
+			protected override void Dispose(bool disposing) => base.Dispose();
 		}
 
 		/// <summary>


### PR DESCRIPTION
We received a report that the finalizer of `EventPipeEventProvider` for a customer was failing on disposing the `Elasticsearch-Net-RecyclableMemoryStream`. 

By power of elimination we localized it to our counters. Initially we suspected the `instance` reference to be the problem but only removing those counters did not fix the problem.
