### PR TITLE
[Backport 7.x] Fixing BulkAll indefinitely hanging when failing (#5077)

### DIFF
--- a/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
+++ b/src/Nest/Document/Multiple/BulkAll/BulkAllObservable.cs
@@ -202,7 +202,7 @@ namespace Nest
 
 			void ThrowOnExhaustedRetries()
 			{
-				if (_partitionedBulkRequest.ContinueAfterDroppedDocuments || backOffRetries < _backOffRetries) return;
+				if (backOffRetries < _backOffRetries) return;
 
 				throw ThrowOnBadBulk(response,
 					$"{nameof(BulkAll)} halted after {nameof(PipelineFailure)}.{reason} from _bulk and exhausting retries ({backOffRetries})"


### PR DESCRIPTION
Backport 9b65068 from #5077