### PR TITLE
Add ignore_keywords flag to word delimiter graph

### DIFF
--- a/src/Nest/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
+++ b/src/Nest/Analysis/TokenFilters/WordDelimiterGraph/WordDelimiterGraphTokenFilter.cs
@@ -57,6 +57,13 @@ namespace Nest
 		bool? GenerateWordParts { get; set; }
 
 		/// <summary>
+		/// If true, the filter skips tokens with a keyword attribute of true. Defaults to false.
+		/// </summary>
+		[DataMember(Name = "ignore_keywords")]
+		[JsonFormatter(typeof(NullableStringBooleanFormatter))]
+		bool? IgnoreKeywords { get; set; }
+
+		/// <summary>
 		/// If true includes original words in subwords: "500-42" ⇒ "500-42" "500" "42". Defaults to false.
 		/// </summary>
 		[DataMember(Name ="preserve_original")]
@@ -134,6 +141,9 @@ namespace Nest
 		public bool? GenerateWordParts { get; set; }
 
 		/// <inheritdoc />
+		public bool? IgnoreKeywords { get; set; }
+
+		/// <inheritdoc />
 		public bool? PreserveOriginal { get; set; }
 
 		/// <inheritdoc />
@@ -169,8 +179,8 @@ namespace Nest
 		bool? IWordDelimiterGraphTokenFilter.CatenateWords { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.GenerateNumberParts { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.GenerateWordParts { get; set; }
+		bool? IWordDelimiterGraphTokenFilter.IgnoreKeywords { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.PreserveOriginal { get; set; }
-
 		IEnumerable<string> IWordDelimiterGraphTokenFilter.ProtectedWords { get; set; }
 		string IWordDelimiterGraphTokenFilter.ProtectedWordsPath { get; set; }
 		bool? IWordDelimiterGraphTokenFilter.SplitOnCaseChange { get; set; }
@@ -186,6 +196,14 @@ namespace Nest
 		/// <inheritdoc />
 		public WordDelimiterGraphTokenFilterDescriptor GenerateNumberParts(bool? generateNumberParts = true) =>
 			Assign(generateNumberParts, (a, v) => a.GenerateNumberParts = v);
+
+		/// <summary>
+		/// <para>Configure whether the filter will skip tokens with a keyword attribute of true.</para>
+		/// <para>(Optional) When not configured, this defaults to false in Elasticsearch.</para>
+		/// </summary>
+		/// <param name="ignoreKeywords">If true, the filter skips tokens with a keyword attribute of true.</param>
+		public WordDelimiterGraphTokenFilterDescriptor IgnoreKeywords(bool? ignoreKeywords = true) =>
+			Assign(ignoreKeywords, (a, v) => a.IgnoreKeywords = v);
 
 		/// <inheritdoc />
 		public WordDelimiterGraphTokenFilterDescriptor CatenateWords(bool? catenateWords = true) => Assign(catenateWords, (a, v) => a.CatenateWords = v);

--- a/tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
+++ b/tests/Tests/Analysis/TokenFilters/TokenFilterTests.cs
@@ -923,6 +923,7 @@ namespace Tests.Analysis.TokenFilters
 					.CatenateWords()
 					.GenerateNumberParts()
 					.GenerateWordParts()
+					.IgnoreKeywords()
 					.PreserveOriginal()
 					.ProtectedWords("x", "y", "z")
 					.SplitOnCaseChange()
@@ -939,6 +940,7 @@ namespace Tests.Analysis.TokenFilters
 					CatenateWords = true,
 					GenerateNumberParts = true,
 					GenerateWordParts = true,
+					IgnoreKeywords = true,
 					PreserveOriginal = true,
 					ProtectedWords = new[] { "x", "y", "z" },
 					SplitOnCaseChange = true,
@@ -952,6 +954,7 @@ namespace Tests.Analysis.TokenFilters
 				adjust_offsets = true,
 				generate_word_parts = true,
 				generate_number_parts = true,
+				ignore_keywords = true,
 				catenate_words = true,
 				catenate_numbers = true,
 				catenate_all = true,

--- a/tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs
+++ b/tests/Tests/Analysis/TokenFilters/TokenFilterUsageTests.cs
@@ -141,6 +141,7 @@ namespace Tests.Analysis.TokenFilters
 						.CatenateWords()
 						.GenerateNumberParts()
 						.GenerateWordParts()
+						.IgnoreKeywords()
 						.PreserveOriginal()
 						.ProtectedWords("x", "y", "z")
 						.SplitOnCaseChange()
@@ -301,6 +302,7 @@ namespace Tests.Analysis.TokenFilters
 								CatenateWords = true,
 								GenerateNumberParts = true,
 								GenerateWordParts = true,
+								IgnoreKeywords = true,
 								PreserveOriginal = true,
 								ProtectedWords = new[] { "x", "y", "z" },
 								SplitOnCaseChange = true,
@@ -624,6 +626,7 @@ namespace Tests.Analysis.TokenFilters
 						type = "word_delimiter_graph",
 						generate_word_parts = true,
 						generate_number_parts = true,
+						ignore_keywords = true,
 						catenate_words = true,
 						catenate_numbers = true,
 						catenate_all = true,


### PR DESCRIPTION
This introduces a new property for the word delimiter graph token filter to configure ignoring of keywords.

It relates to this change https://github.com/elastic/elasticsearch/pull/59563

Contributes to #5096 

@Mpdreamz - I included more verbose XML comments for this to make usage via the Fluent API easier. I noticed that currently all descriptor methods use `/// <inheritdoc />` which seems to have no effect. Is there a reason for the existing comments? If this format is reasonable, I'd propose to spend some time updating other comments for the `WordDelimiterGraphTokenFilterDescriptor` and as I come to them, other descriptors.