### PR TITLE
adding support for enable_position_increments property on ITokenCountProperty

### DIFF
--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
@@ -16,7 +16,7 @@ namespace Nest
 
 		public bool EnablePositionIncrements
 		{
-			get => Self.EnablePositionIncrements.GetValueOrDefault();
+			get => Self.EnablePositionIncrements.GetValueOrDefault(true);
 			set => Self.EnablePositionIncrements = value;
 		}
 

--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountAttribute.cs
@@ -14,6 +14,12 @@ namespace Nest
 			set => Self.Analyzer = value;
 		}
 
+		public bool EnablePositionIncrements
+		{
+			get => Self.EnablePositionIncrements.GetValueOrDefault();
+			set => Self.EnablePositionIncrements = value;
+		}
+
 		public bool Index
 		{
 			get => Self.Index.GetValueOrDefault();
@@ -27,6 +33,7 @@ namespace Nest
 		}
 
 		string ITokenCountProperty.Analyzer { get; set; }
+		bool? ITokenCountProperty.EnablePositionIncrements { get; set; }
 		bool? ITokenCountProperty.Index { get; set; }
 		double? ITokenCountProperty.NullValue { get; set; }
 		private ITokenCountProperty Self => this;

--- a/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/TokenCount/TokenCountProperty.cs
@@ -18,6 +18,9 @@ namespace Nest
 		[DataMember(Name ="analyzer")]
 		string Analyzer { get; set; }
 
+		[DataMember(Name ="enable_position_increments")]
+		bool? EnablePositionIncrements { get; set; }
+
 		[DataMember(Name ="index")]
 		bool? Index { get; set; }
 
@@ -33,6 +36,8 @@ namespace Nest
 
 		public string Analyzer { get; set; }
 
+		public bool? EnablePositionIncrements { get; set; }
+
 		public bool? Index { get; set; }
 
 		public double? NullValue { get; set; }
@@ -47,13 +52,14 @@ namespace Nest
 		public TokenCountPropertyDescriptor() : base(FieldType.TokenCount) { }
 
 		string ITokenCountProperty.Analyzer { get; set; }
+		bool? ITokenCountProperty.EnablePositionIncrements { get; set; }
 		bool? ITokenCountProperty.Index { get; set; }
 		double? ITokenCountProperty.NullValue { get; set; }
 
 		public TokenCountPropertyDescriptor<T> Analyzer(string analyzer) => Assign(analyzer, (a, v) => a.Analyzer = v);
-
+		public TokenCountPropertyDescriptor<T> EnablePositionIncrements(bool? enablePositionIncrements = true) =>
+			Assign(enablePositionIncrements, (a, v) => a.EnablePositionIncrements = v);
 		public TokenCountPropertyDescriptor<T> Index(bool? index = true) => Assign(index, (a, v) => a.Index = v);
-
 		public TokenCountPropertyDescriptor<T> NullValue(double? nullValue) => Assign(nullValue, (a, v) => a.NullValue = v);
 	}
 }

--- a/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountAttributeTests.cs
@@ -11,6 +11,7 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 		[TokenCount(
 			Index = false,
 			Analyzer = "standard",
+			EnablePositionIncrements = false,
 			NullValue = 0)]
 		public int Full { get; set; }
 
@@ -28,6 +29,7 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 				{
 					type = "token_count",
 					analyzer = "standard",
+					enable_position_increments = false,
 					index = false,
 					null_value = 0.0,
 				},

--- a/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/TokenCount/TokenCountPropertyTests.cs
@@ -22,6 +22,7 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 				{
 					type = "token_count",
 					analyzer = "standard",
+					enable_position_increments = false,
 					index = false,
 					null_value = 0.0
 				}
@@ -32,6 +33,7 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 			.TokenCount(s => s
 				.Name(p => p.Name)
 				.Analyzer("standard")
+				.EnablePositionIncrements(false)
 				.Index(false)
 				.NullValue(0.0)
 			);
@@ -44,6 +46,7 @@ namespace Tests.Mapping.Types.Specialized.TokenCount
 				{
 					Index = false,
 					Analyzer = "standard",
+					EnablePositionIncrements = false,
 					NullValue = 0.0
 				}
 			}


### PR DESCRIPTION
This PR adds the provisioning of enable_position_increments on `ITokenCountProperty` and `ITokenCountPropertyDescriptor` The problem this PR is solving is described in detail in this Issue: https://github.com/elastic/elasticsearch-net/issues/5186