### PR TITLE
Add hard_bounds for histograms

### DIFF
--- a/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
@@ -24,6 +24,13 @@ namespace Nest
 		ExtendedBounds<DateMath> ExtendedBounds { get; set; }
 
 		/// <summary>
+		/// The hard_bounds is a counterpart of extended_bounds and can limit the range of buckets in the histogram.
+		/// It is particularly useful in the case of open data ranges that can result in a very large number of buckets.
+		/// </summary>
+		[DataMember(Name = "hard_bounds")]
+		HardBounds<DateMath> HardBounds { get; set; }
+
+		/// <summary>
 		/// The field to target
 		/// </summary>
 		[DataMember(Name ="field")]
@@ -103,6 +110,8 @@ namespace Nest
 		/// <inheritdoc />
 		public ExtendedBounds<DateMath> ExtendedBounds { get; set; }
 		/// <inheritdoc />
+		public HardBounds<DateMath> HardBounds { get; set; }
+		/// <inheritdoc />
 		public Field Field { get; set; }
 
 		/// <inheritdoc />
@@ -115,7 +124,6 @@ namespace Nest
 					: _format;
 			set => _format = value;
 		}
-
 
 		[Obsolete("Deprecated in version 7.2.0, use CalendarInterval or FixedInterval instead")]
 		public Union<DateInterval, Time> Interval { get; set; }
@@ -147,6 +155,7 @@ namespace Nest
 		private string _format;
 
 		ExtendedBounds<DateMath> IDateHistogramAggregation.ExtendedBounds { get; set; }
+		HardBounds<DateMath> IDateHistogramAggregation.HardBounds { get; set; }
 		Field IDateHistogramAggregation.Field { get; set; }
 
 		//see: https://github.com/elastic/elasticsearch/issues/9725
@@ -227,6 +236,10 @@ namespace Nest
 		/// <inheritdoc cref="IDateHistogramAggregation.ExtendedBounds" />
 		public DateHistogramAggregationDescriptor<T> ExtendedBounds(DateMath min, DateMath max) =>
 			Assign(new ExtendedBounds<DateMath> { Minimum = min, Maximum = max }, (a, v) => a.ExtendedBounds = v);
+
+		/// <inheritdoc cref="IDateHistogramAggregation.HardBounds" />
+		public DateHistogramAggregationDescriptor<T> HardBounds(DateMath min, DateMath max) =>
+			Assign(new HardBounds<DateMath> { Minimum = min, Maximum = max }, (a, v) => a.HardBounds = v);
 
 		/// <inheritdoc cref="IDateHistogramAggregation.Missing" />
 		public DateHistogramAggregationDescriptor<T> Missing(DateTime? missing) => Assign(missing, (a, v) => a.Missing = v);

