### PR TITLE
Update to .NET 5 SDK

### DIFF
--- a/.ci/DockerFile
+++ b/.ci/DockerFile
@@ -1,5 +1,5 @@
-ARG DOTNET_VERSION=3.1.202
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} AS elasticsearch-net-build
+ARG DOTNET_VERSION=5.0.100
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS elasticsearch-net-build
 
 WORKDIR /sln
 

--- a/.ci/Jenkins.csproj
+++ b/.ci/Jenkins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -21,7 +21,7 @@ set -euo pipefail
 output_folder=".ci/output"
 OUTPUT_DIR="$repo/${output_folder}"
 
-DOTNET_VERSION=${DOTNET_VERSION-3.1.202}
+DOTNET_VERSION=${DOTNET_VERSION-5.0.100}
 
 echo -e "\033[34;1mINFO:\033[0m VERSION ${STACK_VERSION}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m OUTPUT_DIR ${OUTPUT_DIR}\033[0m"

--- a/.ci/readme.md
+++ b/.ci/readme.md
@@ -30,7 +30,7 @@ $ STACK_VERSION=8.0.0-SNAPSHOT ./.ci/run-tests
 |-------------------------|-------------|-------------|
 | `STACK_VERSION` | `N/A`       | The elasticsearch version to target
 | `TEST_SUITE`            | `oss`       | `oss` or `xpack` sets which test suite to run and which container to run against. |
-| `DOTNET_VERSION`        | `3.1.202`   | The .NET sdk version used to grab the proper container |
+| `DOTNET_VERSION`        | `5.0.100`   | The .NET sdk version used to grab the proper container |
 
 
 If you want to manually spin up elasticsearch for this tests and call the runner afterwards you can use

--- a/.ci/run-repository.ps1
+++ b/.ci/run-repository.ps1
@@ -14,7 +14,7 @@ param(
     $NODE_NAME,
     
     [string]
-    $DOTNET_VERSION = "3.1.202"
+    $DOTNET_VERSION = "5.0.100"
 )
 
 $ESC = [char]27

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -10,7 +10,7 @@ script_path=$(dirname $(realpath -s $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 
-DOTNET_VERSION=${DOTNET_VERSION-3.1.202}
+DOTNET_VERSION=${DOTNET_VERSION-5.0.100}
 ELASTICSEARCH_URL=${ELASTICSEARCH_URL-"$elasticsearch_url"}
 elasticsearch_container=${elasticsearch_container-}
 

--- a/.ci/run-tests.ps1
+++ b/.ci/run-tests.ps1
@@ -8,7 +8,7 @@ param (
     $TEST_SUITE = "oss",
 
     [string]
-    $DOTNET_VERSION = "3.1.202"
+    $DOTNET_VERSION = "5.0.100"
 )
 
 $ESC = [char]27

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -8,6 +8,6 @@ TEST_SUITE:
   - xpack
 
 DOTNET_VERSION:
-    - 3.1.202
+    - 5.0.100
 
 exclude: ~

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,23 +16,4 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   
-  <Target Name="AssemblyInfos" 
-          BeforeTargets="CoreGenerateAssemblyInfo" 
-          Inputs="@InternalsVisibleTo" Outputs="%(InternalsVisibleTo.Identity)"
-          Condition="$(IsPackable) == True"
-  >
-    <PropertyGroup>
-      <ExposedAssembly>%(InternalsVisibleTo.Identity)</ExposedAssembly>
-      <VersionNamespaced>$(ExposedAssembly.Replace("Nest", "Nest$(MajorVersion)").Replace("Elasticsearch.Net","Elasticsearch.Net$(MajorVersion)"))</VersionNamespaced>
-    </PropertyGroup>
-    <ItemGroup>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-        <_Parameter1>%(InternalsVisibleTo.Identity), PublicKey=$(ExposedPublicKey)</_Parameter1>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-        <_Parameter1>$(VersionNamespaced), PublicKey=$(ExposedPublicKey)</_Parameter1>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-    - cmd: choco install dotnetcore-sdk --version 5.0.100
+    - cmd: choco install dotnet-5.0-sdk --version 5.0.100
 build_script:
     - cmd: build.bat canary
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-    - cmd: choco install dotnetcore-sdk --version 3.1.202
+    - cmd: choco install dotnetcore-sdk --version 5.0.100
 build_script:
     - cmd: build.bat canary
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-       version: '3.1.202'
+       version: '5.0.100'
   - script: ./build.sh documentation
     displayName: 'Generate Documentation'
   - script: |
@@ -30,7 +30,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-        version: '3.1.202'
+        version: '5.0.100'
   - script: ./build.sh test-one
     displayName: 'build and unit test'
   - task: PublishTestResults@2
@@ -62,7 +62,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: '3.1.202'
+      version: '5.0.100'
   - script: build.bat canary
     displayName: 'build and unit test'
   - task: PublishTestResults@2
@@ -84,7 +84,7 @@ jobs:
   steps:
       - task: UseDotNet@2
         inputs:
-            version: '3.1.202'
+            version: '5.0.100'
       - script: 'build.bat integrate-one $(esVersion) "readonly,writable,bool,xpack"'
         displayName: '$(esVersion) windows integration tests'
       - task: PublishTestResults@2
@@ -106,7 +106,7 @@ jobs:
   steps:
       - task: UseDotNet@2
         inputs:
-            version: '3.1.202'
+            version: '5.0.100'
       - script: './build.sh integrate-one $(esVersion) "readonly,writable"'
         displayName: '$(esVersion) linux integration tests'
       - task: PublishTestResults@2

--- a/build/scripts/Benchmarking.fs
+++ b/build/scripts/Benchmarking.fs
@@ -18,7 +18,7 @@ module Benchmarker =
         let password = match args.CommandArguments with | Benchmark b -> b.Password | _ -> None
         let runInteractive = not args.NonInteractive
         let credentials  = (username, password)
-        let runCommandPrefix = "run -f netcoreapp3.0 -c Release"
+        let runCommandPrefix = "run -f net5.0 -c Release"
         let runCommand =
             match (runInteractive, url, credentials) with
             | (false, Some url, (Some username, Some password)) -> sprintf "%s -- --all \"%s\" \"%s\" \"%s\"" runCommandPrefix url username password

--- a/build/scripts/Documentation.fs
+++ b/build/scripts/Documentation.fs
@@ -13,7 +13,7 @@ module Documentation =
 
     exception DocGenError of string 
     let Generate args = 
-        let path = Paths.InplaceBuildOutput "DocGenerator" "netcoreapp3.0"
+        let path = Paths.InplaceBuildOutput "DocGenerator" "net5.0"
         let generator = sprintf "%s.dll" "DocGenerator"
         
         printfn "==> %s" path

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -15,7 +15,7 @@ module ReposTooling =
         let clusterName = Option.defaultValue "" <| match args.CommandArguments with | Cluster c -> Some c.Name | _ -> None
         let clusterVersion = Option.defaultValue "" <|match args.CommandArguments with | Cluster c -> c.Version | _ -> None
         
-        let testsProjectDirectory = Path.GetFullPath(Paths.InplaceTestOutput "Tests.ClusterLauncher" "netcoreapp3.0")
+        let testsProjectDirectory = Path.GetFullPath(Paths.InplaceTestOutput "Tests.ClusterLauncher" "net5.0")
         let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         
         printfn "%s" testsProjectDirectory

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Type Providers are restored using net461, fine for netcoreapp2.2 so we kill the warning -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "assembly-rewriter": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "commands": [
         "assembly-rewriter"
       ]
     },
     "assembly-differ": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "commands": [
         "assembly-differ"
       ]
     },
     "nupkg-validator": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "commands": [
         "nupkg-validator"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "3.1.100",
+    "version": "5.0.100",
     "rollForward": "latestFeature",
     "allowPrerelease": false
   },

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     
     <NoWarn>CS1591;NU1701</NoWarn>

