### PR TITLE
Update VS image for AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 1.0.{build}
 image:
-    - Visual Studio 2017
+    - Visual Studio 2019
 test: off
 environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: true


### PR DESCRIPTION
Suggest we merge this and allow backport after backporting is complete for the main update to .NET 5 to 7.x and 7.10.