### PR TITLE
Support mapping runtime fields

### DIFF
--- a/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
+++ b/src/Nest/Indices/MappingManagement/PutMapping/PutMappingRequest.cs
@@ -57,6 +57,9 @@ namespace Nest
 		public IRoutingField RoutingField { get; set; }
 
 		/// <inheritdoc />
+		public IRuntimeFields RuntimeFields { get; set; }
+		
+		/// <inheritdoc />
 		public ISizeField SizeField { get; set; }
 
 		/// <inheritdoc />
@@ -82,6 +85,7 @@ namespace Nest
 		bool? ITypeMapping.NumericDetection { get; set; }
 		IProperties ITypeMapping.Properties { get; set; }
 		IRoutingField ITypeMapping.RoutingField { get; set; }
+		IRuntimeFields ITypeMapping.RuntimeFields { get; set; }
 		ISizeField ITypeMapping.SizeField { get; set; }
 		ISourceField ITypeMapping.SourceField { get; set; }
 
@@ -149,6 +153,10 @@ namespace Nest
 		/// <inheritdoc cref="ITypeMapping.RoutingField" />
 		public PutMappingDescriptor<TDocument> RoutingField(Func<RoutingFieldDescriptor<TDocument>, IRoutingField> routingFieldSelector) =>
 			Assign(routingFieldSelector, (a, v) => a.RoutingField = v?.Invoke(new RoutingFieldDescriptor<TDocument>()));
+
+		/// <inheritdoc cref="ITypeMapping.RuntimeFields" />
+		public PutMappingDescriptor<TDocument> RuntimeFields(Func<RuntimeFieldsDescriptor, IPromise<IRuntimeFields>> runtimeFieldsSelector) =>
+			Assign(runtimeFieldsSelector, (a, v) => a.RuntimeFields = v?.Invoke(new RuntimeFieldsDescriptor())?.Value);
 
 		/// <inheritdoc cref="ITypeMapping.FieldNamesField" />
 		public PutMappingDescriptor<TDocument> FieldNamesField(Func<FieldNamesFieldDescriptor<TDocument>, IFieldNamesField> fieldNamesFieldSelector) =>

--- a/src/Nest/Mapping/Mappings.cs
+++ b/src/Nest/Mapping/Mappings.cs
@@ -57,6 +57,8 @@ namespace Nest
 		IProperties ITypeMapping.Properties { get => Wrapped.Properties; set => Wrapped.Properties = value; }
 		[DataMember(Name = "_routing")]
 		IRoutingField ITypeMapping.RoutingField { get => Wrapped.RoutingField; set => Wrapped.RoutingField = value; }
+		[DataMember(Name = "runtime")]
+		IRuntimeFields ITypeMapping.RuntimeFields { get => Wrapped.RuntimeFields; set => Wrapped.RuntimeFields = value; }
 		[DataMember(Name = "_size")]
 		ISizeField ITypeMapping.SizeField { get => Wrapped.SizeField; set => Wrapped.SizeField = value; }
 		[DataMember(Name = "_source")]

