### PR TITLE
[Backport master] Fix failing transform tests and support dates_as_epoch_millis

### DIFF
--- a/src/Nest/XPack/Transform/TransformSettings.cs
+++ b/src/Nest/XPack/Transform/TransformSettings.cs
@@ -21,6 +21,9 @@ namespace Nest
 
 		[DataMember(Name = "max_page_search_size")]
 		public int? MaxPageSearchSize { get; set; }
+
+		[DataMember(Name = "dates_as_epoch_millis")]
+		public bool? DatesAsEpochMilliseconds { get; set; }
 	}
 
 	/// <inheritdoc />
@@ -31,12 +34,16 @@ namespace Nest
 
 		/// <inheritdoc />
 		public int? MaxPageSearchSize { get; set; }
+
+		/// <inheritdoc />
+		public bool? DatesAsEpochMilliseconds { get; set; }
 	}
 
 	public class TransformSettingsDescriptor : DescriptorBase<TransformSettingsDescriptor, ITransformSettings>, ITransformSettings
 	{
 		float? ITransformSettings.DocsPerSecond { get; set; }
 		int? ITransformSettings.MaxPageSearchSize { get; set; }
+		bool? ITransformSettings.DatesAsEpochMilliseconds { get; set; }
 
 		/// <inheritdoc cref="ITransformSettings.DocsPerSecond"/>
 		public TransformSettingsDescriptor DocsPerSecond(float? docsPerSecond) =>
@@ -45,5 +52,9 @@ namespace Nest
 		/// <inheritdoc cref="ITransformSettings.MaxPageSearchSize"/>
 		public TransformSettingsDescriptor MaxPageSearchSize(int? maxPageSearchSize) =>
 			Assign(maxPageSearchSize, (a, v) => a.MaxPageSearchSize = v);
+
+		/// <inheritdoc cref="ITransformSettings.DatesAsEpochMilliseconds"/>
+		public TransformSettingsDescriptor DatesAsEpochMilliseconds(bool? datesAsEpochMillis = true) =>
+			Assign(datesAsEpochMillis, (a, v) => a.DatesAsEpochMilliseconds = v);
 	}
 }

--- a/tests/Tests.Domain/Project.cs
+++ b/tests/Tests.Domain/Project.cs
@@ -196,8 +196,10 @@ namespace Tests.Domain
 	public class ProjectTransform
 	{
 		public double? AverageCommits { get; set; }
+		
+		public long WeekStartedOnMillis { get; set; }
 
-		public long WeekStartedOn { get; set; }
+		public DateTime WeekStartedOnDate { get; set; }
 
 		public long SumIntoMaster { get; set; }
 	}

--- a/tests/Tests/XPack/Transform/TransformApiWithSettingsTests.cs
+++ b/tests/Tests/XPack/Transform/TransformApiWithSettingsTests.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elastic.Transport;
 using Nest;
+using Tests.Core.Client;
+using Tests.Core.Extensions;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
 using Tests.Framework.EndpointTests;
