### PR TITLE
Introduce assemble of SNAPSHOT builds

### DIFF
--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -97,12 +97,16 @@ module Versioning =
         | ("release", version) ->
             match version with
             | NoChange _ -> failwithf "cannot run release because no explicit version number was passed on the command line"
-            | Update (newVersion, currentVersion) -> 
-                // fail if current is greater than the new version
-                if (currentVersion > newVersion) then
-                    failwithf "Can not release %O as it's lower then current %O" newVersion.Full currentVersion.Full
-                writeVersionIntoGlobalJson newVersion.Full
-                writeVersionIntoAutoLabel (currentVersion.Full.ToString()) (newVersion.Full.ToString())
+            | Update (newVersion, currentVersion) ->
+                match newVersion.Full.PreRelease with
+                | Some v when v.Name.StartsWith("SNAPSHOT", StringComparison.OrdinalIgnoreCase) ->
+                    printfn "Building snapshot, foregoing persisting version information"
+                | _ ->
+                    // fail if current is greater than the new version
+                    if (currentVersion > newVersion) then
+                        failwithf "Can not release %O as it's lower then current %O" newVersion.Full currentVersion.Full
+                    writeVersionIntoGlobalJson newVersion.Full
+                    writeVersionIntoAutoLabel (currentVersion.Full.ToString()) (newVersion.Full.ToString())
         | _ -> ignore()
     
     let ArtifactsVersion buildVersions =


### PR DESCRIPTION
Without affecting the version number stored in global.json

`.ci/make.sh` is the common entry for all clients builds and one of its
jobs is to build SNAPSHOT builds.

Long term we want to move to minver which means we no longer need to
store the version in global.json to begin with.
