### PR TITLE
Fix deserialisation of aggs in Translate response

### DIFF
--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -294,7 +294,15 @@ namespace Nest
 	{
 		public IAdjacencyMatrixAggregation AdjacencyMatrix { get; set; }
 
-		public AggregationDictionary Aggregations { get; set; }
+		// This is currently used to support deserializing the response from SQL Translate,
+		// which forms a response which uses "aggregations", rather than "aggs". Longer term
+		// it would be preferred to address that in Elasticsearch itself.
+		[DataMember(Name = "aggregations")]
+		private AggregationDictionary _aggs;
+		
+		// ReSharper disable once ConvertToAutoProperty
+		public AggregationDictionary Aggregations { get => _aggs; set => _aggs = value; }
+		
 		public IAverageAggregation Average { get; set; }
 
 		public IAverageBucketAggregation AverageBucket { get; set; }

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -179,8 +179,15 @@ namespace Nest
 	[DataContract]
 	public partial class SearchRequest
 	{
+		// This is currently used to support deserializing the response from SQL Translate,
+		// which forms a response which uses "aggregations", rather than "aggs". Longer term
+		// it would be preferred to address that in Elasticsearch itself.
+		[DataMember(Name = "aggregations")]
+		private AggregationDictionary _aggs;
+
 		/// <inheritdoc />
-		public AggregationDictionary Aggregations { get; set; }
+		// ReSharper disable once ConvertToAutoProperty
+		public AggregationDictionary Aggregations { get => _aggs; set => _aggs = value; }
 		/// <inheritdoc />
 		public IFieldCollapse Collapse { get; set; }
 		/// <inheritdoc />

--- a/tests/Tests.Reproduce/GithubIssue5201.cs
+++ b/tests/Tests.Reproduce/GithubIssue5201.cs
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue5201
+	{
+		private static readonly byte[] ResponseBytes = Encoding.UTF8.GetBytes(@"{
+		          ""size"" : 0,
+		          ""_source"" : false,
+		          ""stored_fields"" : ""_none_"",
+		          ""aggregations"" : {
+		            ""groupby"" : {
+		                ""composite"" : {
+		                    ""size"" : 1000,
+		                    ""sources"" : [
+		                        {
+		                            ""ccf51bfa"" : {
+		                                ""terms"" : {
+		                                    ""field"" : ""id"",
+		                                    ""missing_bucket"" : true,
+		                                    ""order"" : ""asc""
+		                                }
+		                            }
+		                        }
+		                    ]
+		                }
+		            }
+		        }
+		    }");
+
+		[U] public async Task DeserializeAggregations()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri($"http://localhost:9200"));
+			var settings = new ConnectionSettings(pool, new InMemoryConnection(ResponseBytes));
+			var client = new ElasticClient(settings);
+
+			var translateResponseAsync = await client.Sql.TranslateAsync(t => t.Query("select UDFvarchar1, count(1) from interactions group by UDFvarchar1 order by UDFvarchar1"));
+			translateResponseAsync.Result.Aggregations.Should().NotBeNull();
+
+			var translateResponse = client.Sql.Translate(t => t.Query("select UDFvarchar1, count(1) from interactions group by UDFvarchar1 order by UDFvarchar1"));
+			translateResponse.Result.Aggregations.Should().NotBeNull();
+		}
+	}
+}


### PR DESCRIPTION
The Translate API in Elasticsearch returns aggregations using the key "aggregations" rather than "aggs". This results in aggregations not appearing in the `SearchRequest` instance.

This fix adds a field so that aggregations deserialise correctly using UTF8Json in the `DefaultHighLevelSerializer`.

I'll open an issue in Elasticsearch to review whether in 8.0, it should prefer "aggs" by default.

Fixes #5201 