--- a/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/DateHistogram/DateHistogramAggregation.cs
@@ -119,7 +119,7 @@ namespace Nest
 		{
 			get => !string.IsNullOrEmpty(_format) &&
 				!_format.Contains("date_optional_time") &&
-				(ExtendedBounds != null || Missing.HasValue)
+				(ExtendedBounds != null || HardBounds != null || Missing.HasValue)
 					? _format + "||date_optional_time"
 					: _format;
 			set => _format = value;
@@ -163,7 +163,7 @@ namespace Nest
 		{
 			get => !string.IsNullOrEmpty(_format) &&
 				!_format.Contains("date_optional_time") &&
-				(Self.ExtendedBounds != null || Self.Missing.HasValue)
+				(Self.ExtendedBounds != null || Self.HardBounds != null || Self.Missing.HasValue)
 					? _format + "||date_optional_time"
 					: _format;
 			set => _format = value;

--- a/src/Nest/Aggregations/Bucket/Histogram/HardBounds.cs
+++ b/src/Nest/Aggregations/Bucket/Histogram/HardBounds.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	public class HardBounds<T>
+	{
+		[DataMember(Name = "max")]
+		public T Maximum { get; set; }
+
+		[DataMember(Name = "min")]
+		public T Minimum { get; set; }
+	}
+}

--- a/src/Nest/Aggregations/Bucket/Histogram/HistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/Histogram/HistogramAggregation.cs
@@ -16,6 +16,9 @@ namespace Nest
 		[DataMember(Name ="extended_bounds")]
 		ExtendedBounds<double> ExtendedBounds { get; set; }
 
+		[DataMember(Name = "hard_bounds")]
+		HardBounds<double> HardBounds { get; set; }
+
 		[DataMember(Name ="field")]
 		Field Field { get; set; }
 
@@ -45,6 +48,7 @@ namespace Nest
 		public HistogramAggregation(string name) : base(name) { }
 
 		public ExtendedBounds<double> ExtendedBounds { get; set; }
+		public HardBounds<double> HardBounds { get; set; }
 		public Field Field { get; set; }
 		public double? Interval { get; set; }
 		public int? MinimumDocumentCount { get; set; }
@@ -61,6 +65,7 @@ namespace Nest
 		where T : class
 	{
 		ExtendedBounds<double> IHistogramAggregation.ExtendedBounds { get; set; }
+		HardBounds<double> IHistogramAggregation.HardBounds { get; set; }
 		Field IHistogramAggregation.Field { get; set; }
 
 		double? IHistogramAggregation.Interval { get; set; }
@@ -99,6 +104,9 @@ namespace Nest
 
 		public HistogramAggregationDescriptor<T> ExtendedBounds(double min, double max) =>
 			Assign(new ExtendedBounds<double> { Minimum = min, Maximum = max }, (a, v) => a.ExtendedBounds = v);
+
+		public HistogramAggregationDescriptor<T> HardBounds(double min, double max) =>
+			Assign(new HardBounds<double> { Minimum = min, Maximum = max }, (a, v) => a.HardBounds = v);
 
 		public HistogramAggregationDescriptor<T> Offset(double? offset) => Assign(offset, (a, v) => a.Offset = v);
 

--- a/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -46,6 +46,11 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 						min = FixedDate.AddYears(-1),
 						max = FixedDate.AddYears(1)
 					},
+					hard_bounds = new
+					{
+						min = FixedDate.AddYears(-1),
+						max = FixedDate.AddYears(1)
+					},
 					missing = FixedDate
 				},
 				aggs = new
@@ -76,6 +81,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 				.MinimumDocumentCount(2)
 				.Format("yyyy-MM-dd'T'HH:mm:ss")
 				.ExtendedBounds(FixedDate.AddYears(-1), FixedDate.AddYears(1))
