### PR TITLE
Implement grant API key

### DIFF
--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -417,6 +417,16 @@ namespace Nest
 	// Request parameters
 	}
 
+	///<summary>Descriptor for GrantApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</para></summary>
+	public partial class GrantApiKeyDescriptor : RequestDescriptorBase<GrantApiKeyDescriptor, GrantApiKeyRequestParameters, IGrantApiKeyRequest>, IGrantApiKeyRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGrantApiKey;
+		// values part of the url path
+		// Request parameters
+		///<summary>If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh to make this operation visible to search, if `false` then do nothing with refreshes.</summary>
+		public GrantApiKeyDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
+	}
+
 	///<summary>Descriptor for HasPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</para></summary>
 	public partial class HasPrivilegesDescriptor : RequestDescriptorBase<HasPrivilegesDescriptor, HasPrivilegesRequestParameters, IHasPrivilegesRequest>, IHasPrivilegesRequest
 	{

--- a/src/Nest/ElasticClient.Security.cs
+++ b/src/Nest/ElasticClient.Security.cs
@@ -517,6 +517,30 @@ namespace Nest.Specification.SecurityApi
 		/// </summary>
 		public Task<GetUserPrivilegesResponse> GetUserPrivilegesAsync(IGetUserPrivilegesRequest request, CancellationToken ct = default) => DoRequestAsync<IGetUserPrivilegesRequest, GetUserPrivilegesResponse>(request, request.RequestParameters, ct);
 		/// <summary>
+		/// <c>POST</c> request to the <c>security.grant_api_key</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</a>
+		/// </summary>
+		public GrantApiKeyResponse GrantApiKey(Func<GrantApiKeyDescriptor, IGrantApiKeyRequest> selector) => GrantApiKey(selector.InvokeOrDefault(new GrantApiKeyDescriptor()));
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.grant_api_key</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</a>
+		/// </summary>
+		public Task<GrantApiKeyResponse> GrantApiKeyAsync(Func<GrantApiKeyDescriptor, IGrantApiKeyRequest> selector, CancellationToken ct = default) => GrantApiKeyAsync(selector.InvokeOrDefault(new GrantApiKeyDescriptor()), ct);
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.grant_api_key</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</a>
+		/// </summary>
+		public GrantApiKeyResponse GrantApiKey(IGrantApiKeyRequest request) => DoRequest<IGrantApiKeyRequest, GrantApiKeyResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.grant_api_key</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</a>
+		/// </summary>
+		public Task<GrantApiKeyResponse> GrantApiKeyAsync(IGrantApiKeyRequest request, CancellationToken ct = default) => DoRequestAsync<IGrantApiKeyRequest, GrantApiKeyResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>POST</c> request to the <c>security.has_privileges</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-has-privileges.html</a>

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -709,6 +709,29 @@ namespace Nest
 	}
 
 	[InterfaceDataContract]
