### PR TITLE
Docs generator producing bad line endings

### DIFF
--- a/src/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
+++ b/src/DocGenerator/AsciiDoc/GeneratedAsciidocVisitor.cs
@@ -198,7 +198,7 @@ namespace DocGenerator.AsciiDoc
 
 			// Replace tabs with spaces and remove C# comment escaping from callouts
 			// (elastic docs generation does not like this callout format)
-			source.Text = Regex.Replace(source.Text.Replace("\t", "    "), @"//[ \t]*\<(\d+)\>.*", "<$1>");
+			source.Text = Regex.Replace(source.Text.Replace("\t", "    "), @"//[ \t]*\<(\d+)\>[^\r\n]*", "<$1>");
 
 			base.VisitSource(source);
 		}

--- a/src/DocGenerator/Documentation/Blocks/CSharpBlock.cs
+++ b/src/DocGenerator/Documentation/Blocks/CSharpBlock.cs
@@ -14,7 +14,7 @@ namespace DocGenerator.Documentation.Blocks
 	public class CSharpBlock : CodeBlock
 	{
 		private static readonly Regex Callout = new Regex(@"//[ \t]*(?<callout>\<\d+\>)[ \t]*(?<text>\S.*)", RegexOptions.Compiled);
-		private static readonly Regex CalloutReplacer = new Regex(@"//[ \t]*\<(\d+)\>.*", RegexOptions.Compiled);
+		private static readonly Regex CalloutReplacer = new Regex(@"//[ \t]*\<(\d+)\>[^\r\n]*", RegexOptions.Compiled);
 
 		public CSharpBlock(SyntaxNode node, int depth, string memberName = null)
 			: base(node.WithoutLeadingTrivia().ToFullStringWithoutPragmaWarningDirectiveTrivia(),


### PR DESCRIPTION
Exclude matching \r\n

When generating docs locally, on Windows, after running the tool, all files which include callouts then showed as modified, making review very difficult. I noticed that some of the callouts only included a newline (\n) and were missing the carriage return (\r). 

Upon investigation, I found that the regex used for callout replacement was catching and removing the \r character. This change fixes the two places such replacement may occur and ensures we stop matching before the \r\n.

I'm not super hot on Regex so welcome opinions on the approach!