### PR TITLE
Implement version field type

### DIFF
--- a/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
+++ b/src/Nest/Mapping/DynamicTemplate/SingleMapping.cs
@@ -148,6 +148,10 @@ namespace Nest
 		/// <inheritdoc />
 		public IProperty Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) =>
 			selector?.Invoke(new WildcardPropertyDescriptor<T>());
+		
+		/// <inheritdoc />
+		public IProperty Version(Func<VersionPropertyDescriptor<T>, IVersionProperty> selector) =>
+			selector?.Invoke(new VersionPropertyDescriptor<T>());
 
 #pragma warning disable CS3001 // Argument type is not CLS-compliant
 		public IProperty Scalar(Expression<Func<T, int>> field, Func<NumberPropertyDescriptor<T>, INumberProperty> selector = null) =>

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -154,5 +154,11 @@ namespace Nest
 
 		[EnumMember(Value = "point")]
 		Point,
+
+		/// <summary>
+		/// Version field type for storing semver compatible version numbers.
+		/// </summary>
+		[EnumMember(Value = "version")]
+		Version
 	}
 }

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -151,6 +151,9 @@ namespace Nest
 
 		/// <inheritdoc cref="IWildcardProperty"/>
 		TReturnType Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector);
+
+		/// <inheritdoc cref="IVersionProperty"/>
+		TReturnType Version(Func<VersionPropertyDescriptor<T>, IVersionProperty> selector);
 	}
 
 	public partial class PropertiesDescriptor<T> where T : class

--- a/src/Nest/Mapping/Types/Properties.cs
+++ b/src/Nest/Mapping/Types/Properties.cs
@@ -263,8 +263,10 @@ namespace Nest
 			SetProperty(selector);
 
 		/// <inheritdoc cref="IWildcardProperty"/>
-		public PropertiesDescriptor<T> Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) =>
-			SetProperty(selector);
+		public PropertiesDescriptor<T> Wildcard(Func<WildcardPropertyDescriptor<T>, IWildcardProperty> selector) => SetProperty(selector);
+
+		/// <inheritdoc cref="IVersionProperty"/>
+		public PropertiesDescriptor<T> Version(Func<VersionPropertyDescriptor<T>, IVersionProperty> selector) => SetProperty(selector);
 
 		/// <summary>
 		/// Map a custom property.

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -100,6 +100,7 @@ namespace Nest
 				case FieldType.Histogram: return Deserialize<HistogramProperty>(ref segmentReader, formatterResolver);
 				case FieldType.ConstantKeyword: return Deserialize<ConstantKeywordProperty>(ref segmentReader, formatterResolver);
 				case FieldType.Wildcard: return Deserialize<WildcardProperty>(ref segmentReader, formatterResolver);
+				case FieldType.Version: return Deserialize<VersionProperty>(ref segmentReader, formatterResolver);
 				case FieldType.None:
 					// no "type" field in the property mapping, or FieldType enum could not be parsed from typeString
 					return Deserialize<ObjectProperty>(ref segmentReader, formatterResolver);
@@ -219,6 +220,9 @@ namespace Nest
 					break;
 				case IGenericProperty genericProperty:
 					Serialize(ref writer, genericProperty, formatterResolver);
+					break;
+				case IVersionProperty versionProperty:
+					Serialize(ref writer, versionProperty, formatterResolver);
 					break;
 				default:
 					var formatter = formatterResolver.GetFormatter<object>();

--- a/src/Nest/Mapping/Types/Specialized/Version/VersionAttribute.cs
+++ b/src/Nest/Mapping/Types/Specialized/Version/VersionAttribute.cs
@@ -1,0 +1,13 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Nest
+{
+	public class VersionAttribute : ElasticsearchPropertyAttributeBase, IVersionProperty
+	{
+		public VersionAttribute() : base(FieldType.Version) { }
+
+		private IVersionProperty Self => this;
+	}
+}

--- a/src/Nest/Mapping/Types/Specialized/Version/VersionProperty.cs
+++ b/src/Nest/Mapping/Types/Specialized/Version/VersionProperty.cs
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Diagnostics;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	/// <summary>
+	/// A version field can index/store semver version numbers.
+	/// </summary>
+	[InterfaceDataContract]
+	public interface IVersionProperty : IProperty
+	{
+	}
+
+	/// <inheritdoc cref="IVersionProperty"/>
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class VersionProperty : PropertyBase, IVersionProperty
+	{
+		public VersionProperty() : base(FieldType.Version) { }
+	}
+
+	/// <inheritdoc cref="IVersionProperty" />
+	[DebuggerDisplay("{DebugDisplay}")]
+	public class VersionPropertyDescriptor<T>
+		: PropertyDescriptorBase<VersionPropertyDescriptor<T>, IVersionProperty, T>, IVersionProperty
+		where T : class
+	{
+		public VersionPropertyDescriptor() : base(FieldType.Version) { }
+	}
+}

--- a/src/Nest/Mapping/Visitor/IMappingVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IMappingVisitor.cs
@@ -71,6 +71,8 @@ namespace Nest
 		void Visit(IHistogramProperty property);
 
 		void Visit(IConstantKeywordProperty property);
+
+		void Visit(IVersionProperty property);
 	}
 
 	public class NoopMappingVisitor : IMappingVisitor
@@ -140,5 +142,7 @@ namespace Nest
 		public virtual void Visit(IHistogramProperty property) { }
 
 		public virtual void Visit(IConstantKeywordProperty property) { }
+
+		public virtual void Visit(IVersionProperty property) { }
 	}
 }