+	public partial interface IGrantApiKeyRequest : IRequest<GrantApiKeyRequestParameters>
+	{
+	}
+
+	///<summary>Request for GrantApiKey <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-grant-api-key.html</para></summary>
+	public partial class GrantApiKeyRequest : PlainRequestBase<GrantApiKeyRequestParameters>, IGrantApiKeyRequest
+	{
+		protected IGrantApiKeyRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityGrantApiKey;
+		// values part of the url path
+		// Request parameters
+		///<summary>
+		/// If `true` (the default) then refresh the affected shards to make this operation visible to search, if `wait_for` then wait for a refresh
+		/// to make this operation visible to search, if `false` then do nothing with refreshes.
+		///</summary>
+		public Refresh? Refresh
+		{
+			get => Q<Refresh? >("refresh");
+			set => Q("refresh", value);
+		}
+	}
+
+	[InterfaceDataContract]
 	public partial interface IHasPrivilegesRequest : IRequest<HasPrivilegesRequestParameters>
 	{
 		[IgnoreDataMember]

--- a/src/Nest/XPack/Security/ApiKey/GrantApiKey/ApiKey.cs
+++ b/src/Nest/XPack/Security/ApiKey/GrantApiKey/ApiKey.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	[InterfaceDataContract]
+	[ReadAs(typeof(ApiKey))]
+	public interface IApiKey
+	{
+		/// <summary>
+		/// Optional expiration for the API key being generated.
+		/// If an expiration is not provided then the API keys do not expire.
+		/// </summary>
+		[DataMember(Name = "expiration")]
+		Time Expiration { get; set; }
+
+		/// <summary>
+		/// A name for this API key.
+		/// </summary>
+		[DataMember(Name = "name")]
+		string Name { get; set; }
+
+		/// <summary>
+		/// Optional role descriptors for this API key, if not provided then permissions of authenticated user are applied.
+		/// </summary>
+		[DataMember(Name = "role_descriptors")]
+		IApiKeyRoles Roles { get; set; }
+	}
+
+	public class ApiKey : IApiKey
+	{
+		/// <inheritdoc cref="IApiKey.Expiration" />
+		public Time Expiration { get; set; }
+
+		/// <inheritdoc cref="IApiKey.Name" />
+		public string Name { get; set; }
+
+		/// <inheritdoc cref="IApiKey.Roles" />
+		public IApiKeyRoles Roles { get; set; }
+	}
+
+	public class ApiKeyDescriptor : DescriptorBase<ApiKeyDescriptor, IApiKey>, IApiKey
+	{
+		/// <inheritdoc cref="IApiKey.Expiration" />
+		Time IApiKey.Expiration { get; set; }
+
+		/// <inheritdoc cref="IApiKey.Name" />
+		string IApiKey.Name { get; set; }
+
+		/// <inheritdoc cref="IApiKey.Roles" />
+		IApiKeyRoles IApiKey.Roles { get; set; }
+
+		/// <inheritdoc cref="IApiKey.Expiration" />
+		public ApiKeyDescriptor Expiration(Time expiration) => Assign(expiration, (a, v) => a.Expiration = v);
+
+		/// <inheritdoc cref="IApiKey.Name" />
+		public ApiKeyDescriptor Name(string name) => Assign(name, (a, v) => a.Name = v);
+
+		/// <inheritdoc cref="IApiKey.Roles" />
+		public ApiKeyDescriptor Roles(Func<ApiKeyRolesDescriptor, IPromise<IApiKeyRoles>> selector) =>
+			Assign(selector, (a, v) => a.Roles = v.InvokeOrDefault(new ApiKeyRolesDescriptor()).Value);
+	}
+}

