### PR TITLE
Support call outs in JSON (JavaScript) blocks.

### DIFF
--- a/src/DocGenerator/DocGenerator.csproj
+++ b/src/DocGenerator/DocGenerator.csproj
@@ -7,7 +7,7 @@
     
     <!-- CAC001: We dont need to set ConfigureAwait(false) here -->
     <NoWarn>NU1701,NU1605,CAC001</NoWarn>
-    <LangVersion>8.0</LangVersion>
+    <LangVersion>9.0</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="$(SolutionRoot)\src\Nest\Nest.csproj" />

--- a/src/DocGenerator/Documentation/Blocks/BlockCallOutHelper.cs
+++ b/src/DocGenerator/Documentation/Blocks/BlockCallOutHelper.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using DocGenerator.Walkers;
+
+namespace DocGenerator.Documentation.Blocks
+{
+	public class BlockCallOutHelper
+	{
+		private static readonly Regex CallOutMatcher = new(Constants.CallOutMatcherRegex, RegexOptions.Compiled);
+		private static readonly Regex CallOutReplacer = new(@"//[ \t]*\<(\d+)\>[^\r\n]*", RegexOptions.Compiled);
+
+		/// <summary>
+		/// Extracts the callouts from code. The callout comment is defined inline within
+		/// source code to play nicely with C# semantics, but needs to be extracted and placed after the
+		/// source block delimiter to be valid asciidoc.
+		/// </summary>
+		public static (string code, IReadOnlyList<string> callOuts) ExtractCallOutsFromCode(string code)
+		{
+			var matches = CallOutMatcher.Matches(code);
+			var callOuts = new List<string>();
+
+			foreach (Match match in matches)
+				callOuts.Add($"{match.Groups["callout"].Value} {match.Groups["text"].Value.TrimEnd()}");
+
+			if (callOuts.Any())
+				code = CallOutReplacer.Replace(code, "//<$1>");
+
+			return (code.Trim(), callOuts);
+		}
+	}
+}

--- a/src/DocGenerator/Documentation/Blocks/JavaScriptBlock.cs
+++ b/src/DocGenerator/Documentation/Blocks/JavaScriptBlock.cs
@@ -12,7 +12,7 @@ namespace DocGenerator.Documentation.Blocks
 			: base(text, startingLine, depth, "javascript", memberName) { }
 
 		public string Title { get; set; }
-
+		
 		public override string ToAsciiDoc()
 		{
 			var builder = new StringBuilder();
@@ -23,8 +23,13 @@ namespace DocGenerator.Documentation.Blocks
 				? $"[source, {Language.ToLowerInvariant()}, method=\"{MemberName.ToLowerInvariant()}\"]"
 				: $"[source, {Language.ToLowerInvariant()}]");
 			builder.AppendLine("----");
-			builder.AppendLine(Value);
+
+			var (code, callOuts) = BlockCallOutHelper.ExtractCallOutsFromCode(Value);
+
+			builder.AppendLine(code);
+
 			builder.AppendLine("----");
+			foreach (var callOut in callOuts) builder.AppendLine(callOut);
 			return builder.ToString();
 		}
 	}

--- a/src/DocGenerator/Walkers/Constants.cs
+++ b/src/DocGenerator/Walkers/Constants.cs
@@ -1,0 +1,11 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace DocGenerator.Walkers
+{
+	public class Constants
+	{
+		public const string CallOutMatcherRegex = @"//[ \t]*(?<callout>\<\d+\>)[ \t]*(?<text>\S.*)";
+	}
+}

