### PR TITLE
[Backport 7.11] TcpStats.GetStats() now handles error when host cannot disclose information

### DIFF
--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -295,6 +295,7 @@ InitializerExample
         "type": "word_delimiter_graph",
         "generate_word_parts": true,
         "generate_number_parts": true,
+        "ignore_keywords": true,
         "catenate_words": true,
         "catenate_numbers": true,
         "catenate_all": true,

--- a/docs/client-concepts/troubleshooting/debug-information.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-information.asciidoc
@@ -137,6 +137,13 @@ var response = client.Search<Project>(s => s
 <2> Retrieve statistics about IPv4
 <3> Retrieve statistics about IPv6
 
+[NOTE]
+--
+Collecting TCP statistics may not be accessible in all environments, for example, Azure App Services.
+When this is the case, `TcpStats.GetActiveTcpConnections()` returns `null`.
+
+--
+
 ==== ThreadPool statistics
 
 It can often be useful to see the statistics for thread pool threads, particularly when

--- a/docs/search.asciidoc
+++ b/docs/search.asciidoc
@@ -29,6 +29,8 @@ NEST exposes all of the search request parameters available in Elasticsearch
 
 * <<min-score-usage,Min Score Usage>>
 
+* <<point-in-time-usage,Point In Time Usage>>
+
 * <<post-filter-usage,Post Filter Usage>>
 
 * <<profile-usage,Profile Usage>>
@@ -66,6 +68,8 @@ include::search/request/indices-boost-usage.asciidoc[]
 include::search/request/inner-hits-usage.asciidoc[]
 
 include::search/request/min-score-usage.asciidoc[]
+
+include::search/request/point-in-time-usage.asciidoc[]
 
 include::search/request/post-filter-usage.asciidoc[]
 

--- a/docs/search/request/point-in-time-usage.asciidoc
+++ b/docs/search/request/point-in-time-usage.asciidoc
@@ -1,0 +1,58 @@
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+
+:github: https://github.com/elastic/elasticsearch-net
+
+:nuget: https://www.nuget.org/packages
+
+////
+IMPORTANT NOTE
+==============
+This file has been generated from https://github.com/elastic/elasticsearch-net/tree/master/src/Tests/Tests/Search/Request/PointInTimeUsageTests.cs. 
+If you wish to submit a PR for any spelling mistakes, typos or grammatical errors for this file,
+please modify the original csharp file found at the link and submit the PR with that change. Thanks!
+////
+
+[[point-in-time-usage]]
+== Point In Time Usage
+
+A search request by default executes against the most recent visible data of the target indices, which is called point in time.
+Elasticsearch pit (point in time) is a lightweight view into the state of the data as it existed when initiated. In some cases,
+it's preferred to perform multiple search requests using the same point in time.
+
+IMPORTANT: Point in time search requests should not specify an index path parameter. When including a point in time in a
+search request, it will cause the URL path of the request to become the rooted '/_search' path instead of '/{index}/_search'.
+
+See the Elasticsearch documentation on {ref_current}/point-in-time-api.html[point in time API] for more detail.
+
+[float]
+=== Fluent DSL example
+
+[source,csharp]
+----
+s => s
+.PointInTime("a-point-in-time-id", p => p
+.KeepAlive("1m"))
+----
+
+[float]
+=== Object Initializer syntax example
+
+[source,csharp]
+----
+new SearchRequest<Project>
+{
+    PointInTime = new Nest.PointInTime("a-point-in-time-id", "1m")
+}
+----
+
+[source,javascript]
+.Example json output
+----
+{
+  "pit": {
+    "id": "a-point-in-time-id",
+    "keep_alive": "1m"
+  }
+}
+----
+

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugInformation.doc.cs
@@ -221,7 +221,12 @@ namespace Tests.ClientConcepts.Troubleshooting
 		}
 
 		 /**
-		 *
+		 * [NOTE]
+		 * --
+		 * Collecting TCP statistics may not be accessible in all environments, for example, Azure App Services.
+		 * When this is the case, `TcpStats.GetActiveTcpConnections()` returns `null`.
+		 * --
+		 * 
 		 * ==== ThreadPool statistics
          *
 		 * It can often be useful to see the statistics for thread pool threads, particularly when


### PR DESCRIPTION
Backport e777c37c25c0d18a8a908830b81dc5dc2a5a406e from #5177 