--- a/src/DocGenerator/DocGenerator.csproj
+++ b/src/DocGenerator/DocGenerator.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     
     <!-- CAC001: We dont need to set ConfigureAwait(false) here -->

--- a/src/Elastic.Transport/Responses/ServerException/ServerError.cs
+++ b/src/Elastic.Transport/Responses/ServerException/ServerError.cs
@@ -14,7 +14,7 @@ namespace Elastic.Transport
 	[DataContract]
 	public class ServerError
 	{
-		internal ServerError() { }
+		public ServerError() { }
 
 		public ServerError(Error error, int? statusCode)
 		{

--- a/src/ExamplesGenerator/ExamplesGenerator.csproj
+++ b/src/ExamplesGenerator/ExamplesGenerator.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -27,15 +27,19 @@
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="Nest.Utf8Json.CustomDynamicObjectResolver" />
-    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicCompositeResolver" />
-    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" />
-    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" />
+    <InternalsVisibleTo Include="Nest.Utf8Json.CustomDynamicObjectResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicCompositeResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest.Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" Key="$(ExposedPublicKey)" />
 
+    <InternalsVisibleTo Include="Nest$(MajorVersion).Utf8Json.CustomDynamicObjectResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest$(MajorVersion).Utf8Json.DynamicCompositeResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest$(MajorVersion).Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Nest$(MajorVersion).Utf8Json.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" Key="$(ExposedPublicKey)" />
 
     <!-- TODO this is necessary for code standards tests, would be nicer as roslyn analyzers instead -->
-    <InternalsVisibleTo Include="Tests" />
-    <InternalsVisibleTo Include="Tests.Domain" />
+    <InternalsVisibleTo Include="Tests" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Tests.Domain" Key="$(ExposedPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Requests.*.cs">

--- a/tests/Elastic.Transport.Tests/Elastic.Transport.Tests.csproj
+++ b/tests/Elastic.Transport.Tests/Elastic.Transport.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
 
     <IsTestProject>True</IsTestProject>
     <IsPackable>false</IsPackable>

--- a/tests/Examples/Examples.csproj
+++ b/tests/Examples/Examples.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsTestProject>True</IsTestProject>
   </PropertyGroup>
 

--- a/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>

--- a/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
+++ b/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />

--- a/tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsTestProject>True</IsTestProject>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Optimize>true</Optimize>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
+++ b/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TieredCompilation>false</TieredCompilation>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-<!--    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>-->
     <TargetFramework>net5.0</TargetFramework>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <DebugSymbols>True</DebugSymbols>
     <IsTestProject>True</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="Elastic.Transport.VirtualizedCluster" Version="$(TestPackageVersion)" />
@@ -14,14 +13,9 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="FSharp.Core" Version="4.7.0" />
-      
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Bogus" Version="22.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="SharpZipLib" Version="1.0.0-alpha2" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />
     <PackageReference Include="SemanticVersioning" Version="0.8.0" />

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
 <!--    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>-->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <DebugSymbols>True</DebugSymbols>
     <IsTestProject>True</IsTestProject>


### PR DESCRIPTION
One interesting side-effect is a change to `System.Text.Json` which meant that `ErrorWithNullRootCausesTests` in the Tests project broke. Deserialisation now attempts to use ctors with parameters. The parameterless ctor is internal, and despite being reachable `System.Text.Json` is still preferring the ctor with params. However, it expects these to match the property names in the JSON so throws an exception.

A downside of this is we open up the parameterless constructor. Open to other suggestions here. A wider concern may be how this deserialisation behaves today for anyone using the library in a 5.0 runtime.