@@ -16,87 +18,232 @@ using static Nest.Infer;
 namespace Tests.XPack.Transform
 {
 	[SkipVersion("<7.8.0", "Settings introduced in 7.8.0")]
-	public class TransformApiWithSettingsTests : ApiIntegrationTestBase<WritableCluster, PreviewTransformResponse<ProjectTransform>, IPreviewTransformRequest, PreviewTransformDescriptor<Project>, PreviewTransformRequest>
+	public class TransformApiWithSettingsTests
+		: ApiIntegrationTestBase<WritableCluster, PreviewTransformResponse<ProjectTransform>, IPreviewTransformRequest, PreviewTransformDescriptor<Project>, PreviewTransformRequest>
 	{
 		public TransformApiWithSettingsTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
 		protected override LazyResponses ClientUsage() => Calls(
-			(client, f) => client.Transform.Preview<Project, ProjectTransform>(f),
-			(client, f) => client.Transform.PreviewAsync<Project, ProjectTransform>(f),
-			(client, r) => client.Transform.Preview<ProjectTransform>(r),
-			(client, r) => client.Transform.PreviewAsync<ProjectTransform>(r)
-		);
+				(client, f) => client.Transform.Preview<Project, ProjectTransform>(f),
+				(client, f) => client.Transform.PreviewAsync<Project, ProjectTransform>(f),
+				(client, r) => client.Transform.Preview<ProjectTransform>(r),
+				(client, r) => client.Transform.PreviewAsync<ProjectTransform>(r));
 
 		protected override HttpMethod HttpMethod => HttpMethod.POST;
-		protected override string UrlPath => $"_transform/_preview";
+		protected override string UrlPath => "_transform/_preview";
 		protected override bool ExpectIsValid => true;
 		protected override int ExpectStatusCode => 200;
 		protected override bool SupportsDeserialization => false;
-		protected override object ExpectJson => new
+
+		protected override object ExpectJson
 		{
-			description = CallIsolatedValue,
-			frequency = "1s",
-			source = new { index = new[] { "project" }, query = new { match_all = new { } } },
-			dest = new { index = $"transform-{CallIsolatedValue}" },
-			pivot = new
+			get
 			{
-				aggregations = new
+				var settings = TestClient.Configuration.InRange("<7.11.0")
+					? (dynamic)new { docs_per_second = 200.0, max_page_search_size = 200 }
+					: new { docs_per_second = 200.0, max_page_search_size = 200, dates_as_epoch_millis = true };
+
+				return new
 				{
-					averageCommits = new
+					description = CallIsolatedValue,
+					frequency = "1s",
+					source = new { index = new[] { "project" }, query = new { match_all = new { } } },
+					dest = new { index = $"transform-{CallIsolatedValue}" },
+					pivot = new
 					{
-						avg = new
+						aggregations = new
 						{
-							field = "numberOfCommits"
-						}
-					},
-					sumIntoMaster = new
-					{
-						scripted_metric = new
+							averageCommits = new
+							{
+								avg = new
+								{
+									field = "numberOfCommits"
+								}
+							},
+							sumIntoMaster = new
+							{
+								scripted_metric = new
+								{
+									combine_script = new
+									{
+										source = "long sum = 0; for (s in state.masterCommits) { sum += s } return sum"
+									},
+									init_script = new
+									{
+										source = "state.masterCommits = []"
+									},
+									map_script = new
+									{
+										source = "state.masterCommits.add(doc['branches.keyword'].contains('master')? 1 : 0)"
+									},
+									reduce_script = new
+									{
+										source = "long sum = 0; for (s in states) { sum += s } return sum"
+									}
+								}
+							}
+						},
+						group_by = new
 						{
-							combine_script = new
+							weekStartedOnMillis = new
 							{
-								source = "long sum = 0; for (s in state.masterCommits) { sum += s } return sum"
-							},
-							init_script = new
-							{
-								source = "state.masterCommits = []"
-							},
-							map_script = new
-							{
-								source = "state.masterCommits.add(doc['branches.keyword'].contains('master')? 1 : 0)"
-							},
-							reduce_script = new
-							{
-								source = "long sum = 0; for (s in states) { sum += s } return sum"
+								date_histogram = new
+								{
+									calendar_interval = "week",
+									field = "startedOn"
+								}
 							}
 						}
-					}
-				},
-				group_by = new
-				{
-					weekStartedOn = new
+					},
+					sync = new
 					{
-						date_histogram = new
+						time = new
 						{
-							calendar_interval = "week",
-							field = "startedOn"
+							field = "lastActivity"
 						}
-					}
-				}
-			},
-			sync = new
-			{
-				time = new
-				{
-					field = "lastActivity"
-				}
-			},
-			settings = new
-			{
-				docs_per_second = 200.0,
-				max_page_search_size = 200
+					},
+					settings
+				};
 			}