+				.HardBounds(FixedDate.AddYears(-1), FixedDate.AddYears(1))
 				.Order(HistogramOrder.CountAscending)
 				.Missing(FixedDate)
 				.Aggregations(childAggs => childAggs
@@ -96,6 +102,11 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 				MinimumDocumentCount = 2,
 				Format = "yyyy-MM-dd'T'HH:mm:ss",
 				ExtendedBounds = new ExtendedBounds<DateMath>
+				{
+					Minimum = FixedDate.AddYears(-1),
+					Maximum = FixedDate.AddYears(1),
+				},
+				HardBounds = new HardBounds<DateMath>
 				{
 					Minimum = FixedDate.AddYears(-1),
 					Maximum = FixedDate.AddYears(1),

--- a/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -226,8 +226,8 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 
 			var projects = Project.Projects.OrderBy(p => p.StartedOn).Skip(2).Take(5).ToArray();
 			
-			_hardBoundsMinimum = DateTime.SpecifyKind(projects.Min(p => p.StartedOn.Date), DateTimeKind.Unspecified);
-			_hardBoundsMaximum = DateTime.SpecifyKind(projects.Max(p => p.StartedOn.Date), DateTimeKind.Unspecified);
+			_hardBoundsMinimum = projects.Min(p => p.StartedOn.Date);
+			_hardBoundsMaximum = projects.Max(p => p.StartedOn.Date);
 		}
 
 		protected override object AggregationJson => new
@@ -238,7 +238,6 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 				{
 					field = "startedOn",
 					calendar_interval = "day",
-					format = "yyyy-MM-dd'T'HH:mm:ss",
 					min_doc_count = 1,
 					hard_bounds = new
 					{
@@ -255,7 +254,6 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 			.DateHistogram("projects_started_per_day", date => date
 				.Field(p => p.StartedOn)
 				.CalendarInterval(DateInterval.Day)
-				.Format("yyyy-MM-dd'T'HH:mm:ss")
 				.HardBounds(_hardBoundsMinimum, _hardBoundsMaximum)
 				.MinimumDocumentCount(1)
 				.Order(HistogramOrder.KeyAscending)
@@ -266,7 +264,6 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 			{
 				Field = Field<Project>(p => p.StartedOn),
 				CalendarInterval = DateInterval.Day,
-				Format = "yyyy-MM-dd'T'HH:mm:ss",
 				HardBounds = new HardBounds<DateMath>
 				{
 					Minimum = _hardBoundsMinimum,

--- a/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -225,9 +225,9 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 			// pass if this is the case. For best results locally, force a reseed. This is not an issue in CI.
 
 			var projects = Project.Projects.OrderBy(p => p.StartedOn).Skip(2).Take(5).ToArray();
-
-			_hardBoundsMinimum = DateTime.SpecifyKind(projects.First().StartedOn.Date, DateTimeKind.Unspecified);
-			_hardBoundsMaximum = DateTime.SpecifyKind(projects.Last().StartedOn.Date, DateTimeKind.Unspecified);
+			
+			_hardBoundsMinimum = DateTime.SpecifyKind(projects.Min(p => p.StartedOn.Date), DateTimeKind.Unspecified);
+			_hardBoundsMaximum = DateTime.SpecifyKind(projects.Max(p => p.StartedOn.Date), DateTimeKind.Unspecified);
 		}
 
 		protected override object AggregationJson => new

--- a/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogram/DateHistogramAggregationUsageTests.cs
@@ -21,7 +21,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 	 * From a functionality perspective, this histogram supports the same features as the normal histogram.
 	 * The main difference is that the interval can be specified by date/time expressions.
 	 *
-	 * NOTE: When specifying a `format` **and** `extended_bounds` or `missing`, in order for Elasticsearch to be able to parse
+	 * NOTE: When specifying a `format` **and** `extended_bounds`, `hard_bounds` or `missing`, in order for Elasticsearch to be able to parse
 	 * the serialized `DateTime` of `extended_bounds` or `missing` correctly, the `date_optional_time` format is included
 	 * as part of the `format` value.
 	 *
@@ -40,7 +40,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 					field = "startedOn",
 					calendar_interval = "month",
 					min_doc_count = 2,
-					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", //<1> Note the inclusion of `date_optional_time` to `format`
+					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", // <1> Note the inclusion of `date_optional_time` to `format`
 					order = new { _count = "asc" },
 					extended_bounds = new
 					{
@@ -238,6 +238,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 				{
 					field = "startedOn",
 					calendar_interval = "day",
+					format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time",
 					min_doc_count = 1,
 					hard_bounds = new
 					{
@@ -253,6 +254,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
 			.DateHistogram("projects_started_per_day", date => date
 				.Field(p => p.StartedOn)
+				.Format("yyyy-MM-dd'T'HH:mm:ss")
 				.CalendarInterval(DateInterval.Day)
 				.HardBounds(_hardBoundsMinimum, _hardBoundsMaximum)
 				.MinimumDocumentCount(1)
@@ -263,6 +265,7 @@ namespace Tests.Aggregations.Bucket.DateHistogram
 			new DateHistogramAggregation("projects_started_per_day")
 			{
 				Field = Field<Project>(p => p.StartedOn),
+				Format = "yyyy-MM-dd'T'HH:mm:ss",
 				CalendarInterval = DateInterval.Day,
 				HardBounds = new HardBounds<DateMath>
 				{

--- a/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
@@ -24,6 +24,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 				histogram = new
 				{
 					field = "numberOfCommits",
+					hard_bounds = new { max = 100.0, min = 1.0 },
 					interval = 100.0,
 					min_doc_count = 1,
 					order = new
@@ -31,6 +32,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 						_key = "desc"
 					},
 					offset = 1.1
+
 				}
 			}
 		};
@@ -42,6 +44,7 @@ namespace Tests.Aggregations.Bucket.Histogram
 				.MinimumDocumentCount(1)
 				.Order(HistogramOrder.KeyDescending)
 				.Offset(1.1)
+				.HardBounds(1, 100)
 			);
 
 		protected override AggregationDictionary InitializerAggs =>
@@ -51,7 +54,12 @@ namespace Tests.Aggregations.Bucket.Histogram
 				Interval = 100,
 				MinimumDocumentCount = 1,
 				Order = HistogramOrder.KeyDescending,
-				Offset = 1.1
+				Offset = 1.1,
+				HardBounds = new HardBounds<double>
+				{
+					Minimum = 1,
+					Maximum = 100
+				}
 			};
 
 		protected override void ExpectResponse(ISearchResponse<Project> response)

--- a/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Extensions;
@@ -16,6 +17,62 @@ namespace Tests.Aggregations.Bucket.Histogram
 	public class HistogramAggregationUsageTests : AggregationUsageTestBase
 	{
 		public HistogramAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		protected override object AggregationJson => new
+		{
+			commits = new
+			{
+				histogram = new
+				{
+					field = "numberOfCommits",
+					interval = 100.0,
+					min_doc_count = 1,
+					order = new
+					{
+						_key = "desc"
+					},
+					offset = 1.1
+
+				}
+			}
+		};
+
+		protected override Func<AggregationContainerDescriptor<Project>, IAggregationContainer> FluentAggs => a => a
+			.Histogram("commits", h => h
+				.Field(p => p.NumberOfCommits)
+				.Interval(100)
+				.MinimumDocumentCount(1)
+				.Order(HistogramOrder.KeyDescending)
+				.Offset(1.1)
+			);
+
+		protected override AggregationDictionary InitializerAggs =>
+			new HistogramAggregation("commits")
+			{
+				Field = Field<Project>(p => p.NumberOfCommits),
+				Interval = 100,
+				MinimumDocumentCount = 1,
+				Order = HistogramOrder.KeyDescending,
+				Offset = 1.1
+			};
+
+		protected override void ExpectResponse(ISearchResponse<Project> response)
+		{
+			response.ShouldBeValid();
+			var commits = response.Aggregations.Histogram("commits");
+			commits.Should().NotBeNull();
+			commits.Buckets.Should().NotBeNull();
+			commits.Buckets.Count.Should().BeGreaterThan(0);
+			foreach (var item in commits.Buckets)
+				item.DocCount.Should().BeGreaterThan(0);
+		}
+	}
+
+	// hide
+	[SkipVersion("<7.10.0", "hard_bounds introduced in 7.10.0")]
+	public class HistogramAggregationWithHardBoundsUsageTests : AggregationUsageTestBase
+	{
+		public HistogramAggregationWithHardBoundsUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
 		protected override object AggregationJson => new
 		{
@@ -68,9 +125,6 @@ namespace Tests.Aggregations.Bucket.Histogram
 			var commits = response.Aggregations.Histogram("commits");
 			commits.Should().NotBeNull();
 			commits.Buckets.Should().NotBeNull();
-			commits.Buckets.Count.Should().BeGreaterThan(0);
-			foreach (var item in commits.Buckets)
-				item.DocCount.Should().BeGreaterThan(0);
 		}
 	}
 }


### PR DESCRIPTION
Please consider this a WIP for review to check I'm on the best track.

Adds hard_bounds parameter to histogram aggregations per https://github.com/elastic/elasticsearch/pull/59175.

Questions:

For now, I've made `HardBounds` a copy of `ExtendedBounds`. I suspect we can't safely rename this public type to something more general. An option would be to define the properties in a base class from which these two could derive. Perhaps overkill here though.

I've updated two usage tests to confirm that the final JSON is built as expected. Are there any further tests we should be considering on additional such as this one?