### PR TITLE
Support indexing pressure on NodeStats

### DIFF
--- a/src/Nest/Cluster/NodesStats/NodeStats.cs
+++ b/src/Nest/Cluster/NodesStats/NodeStats.cs
@@ -80,6 +80,9 @@ namespace Nest
 
 		[DataMember(Name = "transport_address")]
 		public string TransportAddress { get; internal set; }
+
+		[DataMember(Name = "indexing_pressure")]
+		public IndexingPressureStats IndexingPressure { get; internal set; }
 	}
 
 	[DataContract]
@@ -570,5 +573,75 @@ namespace Nest
 
 		[DataMember(Name = "total_opened")]
 		public long TotalOpened { get; internal set; }
+	}
+
+	[DataContract]
+	public class IndexingPressureStats
+	{
+		[DataMember(Name = "memory")]
+		public MemoryStats Memory { get; internal set; }
+
+		[DataContract]
+		public class MemoryStats
+		{
+			[DataMember(Name = "current")]
+			public IndexingLoad Current { get; internal set; }
+
+			[DataMember(Name = "total")]
+			public TotalIndexingLoad Total { get; internal set; }
+
+			[DataMember(Name = "limit_in_bytes")]
+			public long LimitInBytes { get; internal set; }
+
+			[DataMember(Name = "limit")]
+			public string Limit { get; internal set; }
+
+			[DataContract]
+			public class TotalIndexingLoad : IndexingLoad
+			{
+				[DataMember(Name = "coordinating_rejections")]
+				public int CoordinatingRejections { get; internal set; }
+
+				[DataMember(Name = "primary_rejections")]
+				public int PrimaryRejections { get; internal set; }
+
+				[DataMember(Name = "replica_rejections")]
+				public int ReplicaRejections { get; internal set; }
+			}
+
+			[DataContract]
+			public class IndexingLoad
+			{
+				[DataMember(Name = "combined_coordinating_and_primary_in_bytes")]
+				public long CombinedCoordinatingAndPrimaryInBytes { get; internal set; }
+
+				[DataMember(Name = "combined_coordinating_and_primary")]
+				public string CombinedCoordinatingAndPrimary { get; internal set; }
+
+				[DataMember(Name = "coordinating_in_bytes")]
+				public long CoordinatingInBytes { get; internal set; }
+
+				[DataMember(Name = "coordinating")]
+				public string Coordinating { get; internal set; }
+
+				[DataMember(Name = "primary_in_bytes")]
+				public long PrimaryInBytes { get; internal set; }
+
+				[DataMember(Name = "primary")]
+				public string Primary { get; internal set; }
+
+				[DataMember(Name = "replica_in_bytes")]
+				public long ReplicaInBytes { get; internal set; }
+
+				[DataMember(Name = "replica")]
+				public string Replica { get; internal set; }
+
+				[DataMember(Name = "all_in_bytes")]
+				public long AllInBytes { get; internal set; }
+
+				[DataMember(Name = "all")]
+				public string All { get; internal set; }
+			}
+		}
 	}
 }

--- a/src/Nest/Cluster/NodesStats/NodeStats.cs
+++ b/src/Nest/Cluster/NodesStats/NodeStats.cs
@@ -579,69 +579,69 @@ namespace Nest
 	public class IndexingPressureStats
 	{
 		[DataMember(Name = "memory")]
-		public MemoryStats Memory { get; internal set; }
+		public IndexingPressureMemoryStats Memory { get; internal set; }
+	}
 
