### PR TITLE
[Backport 7.x] Update to .NET 5 SDK (#5099)

### DIFF
--- a/.ci/DockerFile
+++ b/.ci/DockerFile
@@ -1,5 +1,5 @@
-ARG DOTNET_VERSION=3.0.100
-FROM mcr.microsoft.com/dotnet/core/sdk:${DOTNET_VERSION} AS elasticsearch-net-build
+ARG DOTNET_VERSION=5.0.100
+FROM mcr.microsoft.com/dotnet/sdk:${DOTNET_VERSION} AS elasticsearch-net-build
 
 WORKDIR /sln
 

--- a/.ci/Jenkins.csproj
+++ b/.ci/Jenkins.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFramework>net5.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -20,7 +20,7 @@ set -euo pipefail
 output_folder=".ci/output"
 OUTPUT_DIR="$repo/${output_folder}"
 
-DOTNET_VERSION=${DOTNET_VERSION-3.0.100}
+DOTNET_VERSION=${DOTNET_VERSION-5.0.100}
 
 echo -e "\033[34;1mINFO:\033[0m VERSION ${STACK_VERSION}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m OUTPUT_DIR ${OUTPUT_DIR}\033[0m"

--- a/.ci/readme.md
+++ b/.ci/readme.md
@@ -30,7 +30,7 @@ $ ELASTICSEARCH_VERSION=8.0.0-SNAPSHOT ./.ci/run-tests
 |-------------------------|-------------|-------------|
 | `ELASTICSEARCH_VERSION` | `N/A`       | The elasticsearch version to target
 | `TEST_SUITE`            | `oss`       | `oss` or `xpack` sets which test suite to run and which container to run against. |
-| `DOTNET_VERSION`        | `3.0.100`   | The .NET sdk version used to grab the proper container |
+| `DOTNET_VERSION`        | `5.0.100`   | The .NET sdk version used to grab the proper container |
 
 
 If you want to manually spin up elasticsearch for this tests and call the runner afterwards you can use

--- a/.ci/run-repository.ps1
+++ b/.ci/run-repository.ps1
@@ -14,7 +14,7 @@ param(
     $NODE_NAME,
     
     [string]
-    $DOTNET_VERSION = "3.0.100"
+    $DOTNET_VERSION = "5.0.100"
 )
 
 $ESC = [char]27

--- a/.ci/run-repository.sh
+++ b/.ci/run-repository.sh
@@ -9,7 +9,7 @@ script_path=$(dirname $(realpath -s $0))
 source $script_path/functions/imports.sh
 set -euo pipefail
 
-DOTNET_VERSION=${DOTNET_VERSION-3.0.100}
+DOTNET_VERSION=${DOTNET_VERSION-5.0.100}
 ELASTICSEARCH_URL=${ELASTICSEARCH_URL-"$elasticsearch_url"}
 elasticsearch_container=${elasticsearch_container-}
 

--- a/.ci/run-tests.ps1
+++ b/.ci/run-tests.ps1
@@ -8,7 +8,7 @@ param (
     $TEST_SUITE = "oss",
 
     [string]
-    $DOTNET_VERSION = "3.0.100"
+    $DOTNET_VERSION = "5.0.100"
 )
 
 $ESC = [char]27

--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -8,6 +8,6 @@ TEST_SUITE:
   - xpack
 
 DOTNET_VERSION:
-    - 3.0.100
+    - 5.0.100
 
 exclude: ~

--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -16,23 +16,4 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
   
-  <Target Name="AssemblyInfos" 
-          BeforeTargets="CoreGenerateAssemblyInfo" 
-          Inputs="@InternalsVisibleTo" Outputs="%(InternalsVisibleTo.Identity)"
-          Condition="$(IsPackable) == True"
-  >
-    <PropertyGroup>
-      <ExposedAssembly>%(InternalsVisibleTo.Identity)</ExposedAssembly>
-      <VersionNamespaced>$(ExposedAssembly.Replace("Nest", "Nest$(MajorVersion)").Replace("Elasticsearch.Net","Elasticsearch.Net$(MajorVersion)"))</VersionNamespaced>
-    </PropertyGroup>
-    <ItemGroup>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-        <_Parameter1>%(InternalsVisibleTo.Identity), PublicKey=$(ExposedPublicKey)</_Parameter1>
-      </AssemblyAttribute>
-      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
-        <_Parameter1>$(VersionNamespaced), PublicKey=$(ExposedPublicKey)</_Parameter1>
-      </AssemblyAttribute>
-    </ItemGroup>
-  </Target>
-
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
     DOTNET_CLI_TELEMETRY_OPTOUT: true
     DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
 install:
-    - cmd: choco install dotnetcore-sdk --version 3.0.100
+    - cmd: choco install dotnet-5.0-sdk --version 5.0.100
 build_script:
     - cmd: build.bat canary
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-       version: '3.0.100'
+       version: '5.0.100'
   - script: ./build.sh documentation
     displayName: 'Generate Documentation'
   - script: |
@@ -30,7 +30,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-        version: '3.0.100'
+        version: '5.0.100'
   - script: ./build.sh test-one
     displayName: 'build and unit test'
   - task: PublishTestResults@2
@@ -62,7 +62,7 @@ jobs:
   steps:
   - task: UseDotNet@2
     inputs:
-      version: '3.0.100'
+      version: '5.0.100'
   - script: build.bat canary
     displayName: 'build and unit test'
   - task: PublishTestResults@2
@@ -102,7 +102,7 @@ jobs:
   steps:
       - task: UseDotNet@2
         inputs:
-            version: '3.0.100'
+            version: '5.0.100'
       - script: 'build.bat integrate-one $(esVersion) "readonly,writable,bool,xpack"'
         displayName: '$(esVersion) windows integration tests'
       - task: PublishTestResults@2
@@ -142,7 +142,7 @@ jobs:
   steps:
       - task: UseDotNet@2
         inputs:
-            version: '3.0.100'
+            version: '5.0.100'
       - script: './build.sh integrate-one $(esVersion) "readonly,writable"'
         displayName: '$(esVersion) linux integration tests'
       - task: PublishTestResults@2

--- a/build/scripts/Benchmarking.fs
+++ b/build/scripts/Benchmarking.fs
@@ -18,7 +18,7 @@ module Benchmarker =
         let password = match args.CommandArguments with | Benchmark b -> b.Password | _ -> None
         let runInteractive = not args.NonInteractive
         let credentials  = (username, password)
-        let runCommandPrefix = "run -f netcoreapp3.0 -c Release"
+        let runCommandPrefix = "run -f net5.0 -c Release"
         let runCommand =
             match (runInteractive, url, credentials) with
             | (false, Some url, (Some username, Some password)) -> sprintf "%s -- --all \"%s\" \"%s\" \"%s\"" runCommandPrefix url username password

--- a/build/scripts/Documentation.fs
+++ b/build/scripts/Documentation.fs
@@ -13,7 +13,7 @@ module Documentation =
 
     exception DocGenError of string 
     let Generate args = 
-        let path = Paths.InplaceBuildOutput "DocGenerator" "netcoreapp3.0"
+        let path = Paths.InplaceBuildOutput "DocGenerator" "net5.0"
         let generator = sprintf "%s.dll" "DocGenerator"
         
         printfn "==> %s" path

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -15,7 +15,7 @@ module ReposTooling =
         let clusterName = Option.defaultValue "" <| match args.CommandArguments with | Cluster c -> Some c.Name | _ -> None
         let clusterVersion = Option.defaultValue "" <|match args.CommandArguments with | Cluster c -> c.Version | _ -> None
         
-        let testsProjectDirectory = Path.Combine(Path.GetFullPath(Paths.Output("Tests.ClusterLauncher")), "netcoreapp3.0")
+        let testsProjectDirectory = Path.Combine(Path.GetFullPath(Paths.Output("Tests.ClusterLauncher")), "net5.0")
         let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         
         printfn "%s" testsProjectDirectory

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <!-- Type Providers are restored using net461, fine for netcoreapp2.2 so we kill the warning -->
     <NoWarn>$(NoWarn);NU1701</NoWarn>

--- a/dotnet-tools.json
+++ b/dotnet-tools.json
@@ -3,19 +3,19 @@
   "isRoot": true,
   "tools": {
     "assembly-rewriter": {
-      "version": "0.11.0",
+      "version": "0.12.0",
       "commands": [
         "assembly-rewriter"
       ]
     },
     "assembly-differ": {
-      "version": "0.12.0",
+      "version": "0.13.0",
       "commands": [
         "assembly-differ"
       ]
     },
     "nupkg-validator": {
-      "version": "0.3.1",
+      "version": "0.4.0",
       "commands": [
         "nupkg-validator"
       ]

--- a/global.json
+++ b/global.json
@@ -1,6 +1,8 @@
 {
   "sdk": {
-    "version": "3.0.100"
+    "version": "5.0.100",
+    "rollForward": "latestFeature",
+    "allowPrerelease": false
   },
   "version": "7.11.0",
   "doc_current": "7.x",

--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     
     <NoWarn>CS1591;NU1701</NoWarn>

--- a/src/DocGenerator/DocGenerator.csproj
+++ b/src/DocGenerator/DocGenerator.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsPackable>false</IsPackable>
     
     <!-- CAC001: We dont need to set ConfigureAwait(false) here -->

--- a/src/Elasticsearch.Net/Elasticsearch.Net.csproj
+++ b/src/Elasticsearch.Net/Elasticsearch.Net.csproj
@@ -28,17 +28,17 @@
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="Nest" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" />
+    <InternalsVisibleTo Include="Nest" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" Key="$(ExposedPublicKey)" />
     
-    <InternalsVisibleTo Include="Tests" />
+    <InternalsVisibleTo Include="Tests" Key="$(ExposedPublicKey)" />
 
   </ItemGroup>
   <ItemGroup>

--- a/src/Elasticsearch.Net/Responses/ServerException/ServerError.cs
+++ b/src/Elasticsearch.Net/Responses/ServerException/ServerError.cs
@@ -13,7 +13,7 @@ namespace Elasticsearch.Net
 	[DataContract]
 	public class ServerError
 	{
-		internal ServerError() {}
+		public ServerError() { }
 
 		public ServerError(Error error, int? statusCode)
 		{

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -19,14 +19,14 @@
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" />
-    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.CustomDynamicObjectResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicCompositeResolver" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateCamelCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullFalseNameMutateSnakeCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateOriginal" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateCamelCase" Key="$(ExposedPublicKey)" />
+    <InternalsVisibleTo Include="Elasticsearch.Net.DynamicObjectResolverAllowPrivateFalseExcludeNullTrueNameMutateSnakeCase" Key="$(ExposedPublicKey)" />
   </ItemGroup>
   <ItemGroup>
     <Compile Update="Requests.*.cs">

--- a/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <TieredCompilation>false</TieredCompilation>
   </PropertyGroup>

--- a/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
+++ b/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />

--- a/tests/Tests.Reproduce/Tests.Reproduce.csproj
+++ b/tests/Tests.Reproduce/Tests.Reproduce.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <IsTestProject>True</IsTestProject>
   </PropertyGroup>
   <ItemGroup>

--- a/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <Optimize>true</Optimize>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>

--- a/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
+++ b/tests/Tests.YamlRunner/Tests.YamlRunner.fsproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <TieredCompilation>false</TieredCompilation>
     <DebugSymbols>true</DebugSymbols>

--- a/tests/Tests/Tests.csproj
+++ b/tests/Tests/Tests.csproj
@@ -1,12 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-<!--    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>-->
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>$(NoWarn);xUnit1013</NoWarn>
     <DebugSymbols>True</DebugSymbols>
     <IsTestProject>True</IsTestProject>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="Elasticsearch.Net.VirtualizedCluster" Version="$(TestPackageVersion)" />
@@ -17,14 +16,9 @@
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Core\Tests.Core.csproj" />
     <PackageReference Include="FSharp.Core" Version="4.7.0" />
-      
-    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
-    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.2" />
     <PackageReference Include="Bogus" Version="22.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <PackageReference Include="System.Reactive" Version="3.1.1" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
     <PackageReference Include="SharpZipLib" Version="1.0.0-alpha2" />
     <PackageReference Include="System.Net.Http" Version="4.3.2" />
     <PackageReference Include="System.Diagnostics.FileVersionInfo" Version="4.3.0" />


### PR DESCRIPTION
* Update to .NET 5 SDK
* Update InternalsVisibleTo as .NET 5 SDK now supports passing a key
* Fix test after upgrading tests to net5.0

In .NET 5, System.Text.Json added support for creating types using a
constructor with parameters. Despite the internal parameterless ctor
being accessible, STJ is not using it. The solution for now seems to be
to make this public.

(cherry picked from commit fa2edcc)