### PR TITLE
TcpStats.GetStats() now handles error when host cannot disclose information

### DIFF
--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -295,6 +295,7 @@ InitializerExample
         "type": "word_delimiter_graph",
         "generate_word_parts": true,
         "generate_number_parts": true,
+        "ignore_keywords": true,
         "catenate_words": true,
         "catenate_numbers": true,
         "catenate_all": true,

--- a/docs/client-concepts/troubleshooting/debug-information.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-information.asciidoc
@@ -137,6 +137,13 @@ var response = client.Search<Project>(s => s
 <2> Retrieve statistics about IPv4
 <3> Retrieve statistics about IPv6
 
+[NOTE]
+--
+Collecting TCP statistics may not be accessible in all environments, for example, Azure App Services.
+When this is the case, `TcpStats.GetActiveTcpConnections()` returns `null`.
+
+--
+
 ==== ThreadPool statistics
 
 It can often be useful to see the statistics for thread pool threads, particularly when

--- a/docs/search.asciidoc
+++ b/docs/search.asciidoc
@@ -29,6 +29,8 @@ NEST exposes all of the search request parameters available in Elasticsearch
 
 * <<min-score-usage,Min Score Usage>>
 
+* <<point-in-time-usage,Point In Time Usage>>
+
 * <<post-filter-usage,Post Filter Usage>>
 
 * <<profile-usage,Profile Usage>>
@@ -66,6 +68,8 @@ include::search/request/indices-boost-usage.asciidoc[]
 include::search/request/inner-hits-usage.asciidoc[]
 
 include::search/request/min-score-usage.asciidoc[]
+
+include::search/request/point-in-time-usage.asciidoc[]
 
 include::search/request/post-filter-usage.asciidoc[]
 

--- a/docs/search/request/point-in-time-usage.asciidoc
+++ b/docs/search/request/point-in-time-usage.asciidoc
@@ -1,0 +1,58 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/PointInTimeUsageTests.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[point-in-time-usage]]
+== Point In Time Usage
+
+A search request by default executes against the most recent visible data of the target indices, which is called point in time.
+Elasticsearch pit (point in time) is a lightweight view into the state of the data as it existed when initiated. In some cases,
+it's preferred to perform multiple search requests using the same point in time.
+
+IMPORTANT: Point in time search requests should not specify an index path parameter. When including a point in time in a
+search request, it will cause the URL path of the request to become the rooted '/_search' path instead of '/{index}/_search'.
+
+See the Elasticsearch documentation on {ref_current}/point-in-time-api.html[point in time API] for more detail.
+
+[float]
+=== Fluent DSL example
+
+[source,csharp]
+----
+s => s
+.PointInTime("a-point-in-time-id", p => p
+.KeepAlive("1m"))
+----
+
+[float]
+=== Object Initializer syntax example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    PointInTime = new Nest.PointInTime("a-point-in-time-id", "1m")
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "pit": {
+    "id": "a-point-in-time-id",
+    "keep_alive": "1m"
+  }
+}
+----
+

