### PR TITLE
Support clear api key cache

### DIFF
--- a/src/ApiGenerator/Domain/Specification/UrlPart.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPart.cs
@@ -69,6 +69,7 @@ namespace ApiGenerator.Domain.Specification
 
 					case "forecast_id":
 					case "action_id":
+					case "ids" when Type == "list":
 						return "Ids";
 
 					case "index":

--- a/src/ApiGenerator/RestSpecification/_Patches/security.clear_api_key_cache.patch.json
+++ b/src/ApiGenerator/RestSpecification/_Patches/security.clear_api_key_cache.patch.json
@@ -1,0 +1,7 @@
+{
+  "security.clear_api_key_cache": {
+    "url": {
+      "paths": ["/_security/api_key/{ids}/_clear_cache", "/_security/api_key/*/_clear_cache"]
+    }
+  }
+}

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Security.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Security.cs
@@ -87,6 +87,15 @@ namespace Elasticsearch.Net.Specification.SecurityApi
 		[MapsApi("security.clear_api_key_cache", "ids")]
 		public Task<TResponse> ClearApiKeyCacheAsync<TResponse>(string ids, ClearApiKeyCacheRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"_security/api_key/{ids:ids}/_clear_cache"), ctx, null, RequestParams(requestParameters));
+		///<summary>POST on /_security/api_key/*/_clear_cache <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</para></summary>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		public TResponse ClearApiKeyCache<TResponse>(ClearApiKeyCacheRequestParameters requestParameters = null)
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, "_security/api_key/*/_clear_cache", null, RequestParams(requestParameters));
+		///<summary>POST on /_security/api_key/*/_clear_cache <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</para></summary>
+		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
+		[MapsApi("security.clear_api_key_cache", "")]
+		public Task<TResponse> ClearApiKeyCacheAsync<TResponse>(ClearApiKeyCacheRequestParameters requestParameters = null, CancellationToken ctx = default)
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, "_security/api_key/*/_clear_cache", ctx, null, RequestParams(requestParameters));
 		///<summary>POST on /_security/privilege/{application}/_clear_cache <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-privilege-cache.html</para></summary>
 		///<param name = "application">A comma-separated list of application names</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>

--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -62,6 +62,27 @@ namespace Nest
 		public ChangePasswordDescriptor Refresh(Refresh? refresh) => Qs("refresh", refresh);
 	}
 
+	///<summary>Descriptor for ClearApiKeyCache <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</para></summary>
+	public partial class ClearApiKeyCacheDescriptor : RequestDescriptorBase<ClearApiKeyCacheDescriptor, ClearApiKeyCacheRequestParameters, IClearApiKeyCacheRequest>, IClearApiKeyCacheRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearApiKeyCache;
+		///<summary>/_security/api_key/{ids}/_clear_cache</summary>
+		///<param name = "ids">this parameter is required</param>
+		public ClearApiKeyCacheDescriptor(Ids ids): base(r => r.Required("ids", ids))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected ClearApiKeyCacheDescriptor(): base()
+		{
+		}
+
+		// values part of the url path
+		Ids IClearApiKeyCacheRequest.Ids => Self.RouteValues.Get<Ids>("ids");
+	// Request parameters
+	}
+
 	///<summary>Descriptor for ClearCachedPrivileges <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-privilege-cache.html</para></summary>
 	public partial class ClearCachedPrivilegesDescriptor : RequestDescriptorBase<ClearCachedPrivilegesDescriptor, ClearCachedPrivilegesRequestParameters, IClearCachedPrivilegesRequest>, IClearCachedPrivilegesRequest
 	{

--- a/src/Nest/Descriptors.Security.cs
+++ b/src/Nest/Descriptors.Security.cs
@@ -67,19 +67,20 @@ namespace Nest
 	{
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearApiKeyCache;
 		///<summary>/_security/api_key/{ids}/_clear_cache</summary>
-		///<param name = "ids">this parameter is required</param>
-		public ClearApiKeyCacheDescriptor(Ids ids): base(r => r.Required("ids", ids))
+		///<param name = "ids">Optional, accepts null</param>
+		public ClearApiKeyCacheDescriptor(Ids ids): base(r => r.Optional("ids", ids))
 		{
 		}
 
-		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
-		[SerializationConstructor]
-		protected ClearApiKeyCacheDescriptor(): base()
+		///<summary>/_security/api_key/*/_clear_cache</summary>
+		public ClearApiKeyCacheDescriptor(): base()
 		{
 		}
 
 		// values part of the url path
 		Ids IClearApiKeyCacheRequest.Ids => Self.RouteValues.Get<Ids>("ids");
+		///<summary>A comma-separated list of IDs of API keys to clear from the cache</summary>
+		public ClearApiKeyCacheDescriptor Ids(Ids ids) => Assign(ids, (a, v) => a.RouteValues.Optional("ids", v));
 	// Request parameters
 	}
 

--- a/src/Nest/ElasticClient.Security.cs
+++ b/src/Nest/ElasticClient.Security.cs
@@ -85,6 +85,30 @@ namespace Nest.Specification.SecurityApi
 		/// </summary>
 		public Task<ChangePasswordResponse> ChangePasswordAsync(IChangePasswordRequest request, CancellationToken ct = default) => DoRequestAsync<IChangePasswordRequest, ChangePasswordResponse>(request, request.RequestParameters, ct);
 		/// <summary>
+		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
+		/// </summary>
+		public ClearApiKeyCacheResponse ClearApiKeyCache(Ids ids, Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null) => ClearApiKeyCache(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor(ids: ids)));
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
+		/// </summary>
+		public Task<ClearApiKeyCacheResponse> ClearApiKeyCacheAsync(Ids ids, Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null, CancellationToken ct = default) => ClearApiKeyCacheAsync(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor(ids: ids)), ct);
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
+		/// </summary>
+		public ClearApiKeyCacheResponse ClearApiKeyCache(IClearApiKeyCacheRequest request) => DoRequest<IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
+		/// </summary>
+		public Task<ClearApiKeyCacheResponse> ClearApiKeyCacheAsync(IClearApiKeyCacheRequest request, CancellationToken ct = default) => DoRequestAsync<IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_cached_privileges</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-privilege-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-privilege-cache.html</a>