-		};
+		}
+
+		protected override PreviewTransformRequest Initializer
+		{
+			get
+			{
+				var settings = new TransformSettings { MaxPageSearchSize = 200, DocsPerSecond = 200 };
+
+				if (TestClient.Configuration.InRange(">=7.11.0"))
+					settings.DatesAsEpochMilliseconds = true;
+
+				return new PreviewTransformRequest
+				{
+					Description = CallIsolatedValue,
+					Frequency = "1s",
+					Source = new TransformSource { Index = Index<Project>(), Query = new MatchAllQuery() },
+					Destination = new TransformDestination { Index = $"transform-{CallIsolatedValue}" },
+					Pivot = new TransformPivot
+					{
+						Aggregations =
+							new AverageAggregation("averageCommits", Field<Project>(f => f.NumberOfCommits)) &&
+							new ScriptedMetricAggregation("sumIntoMaster")
+							{
+								InitScript = new InlineScript("state.masterCommits = []"),
+								MapScript = new InlineScript("state.masterCommits.add(doc['branches.keyword'].contains('master')? 1 : 0)"),
+								CombineScript = new InlineScript("long sum = 0; for (s in state.masterCommits) { sum += s } return sum"),
+								ReduceScript = new InlineScript("long sum = 0; for (s in states) { sum += s } return sum")
+							},
+						GroupBy = new Dictionary<string, ISingleGroupSource>
+						{
+							{
+								"weekStartedOnMillis",
+								new DateHistogramGroupSource { Field = Field<Project>(f => f.StartedOn), CalendarInterval = DateInterval.Week }
+							}
+						}
+					},
+					Sync = new TransformSyncContainer(new TransformTimeSync { Field = Field<Project>(f => f.LastActivity) }),
+					Settings = settings
+				};
+			}
+		}
+
+		protected override Func<PreviewTransformDescriptor<Project>, IPreviewTransformRequest> Fluent => f => f
+			.Description(CallIsolatedValue)
+			.Frequency(new Time(1, TimeUnit.Second))
+			.Source(s => s
+				.Index<Project>()
+				.Query(q => q.MatchAll())
+			)
+			.Destination(de => de
+				.Index($"transform-{CallIsolatedValue}")
+			)
+			.Pivot(p => p
+				.Aggregations(a => a
+					.Average("averageCommits", avg => avg
+						.Field(fld => fld.NumberOfCommits)
+					)
+					.ScriptedMetric("sumIntoMaster", sm => sm
+						.InitScript("state.masterCommits = []")
+						.MapScript("state.masterCommits.add(doc['branches.keyword'].contains('master')? 1 : 0)")
+						.CombineScript("long sum = 0; for (s in state.masterCommits) { sum += s } return sum")
+						.ReduceScript("long sum = 0; for (s in states) { sum += s } return sum")
+					)
+				)
+				.GroupBy(g => g
+					.DateHistogram("weekStartedOnMillis", dh => dh
+						.Field(fld => fld.StartedOn)
+						.CalendarInterval(DateInterval.Week)
+					)
+				)
+			)
+			.Sync(sy => sy
+				.Time(t => t
+					.Field(fld => fld.LastActivity)
+				)
+			).Settings(s =>
+				{
+					var descriptor = s
+						.MaxPageSearchSize(200)
+						.DocsPerSecond(200);
+
+					if (TestClient.Configuration.InRange(">=7.11.0"))
+						descriptor.DatesAsEpochMilliseconds(true);
+
+					return descriptor;
+				});
+	}
+
+	[SkipVersion("<7.11.0", "Settings introduced in 7.11.0")]
+	public class TransformApiWithSettingsAndNoDatesAsMillisTests
+		: ApiIntegrationTestBase<WritableCluster, PreviewTransformResponse<ProjectTransform>, IPreviewTransformRequest, PreviewTransformDescriptor<Project>, PreviewTransformRequest>
+	{
+		// From 7.11, by default, ISO dates are used for transforms, rather than epoch millis.
+		// This test verifies the default behaviour, without configuring the setting, results in a date
+
+		public TransformApiWithSettingsAndNoDatesAsMillisTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override LazyResponses ClientUsage() =>
+			Calls(
+				(client, f) => client.Transform.Preview<Project, ProjectTransform>(f),
+				(client, f) => client.Transform.PreviewAsync<Project, ProjectTransform>(f),
+				(client, r) => client.Transform.Preview<ProjectTransform>(r),
+				(client, r) => client.Transform.PreviewAsync<ProjectTransform>(r));
+
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+		protected override string UrlPath => "_transform/_preview";
+		protected override bool ExpectIsValid => true;
+		protected override int ExpectStatusCode => 200;
+		protected override bool SupportsDeserialization => false;
+
+		protected override object ExpectJson =>
+			new
+			{
+				description = CallIsolatedValue,
+				frequency = "1s",
+				source = new { index = new[] { "project" }, query = new { match_all = new { } } },
+				dest = new { index = $"transform-{CallIsolatedValue}" },
+				pivot = new
+				{
+					aggregations = new
+					{
+						averageCommits = new { avg = new { field = "numberOfCommits" } },
+						sumIntoMaster = new
+						{
+							scripted_metric = new
+							{
+								combine_script =
+									new { source = "long sum = 0; for (s in state.masterCommits) { sum += s } return sum" },
+								init_script = new { source = "state.masterCommits = []" },
+								map_script = new { source = "state.masterCommits.add(doc['branches.keyword'].contains('master')? 1 : 0)" },
+								reduce_script = new { source = "long sum = 0; for (s in states) { sum += s } return sum" }
+							}
+						}
+					},
+					group_by = new { weekStartedOnDate = new { date_histogram = new { calendar_interval = "week", field = "startedOn" } } }
+				},
+				sync = new { time = new { field = "lastActivity" } },
+				settings = new { docs_per_second = 200.0, max_page_search_size = 200 }
+			};
 
 		protected override PreviewTransformRequest Initializer => new PreviewTransformRequest
 		{
@@ -118,8 +265,8 @@ namespace Tests.XPack.Transform
 				GroupBy = new Dictionary<string, ISingleGroupSource>
 				{
 					{
-						"weekStartedOn",
-						new DateHistogramGroupSource() { Field = Field<Project>(f => f.StartedOn), CalendarInterval = DateInterval.Week }
+						"weekStartedOnDate",
+						new DateHistogramGroupSource { Field = Field<Project>(f => f.StartedOn), CalendarInterval = DateInterval.Week }
 					}
 				}
 			},
@@ -140,7 +287,7 @@ namespace Tests.XPack.Transform
 			.Pivot(p => p
 				.Aggregations(a => a
 					.Average("averageCommits", avg => avg
-						.Field(af => af.NumberOfCommits)
+						.Field(fld => fld.NumberOfCommits)
 					)
 					.ScriptedMetric("sumIntoMaster", sm => sm
 						.InitScript("state.masterCommits = []")
@@ -150,20 +297,18 @@ namespace Tests.XPack.Transform
 					)
 				)
 				.GroupBy(g => g
-					.DateHistogram("weekStartedOn", dh => dh
-						.Field(df => df.StartedOn)
+					.DateHistogram("weekStartedOnDate", dh => dh
+						.Field(fld => fld.StartedOn)
 						.CalendarInterval(DateInterval.Week)
 					)
 				)
 			)
 			.Sync(sy => sy
 				.Time(t => t
-					.Field(tf => tf.LastActivity)
+					.Field(fld => fld.LastActivity)
 				)
-			)
-			.Settings(s => s
+			).Settings(s => s
 				.MaxPageSearchSize(200)
-				.DocsPerSecond(200)
-			);
+				.DocsPerSecond(200));
 	}
 }


### PR DESCRIPTION
Tests were failing due to a change in the transform API which now
prefers ISO dates, rather than epoch milliseconds for dates. This
resulted in a serialisation failure.

This commit addresses that by conditionally producing the requests
based on the version of ES being tested, so that a property of the
appropriate type is used for deserialisation of the preview.

This also adds support for the now dates_as_epoch_millis setting which
allows the original epoch millisecond format to be returned for ES 7.11
requests, when the option is true.

(cherry picked from commit 7994d6fdf7734a5cb7b774e80dfc463fefd2b9cb)
Backport 7994d6fdf7734a5cb7b774e80dfc463fefd2b9cb from #5209