### PR TITLE
Fix missing deprecated attributes on low-level

### DIFF
--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="CsQuery.Core" Version="2.0.1" />
     <!-- https://github.com/toddams/RazorLight/issues/172 -->
     <PackageReference Include="RazorLight.Unofficial" Version="2.0.0-beta1.3" />
-    <PackageReference Include="Spectre.Console" Version="0.27.1-preview.0.8" />
+    <PackageReference Include="Spectre.Console" Version="0.30.0" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.3.0-alpha.20371.2" />
     <!--<PackageReference Include="RazorLight" Version="2.0.0-beta1" />-->
   </ItemGroup>

--- a/src/ApiGenerator/Domain/Specification/UrlInformation.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlInformation.cs
@@ -71,16 +71,22 @@ namespace ApiGenerator.Domain.Specification
 
 				// now, check for and prefer deprecated URLs
 
-				foreach (var path in _pathsWithDeprecation.Where(p => p.Deprecation is null).ToArray())
+				var finalPathsWithDeprecations = new List<UrlPath>(_pathsWithDeprecation.Count);
+
+				foreach (var path in _pathsWithDeprecation)
 				{
-					var dpMatch = DeprecatedPaths.SingleOrDefault(p => p.Path.Equals(path.Path, StringComparison.OrdinalIgnoreCase));
-					
-					if (dpMatch is object)
+					if (path.Deprecation is null &&
+						DeprecatedPaths.SingleOrDefault(p => p.Path.Equals(path.Path, StringComparison.OrdinalIgnoreCase)) is { } match)
 					{
-						_pathsWithDeprecation.Remove(path);
-						_pathsWithDeprecation.Add(new UrlPath(dpMatch, OriginalParts, Paths));
+						finalPathsWithDeprecations.Add(new UrlPath(match, OriginalParts, Paths));
+					}
+					else
+					{
+						finalPathsWithDeprecations.Add(path);
 					}
 				}
+
+				_pathsWithDeprecation = finalPathsWithDeprecations;
 
 				return _pathsWithDeprecation;
 			}

--- a/src/ApiGenerator/Program.cs
+++ b/src/ApiGenerator/Program.cs
@@ -3,10 +3,6 @@
 // See the LICENSE file in the project root for more information
 
 using System;
-using System.CommandLine;
-using System.CommandLine.DragonFruit;
-using System.CommandLine.Invocation;
-using System.IO;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -20,8 +16,6 @@ namespace ApiGenerator
 	public static class Program
 	{
 		private static bool Interactive { get; set; } = false;
-
-		public static Style HeaderStyle { get; } = new Style(Color.White, Color.Chartreuse4);
 
 		/// <summary>
 		/// A main function can also take <see cref="CancellationToken"/> which is hooked up to support termination (e.g CTRL+C)
@@ -99,7 +93,7 @@ namespace ApiGenerator
 			Console.WriteLine();
 			AnsiConsole.Render(
 				new Panel(grid)
-					.Header(new PanelHeader(" Elasticsearch .NET client API generator ", HeaderStyle, Justify.Left))
+					.Header(new PanelHeader("[b white on chartreuse4] Elasticsearch .NET client API generator [/]", Justify.Left))
 			);
 			Console.WriteLine();
 


### PR DESCRIPTION
Identified a bug after creating a patch and regenerating code where the low level generate code was not rendering deprecated attributes for some methods.

The deduping logic handles aliases but does not handle non-aliased paths which is corrected by doing a final check to prefer the deprecated versions.

As far as I can tell by running the generator locally, this change doesn't seem to negatively affect any other parts of the code generation.

Additional:
- Updated the version of Spectre.Console
- Fixed breaking change from Spectre.Console
- Fixed typo