--- a/src/Nest/ElasticClient.Security.cs
+++ b/src/Nest/ElasticClient.Security.cs
@@ -89,13 +89,13 @@ namespace Nest.Specification.SecurityApi
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
 		/// </summary>
-		public ClearApiKeyCacheResponse ClearApiKeyCache(Ids ids, Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null) => ClearApiKeyCache(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor(ids: ids)));
+		public ClearApiKeyCacheResponse ClearApiKeyCache(Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null) => ClearApiKeyCache(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor()));
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</a>
 		/// </summary>
-		public Task<ClearApiKeyCacheResponse> ClearApiKeyCacheAsync(Ids ids, Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null, CancellationToken ct = default) => ClearApiKeyCacheAsync(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor(ids: ids)), ct);
+		public Task<ClearApiKeyCacheResponse> ClearApiKeyCacheAsync(Func<ClearApiKeyCacheDescriptor, IClearApiKeyCacheRequest> selector = null, CancellationToken ct = default) => ClearApiKeyCacheAsync(selector.InvokeOrDefault(new ClearApiKeyCacheDescriptor()), ct);
 		/// <summary>
 		/// <c>POST</c> request to the <c>security.clear_api_key_cache</c> API, read more about this API online:
 		/// <para></para>

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -102,14 +102,13 @@ namespace Nest
 		protected IClearApiKeyCacheRequest Self => this;
 		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearApiKeyCache;
 		///<summary>/_security/api_key/{ids}/_clear_cache</summary>
-		///<param name = "ids">this parameter is required</param>
-		public ClearApiKeyCacheRequest(Ids ids): base(r => r.Required("ids", ids))
+		///<param name = "ids">Optional, accepts null</param>
+		public ClearApiKeyCacheRequest(Ids ids): base(r => r.Optional("ids", ids))
 		{
 		}
 
-		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
-		[SerializationConstructor]
-		protected ClearApiKeyCacheRequest(): base()
+		///<summary>/_security/api_key/*/_clear_cache</summary>
+		public ClearApiKeyCacheRequest(): base()
 		{
 		}
 

--- a/src/Nest/Requests.Security.cs
+++ b/src/Nest/Requests.Security.cs
@@ -87,6 +87,39 @@ namespace Nest
 	}
 
 	[InterfaceDataContract]
