### PR TITLE
Mapping time boost was removed in 7.10

### DIFF
--- a/src/Nest/Mapping/Types/Core/Number/NumberAttribute.cs
+++ b/src/Nest/Mapping/Types/Core/Number/NumberAttribute.cs
@@ -16,8 +16,10 @@ namespace Nest
 
 		public double Boost
 		{
+#pragma warning disable 618
 			get => Self.Boost.GetValueOrDefault();
 			set => Self.Boost = value;
+#pragma warning restore 618
 		}
 
 		public bool Coerce

--- a/src/Nest/Mapping/Types/Core/Number/NumberProperty.cs
+++ b/src/Nest/Mapping/Types/Core/Number/NumberProperty.cs
@@ -16,6 +16,7 @@ namespace Nest
 	[InterfaceDataContract]
 	public interface INumberProperty : IDocValuesProperty
 	{
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		[DataMember(Name = "boost")]
 		double? Boost { get; set; }
 
@@ -79,6 +80,7 @@ namespace Nest
 
 		public TDescriptor Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
 
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		public TDescriptor Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
 		public TDescriptor NullValue(double? nullValue) => Assign(nullValue, (a, v) => a.NullValue = v);

--- a/src/Nest/Mapping/Types/Core/Range/RangePropertyAttributeBase.cs
+++ b/src/Nest/Mapping/Types/Core/Range/RangePropertyAttributeBase.cs
@@ -10,8 +10,10 @@ namespace Nest
 
 		public double Boost
 		{
+#pragma warning disable 618
 			get => Self.Boost.GetValueOrDefault();
 			set => Self.Boost = value;
+#pragma warning restore 618
 		}
 
 		public bool Coerce

--- a/src/Nest/Mapping/Types/Core/Range/RangePropertyBase.cs
+++ b/src/Nest/Mapping/Types/Core/Range/RangePropertyBase.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Runtime.Serialization;
 using Elasticsearch.Net.Utf8Json;
 
@@ -13,6 +14,7 @@ namespace Nest
 		/// <summary>
 		/// Mapping field-level query time boosting. Accepts a floating point number, defaults to 1.0.
 		/// </summary>
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		[DataMember(Name ="boost")]
 		double? Boost { get; set; }
 
@@ -59,6 +61,7 @@ namespace Nest
 		public TDescriptor Coerce(bool? coerce = true) => Assign(coerce, (a, v) => a.Coerce = v);
 
 		/// <inheritdoc cref="IRangeProperty.Boost" />
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		public TDescriptor Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
 		/// <inheritdoc cref="IRangeProperty.Index" />

--- a/src/Nest/Mapping/Types/Specialized/Ip/IpAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/Ip/IpAttribute.cs
@@ -2,12 +2,15 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
+
 namespace Nest
 {
 	public class IpAttribute : ElasticsearchDocValuesPropertyAttributeBase, IIpProperty
 	{
 		public IpAttribute() : base(FieldType.Ip) { }
 
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		public double Boost
 		{
 			get => Self.Boost.GetValueOrDefault();

--- a/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Ip/IpProperty.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 using Elasticsearch.Net.Utf8Json;
@@ -14,6 +15,7 @@ namespace Nest
 	[InterfaceDataContract]
 	public interface IIpProperty : IDocValuesProperty
 	{
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		[DataMember(Name ="boost")]
 		double? Boost { get; set; }
 
@@ -49,6 +51,7 @@ namespace Nest
 
 		public IpPropertyDescriptor<T> Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
 
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		public IpPropertyDescriptor<T> Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
 		public IpPropertyDescriptor<T> NullValue(string nullValue) => Assign(nullValue, (a, v) => a.NullValue = v);

--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
@@ -16,8 +16,10 @@ namespace Nest
 
 		public double Boost
 		{
+#pragma warning disable 618
 			get => Self.Boost.GetValueOrDefault();
 			set => Self.Boost = value;
+#pragma warning restore 618
 		}
 
 		public bool Index

--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Diagnostics;
 using System.Runtime.Serialization;
 using Elasticsearch.Net.Utf8Json;
@@ -18,6 +19,7 @@ namespace Nest
 		[DataMember(Name ="analyzer")]
 		string Analyzer { get; set; }
 
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		[DataMember(Name ="boost")]
 		double? Boost { get; set; }
 
@@ -58,6 +60,7 @@ namespace Nest
 
 		public TokenCountPropertyDescriptor<T> Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
 
+		[Obsolete("The server always treated this as a noop and has been removed in 7.10")]
 		public TokenCountPropertyDescriptor<T> Boost(double? boost) => Assign(boost, (a, v) => a.Boost = v);
 
 		public TokenCountPropertyDescriptor<T> Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebuggerDisplayTests.cs
@@ -132,7 +132,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 		public void MappingProperties()
 		{
 			var nested = new NestedProperty() { Name = "hello" };
-			var ip = new IpPropertyDescriptor<Project>().Name("field").Boost(2);
+			var ip = new IpPropertyDescriptor<Project>().Name("field");
 
 			DebugFor(nested).Should().StartWith("Type: nested");
 			DebugFor(ip).Should().StartWith("Type: ip");

--- a/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
@@ -25,7 +25,6 @@ namespace Tests.Mapping.Types.Core.Number
 					similarity = "BM25",
 					store = true,
 					index = false,
-					boost = 1.5,
 					null_value = 0.0,
 					ignore_malformed = true,
 					coerce = true
@@ -41,7 +40,6 @@ namespace Tests.Mapping.Types.Core.Number
 				.Similarity("BM25")
 				.Store()
 				.Index(false)
-				.Boost(1.5)
 				.NullValue(0.0)
 				.IgnoreMalformed()
 				.Coerce()
@@ -57,7 +55,6 @@ namespace Tests.Mapping.Types.Core.Number
 					Similarity = "BM25",
 					Store = true,
 					Index = false,
-					Boost = 1.5,
 					NullValue = 0.0,
 					IgnoreMalformed = true,
 					Coerce = true
@@ -82,7 +79,6 @@ namespace Tests.Mapping.Types.Core.Number
 					similarity = "BM25",
 					store = true,
 					index = false,
-					boost = 1.5,
 					null_value = 0.0,
 					ignore_malformed = true,
 					coerce = true
@@ -99,7 +95,6 @@ namespace Tests.Mapping.Types.Core.Number
 				.Similarity("BM25")
 				.Store()
 				.Index(false)
-				.Boost(1.5)
 				.NullValue(0.0)
 				.IgnoreMalformed()
 				.Coerce()
@@ -116,7 +111,6 @@ namespace Tests.Mapping.Types.Core.Number
 					Similarity = "BM25",
 					Store = true,
 					Index = false,
-					Boost = 1.5,
 					NullValue = 0.0,
 					IgnoreMalformed = true,
 					Coerce = true

--- a/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.DateRange
 							type = "date_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.DateRange
 						.Name(p => p.Dates)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)

--- a/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DateRange/DateRangePropertyTests.cs
@@ -63,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.DateRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/DoubleRange/DoubleRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.DoubleRange
 							type = "double_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.DoubleRange
 						.Name(p => p.Doubles)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)
@@ -65,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.DoubleRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/FloatRange/FloatRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.FloatRange
 							type = "float_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.FloatRange
 						.Name(p => p.Floats)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)
@@ -65,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.FloatRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IntegerRange/IntegerRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.IntegerRange
 							type = "integer_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.IntegerRange
 						.Name(p => p.Integers)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)
@@ -65,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.IntegerRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/IpRange/IpRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.IpRange
 							type = "ip_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.IpRange
 						.Name(p => p.Ips)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)
@@ -65,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.IpRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangePropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Range/LongRange/LongRangePropertyTests.cs
@@ -30,7 +30,6 @@ namespace Tests.Mapping.Types.Core.Range.LongRange
 							type = "long_range",
 							store = true,
 							index = false,
-							boost = 1.5,
 							coerce = true
 						}
 					}