--- a/src/Nest/Mapping/RuntimeFields/RuntimeField.cs
+++ b/src/Nest/Mapping/RuntimeFields/RuntimeField.cs
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Runtime.Serialization;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	[InterfaceDataContract]
+	[ReadAs(typeof(RuntimeField))]
+	public interface IRuntimeField
+	{
+		/// <summary>
+		/// Runtime fields with a type of date can accept the format parameter exactly as the date field type.
+		/// <see cref="DateFormat" />
+		/// </summary>
+		[DataMember(Name = "format")]
+		string Format { get; set; }
+
+		/// <summary>
+		/// The script to be evaluated for field calculation at search time.
+		/// </summary>
+		[DataMember(Name = "script")]
+		IStoredScript Script { get; set; }
+
+		/// <summary>
+		/// The datatype of the runtime field.
+		/// </summary>
+		[DataMember(Name = "type")]
+		FieldType Type { get; set; }
+	}
+
+	public class RuntimeField : IRuntimeField
+	{
+		/// <inheritdoc />
+		public string Format { get; set; }
+		/// <inheritdoc />
+		public IStoredScript Script { get; set; }
+		/// <inheritdoc />
+		public FieldType Type { get; set; }
+	}
+
+	public class RuntimeFieldDescriptor
+		: DescriptorBase<RuntimeFieldDescriptor, IRuntimeField>, IRuntimeField
+	{
+		public RuntimeFieldDescriptor(FieldType fieldType) => Self.Type = fieldType;
+
+		string IRuntimeField.Format { get; set; }
+		IStoredScript IRuntimeField.Script { get; set; }
+		FieldType IRuntimeField.Type { get; set; }
+
+		public RuntimeFieldDescriptor Format(string format) => Assign(format, (a, v) => a.Format = v);
+		
+		public RuntimeFieldDescriptor Script(IStoredScript script) => Assign(script, (a, v) => a.Script = v);
+
+		public RuntimeFieldDescriptor Script(string source) => Assign(source, (a, v) => a.Script = new PainlessScript(source));
+	}
+}

--- a/src/Nest/Mapping/RuntimeFields/RuntimeFields.cs
+++ b/src/Nest/Mapping/RuntimeFields/RuntimeFields.cs
@@ -1,0 +1,36 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elasticsearch.Net.Utf8Json;
+
+namespace Nest
+{
+	[JsonFormatter(typeof(VerbatimDictionaryKeysFormatter<RuntimeFields, IRuntimeFields, string, IRuntimeField>))]
+	public interface IRuntimeFields : IIsADictionary<string, IRuntimeField> { }
+
+	public class RuntimeFields : IsADictionaryBase<string, IRuntimeField>, IRuntimeFields
+	{
+		public RuntimeFields() { }
+
+		public RuntimeFields(IDictionary<string, IRuntimeField> container) : base(container) { }
+
+		public RuntimeFields(Dictionary<string, IRuntimeField> container) : base(container) { }
+
+		public void Add(string name, IRuntimeField runtimeField) => BackingDictionary.Add(name, runtimeField);
+	}
+
+	public class RuntimeFieldsDescriptor
+		: IsADictionaryDescriptorBase<RuntimeFieldsDescriptor, RuntimeFields, string, IRuntimeField>
+	{
+		public RuntimeFieldsDescriptor() : base(new RuntimeFields()) { }
+
+		public RuntimeFieldsDescriptor RuntimeField(string name, FieldType type, Func<RuntimeFieldDescriptor, IRuntimeField> selector) =>
+			Assign(name, selector?.Invoke(new RuntimeFieldDescriptor(type)));
+
+		public RuntimeFieldsDescriptor RuntimeField(string name, FieldType type) =>
+			Assign(name, new RuntimeFieldDescriptor(type));
+	}
+}

--- a/src/Nest/Mapping/TypeMapping.cs
+++ b/src/Nest/Mapping/TypeMapping.cs
@@ -97,6 +97,12 @@ namespace Nest
 		IRoutingField RoutingField { get; set; }
 
 		/// <summary>
+		/// Specifies runtime fields for the mapping.
+		/// </summary>
+		[DataMember(Name = "runtime")]
+		IRuntimeFields RuntimeFields { get; set; }
+
+		/// <summary>
 		/// If enabled, indexes the size in bytes of the original _source field.
 		/// Requires mapper-size plugin be installed
 		/// </summary>
@@ -148,6 +154,9 @@ namespace Nest
 		public IRoutingField RoutingField { get; set; }
 
 		/// <inheritdoc />
+		public IRuntimeFields RuntimeFields { get; set; }
+
+		/// <inheritdoc />
 		public ISizeField SizeField { get; set; }
 
 		/// <inheritdoc />