-		[DataContract]
-		public class MemoryStats
-		{
-			[DataMember(Name = "current")]
-			public IndexingLoad Current { get; internal set; }
+	[DataContract]
+	public class IndexingPressureMemoryStats
+	{
+		[DataMember(Name = "current")]
+		public IndexingLoad Current { get; internal set; }
 
-			[DataMember(Name = "total")]
-			public TotalIndexingLoad Total { get; internal set; }
+		[DataMember(Name = "total")]
+		public TotalIndexingLoad Total { get; internal set; }
 
-			[DataMember(Name = "limit_in_bytes")]
-			public long LimitInBytes { get; internal set; }
+		[DataMember(Name = "limit_in_bytes")]
+		public long LimitInBytes { get; internal set; }
 
-			[DataMember(Name = "limit")]
-			public string Limit { get; internal set; }
+		[DataMember(Name = "limit")]
+		public string Limit { get; internal set; }
+	}
 
-			[DataContract]
-			public class TotalIndexingLoad : IndexingLoad
-			{
-				[DataMember(Name = "coordinating_rejections")]
-				public int CoordinatingRejections { get; internal set; }
+	[DataContract]
+	public class IndexingLoad
+	{
+		[DataMember(Name = "combined_coordinating_and_primary_in_bytes")]
+		public long CombinedCoordinatingAndPrimaryInBytes { get; internal set; }
 
-				[DataMember(Name = "primary_rejections")]
-				public int PrimaryRejections { get; internal set; }
+		[DataMember(Name = "combined_coordinating_and_primary")]
+		public string CombinedCoordinatingAndPrimary { get; internal set; }
 
-				[DataMember(Name = "replica_rejections")]
-				public int ReplicaRejections { get; internal set; }
-			}
+		[DataMember(Name = "coordinating_in_bytes")]
+		public long CoordinatingInBytes { get; internal set; }
 
-			[DataContract]
-			public class IndexingLoad
-			{
-				[DataMember(Name = "combined_coordinating_and_primary_in_bytes")]
-				public long CombinedCoordinatingAndPrimaryInBytes { get; internal set; }
+		[DataMember(Name = "coordinating")]
+		public string Coordinating { get; internal set; }
 
-				[DataMember(Name = "combined_coordinating_and_primary")]
-				public string CombinedCoordinatingAndPrimary { get; internal set; }
+		[DataMember(Name = "primary_in_bytes")]
+		public long PrimaryInBytes { get; internal set; }
 
-				[DataMember(Name = "coordinating_in_bytes")]
-				public long CoordinatingInBytes { get; internal set; }
+		[DataMember(Name = "primary")]
+		public string Primary { get; internal set; }
 
-				[DataMember(Name = "coordinating")]
-				public string Coordinating { get; internal set; }
+		[DataMember(Name = "replica_in_bytes")]
+		public long ReplicaInBytes { get; internal set; }
 
-				[DataMember(Name = "primary_in_bytes")]
-				public long PrimaryInBytes { get; internal set; }
+		[DataMember(Name = "replica")]
+		public string Replica { get; internal set; }
 
-				[DataMember(Name = "primary")]
-				public string Primary { get; internal set; }
+		[DataMember(Name = "all_in_bytes")]
+		public long AllInBytes { get; internal set; }
 
-				[DataMember(Name = "replica_in_bytes")]
-				public long ReplicaInBytes { get; internal set; }
+		[DataMember(Name = "all")]
+		public string All { get; internal set; }
+	}
 
-				[DataMember(Name = "replica")]
-				public string Replica { get; internal set; }
+	[DataContract]
+	public class TotalIndexingLoad : IndexingLoad
+	{
+		[DataMember(Name = "coordinating_rejections")]
+		public int CoordinatingRejections { get; internal set; }
 
-				[DataMember(Name = "all_in_bytes")]
-				public long AllInBytes { get; internal set; }
+		[DataMember(Name = "primary_rejections")]
+		public int PrimaryRejections { get; internal set; }
 
-				[DataMember(Name = "all")]
-				public string All { get; internal set; }
-			}
-		}
+		[DataMember(Name = "replica_rejections")]
+		public int ReplicaRejections { get; internal set; }
 	}
 }

--- a/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
+++ b/tests/Tests/Cluster/NodesStats/NodesStatsApiTests.cs
@@ -78,6 +78,11 @@ namespace Tests.Cluster.NodesStats
 			{
 				Assert(node.ScriptCache);
 			}
+
+			if (TestClient.Configuration.InRange(">=7.9.0"))
+			{
+				Assert(node.IndexingPressure);
+			}
 		}
 
 		protected void Assert(NodeIngestStats nodeIngestStats)
@@ -277,6 +282,40 @@ namespace Tests.Cluster.NodesStats
 			jvm.Threads.Should().NotBeNull();
 			//jvm.Threads.Count.Should().BeGreaterThan(0);
 			//jvm.Threads.PeakCount.Should().BeGreaterThan(0);
+		}
+
+		protected void Assert(IndexingPressureStats indexingPressureStats)
+		{
+			if (TestClient.Configuration.InRange(">=7.10.0"))
+			{
+				indexingPressureStats.Memory.LimitInBytes.Should().BeGreaterOrEqualTo(0);
+				//indexingPressureStats.Memory.Limit.Should().NotBeNull();
+			}
+
+			indexingPressureStats.Memory.Current.CombinedCoordinatingAndPrimaryInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Current.CombinedCoordinatingAndPrimary.Should().NotBeNull();
+			indexingPressureStats.Memory.Current.CoordinatingInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Current.Coordinating.Should().NotBeNull();
+			indexingPressureStats.Memory.Current.PrimaryInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Current.Primary.Should().NotBeNull();
+			indexingPressureStats.Memory.Current.ReplicaInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Current.Replica.Should().NotBeNull();
+			indexingPressureStats.Memory.Current.AllInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Current.All.Should().NotBeNull();
+
+			indexingPressureStats.Memory.Total.CombinedCoordinatingAndPrimaryInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Total.CombinedCoordinatingAndPrimary.Should().NotBeNull();
+			indexingPressureStats.Memory.Total.CoordinatingInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Total.Coordinating.Should().NotBeNull();
+			indexingPressureStats.Memory.Total.PrimaryInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Total.Primary.Should().NotBeNull();
+			indexingPressureStats.Memory.Total.ReplicaInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Total.Replica.Should().NotBeNull();
+			indexingPressureStats.Memory.Total.AllInBytes.Should().BeGreaterOrEqualTo(0);
+			//indexingPressureStats.Memory.Total.All.Should().NotBeNull();
+			indexingPressureStats.Memory.Total.CoordinatingRejections.Should().BeGreaterOrEqualTo(0);
+			indexingPressureStats.Memory.Total.PrimaryRejections.Should().BeGreaterOrEqualTo(0);
+			indexingPressureStats.Memory.Total.ReplicaRejections.Should().BeGreaterOrEqualTo(0);
 		}
 	}
 }


### PR DESCRIPTION
Indexing pressure stats were added in 7.9.0
https://github.com/elastic/elasticsearch/pull/59467

They were updated to include memory limit stats in 7.10.0
https://github.com/elastic/elasticsearch/pull/60342

Contributes to #5096