### PR TITLE
Tweaks .ci/make.sh to clean up after itself

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # parameters are available to this script
 
-
 # common build entry script for all elasticsearch clients
 
-# ./.ci/make.sh bump VERSION
-# ./.ci/make.sh release VERSION
+# ./.ci/make.sh assemble VERSION
 
 script_path=$(dirname "$(realpath -s "$0")")
 repo=$(realpath "$script_path/../")
@@ -15,11 +13,11 @@ CMD=$1
 TASK=$1
 VERSION=$2
 STACK_VERSION=$VERSION
-source "$script_path/functions/imports.sh"
 set -euo pipefail
 
 output_folder=".ci/output"
 OUTPUT_DIR="$repo/${output_folder}"
+mkdir -p "$OUTPUT_DIR"
 
 DOTNET_VERSION=${DOTNET_VERSION-5.0.100}
 
@@ -33,8 +31,6 @@ docker build --file .ci/DockerFile --tag elastic/elasticsearch-net .
 
 echo -e "\033[1m>>>>> Run [elastic/elasticsearch-net container] >>>>>>>>>>>>>>>>>>>>>>>>>>>>>\033[0m"
 
-mkdir -p "$OUTPUT_DIR"
-
 case $CMD in
     assemble)
         TASK=release
@@ -46,7 +42,6 @@ esac
 
 
 docker run \
-  --network=${network_name} \
   --env "DOTNET_VERSION" \
   --name test-runner \
   --volume "${OUTPUT_DIR}:/sln/${output_folder}" \

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -50,7 +50,7 @@
     would take on docker'esque proportions!
     -->
   <PropertyGroup Condition="'$(TestPackageVersion)'!=''">
-    <RestoreSources>$(SolutionRoot)/build/output/_packages;https://api.nuget.org/v3/index.json</RestoreSources>
+    <RestoreSources>$(SolutionRoot)/build/output;https://api.nuget.org/v3/index.json</RestoreSources>
   </PropertyGroup>
 
 </Project>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,5 +19,5 @@ for:
           only:
               - /^(master|\d+\.x)$/
       artifacts:
-          - path: .\build\output\_packages\*.nupkg
+          - path: .\build\output\*.nupkg
             name: NuGet

--- a/build/scripts/Building.fs
+++ b/build/scripts/Building.fs
@@ -55,7 +55,7 @@ module Build =
         DotNet.Exec ["clean"; Paths.Solution; "-c"; "Release"; "-v"; "q"] 
             
     let private keyFile = Paths.Keys "keypair.snk"
-    let private tmp = "build/output/_packages/tmp" 
+    let private tmp = "build/output/tmp" 
     
     let VersionedPack version =
         let packages = BuiltArtifacts version

--- a/build/scripts/Building.fs
+++ b/build/scripts/Building.fs
@@ -6,6 +6,7 @@ namespace Scripts
 
 open System.IO
 
+open Scripts.Commandline
 open Tooling
 open Versioning
 open Fake.Core
@@ -46,11 +47,12 @@ module Build =
             
         DotNet.Exec ["pack"; Paths.Solution; "-c"; "Release"; "-o"; Paths.NugetOutput ; props] |> ignore
 
-    let Clean isCanary =
+    let Clean (parsed:PassedArguments) =
+        let outputPath = match parsed.CommandArguments with | SetVersion c -> c.OutputLocation | _ -> None
         printfn "Cleaning known output folders"
+        if (Option.isSome outputPath) then Shell.cleanDir outputPath.Value
         Shell.cleanDir Paths.BuildOutput
-        if isCanary then 
-            DotNet.Exec ["clean"; Paths.Solution; "-c"; "Release"; "-v"; "q"] |> ignore 
+        DotNet.Exec ["clean"; Paths.Solution; "-c"; "Release"; "-v"; "q"] 
             
     let private keyFile = Paths.Keys "keypair.snk"
     let private tmp = "build/output/_packages/tmp" 

--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -26,7 +26,7 @@ module Paths =
     let Tool tool = sprintf "packages/build/%s" tool
     let CheckedInToolsFolder = "build/tools"
     let KeysFolder = sprintf "%s/keys" BuildFolder
-    let NugetOutput = sprintf "%s/_packages" BuildOutput
+    let NugetOutput = sprintf "%s" BuildOutput
     let SourceFolder = "src"
     
     let Solution = "Elasticsearch.sln"

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -60,8 +60,7 @@ module Main =
         let canaryChain = [ "version"; "release"; "test-nuget-package";]
         
         // the following are expected to be called as targets directly        
-        conditional "clean" parsed.ReleaseBuild  <| fun _ -> Build.Clean isCanary
-        
+        conditional "clean" parsed.ReleaseBuild  <| fun _ -> Build.Clean parsed 
         target "version" <| fun _ -> printfn "Artifacts Version: %O" artifactsVersion
         
         target "restore" Build.Restore
@@ -90,7 +89,8 @@ module Main =
         command "release" releaseChain <| fun _ ->
             let outputPath = match parsed.CommandArguments with | Commandline.SetVersion c -> c.OutputLocation | _ -> None
             match outputPath with
-            | None -> printfn "Finished Release Build %O, artifacts available at: %s" artifactsVersion Paths.BuildOutput
+            | None ->
+                printfn "Finished Release Build %O, artifacts available at: %s" artifactsVersion Paths.BuildOutput
             | Some path ->
                 Fake.IO.Shell.cp_r Paths.BuildOutput path
                 printfn "Finished Release Build %O, output copied to: %s" artifactsVersion path

--- a/build/scripts/Testing.fs
+++ b/build/scripts/Testing.fs
@@ -61,7 +61,7 @@ module Tests =
 
     let RunReleaseUnitTests version args =
         //xUnit always does its own build, this env var is picked up by Tests.csproj
-        //if its set it will include the local package source (build/output/_packages)
+        //if its set it will include the local package source (build/output/)
         //and references NEST and NEST.JsonNetSerializer by the current version
         //this works by not including the local package cache (nay source) 
         //in the project file via:

--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -118,7 +118,7 @@ module Versioning =
 
     let BuiltArtifacts (version: AnchoredVersion) = 
         let packages =
-            let allPackages = !! "build/output/_packages/*.nupkg" |> Seq.toList
+            let allPackages = !! "build/output/*.nupkg" |> Seq.toList
             let toProject (package: string) =
                 let id = Path.GetFileName(package) |> String.replace (version.Full.ToString()) "" |> String.replace "..nupkg" ""
                 let assembly = id |> String.replace "NEST" "Nest"
@@ -128,7 +128,7 @@ module Versioning =
         packages
     
     let ValidateArtifacts version =
-        let tmp = "build/output/_packages/tmp"
+        let tmp = "build/output/tmp"
         
         let packages = BuiltArtifacts version
         printf "%O" packages

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -35,7 +35,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.7.0" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0" />
 
     <PackageReference Include="Bullseye" Version="3.3.0" />
     <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />


### PR DESCRIPTION
- Tweaks to .ci/make.sh

Now also removes the specified output path, not just the hardcoded version.

Publishing nuget packages now no longer uses a special subfolder `_packages` to publish.
This to fall in line with how other clients  will use `.ci/make.sh`.

- remove references to _packages from other targets
