### PR TITLE
Reintroduce set for JsonParsingException.ActualChar

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
@@ -1168,7 +1168,7 @@ namespace Elasticsearch.Net.Utf8Json
 		private readonly WeakReference _underlyingBytes;
 		private readonly int _limit;
         public int Offset { get; }
-        public string ActualChar { get; }
+        public string ActualChar { get; set; }
 
         public JsonParsingException(string message)
             : base(message)


### PR DESCRIPTION
Removes a potentially breaking change for7.10 release.