--- a/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/IPropertyVisitor.cs
@@ -76,6 +76,8 @@ namespace Nest
 
 		void Visit(IWildcardProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
+		void Visit(IVersionProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
+
 		IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);
 
 		bool SkipProperty(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute);

--- a/src/Nest/Mapping/Visitor/MappingWalker.cs
+++ b/src/Nest/Mapping/Visitor/MappingWalker.cs
@@ -273,6 +273,12 @@ namespace Nest
 							_visitor.Visit(t);
 						});
 						break;
+					case FieldType.Version:
+						Visit<IVersionProperty>(field, t =>
+						{
+							_visitor.Visit(t);
+						});
+						break;
 					case FieldType.None:
 						continue;
 				}

--- a/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
+++ b/src/Nest/Mapping/Visitor/NoopPropertyVisitor.cs
@@ -77,6 +77,8 @@ namespace Nest
 
 		public virtual void Visit(IWildcardProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
 
+		public virtual void Visit(IVersionProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) { }
+
 		public virtual IProperty Visit(PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute) => null;
 
 		public void Visit(IProperty type, PropertyInfo propertyInfo, ElasticsearchPropertyAttributeBase attribute)
@@ -169,7 +171,7 @@ namespace Nest
 					break;
 				case IPointProperty point:
 					Visit(point, propertyInfo, attribute);
-          break;
+					break;
 				case ISearchAsYouTypeProperty searchAsYouType:
 					Visit(searchAsYouType, propertyInfo, attribute);
 					break;
@@ -178,6 +180,9 @@ namespace Nest
 					break;
 				case IFieldAliasProperty fieldAlias:
 					Visit(fieldAlias, propertyInfo, attribute);
+					break;
+				case IVersionProperty version:
+					Visit(version, propertyInfo, attribute);
 					break;
 			}
 		}

--- a/src/Nest/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
+++ b/src/Nest/Search/FieldCapabilities/FieldCapabilitiesResponse.cs
@@ -53,7 +53,6 @@ namespace Nest
 		public FieldCapabilities Integer => BackingDictionary.TryGetValue("integer", out var f) ? f : null;
 		public FieldCapabilities IntegerRange => BackingDictionary.TryGetValue("integer_range", out var f) ? f : null;
 		public FieldCapabilities Ip => BackingDictionary.TryGetValue("ip", out var f) ? f : null;
-
 		public FieldCapabilities Keyword => BackingDictionary.TryGetValue("keyword", out var f) ? f : null;
 		public FieldCapabilities Long => BackingDictionary.TryGetValue("long", out var f) ? f : null;
 		public FieldCapabilities LongRange => BackingDictionary.TryGetValue("long_range", out var f) ? f : null;
@@ -71,6 +70,7 @@ namespace Nest
 		public FieldCapabilities Uid => BackingDictionary.TryGetValue("_uid", out var f) ? f : null;
 		public FieldCapabilities ParentJoin => BackingDictionary.TryGetValue("_parent_join", out var f) ? f : null;
 		public FieldCapabilities Version => BackingDictionary.TryGetValue("_version", out var f) ? f : null;
+		public FieldCapabilities VersionField => BackingDictionary.TryGetValue("version", out var f) ? f : null;
 	}
 
 	public class FieldCapabilities

--- a/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/GetMapping/GetMappingApiTest.cs
@@ -229,6 +229,8 @@ namespace Tests.Indices.MappingManagement.GetMapping
 
 		public void Visit(IConstantKeywordProperty property) => Increment("constant_keyword");
 
+		public void Visit(IVersionProperty property) => Increment("version");
+
 		private void Increment(string key)
 		{
 			if (!Counts.ContainsKey(key)) Counts.Add(key, 0);

--- a/tests/Tests/Mapping/Types/Specialized/Version/VersionAttributeTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Version/VersionAttributeTests.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using Nest;
+
+namespace Tests.Mapping.Types.Specialized.Version
+{
+	public class VersionTest
+	{
+		[Version]
+		public string VersionNumber { get; set; }
+	}
+
+	public class VersionAttributeTests : AttributeTestsBase<VersionTest>
+	{
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				versionNumber = new
+				{
+					type = "version"
+				}
+			}
+		};
+	}
+}

--- a/tests/Tests/Mapping/Types/Specialized/Version/VersionPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Version/VersionPropertyTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -10,6 +11,7 @@ using Tests.Framework.EndpointTests.TestState;
 
 namespace Tests.Mapping.Types.Specialized.Version
 {
+	[SkipVersion("<7.10.0", "Version property introduced in 7.10.0")]
 	public class VersionPropertyTests : PropertyTestsBase
 	{
 		public VersionPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }

--- a/tests/Tests/Mapping/Types/Specialized/Version/VersionPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Specialized/Version/VersionPropertyTests.cs
@@ -1,0 +1,42 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.Types.Specialized.Version
+{
+	public class VersionPropertyTests : PropertyTestsBase
+	{
+		public VersionPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				name = new
+				{
+					type = "version"
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.Version(s => s
+				.Name(p => p.Name)
+			);
+
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"name", new VersionProperty
+				{
+				}
+			}
+		};
+	}
+}


### PR DESCRIPTION
@Mpdreamz I've attempted this by reviewing previous PRs and a bit of sleuthing! Please let me know if I've missed anything. I've been able to use the mapping on a test project.

Main challenge in naming in `FieldCapabilities` since that already has the concept of the "_version" field. I welcome opinions on the naming. Perhaps in 8.0 we can consider renaming both of these so that `Version` becomes `DocVersion`?