@@ -171,6 +180,7 @@ namespace Nest
 		bool? ITypeMapping.NumericDetection { get; set; }
 		IProperties ITypeMapping.Properties { get; set; }
 		IRoutingField ITypeMapping.RoutingField { get; set; }
+		IRuntimeFields ITypeMapping.RuntimeFields { get; set; }
 		ISizeField ITypeMapping.SizeField { get; set; }
 		ISourceField ITypeMapping.SourceField { get; set; }
 
@@ -258,6 +268,10 @@ namespace Nest
 		/// <inheritdoc cref="ITypeMapping.RoutingField" />
 		public TypeMappingDescriptor<T> RoutingField(Func<RoutingFieldDescriptor<T>, IRoutingField> routingFieldSelector) =>
 			Assign(routingFieldSelector, (a, v) => a.RoutingField = v?.Invoke(new RoutingFieldDescriptor<T>()));
+
+		/// <inheritdoc cref="ITypeMapping.RuntimeFields" />
+		public TypeMappingDescriptor<T> RuntimeFields(Func<RuntimeFieldsDescriptor, IPromise<IRuntimeFields>> runtimeFieldsSelector) =>
+			Assign(runtimeFieldsSelector, (a, v) => a.RuntimeFields = v?.Invoke(new RuntimeFieldsDescriptor())?.Value);
 
 		/// <inheritdoc cref="ITypeMapping.FieldNamesField" />
 		public TypeMappingDescriptor<T> FieldNamesField(Func<FieldNamesFieldDescriptor<T>, IFieldNamesField> fieldNamesFieldSelector) =>

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -167,6 +167,9 @@ namespace Nest
 		[DataMember(Name = "version")]
 		bool? Version { get; set; }
 
+		/// <summary>
+		/// The <see cref="PointInTime"/> to search over.
+		/// </summary>
 		[DataMember(Name = "pit")]
 		IPointInTime PointInTime { get; set; }
 	}