--- a/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyRequest.cs
+++ b/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyRequest.cs
@@ -1,0 +1,99 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	[MapsApi("security.grant_api_key.json")]
+	[ReadAs(typeof(GrantApiKeyRequest))]
+	public partial interface IGrantApiKeyRequest
+	{
+		/// <summary>
+		/// The user’s access token. If you specify the access_token grant type,
+		/// this parameter is required. It is not valid with other grant types.
+		/// </summary>
+		[DataMember(Name = "access_token")]
+		string AccessToken { get; set; }
+
+		/// <summary>
+		/// The type of grant. Supported grant types are: access_token,password.
+		/// </summary>
+		[DataMember(Name = "grant_type")]
+		GrantType? GrantType { get; set; }
+
+		/// <summary>
+		/// The user’s password. If you specify the password grant type,
+		/// this parameter is required. It is not valid with other grant types.
+		/// </summary>
+		[DataMember(Name = "password")]
+		string Password { get; set; }
+
+		/// <summary>
+		/// The user name that identifies the user. If you specify the password grant type, 
+		/// this parameter is required. It is not valid with other grant types.
+		/// </summary>
+		[DataMember(Name = "username")]
+		string Username { get; set; }
+
+		/// <summary>
+		/// Defines the API key.
+		/// </summary>
+		[DataMember(Name = "api_key")]
+		IApiKey ApiKey { get; set; }
+	}
+
+	public partial class GrantApiKeyRequest
+	{
+		/// <inheritdoc cref="IGrantApiKeyRequest.AccessToken" />
+		public string AccessToken { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.GrantType" />
+		public GrantType? GrantType { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Password" />
+		public string Password { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Username" />
+		public string Username { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.ApiKey" />
+		public IApiKey ApiKey { get; set; }
+	}
+
+	public partial class GrantApiKeyDescriptor
+	{
+		/// <inheritdoc cref="IGrantApiKeyRequest.AccessToken" />
+		string IGrantApiKeyRequest.AccessToken { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.GrantType" />
+		GrantType? IGrantApiKeyRequest.GrantType { get; set; } = Nest.GrantType.AccessToken;
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Password" />
+		string IGrantApiKeyRequest.Password { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Username" />
+		string IGrantApiKeyRequest.Username { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.ApiKey" />
+		IApiKey IGrantApiKeyRequest.ApiKey { get; set; }
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.AccessToken" />
+		public GrantApiKeyDescriptor AccessToken(string accessToken) => Assign(accessToken, (a, v) => a.AccessToken = v);
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.GrantType" />
+		public GrantApiKeyDescriptor GrantType(GrantType? type) => Assign(type, (a, v) => a.GrantType = v);
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Password" />
+		public GrantApiKeyDescriptor Password(string password) => Assign(password, (a, v) => a.Password = v);
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.Username" />
+		public GrantApiKeyDescriptor Username(string username) => Assign(username, (a, v) => a.Username = v);
+
+		/// <inheritdoc cref="IGrantApiKeyRequest.ApiKey" />
+		public GrantApiKeyDescriptor ApiKey(Func<ApiKeyDescriptor, IApiKey> selector) =>
+			Assign(selector, (a, v) => a.ApiKey = v?.Invoke(new ApiKeyDescriptor()));
+	}
+}

--- a/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyResponse.cs
+++ b/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyResponse.cs
@@ -1,0 +1,38 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	public class GrantApiKeyResponse : ResponseBase
+	{
+		/// <summary>
+		/// Id for the API key
+		/// </summary>
+		[DataMember(Name = "id")]
+		public string Id { get; internal set; }
+
+		/// <summary>
+		/// Name of the API key
+		/// </summary>
+		[DataMember(Name = "name")]
+		public string Name { get; internal set; }
+
+		/// <summary>
+		/// Optional expiration time for the API key in milliseconds
+		/// </summary>
+		[DataMember(Name = "expiration")]
+		[JsonFormatter(typeof(NullableDateTimeOffsetEpochMillisecondsFormatter))]
+		public DateTimeOffset? Expiration { get; internal set; }
+
+		/// <summary>
+		/// Generated API key
+		/// </summary>
+		[DataMember(Name = "api_key")]
+		public string ApiKey { get; internal set; }
+	}
+}

--- a/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantType.cs
+++ b/src/Nest/XPack/Security/ApiKey/GrantApiKey/GrantType.cs
@@ -1,0 +1,16 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Runtime.Serialization;
+using Elasticsearch.Net;
+
+namespace Nest
+{
+	[StringEnum]
+	public enum GrantType
+	{
+		[EnumMember(Value = "password")] Password,
+		[EnumMember(Value = "access_token")] AccessToken
+	}
+}

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -257,6 +257,7 @@ namespace Nest
 		internal static ApiUrls SecurityGetUserAccessToken = new ApiUrls(new[]{"_security/oauth2/token"});
 		internal static ApiUrls SecurityGetUser = new ApiUrls(new[]{"_security/user/{username}", "_security/user"});
 		internal static ApiUrls SecurityGetUserPrivileges = new ApiUrls(new[]{"_security/user/_privileges"});
+		internal static ApiUrls SecurityGrantApiKey = new ApiUrls(new[]{"_security/api_key/grant"});
 		internal static ApiUrls SecurityHasPrivileges = new ApiUrls(new[]{"_security/user/_has_privileges", "_security/user/{user}/_has_privileges"});
 		internal static ApiUrls SecurityInvalidateApiKey = new ApiUrls(new[]{"_security/api_key"});
 		internal static ApiUrls SecurityInvalidateUserAccessToken = new ApiUrls(new[]{"_security/oauth2/token"});

--- a/tests/Tests/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyTests.cs
@@ -1,0 +1,195 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.XPack.Security.ApiKey.GrantApiKey
+{
+	[SkipVersion("<7.10.0", "APIs introduced in 7.10.0")]
+	public class GrantApiKeyTests : CoordinatedIntegrationTestBase<XPackCluster>
+	{
+		private const string PutAdminUserStep = nameof(PutAdminUserStep);
+		private const string PutTargetUserStep = nameof(PutTargetUserStep);
+		private const string GrantApiKeyStep = nameof(GrantApiKeyStep);
+		private const string GrantApiKeyWithExpirationStep = nameof(GrantApiKeyWithExpirationStep);
+		private const string GenerateAccessTokenStep = nameof(GenerateAccessTokenStep);
+		private const string GrantApiKeyUsingAccessTokenStep = nameof(GrantApiKeyUsingAccessTokenStep);
+		
+		public GrantApiKeyTests(XPackCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage)
+		{
+			{
+				PutAdminUserStep, u =>
+					u.Calls<PutUserDescriptor, PutUserRequest, IPutUserRequest, PutUserResponse>(
+						v => new PutUserRequest($"user-{v}-admin")
+						{
+							Password = "password",
+							Roles = new[] { "superuser" },
+							FullName = "API key superuser"
+						},
+						(v, d) => d
+							.Password("password")
+							.Roles("superuser")
+							.FullName("API key superuser")
+						,
+						(v, c, f) => c.Security.PutUser($"user-{v}-admin", f),
+						(v, c, f) => c.Security.PutUserAsync($"user-{v}-admin", f),
+						(v, c, r) => c.Security.PutUser(r),
+						(v, c, r) => c.Security.PutUserAsync(r)
+					)
+			},
+			{
+				PutTargetUserStep, u =>
+					u.Calls<PutUserDescriptor, PutUserRequest, IPutUserRequest, PutUserResponse>(
+						v => new PutUserRequest($"user-{v}-target")
+						{
+							Password = "password",
+							Roles = new[] { "basic" },
+							FullName = "API key target"
+						},
+						(v, d) => d
+							.Password("password")
+							.Roles("basic")
+							.FullName("API key target")
+						,
+						(v, c, f) => c.Security.PutUser($"user-{v}-target", f),
+						(v, c, f) => c.Security.PutUserAsync($"user-{v}-target", f),
+						(v, c, r) => c.Security.PutUser(r),
+						(v, c, r) => c.Security.PutUserAsync(r)
+					)
+			},
+			{
+				GrantApiKeyStep, u =>
+					u.Calls<GrantApiKeyDescriptor, GrantApiKeyRequest, IGrantApiKeyRequest, GrantApiKeyResponse>(
+						v => new GrantApiKeyRequest
+						{
+							GrantType = GrantType.Password,
+							Username = $"user-{v}-target",
+							Password = "password",
+							ApiKey = new Nest.ApiKey
+							{
+								Name = $"api-key-{v}"
+							},
+							RequestConfiguration = new RequestConfiguration
+							{
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}-admin", "password")
+							}
+						},
+						(v, d) => d
+							.Username($"user-{v}-target")
+							.Password("password")
+							.ApiKey(k => k.Name($"api-key-{v}"))
+							.GrantType(GrantType.Password)
+							.RequestConfiguration(r => r.BasicAuthentication($"user-{v}-admin", "password")),
+						(v, c, f) => c.Security.GrantApiKey(f),
+						(v, c, f) => c.Security.GrantApiKeyAsync(f),
+						(v, c, r) => c.Security.GrantApiKey(r),
+						(v, c, r) => c.Security.GrantApiKeyAsync(r)
+					)
+			},
+			{
+				GrantApiKeyWithExpirationStep, u =>
+					u.Calls<GrantApiKeyDescriptor, GrantApiKeyRequest, IGrantApiKeyRequest, GrantApiKeyResponse>(
+						v => new GrantApiKeyRequest
+						{
+							GrantType = GrantType.Password,
+							Username = $"user-{v}-target",
+							Password = "password",
+							ApiKey = new Nest.ApiKey
+							{
+								Name = $"api-key-{v}",
+								Expiration = new Time(TimeSpan.FromMinutes(1))
+							},
+							RequestConfiguration = new RequestConfiguration
+							{
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}-admin", "password")
+							}
+						},
+						(v, d) => d
+							.Username($"user-{v}-target")
+							.Password("password")
+							.ApiKey(k => k
+								.Name($"api-key-{v}")
+								.Expiration(new Time(TimeSpan.FromMinutes(1))))
+							.GrantType(GrantType.Password)
+							.RequestConfiguration(r => r.BasicAuthentication($"user-{v}-admin", "password")),
+						(v, c, f) => c.Security.GrantApiKey(f),
+						(v, c, f) => c.Security.GrantApiKeyAsync(f),
+						(v, c, r) => c.Security.GrantApiKey(r),
+						(v, c, r) => c.Security.GrantApiKeyAsync(r)
+					)
+			},
+			{
+				GenerateAccessTokenStep, u =>
+					u.Calls<GetUserAccessTokenDescriptor, GetUserAccessTokenRequest, IGetUserAccessTokenRequest, GetUserAccessTokenResponse>(
+						v => new GetUserAccessTokenRequest($"user-{v}-target","password"),
+						(v, d) => d,
+						(v, c, f) => c.Security.GetUserAccessToken($"user-{v}-target", "password", f),
+						(v, c, f) => c.Security.GetUserAccessTokenAsync($"user-{v}-target", "password", f),
+						(_, c, r) => c.Security.GetUserAccessToken(r),
+						(_, c, r) => c.Security.GetUserAccessTokenAsync(r),
+						(r, values) => values.ExtendedValue("accessToken", r.AccessToken)
+					)
+			},
+			{
+				GrantApiKeyUsingAccessTokenStep, u =>
+					u.Calls<GrantApiKeyDescriptor, GrantApiKeyRequest, IGrantApiKeyRequest, GrantApiKeyResponse>(v => new GrantApiKeyRequest
+						{
+							GrantType = GrantType.AccessToken,
+							AccessToken = u.Usage.CallUniqueValues.ExtendedValue<string>("accessToken") ?? string.Empty,
+							ApiKey = new Nest.ApiKey
+							{
+								Name = $"api-key-{v}"
+							},
+							RequestConfiguration = new RequestConfiguration
+							{
+								BasicAuthenticationCredentials = new BasicAuthenticationCredentials($"user-{v}-admin", "password")
+							}
+						},
+						(v, d) => d
+							.GrantType(GrantType.AccessToken)
+							.AccessToken(u.Usage.CallUniqueValues.ExtendedValue<string>("accessToken") ?? string.Empty)
+							.ApiKey(k => k.Name($"api-key-{v}"))
+							.RequestConfiguration(r => r.BasicAuthentication($"user-{v}-admin", "password")),
+						(_, c, f) => c.Security.GrantApiKey(f),
+						(_, c, f) => c.Security.GrantApiKeyAsync(f),
+						(_, c, r) => c.Security.GrantApiKey(r),
+						(_, c, r) => c.Security.GrantApiKeyAsync(r)
+					)
+			}
+		}) { }
+
+		[I] public async Task GrantApiKeyResponse() => await Assert<GrantApiKeyResponse>(GrantApiKeyStep, r =>
+		{
+			r.IsValid.Should().BeTrue();
+			r.Id.Should().NotBeNullOrEmpty();
+			r.Name.Should().NotBeNullOrEmpty();
+			r.ApiKey.Should().NotBeNullOrEmpty();
+		});
+
+		[I] public async Task GrantApiKeyWithExpirationResponse() => await Assert<GrantApiKeyResponse>(GrantApiKeyWithExpirationStep, r =>
+		{
+			r.IsValid.Should().BeTrue();
+			r.Id.Should().NotBeNullOrEmpty();
+			r.Name.Should().NotBeNullOrEmpty();
+			r.Expiration.Should().NotBeNull();
+			r.ApiKey.Should().NotBeNullOrEmpty();
+		});
+
+		[I] public async Task GrantApiKeyWithAccessTokenResponse() => await Assert<GrantApiKeyResponse>(GrantApiKeyUsingAccessTokenStep, r =>
+		{
+			r.IsValid.Should().BeTrue();
+			r.Id.Should().NotBeNullOrEmpty();
+			r.Name.Should().NotBeNullOrEmpty();
+			r.ApiKey.Should().NotBeNullOrEmpty();
+		});
+	}
+}

--- a/tests/Tests/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyUrlTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/GrantApiKey/GrantApiKeyUrlTests.cs
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+
+namespace Tests.XPack.Security.ApiKey.GrantApiKey
+{
+	public class GrantApiKeyUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() => await UrlTester.POST("/_security/api_key/grant")
+			.Fluent(c => c.Security.GrantApiKey(p => p))
+			.Request(c => c.Security.GrantApiKey(new GrantApiKeyRequest()))
+			.FluentAsync(c => c.Security.GrantApiKeyAsync(p => p))
+			.RequestAsync(c => c.Security.GrantApiKeyAsync(new GrantApiKeyRequest()));
+	}
+}


### PR DESCRIPTION
Contributes to #5096

Perhaps requires a simple test derived from `ApiTestBase` to assert on the expected JSON, URL etc? These are pretty much exercised by the main coordinated test.