+	public partial interface IClearApiKeyCacheRequest : IRequest<ClearApiKeyCacheRequestParameters>
+	{
+		[IgnoreDataMember]
+		Ids Ids
+		{
+			get;
+		}
+	}
+
+	///<summary>Request for ClearApiKeyCache <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/security-api-clear-api-key-cache.html</para></summary>
+	public partial class ClearApiKeyCacheRequest : PlainRequestBase<ClearApiKeyCacheRequestParameters>, IClearApiKeyCacheRequest
+	{
+		protected IClearApiKeyCacheRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.SecurityClearApiKeyCache;
+		///<summary>/_security/api_key/{ids}/_clear_cache</summary>
+		///<param name = "ids">this parameter is required</param>
+		public ClearApiKeyCacheRequest(Ids ids): base(r => r.Required("ids", ids))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected ClearApiKeyCacheRequest(): base()
+		{
+		}
+
+		// values part of the url path
+		[IgnoreDataMember]
+		Ids IClearApiKeyCacheRequest.Ids => Self.RouteValues.Get<Ids>("ids");
+	// Request parameters
+	}
+
+	[InterfaceDataContract]
 	public partial interface IClearCachedPrivilegesRequest : IRequest<ClearCachedPrivilegesRequestParameters>
 	{
 		[IgnoreDataMember]

--- a/src/Nest/XPack/Security/ApiKey/ClearApiKeyCache/ClearApiKeyCacheRequest.cs
+++ b/src/Nest/XPack/Security/ApiKey/ClearApiKeyCache/ClearApiKeyCacheRequest.cs
@@ -1,0 +1,14 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Nest
+{
+	[MapsApi("security.clear_api_key_cache")]
+	[ReadAs(typeof(ClearApiKeyCacheRequest))]
+	public partial interface IClearApiKeyCacheRequest { }
+
+	public partial class ClearApiKeyCacheRequest { }
+
+	public partial class ClearApiKeyCacheDescriptor { }
+}

--- a/src/Nest/XPack/Security/ApiKey/ClearApiKeyCache/ClearApiKeyCacheResponse.cs
+++ b/src/Nest/XPack/Security/ApiKey/ClearApiKeyCache/ClearApiKeyCacheResponse.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+using Elasticsearch.Net;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	public class ClearApiKeyCacheResponse : NodesResponseBase
+	{
+		/// <summary>
+		/// The cluster name.
+		/// </summary>
+		[DataMember(Name = "cluster_name")]
+		public string ClusterName { get; internal set; }
+
+		/// <summary>
+		/// A dictionary of <see cref="CompactNodeInfo"/> container details of the nodes that cleared the cache.
+		/// </summary>
+		[DataMember(Name = "nodes")]
+		[JsonFormatter(typeof(VerbatimInterfaceReadOnlyDictionaryKeysFormatter<string, CompactNodeInfo>))]
+		public IReadOnlyDictionary<string, CompactNodeInfo> Nodes { get; internal set; } = EmptyReadOnly<string, CompactNodeInfo>.Dictionary;
+	}
+}

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -241,7 +241,7 @@ namespace Nest
 		internal static ApiUrls NoNamespaceSearchTemplate = new ApiUrls(new[]{"_search/template", "{index}/_search/template"});
 		internal static ApiUrls SecurityAuthenticate = new ApiUrls(new[]{"_security/_authenticate"});
 		internal static ApiUrls SecurityChangePassword = new ApiUrls(new[]{"_security/user/{username}/_password", "_security/user/_password"});