--- a/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
+++ b/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
@@ -1,0 +1,178 @@
+﻿// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Linq;
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.Mapping.RuntimeFields
+{
+	[SkipVersion("<7.11.0", "Runtime fields introduced in 7.11.0")]
+	public class RuntimeFieldsTests : CoordinatedIntegrationTestBase<WritableCluster>
+	{
+		private const string ScriptValue = "emit(doc['lastActivity'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))";
+		private const string DateFormat = "yyyy-MM-dd";
+		private const string RuntimeFieldNameOne = "runtimeFieldOne";
+		private const string RuntimeFieldNameTwo = "runtimeFieldTwo";
+
+		private const string CreateIndexWithMappingStep = nameof(CreateIndexWithMappingStep);
+		private const string GetCreatedIndexMappingStep = nameof(GetCreatedIndexMappingStep);
+		private const string DeleteIndexStep = nameof(DeleteIndexStep);
+		private const string CreateIndexWithoutMappingStep = nameof(CreateIndexWithoutMappingStep);
+		private const string CreateMappingStep = nameof(CreateMappingStep);
+		private const string GetMappingStep = nameof(GetMappingStep);
+
+		public RuntimeFieldsTests(WritableCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage)
+		{
+			{
+				CreateIndexWithMappingStep, u =>
+					u.Calls<CreateIndexDescriptor, CreateIndexRequest, ICreateIndexRequest, CreateIndexResponse>(
+						v => new CreateIndexRequest(v)
+						{
+							Mappings = new TypeMapping
+							{
+								RuntimeFields = new Nest.RuntimeFields
+								{
+									{RuntimeFieldNameOne, new RuntimeField
+									{
+										Type = FieldType.Keyword,
+										Script = new PainlessScript(ScriptValue)
+									}},
+									{RuntimeFieldNameTwo, new RuntimeField
+									{
+										Type = FieldType.Date,
+										Format = DateFormat
+									}}
+								}
+							}
+						},
+						(v, d) => d.Index(v).Map(mapping => mapping
+							.RuntimeFields(rtf => rtf
+								.RuntimeField(RuntimeFieldNameOne, FieldType.Keyword, f1 => f1
+									.Script(ScriptValue))
+								.RuntimeField(RuntimeFieldNameTwo, FieldType.Date, f2 => f2.Format(DateFormat)))),
+						(v, c, f) => c.Indices.Create(v, f),
+						(v, c, f) => c.Indices.CreateAsync(v, f),
+						(v, c, r) => c.Indices.Create(r),
+						(v, c, r) => c.Indices.CreateAsync(r)
+					)
+			},
+			{
+				GetCreatedIndexMappingStep, u =>
+					u.Calls<GetMappingDescriptor<Project>, GetMappingRequest, IGetMappingRequest, GetMappingResponse>(
+						v => new GetMappingRequest(v),
+						(v, d) => d.Index(v),
+						(v, c, f) => c.Indices.GetMapping(f),
+						(v, c, f) => c.Indices.GetMappingAsync(f),
+						(v, c, r) => c.Indices.GetMapping(r),
+						(v, c, r) => c.Indices.GetMappingAsync(r)
+					)
+			},
+			{
+				DeleteIndexStep, u =>
+					u.Calls<DeleteIndexDescriptor, DeleteIndexRequest, IDeleteIndexRequest, DeleteIndexResponse>(
+						v => new DeleteIndexRequest(v),
+						(v, d) => d,
+						(v, c, f) => c.Indices.Delete(v, f),
+						(v, c, f) => c.Indices.DeleteAsync(v, f),
+						(v, c, r) => c.Indices.Delete(r),
+						(v, c, r) => c.Indices.DeleteAsync(r)
+					)
+			},
+			{
+				CreateIndexWithoutMappingStep, u =>
+					u.Calls<CreateIndexDescriptor, CreateIndexRequest, ICreateIndexRequest, CreateIndexResponse>(
+						v => new CreateIndexRequest(v),
+						(v, d) => d.Index(v),
+						(v, c, f) => c.Indices.Create(v, f),
+						(v, c, f) => c.Indices.CreateAsync(v, f),
+						(v, c, r) => c.Indices.Create(r),
+						(v, c, r) => c.Indices.CreateAsync(r)
+					)
+			},
+			{
+				CreateMappingStep, u =>
+					u.Calls<PutMappingDescriptor<Project>, PutMappingRequest, IPutMappingRequest, PutMappingResponse>(
+						v => new PutMappingRequest(v)
+						{
+							RuntimeFields = new Nest.RuntimeFields
+							{
+								{RuntimeFieldNameOne, new RuntimeField
+								{
+									Type = FieldType.Keyword,
+									Script = new PainlessScript(ScriptValue)
+								}},
+								{RuntimeFieldNameTwo, new RuntimeField
+								{
+									Type = FieldType.Date,
+									Format = DateFormat
+								}}
+							}
+						},
+						(v, d) => d.Index(v)
+							.RuntimeFields(rtf => rtf
+								.RuntimeField(RuntimeFieldNameOne, FieldType.Keyword, f1 => f1
+									.Script(ScriptValue))
+								.RuntimeField(RuntimeFieldNameTwo, FieldType.Date, f2 => f2.Format(DateFormat))),
+						(v, c, f) => c.Indices.PutMapping(f),
+						(v, c, f) => c.Indices.PutMappingAsync(f),
+						(v, c, r) => c.Indices.PutMapping(r),
+						(v, c, r) => c.Indices.PutMappingAsync(r)
+					)
+			},
+			{
+				GetMappingStep, u =>
+					u.Calls<GetMappingDescriptor<Project>, GetMappingRequest, IGetMappingRequest, GetMappingResponse>(
+						v => new GetMappingRequest(v),
+						(v, d) => d.Index(v),
+						(v, c, f) => c.Indices.GetMapping(f),
+						(v, c, f) => c.Indices.GetMappingAsync(f),
+						(v, c, r) => c.Indices.GetMapping(r),
+						(v, c, r) => c.Indices.GetMappingAsync(r)
+					)
+			}
+		})
+		{ }
+
+		[I] public async Task CreateIndexWithRuntimeFieldsMapping() => await Assert<CreateIndexResponse>(CreateIndexWithMappingStep, (v, r) =>
+		{
+			r.ShouldBeValid();
+			r.Acknowledged.Should().BeTrue();
+		});
+
+		[I] public async Task GetIndexMappingWithRuntimeFields() => await Assert<GetMappingResponse>(GetCreatedIndexMappingStep, (v, r) => AssertRuntimeFields(r));
+
+		[I] public async Task PutMappingWithRuntimeFields() => await Assert<PutMappingResponse>(CreateMappingStep, (v, r) =>
+		{
+			r.ShouldBeValid();
+			r.Acknowledged.Should().BeTrue();
+		});
+
+		[I] public async Task GetMappingWithRuntimeFields() => await Assert<GetMappingResponse>(GetMappingStep, (v, r) => AssertRuntimeFields(r));
+
+		private static void AssertRuntimeFields(GetMappingResponse response)
+		{
+			response.ShouldBeValid();
+			var runtimeFields = response.Indices.First().Value.Mappings.RuntimeFields;
+
+			runtimeFields.Count.Should().Be(2);
+			runtimeFields.TryGetValue(RuntimeFieldNameOne, out var fieldOne).Should().BeTrue();
+			runtimeFields.TryGetValue(RuntimeFieldNameTwo, out var fieldTwo).Should().BeTrue();
+
+			fieldOne!.Type.Should().Be(FieldType.Keyword);
+			fieldOne.Script.Lang.Should().Be("painless");
+			fieldOne.Script.Source.Should().Be(ScriptValue);
+
+			fieldTwo!.Type.Should().Be(FieldType.Date);
+			fieldTwo.Format.Should().Be(DateFormat);
+		}
+	}
+}

