### PR TITLE
Generate initial NEST code for 7.10.1

### DIFF
--- a/src/ApiGenerator/RestSpecification/_Patches/indices.flush_synced.patch.json
+++ b/src/ApiGenerator/RestSpecification/_Patches/indices.flush_synced.patch.json
@@ -1,0 +1,20 @@
+{
+  "indices.flush_synced": {
+    "url": {
+      "path": "/_flush/synced",
+      "paths": [ "/_flush/synced", "/{index}/_flush/synced" ],
+      "deprecated_paths": [
+        {
+          "version": "7.6.0",
+          "path": "/_flush/synced",
+          "description": "Synced flush is deprecated and will be removed in 8.0. Use flush instead."
+        },
+        {
+          "version": "7.6.0",
+          "path": "/{index}/_flush/synced",
+          "description": "Synced flush is deprecated and will be removed in 8.0. Use flush instead."
+        }
+      ]
+    }
+  }
+}

--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -341,7 +341,7 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRole;
 		///<summary>/_security/role/{name}</summary>
 		///<param name = "name">Optional, accepts null</param>
-		public GetRoleDescriptor(Name name): base(r => r.Optional("name", name))
+		public GetRoleDescriptor(Names name): base(r => r.Optional("name", name))
 		{
 		}
 
@@ -351,9 +351,9 @@ namespace Nest
 		}
 
 		// values part of the url path
-		Name IGetRoleRequest.Name => Self.RouteValues.Get<Name>("name");
-		///<summary>Role name</summary>
-		public GetRoleDescriptor Name(Name name) => Assign(name, (a, v) => a.RouteValues.Optional("name", v));
+		Names IGetRoleRequest.Name => Self.RouteValues.Get<Names>("name");
+		///<summary>A comma-separated list of role names</summary>
+		public GetRoleDescriptor Name(Names name) => Assign(name, (a, v) => a.RouteValues.Optional("name", v));
 	// Request parameters
 	}
 
@@ -363,7 +363,7 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRoleMapping;
 		///<summary>/_security/role_mapping/{name}</summary>
 		///<param name = "name">Optional, accepts null</param>
-		public GetRoleMappingDescriptor(Name name): base(r => r.Optional("name", name))
+		public GetRoleMappingDescriptor(Names name): base(r => r.Optional("name", name))
 		{
 		}
 
@@ -373,9 +373,9 @@ namespace Nest
 		}
 
 		// values part of the url path
-		Name IGetRoleMappingRequest.Name => Self.RouteValues.Get<Name>("name");
-		///<summary>Role-Mapping name</summary>
-		public GetRoleMappingDescriptor Name(Name name) => Assign(name, (a, v) => a.RouteValues.Optional("name", v));
+		Names IGetRoleMappingRequest.Name => Self.RouteValues.Get<Names>("name");
+		///<summary>A comma-separated list of role-mapping names</summary>
+		public GetRoleMappingDescriptor Name(Names name) => Assign(name, (a, v) => a.RouteValues.Optional("name", v));
 	// Request parameters
 	}
 

--- a/src/Nest/ElasticClient.Security.cs
+++ b/src/Nest/ElasticClient.Security.cs
@@ -401,13 +401,13 @@ namespace Nest.Specification.SecurityApi
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
-		public GetRoleResponse GetRole(Name name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null) => GetRole(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)));
+		public GetRoleResponse GetRole(Names name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null) => GetRole(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role.html</a>
 		/// </summary>
-		public Task<GetRoleResponse> GetRoleAsync(Name name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null, CancellationToken ct = default) => GetRoleAsync(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)), ct);
+		public Task<GetRoleResponse> GetRoleAsync(Names name = null, Func<GetRoleDescriptor, IGetRoleRequest> selector = null, CancellationToken ct = default) => GetRoleAsync(selector.InvokeOrDefault(new GetRoleDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role</c> API, read more about this API online:
 		/// <para></para>
@@ -425,13 +425,13 @@ namespace Nest.Specification.SecurityApi
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
-		public GetRoleMappingResponse GetRoleMapping(Name name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null) => GetRoleMapping(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)));
+		public GetRoleMappingResponse GetRoleMapping(Names name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null) => GetRoleMapping(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)));
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-get-role-mapping.html</a>
 		/// </summary>
-		public Task<GetRoleMappingResponse> GetRoleMappingAsync(Name name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null, CancellationToken ct = default) => GetRoleMappingAsync(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)), ct);
+		public Task<GetRoleMappingResponse> GetRoleMappingAsync(Names name = null, Func<GetRoleMappingDescriptor, IGetRoleMappingRequest> selector = null, CancellationToken ct = default) => GetRoleMappingAsync(selector.InvokeOrDefault(new GetRoleMappingDescriptor().Name(name: name)), ct);
 		/// <summary>
 		/// <c>GET</c> request to the <c>security.get_role_mapping</c> API, read more about this API online:
 		/// <para></para>

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -588,7 +588,7 @@ namespace Nest
 	public partial interface IGetRoleRequest : IRequest<GetRoleRequestParameters>
 	{
 		[IgnoreDataMember]
-		Name Name
+		Names Name
 		{
 			get;
 		}
@@ -601,7 +601,7 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRole;
 		///<summary>/_security/role/{name}</summary>
 		///<param name = "name">Optional, accepts null</param>
-		public GetRoleRequest(Name name): base(r => r.Optional("name", name))
+		public GetRoleRequest(Names name): base(r => r.Optional("name", name))
 		{
 		}
 
@@ -612,7 +612,7 @@ namespace Nest
 
 		// values part of the url path
 		[IgnoreDataMember]
-		Name IGetRoleRequest.Name => Self.RouteValues.Get<Name>("name");
+		Names IGetRoleRequest.Name => Self.RouteValues.Get<Names>("name");
 	// Request parameters
 	}
 
@@ -620,7 +620,7 @@ namespace Nest
 	public partial interface IGetRoleMappingRequest : IRequest<GetRoleMappingRequestParameters>
 	{
 		[IgnoreDataMember]
-		Name Name
+		Names Name
 		{
 			get;
 		}
@@ -633,7 +633,7 @@ namespace Nest
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGetRoleMapping;
 		///<summary>/_security/role_mapping/{name}</summary>
 		///<param name = "name">Optional, accepts null</param>
-		public GetRoleMappingRequest(Name name): base(r => r.Optional("name", name))
+		public GetRoleMappingRequest(Names name): base(r => r.Optional("name", name))
 		{
 		}
 
@@ -644,7 +644,7 @@ namespace Nest
 
 		// values part of the url path
 		[IgnoreDataMember]
-		Name IGetRoleMappingRequest.Name => Self.RouteValues.Get<Name>("name");
+		Names IGetRoleMappingRequest.Name => Self.RouteValues.Get<Names>("name");
 	// Request parameters
 	}
 


### PR DESCRIPTION
Adds patch for flush_synced specification.

Includes update to get-role after change to API spec identifying this is actually a comma separated list.