### PR TITLE
[Master] Port update DiagnosticSource to 5.0.0 (#5140)

### DIFF
--- a/src/Elastic.Transport/Diagnostics/Diagnostic.cs
+++ b/src/Elastic.Transport/Diagnostics/Diagnostic.cs
@@ -18,13 +18,14 @@ namespace Elastic.Transport.Diagnostics
 			EndState = state;
 	}
 
-	internal class Diagnostic<TState, TStateEnd> : Activity, IDisposable
+	internal class Diagnostic<TState, TStateEnd> : Activity
 	{
 		public static Diagnostic<TState, TStateEnd> Default { get; } = new Diagnostic<TState, TStateEnd>();
 
 		private readonly DiagnosticSource _source;
 		private TStateEnd _endState;
 		private readonly bool _default;
+		private bool _disposed;
 
 		private Diagnostic() : base("__NOOP__") => _default = true;
 
@@ -45,8 +46,19 @@ namespace Elastic.Transport.Diagnostics
 			}
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed) return;
 
-		//_source can be null if Default instance
-		public void Dispose() => _source?.StopActivity(SetEndTime(DateTime.UtcNow), EndState);
+			if (disposing)
+			{
+				//_source can be null if Default instance
+				_source?.StopActivity(SetEndTime(DateTime.UtcNow), EndState);
+			}
+
+			_disposed = true;
+
+			base.Dispose(disposing);
+		}
 	}
 }

--- a/src/Elastic.Transport/Elastic.Transport.csproj
+++ b/src/Elastic.Transport/Elastic.Transport.csproj
@@ -15,12 +15,10 @@
     <TargetFrameworks>netstandard2.0;netstandard2.1;net461</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-
     <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
-    <PackageReference Include="System.Buffers" Version="4.5.0" />
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="4.7.1" />
-
   </ItemGroup>
 
 </Project>

--- a/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
+++ b/tests/Tests.ScratchPad/Tests.ScratchPad.csproj
@@ -5,9 +5,13 @@
     <Optimize>true</Optimize>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  
   <ItemGroup>
-    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="4.5.1" />
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />
-    <PackageReference Include="BenchMarkDotNet" Version="0.11.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="5.0.0" />
+    <PackageReference Include="BenchMarkDotNet" Version="0.12.1" />
   </ItemGroup>
 </Project>

--- a/tests/Tests/Search/PointInTime/Close/ClosePointInTimeApiTests.cs
+++ b/tests/Tests/Search/PointInTime/Close/ClosePointInTimeApiTests.cs
@@ -4,7 +4,7 @@
 
 using System;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
-using Elasticsearch.Net;
+using Elastic.Transport;
 using FluentAssertions;
 using Nest;
 using Tests.Core.Extensions;

--- a/tests/Tests/Search/PointInTime/Open/OpenPointInTimeApiTests.cs
+++ b/tests/Tests/Search/PointInTime/Open/OpenPointInTimeApiTests.cs
@@ -4,7 +4,7 @@
 
 using System;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
-using Elasticsearch.Net;
+using Elastic.Transport;
 using FluentAssertions;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;


### PR DESCRIPTION
* Update `System.Diagnostics.DiagnosticSource` to use the latest 5.0.0 version which supports all targets.
* Implement `IDisposable`
* Includes fixes to point in time tests due to different transport namespace.