-		internal static ApiUrls SecurityClearApiKeyCache = new ApiUrls(new[]{"_security/api_key/{ids}/_clear_cache"});
+		internal static ApiUrls SecurityClearApiKeyCache = new ApiUrls(new[]{"_security/api_key/{ids}/_clear_cache", "_security/api_key/*/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedPrivileges = new ApiUrls(new[]{"_security/privilege/{application}/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedRealms = new ApiUrls(new[]{"_security/realm/{realms}/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedRoles = new ApiUrls(new[]{"_security/role/{name}/_clear_cache"});

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -241,6 +241,7 @@ namespace Nest
 		internal static ApiUrls NoNamespaceSearchTemplate = new ApiUrls(new[]{"_search/template", "{index}/_search/template"});
 		internal static ApiUrls SecurityAuthenticate = new ApiUrls(new[]{"_security/_authenticate"});
 		internal static ApiUrls SecurityChangePassword = new ApiUrls(new[]{"_security/user/{username}/_password", "_security/user/_password"});
+		internal static ApiUrls SecurityClearApiKeyCache = new ApiUrls(new[]{"_security/api_key/{ids}/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedPrivileges = new ApiUrls(new[]{"_security/privilege/{application}/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedRealms = new ApiUrls(new[]{"_security/realm/{realms}/_clear_cache"});
 		internal static ApiUrls SecurityClearCachedRoles = new ApiUrls(new[]{"_security/role/{name}/_clear_cache"});

--- a/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
@@ -214,7 +214,8 @@ namespace Tests.XPack.Security.ApiKey
 					)
 			},
 			{
-				ClearApiKeyCacheStep, u =>
+				// API introduced in 7.10.0
+				ClearApiKeyCacheStep, ">=7.10.0", u =>
 					u.Calls<ClearApiKeyCacheDescriptor, ClearApiKeyCacheRequest, IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(
 						v => new ClearApiKeyCacheRequest(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey") ?? string.Empty),
 						(v, d) => d,
@@ -225,7 +226,8 @@ namespace Tests.XPack.Security.ApiKey
 					)
 			},
 			{
-				ClearAllApiKeyCacheStep, u =>
+				// API introduced in 7.10.0
+				ClearAllApiKeyCacheStep, ">=7.10.0", u =>
 					u.Calls<ClearApiKeyCacheDescriptor, ClearApiKeyCacheRequest, IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(
 						v => new ClearApiKeyCacheRequest(),
 						(v, d) => d,
@@ -284,8 +286,7 @@ namespace Tests.XPack.Security.ApiKey
 			r.Nodes.Count.Should().BeGreaterOrEqualTo(1);
 		});
 
-		[I]
-		public async Task SecurityClearAllApiKeyCacheResponse() => await Assert<ClearApiKeyCacheResponse>(ClearAllApiKeyCacheStep, r =>
+		[I] public async Task SecurityClearAllApiKeyCacheResponse() => await Assert<ClearApiKeyCacheResponse>(ClearAllApiKeyCacheStep, r =>
 		{
 			r.IsValid.Should().BeTrue();
 			r.NodeStatistics.Successful.Should().BeGreaterOrEqualTo(1);

--- a/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyTests.cs
@@ -26,6 +26,7 @@ namespace Tests.XPack.Security.ApiKey
 		private const string InvalidateApiKeyStep = nameof(InvalidateApiKeyStep);
 		private const string GetAnotherApiKeyStep = nameof(GetAnotherApiKeyStep);
 		private const string ClearApiKeyCacheStep = nameof(ClearApiKeyCacheStep);
+		private const string ClearAllApiKeyCacheStep = nameof(ClearAllApiKeyCacheStep);
 
 		public SecurityApiKeyTests(XPackCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage)
 		{
@@ -217,8 +218,19 @@ namespace Tests.XPack.Security.ApiKey
 					u.Calls<ClearApiKeyCacheDescriptor, ClearApiKeyCacheRequest, IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(
 						v => new ClearApiKeyCacheRequest(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey") ?? string.Empty),
 						(v, d) => d,
-						(v, c, f) => c.Security.ClearApiKeyCache(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey") ?? string.Empty, f),
-						(v, c, f) => c.Security.ClearApiKeyCacheAsync(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey") ?? string.Empty, f),
+						(v, c, f) => c.Security.ClearApiKeyCache(f => f.Ids(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey"))),
+						(v, c, f) => c.Security.ClearApiKeyCacheAsync(f => f.Ids(u.Usage.CallUniqueValues.ExtendedValue<string>("apiKey"))),
+						(v, c, r) => c.Security.ClearApiKeyCache(r),
+						(v, c, r) => c.Security.ClearApiKeyCacheAsync(r)
+					)
+			},
+			{
+				ClearAllApiKeyCacheStep, u =>
+					u.Calls<ClearApiKeyCacheDescriptor, ClearApiKeyCacheRequest, IClearApiKeyCacheRequest, ClearApiKeyCacheResponse>(
+						v => new ClearApiKeyCacheRequest(),
+						(v, d) => d,
+						(v, c, f) => c.Security.ClearApiKeyCache(),
+						(v, c, f) => c.Security.ClearApiKeyCacheAsync(),
 						(v, c, r) => c.Security.ClearApiKeyCache(r),
 						(v, c, r) => c.Security.ClearApiKeyCacheAsync(r)
 					)
@@ -265,6 +277,15 @@ namespace Tests.XPack.Security.ApiKey
 		});
 
 		[I] public async Task SecurityClearApiKeyCacheResponse() => await Assert<ClearApiKeyCacheResponse>(ClearApiKeyCacheStep, r =>
+		{
+			r.IsValid.Should().BeTrue();
+			r.NodeStatistics.Successful.Should().BeGreaterOrEqualTo(1);
+			r.ClusterName.Should().NotBeNullOrEmpty();
+			r.Nodes.Count.Should().BeGreaterOrEqualTo(1);
+		});
+
+		[I]
+		public async Task SecurityClearAllApiKeyCacheResponse() => await Assert<ClearApiKeyCacheResponse>(ClearAllApiKeyCacheStep, r =>
 		{
 			r.IsValid.Should().BeTrue();
 			r.NodeStatistics.Successful.Should().BeGreaterOrEqualTo(1);

--- a/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUrlTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUrlTests.cs
@@ -35,4 +35,13 @@ namespace Tests.XPack.Security.ApiKey
 			.FluentAsync(c => c.Security.CreateApiKeyAsync(p => p))
 			.RequestAsync(c => c.Security.CreateApiKeyAsync(new CreateApiKeyRequest()));
 	}
+
+	public class SecurityClearApiKeyCacheUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() => await UrlTester.POST("/_security/api_key/id1%2Cid2/_clear_cache")
+			.Fluent(c => c.Security.ClearApiKeyCache("id1,id2", p => p))
+			.Request(c => c.Security.ClearApiKeyCache(new ClearApiKeyCacheRequest("id1,id2")))
+			.FluentAsync(c => c.Security.ClearApiKeyCacheAsync("id1,id2", p => p))
+			.RequestAsync(c => c.Security.ClearApiKeyCacheAsync(new ClearApiKeyCacheRequest("id1,id2")));
+	}
 }

--- a/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUrlTests.cs
+++ b/tests/Tests/XPack/Security/ApiKey/SecurityApiKeyUrlTests.cs
@@ -38,10 +38,19 @@ namespace Tests.XPack.Security.ApiKey
 
 	public class SecurityClearApiKeyCacheUrlTests : UrlTestsBase
 	{
-		[U] public override async Task Urls() => await UrlTester.POST("/_security/api_key/id1%2Cid2/_clear_cache")
-			.Fluent(c => c.Security.ClearApiKeyCache("id1,id2", p => p))
-			.Request(c => c.Security.ClearApiKeyCache(new ClearApiKeyCacheRequest("id1,id2")))
-			.FluentAsync(c => c.Security.ClearApiKeyCacheAsync("id1,id2", p => p))
-			.RequestAsync(c => c.Security.ClearApiKeyCacheAsync(new ClearApiKeyCacheRequest("id1,id2")));
+		[U] public override async Task Urls()
+		{
+			await UrlTester.POST("/_security/api_key/id1%2Cid2/_clear_cache")
+				.Fluent(c => c.Security.ClearApiKeyCache(f => f.Ids("id1,id2")))
+				.Request(c => c.Security.ClearApiKeyCache(new ClearApiKeyCacheRequest("id1,id2")))
+				.FluentAsync(c => c.Security.ClearApiKeyCacheAsync(f => f.Ids("id1,id2")))
+				.RequestAsync(c => c.Security.ClearApiKeyCacheAsync(new ClearApiKeyCacheRequest("id1,id2")));
+
+			await UrlTester.POST("/_security/api_key/*/_clear_cache")
+				.Fluent(c => c.Security.ClearApiKeyCache())
+				.Request(c => c.Security.ClearApiKeyCache(new ClearApiKeyCacheRequest()))
+				.FluentAsync(c => c.Security.ClearApiKeyCacheAsync())
+				.RequestAsync(c => c.Security.ClearApiKeyCacheAsync(new ClearApiKeyCacheRequest()));
+		}
 	}
 }


### PR DESCRIPTION
I updated `UrlPart` to support the use of the `Ids` type which seemed appropriate.

One query for review... The [docs for this API](https://www.elastic.co/guide/en/elasticsearch/reference/7.10/security-api-clear-api-key-cache.html) suggest that the ids in the path can be empty to clear cache for all keys. The generated code requires the presence of an ID part and I'm not sure if this is okay or how best to address it?

Contributes to #5096