--- a/src/Elastic.Transport/Diagnostics/TcpStats.cs
+++ b/src/Elastic.Transport/Diagnostics/TcpStats.cs
@@ -15,11 +15,14 @@ namespace Elastic.Transport.Diagnostics
 	public static class TcpStats
 	{
 		private static readonly int StateLength = Enum.GetNames(typeof(TcpState)).Length;
+		private static readonly ReadOnlyDictionary<TcpState, int> Empty
+			= new ReadOnlyDictionary<TcpState, int>(new Dictionary<TcpState, int>());
 
 		/// <summary>
 		/// Gets the active TCP connections
 		/// </summary>
-		/// <returns></returns>
+		/// <returns>TcpConnectionInformation[]</returns>
+		/// <remarks>Can return `null` when there is a permissions issue retrieving TCP connections.</remarks>
 		public static TcpConnectionInformation[] GetActiveTcpConnections()
 		{
 			try
@@ -39,11 +42,16 @@ namespace Elastic.Transport.Diagnostics
 		/// </summary>
 		public static ReadOnlyDictionary<TcpState, int> GetStates()
 		{
-			var states = new Dictionary<TcpState, int>(StateLength);
-
 			var connections = GetActiveTcpConnections();
+
+			if (connections == null)
+			{
+				return Empty;
+			}
+
+			var states = new Dictionary<TcpState, int>(StateLength);			
 			
-			for (var index = 0; index < connections?.Length; index++)
+			for (var index = 0; index < connections.Length; index++)
 			{
 				var connection = connections[index];
 				if (states.TryGetValue(connection.State, out var count))

--- a/src/Elastic.Transport/Diagnostics/TcpStats.cs
+++ b/src/Elastic.Transport/Diagnostics/TcpStats.cs
@@ -20,8 +20,19 @@ namespace Elastic.Transport.Diagnostics
 		/// Gets the active TCP connections
 		/// </summary>
 		/// <returns></returns>
-		public static TcpConnectionInformation[] GetActiveTcpConnections() =>
-			IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
+		public static TcpConnectionInformation[] GetActiveTcpConnections()
+		{
+			try
+			{
+				return IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
+			}
+			catch (NetworkInformationException) // host might not allow this information to be fetched.
+			{
+				// ignored
+			}
+
+			return null;			
+		}
 
 		/// <summary>
 		/// Gets the sum for each state of the active TCP connections
@@ -30,16 +41,7 @@ namespace Elastic.Transport.Diagnostics
 		{
 			var states = new Dictionary<TcpState, int>(StateLength);
 
-			TcpConnectionInformation[] connections = null;
-
-			try
-			{
-				connections = GetActiveTcpConnections();
-			}
-			catch (NetworkInformationException) // host might not allow this information to be fetched.
-			{
-				// ignored
-			}
+			var connections = GetActiveTcpConnections();
 			
 			for (var index = 0; index < connections?.Length; index++)
 			{

--- a/src/Elastic.Transport/Diagnostics/TcpStats.cs
+++ b/src/Elastic.Transport/Diagnostics/TcpStats.cs
@@ -29,8 +29,19 @@ namespace Elastic.Transport.Diagnostics
 		public static ReadOnlyDictionary<TcpState, int> GetStates()
 		{
 			var states = new Dictionary<TcpState, int>(StateLength);
-			var connections = GetActiveTcpConnections();
-			for (var index = 0; index < connections.Length; index++)
+
+			TcpConnectionInformation[] connections = null;
+
+			try
+			{
+				connections = GetActiveTcpConnections();
+			}
+			catch (NetworkInformationException) // host might not allow this information to be fetched.
+			{
+				// ignored
+			}
+			
+			for (var index = 0; index < connections?.Length; index++)
 			{
 				var connection = connections[index];
 				if (states.TryGetValue(connection.State, out var count))

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -221,7 +221,12 @@ namespace Tests.ClientConcepts.Troubleshooting
 		}
 
 		 /**
-		 *
+		 * [NOTE]
+		 * --
+		 * Collecting TCP statistics may not be accessible in all environments, for example, Azure App Services.
+		 * When this is the case, `TcpStats.GetActiveTcpConnections()` returns `null`.
+		 * --
+		 * 
 		 * ==== ThreadPool statistics
          *
 		 * It can often be useful to see the statistics for thread pool threads, particularly when


### PR DESCRIPTION
Hi! 👋 Long time consumer, first time contributor 😊 

I had a quick look at what uses these stats, and it appears the code can handle not having any stats, so I though this was the most reasonable approach.

But happy to update with whatever you guys prefer, equally happy to close this PR and leave to the experts if I'm way off! But, thought i'd try and give back if I can.

Fixes https://github.com/elastic/elasticsearch-net/issues/5176

Thanks!