### PR TITLE
Update with additional sdk version properties

### DIFF
--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -20,7 +20,7 @@ module Versioning =
     let parse (v:string) = SemVer.parse(v)
 
     //Versions in form of e.g 6.1.0 is inferred as datetime so we bake the json shape into the provider like this
-    type SdkVersion = { version:string;  }
+    type SdkVersion = { version:string; rollForward:string; allowPrerelease:bool }
     type GlobalJson = { sdk: SdkVersion; version:string; doc_current:string; doc_branch: string; }
         
     let private globalJson () =


### PR DESCRIPTION
After adding rollForward and allowPreRelease to the global.json, this change ensures they remain present after building a release.