--- a/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
+++ b/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
@@ -35,7 +35,7 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				CreateIndexWithMappingStep, u =>
 					u.Calls<CreateIndexDescriptor, CreateIndexRequest, ICreateIndexRequest, CreateIndexResponse>(
-						v => new CreateIndexRequest(v)
+						v => new CreateIndexRequest(IndexName(v))
 						{
 							Mappings = new TypeMapping
 							{
@@ -54,13 +54,13 @@ namespace Tests.Mapping.RuntimeFields
 								}
 							}
 						},
-						(v, d) => d.Index(v).Map(mapping => mapping
+						(v, d) => d.Index(IndexName(v)).Map(mapping => mapping
 							.RuntimeFields(rtf => rtf
 								.RuntimeField(RuntimeFieldNameOne, FieldType.Keyword, f1 => f1
 									.Script(ScriptValue))
 								.RuntimeField(RuntimeFieldNameTwo, FieldType.Date, f2 => f2.Format(DateFormat)))),
-						(v, c, f) => c.Indices.Create(v, f),
-						(v, c, f) => c.Indices.CreateAsync(v, f),
+						(v, c, f) => c.Indices.Create(IndexName(v), f),
+						(v, c, f) => c.Indices.CreateAsync(IndexName(v), f),
 						(v, c, r) => c.Indices.Create(r),
 						(v, c, r) => c.Indices.CreateAsync(r)
 					)