@@ -46,7 +45,6 @@ namespace Tests.Mapping.Types.Core.Range.LongRange
 						.Name(p => p.Longs)
 						.Store()
 						.Index(false)
-						.Boost(1.5)
 						.Coerce()
 					)
 				)
@@ -65,7 +63,6 @@ namespace Tests.Mapping.Types.Core.Range.LongRange
 							{
 								Store = true,
 								Index = false,
-								Boost = 1.5,
 								Coerce = true
 							}
 						}

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpAttributeTests.cs
@@ -10,7 +10,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 	{
 		[Ip(
 			Index = false,
-			Boost = 1.3,
 			NullValue = "127.0.0.1")]
 		public string Full { get; set; }
 
@@ -28,7 +27,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				{
 					type = "ip",
 					index = false,
-					boost = 1.3,
 					null_value = "127.0.0.1"
 				},
 				minimal = new

--- a/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Ip/IpPropertyTests.cs
@@ -22,7 +22,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				{
 					type = "ip",
 					index = false,
-					boost = 1.3,
 					null_value = "127.0.0.1",
 					doc_values = true,
 					store = true,
@@ -34,7 +33,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 			.Ip(s => s
 				.Name(p => p.Name)
 				.Index(false)
-				.Boost(1.3)
 				.NullValue("127.0.0.1")
 				.DocValues()
 				.Store()
@@ -47,7 +45,6 @@ namespace Tests.Mapping.Types.Specialized.Ip
 				"name", new IpProperty
 				{
 					Index = false,
-					Boost = 1.3,
 					NullValue = "127.0.0.1",
 					DocValues = true,
 					Store = true,

--- a/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
@@ -23,7 +23,6 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 					type = "token_count",
 					analyzer = "standard",
 					index = false,
-					boost = 1.2,
 					null_value = 0.0
 				}
 			}
@@ -34,7 +33,6 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 				.Name(p => p.Name)
 				.Analyzer("standard")
 				.Index(false)
-				.Boost(1.2)
 				.NullValue(0.0)
 			);
 
@@ -46,7 +44,6 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 				{
 					Index = false,
 					Analyzer = "standard",
-					Boost = 1.2,
 					NullValue = 0.0
 				}
 			}


### PR DESCRIPTION
This was always a NOOP on the server and was removed from the server.

Here we obsolete them with a compiler warning
