### PR TITLE
Handle additional JSON properties

### DIFF
--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -259,6 +259,10 @@ namespace Nest
 			reader.ReadNext(); // :
 			boxplot.Q3 = reader.ReadDouble();
 
+			// ES 7.11.0 adds these two additional properties on the payload
+			// When present on a 7.11 response, we avoid an exception by
+			// handling (and skipping) over the properties. The 7.11 client
+			// will add support for these new properties on BoxplotAggregate.
 			var token = reader.GetCurrentJsonToken();
 			if (token != JsonToken.EndObject)
 			{

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -258,6 +258,20 @@ namespace Nest
 			reader.ReadNext(); // "q3"
 			reader.ReadNext(); // :
 			boxplot.Q3 = reader.ReadDouble();
+
+			var token = reader.GetCurrentJsonToken();
+			if (token != JsonToken.EndObject)
+			{
+				reader.ReadNext(); // ,
+				reader.ReadNext(); // "lower"
+				reader.ReadNext(); // :
+				reader.ReadDouble();
+				reader.ReadNext(); // ,
+				reader.ReadNext(); // "upper"
+				reader.ReadNext(); // :
+				reader.ReadDouble();
+			}
+
 			return boxplot;
     }
 


### PR DESCRIPTION
The current deserialization logic does not handle additional JSON properties, being added for Elasticsearch 7.11.

This PR reads over them, if they are present to avoid an exception. Since these are not available in 7.10, we do not use the values.