@@ -68,8 +68,8 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				GetCreatedIndexMappingStep, u =>
 					u.Calls<GetMappingDescriptor<Project>, GetMappingRequest, IGetMappingRequest, GetMappingResponse>(
-						v => new GetMappingRequest(v),
-						(v, d) => d.Index(v),
+						v => new GetMappingRequest(IndexName(v)),
+						(v, d) => d.Index(IndexName(v)),
 						(v, c, f) => c.Indices.GetMapping(f),
 						(v, c, f) => c.Indices.GetMappingAsync(f),
 						(v, c, r) => c.Indices.GetMapping(r),
@@ -79,10 +79,10 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				DeleteIndexStep, u =>
 					u.Calls<DeleteIndexDescriptor, DeleteIndexRequest, IDeleteIndexRequest, DeleteIndexResponse>(
-						v => new DeleteIndexRequest(v),
+						v => new DeleteIndexRequest(IndexName(v)),
 						(v, d) => d,
-						(v, c, f) => c.Indices.Delete(v, f),
-						(v, c, f) => c.Indices.DeleteAsync(v, f),
+						(v, c, f) => c.Indices.Delete(IndexName(v), f),
+						(v, c, f) => c.Indices.DeleteAsync(IndexName(v), f),
 						(v, c, r) => c.Indices.Delete(r),
 						(v, c, r) => c.Indices.DeleteAsync(r)
 					)
@@ -90,10 +90,10 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				CreateIndexWithoutMappingStep, u =>
 					u.Calls<CreateIndexDescriptor, CreateIndexRequest, ICreateIndexRequest, CreateIndexResponse>(
-						v => new CreateIndexRequest(v),
-						(v, d) => d.Index(v),
-						(v, c, f) => c.Indices.Create(v, f),
-						(v, c, f) => c.Indices.CreateAsync(v, f),
+						v => new CreateIndexRequest(IndexName(v)),
+						(v, d) => d,
+						(v, c, f) => c.Indices.Create(IndexName(v), f),
+						(v, c, f) => c.Indices.CreateAsync(IndexName(v), f),
 						(v, c, r) => c.Indices.Create(r),
 						(v, c, r) => c.Indices.CreateAsync(r)
 					)
@@ -101,7 +101,7 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				CreateMappingStep, u =>
 					u.Calls<PutMappingDescriptor<Project>, PutMappingRequest, IPutMappingRequest, PutMappingResponse>(
-						v => new PutMappingRequest(v)
+						v => new PutMappingRequest(IndexName(v))
 						{
 							RuntimeFields = new Nest.RuntimeFields
 							{
@@ -117,7 +117,7 @@ namespace Tests.Mapping.RuntimeFields
 								}}
 							}
 						},
-						(v, d) => d.Index(v)
+						(v, d) => d.Index(IndexName(v))
 							.RuntimeFields(rtf => rtf
 								.RuntimeField(RuntimeFieldNameOne, FieldType.Keyword, f1 => f1
 									.Script(ScriptValue))
@@ -131,8 +131,8 @@ namespace Tests.Mapping.RuntimeFields
 			{
 				GetMappingStep, u =>
 					u.Calls<GetMappingDescriptor<Project>, GetMappingRequest, IGetMappingRequest, GetMappingResponse>(
-						v => new GetMappingRequest(v),
-						(v, d) => d.Index(v),
+						v => new GetMappingRequest(IndexName(v)),
+						(v, d) => d.Index(IndexName(v)),
 						(v, c, f) => c.Indices.GetMapping(f),
 						(v, c, f) => c.Indices.GetMappingAsync(f),
 						(v, c, r) => c.Indices.GetMapping(r),
@@ -141,6 +141,8 @@ namespace Tests.Mapping.RuntimeFields
 			}
 		})
 		{ }
+
+		private static string IndexName(string uniqueId) => $"runtime-{uniqueId}";
 
 		[I] public async Task CreateIndexWithRuntimeFieldsMapping() => await Assert<CreateIndexResponse>(CreateIndexWithMappingStep, (v, r) =>
 		{


### PR DESCRIPTION
This PR adds support to map runtime fields on CREATE index and PUT mapping requests. Support for searches using runtime fields will follow in another PR.

@Mpdreamz I made RuntimeFieldsDescriptor non-generic as it doesn't need anything from TDocument. This seems to work fine but I noticed that some other descriptors are generic without accessing `T` so I wanted to check if this is problematic here?

Contributes to #5198