--- a/src/DocGenerator/Walkers/JsonCallOutHelper.cs
+++ b/src/DocGenerator/Walkers/JsonCallOutHelper.cs
@@ -1,0 +1,89 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+namespace DocGenerator.Walkers
+{
+	public class JsonCallOutHelper
+	{
+		private static readonly Regex CallOutMatcher = new(Constants.CallOutMatcherRegex, RegexOptions.Compiled);
+
+		public string ApplyCallOuts(SyntaxNode node, string json)
+		{
+			if (node.DescendantNodes().FirstOrDefault(n => n is AnonymousObjectCreationExpressionSyntax) is not
+				AnonymousObjectCreationExpressionSyntax syntax) return json;
+
+			var syntaxString = syntax.ToFullString() ?? string.Empty;
+
+			if (string.IsNullOrEmpty(syntaxString)) return json;
+
+			var callOuts = new Dictionary<(string, string), string>();
+
+			using var sr = new StringReader(syntaxString);
+
+			while (true)
+			{
+				var line = sr.ReadLine();
+
+				if (line is null)
+					break;
+
+				var matches = CallOutMatcher.Matches(line);
+
+				foreach (Match match in matches)
+				{
+					var equalsPosition = line.IndexOf("=", StringComparison.Ordinal);
+
+					if (equalsPosition < 0) break;
+
+					var property = line.Substring(0, equalsPosition).Replace("\t", string.Empty).Trim();
+
+					var commaPosition = line.IndexOf(",", equalsPosition, StringComparison.Ordinal);
+
+					var value = line.Substring(equalsPosition + 1, commaPosition - (equalsPosition + 1)).Trim();
+						
+					callOuts.Add((property, value), match.Value);
+				}
+			}
+
+			if (callOuts.Any())
+			{
+				var sb = new StringBuilder();
+
+				using var jsonStringReader = new StringReader(json);
+
+				while (true)
+				{
+					var line = jsonStringReader.ReadLine();
+
+					if (line is null) break;
+
+					sb.Append(line);
+
+					foreach (var ((property, propertyValue), callOut) in callOuts)
+					{
+						if (line.Contains(property) && line.Contains(propertyValue))
+						{
+							sb.Append(" " + callOut);
+						}
+					}
+
+					sb.AppendLine();
+				}
+
+				return sb.ToString();
+			}
+
+			return json;
+		}
+	}
+}

--- a/src/DocGenerator/Walkers/UsageTestsWalker.cs
+++ b/src/DocGenerator/Walkers/UsageTestsWalker.cs
@@ -57,6 +57,10 @@ namespace DocGenerator.Walkers
 
 			if (node.TryGetJsonForSyntaxNode(out var json))
 			{
+				var helper = new JsonCallOutHelper();
+
+				json = helper.ApplyCallOuts(node, json);
+
 				var startingLine = node.StartingLine();
 				Blocks.Add(new JavaScriptBlock(json, startingLine, ClassDepth, memberName));
 			}


### PR DESCRIPTION
This isn't fully featured but supports doc generation call outs for properties of JSON defined using anonymous types.

For example, the following code is defined in `DateHistogramAggregationUsageTests`:

```c#
projects_started_per_month = new
{
	date_histogram = new
	{
		field = "startedOn",
		calendar_interval = "month",
		min_doc_count = 2,
		format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", // <1> Note the inclusion of `date_optional_time` to `format`
		order = new { _count = "asc" },
		extended_bounds = new
		{
			min = FixedDate.AddYears(-1),
			max = FixedDate.AddYears(1)
		},
		missing = FixedDate
	},
        ...
```

Currently, this callout is not rendered to the asciidoc.

This PR adds rough parsing of the code above to identify lines where a property is defined and includes a callout. This is then matched to the corresponding line in the generated JSON. Using the same technique as was provided for C# callouts, this is then extracted and rendered into a suitable asciidoc format.

After the change the following is now included in the asciidoc:

```js
[source,javascript]
.Example json output
----
{
  "projects_started_per_month": {
    "date_histogram": {
      "field": "startedOn",
      "calendar_interval": "month",
      "min_doc_count": 2,
      "format": "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", <1>
      "order": {
        "_count": "asc"
      },
      "extended_bounds": {
        "min": "2014-06-06T12:01:02.123",
        "max": "2016-06-06T12:01:02.123"
      },
      "missing": "2015-06-06T12:01:02.123"
    },
    ...
}
----
<1> Note the inclusion of `date_optional_time` to `format`
```

Note: This is not going to catch all callouts but improves the current situation.