### PR TITLE
Add authentication type to  AuthenticateResponse

### DIFF
--- a/src/Nest/XPack/Security/Authenticate/AuthenticateResponse.cs
+++ b/src/Nest/XPack/Security/Authenticate/AuthenticateResponse.cs
@@ -40,5 +40,8 @@ namespace Nest
 
 		[DataMember(Name = "lookup_realm")]
 		public RealmInfo LookupRealm { get; internal set; }
+
+		[DataMember(Name = "authentication_type")]
+		public string AuthenticationType { get; internal set; }
 	}
 }


### PR DESCRIPTION
https://github.com/elastic/elasticsearch/pull/61247 added a new "authentication_type" field to the response of "GET _security/_authenticate". This commit adds this as a property of the `AuthenticateResponse` type.

Contributes to meta issue #5096