### PR TITLE
Implement AsyncSearch Status API

### DIFF
--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.AsyncSearch.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.AsyncSearch.cs
@@ -59,7 +59,7 @@ namespace Elasticsearch.Net.Specification.AsyncSearchApi
 	}
 
 	///<summary>Request options for Status <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
-	public class StatusRequestParameters : RequestParameters<StatusRequestParameters>
+	public class AsyncSearchStatusRequestParameters : RequestParameters<AsyncSearchStatusRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		public override bool SupportsBody => false;

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.AsyncSearch.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.AsyncSearch.cs
@@ -68,13 +68,13 @@ namespace Elasticsearch.Net.Specification.AsyncSearchApi
 		///<summary>GET on /_async_search/status/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
 		///<param name = "id">The async search ID</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
-		public TResponse Status<TResponse>(string id, StatusRequestParameters requestParameters = null)
+		public TResponse Status<TResponse>(string id, AsyncSearchStatusRequestParameters requestParameters = null)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(GET, Url($"_async_search/status/{id:id}"), null, RequestParams(requestParameters));
 		///<summary>GET on /_async_search/status/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
 		///<param name = "id">The async search ID</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("async_search.status", "id")]
-		public Task<TResponse> StatusAsync<TResponse>(string id, StatusRequestParameters requestParameters = null, CancellationToken ctx = default)
+		public Task<TResponse> StatusAsync<TResponse>(string id, AsyncSearchStatusRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(GET, Url($"_async_search/status/{id:id}"), ctx, null, RequestParams(requestParameters));
 		///<summary>POST on /_async_search <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
 		///<param name = "body">The search definition using the Query DSL</param>

--- a/src/Nest/Descriptors.AsyncSearch.cs
+++ b/src/Nest/Descriptors.AsyncSearch.cs
@@ -78,6 +78,27 @@ namespace Nest
 		public AsyncSearchGetDescriptor WaitForCompletionTimeout(Time waitforcompletiontimeout) => Qs("wait_for_completion_timeout", waitforcompletiontimeout);
 	}
 
+	///<summary>Descriptor for Status <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
+	public partial class AsyncSearchStatusDescriptor : RequestDescriptorBase<AsyncSearchStatusDescriptor, AsyncSearchStatusRequestParameters, IAsyncSearchStatusRequest>, IAsyncSearchStatusRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.AsyncSearchStatus;
+		///<summary>/_async_search/status/{id}</summary>
+		///<param name = "id">this parameter is required</param>
+		public AsyncSearchStatusDescriptor(Id id): base(r => r.Required("id", id))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected AsyncSearchStatusDescriptor(): base()
+		{
+		}
+
+		// values part of the url path
+		Id IAsyncSearchStatusRequest.Id => Self.RouteValues.Get<Id>("id");
+	// Request parameters
+	}
+
 	///<summary>Descriptor for Submit <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
 	public partial class AsyncSearchSubmitDescriptor<TInferDocument> : RequestDescriptorBase<AsyncSearchSubmitDescriptor<TInferDocument>, AsyncSearchSubmitRequestParameters, IAsyncSearchSubmitRequest<TInferDocument>>, IAsyncSearchSubmitRequest<TInferDocument>
 	{

--- a/src/Nest/ElasticClient.AsyncSearch.cs
+++ b/src/Nest/ElasticClient.AsyncSearch.cs
@@ -89,6 +89,30 @@ namespace Nest.Specification.AsyncSearchApi
 		public Task<AsyncSearchGetResponse<TDocument>> GetAsync<TDocument>(IAsyncSearchGetRequest request, CancellationToken ct = default)
 			where TDocument : class => DoRequestAsync<IAsyncSearchGetRequest, AsyncSearchGetResponse<TDocument>>(request, request.RequestParameters, ct);
 		/// <summary>
+		/// <c>GET</c> request to the <c>async_search.status</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</a>
+		/// </summary>
+		public AsyncSearchStatusResponse Status(Id id, Func<AsyncSearchStatusDescriptor, IAsyncSearchStatusRequest> selector = null) => Status(selector.InvokeOrDefault(new AsyncSearchStatusDescriptor(id: id)));
+		/// <summary>
+		/// <c>GET</c> request to the <c>async_search.status</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</a>
+		/// </summary>
+		public Task<AsyncSearchStatusResponse> StatusAsync(Id id, Func<AsyncSearchStatusDescriptor, IAsyncSearchStatusRequest> selector = null, CancellationToken ct = default) => StatusAsync(selector.InvokeOrDefault(new AsyncSearchStatusDescriptor(id: id)), ct);
+		/// <summary>
+		/// <c>GET</c> request to the <c>async_search.status</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</a>
+		/// </summary>
+		public AsyncSearchStatusResponse Status(IAsyncSearchStatusRequest request) => DoRequest<IAsyncSearchStatusRequest, AsyncSearchStatusResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>GET</c> request to the <c>async_search.status</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</a>
+		/// </summary>
+		public Task<AsyncSearchStatusResponse> StatusAsync(IAsyncSearchStatusRequest request, CancellationToken ct = default) => DoRequestAsync<IAsyncSearchStatusRequest, AsyncSearchStatusResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>POST</c> request to the <c>async_search.submit</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</a>

--- a/src/Nest/Requests.AsyncSearch.cs
+++ b/src/Nest/Requests.AsyncSearch.cs
@@ -118,6 +118,39 @@ namespace Nest
 	}
 
 	[InterfaceDataContract]
+	public partial interface IAsyncSearchStatusRequest : IRequest<AsyncSearchStatusRequestParameters>
+	{
+		[IgnoreDataMember]
+		Id Id
+		{
+			get;
+		}
+	}
+
+	///<summary>Request for Status <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/async-search.html</para></summary>
+	public partial class AsyncSearchStatusRequest : PlainRequestBase<AsyncSearchStatusRequestParameters>, IAsyncSearchStatusRequest
+	{
+		protected IAsyncSearchStatusRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.AsyncSearchStatus;
+		///<summary>/_async_search/status/{id}</summary>
+		///<param name = "id">this parameter is required</param>
+		public AsyncSearchStatusRequest(Id id): base(r => r.Required("id", id))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected AsyncSearchStatusRequest(): base()
+		{
+		}
+
+		// values part of the url path
+		[IgnoreDataMember]
+		Id IAsyncSearchStatusRequest.Id => Self.RouteValues.Get<Id>("id");
+	// Request parameters
+	}
+
+	[InterfaceDataContract]
 	public partial interface IAsyncSearchSubmitRequest : IRequest<AsyncSearchSubmitRequestParameters>
 	{
 		[IgnoreDataMember]

--- a/src/Nest/XPack/AsyncSearch/AsyncSearch.cs
+++ b/src/Nest/XPack/AsyncSearch/AsyncSearch.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;

--- a/src/Nest/XPack/AsyncSearch/Delete/AsyncSearchDeleteRequest.cs
+++ b/src/Nest/XPack/AsyncSearch/Delete/AsyncSearchDeleteRequest.cs
@@ -1,4 +1,6 @@
-using System.Collections.Generic;
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
 
 namespace Nest
 {

--- a/src/Nest/XPack/AsyncSearch/Delete/AsyncSearchDeleteResponse.cs
+++ b/src/Nest/XPack/AsyncSearch/Delete/AsyncSearchDeleteResponse.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Nest
 {
 	public class AsyncSearchDeleteResponse : AcknowledgedResponseBase { }

--- a/src/Nest/XPack/AsyncSearch/Get/AsyncSearchGetRequest.cs
+++ b/src/Nest/XPack/AsyncSearch/Get/AsyncSearchGetRequest.cs
@@ -1,4 +1,6 @@
-using System.Collections.Generic;
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
 
 namespace Nest
 {

--- a/src/Nest/XPack/AsyncSearch/Get/AsyncSearchGetResponse.cs
+++ b/src/Nest/XPack/AsyncSearch/Get/AsyncSearchGetResponse.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Nest
 {
 	public class AsyncSearchGetResponse<TDocument> : AsyncSearchResponseBase<TDocument> where TDocument : class { }

--- a/src/Nest/XPack/AsyncSearch/Status/AsyncSearchStatusRequest.cs
+++ b/src/Nest/XPack/AsyncSearch/Status/AsyncSearchStatusRequest.cs
@@ -1,0 +1,20 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+namespace Nest
+{
+	[MapsApi("async_search.status.json")]
+	[ReadAs(typeof(AsyncSearchStatusRequest))]
+	public partial interface IAsyncSearchStatusRequest { }
+
+	/// <inheritdoc cref="IAsyncSearchStatusRequest"/>
+	public partial class AsyncSearchStatusRequest
+	{
+	}
+
+	/// <inheritdoc cref="IAsyncSearchStatusRequest"/>
+	public partial class AsyncSearchStatusDescriptor
+	{
+	}
+}

--- a/src/Nest/XPack/AsyncSearch/Status/AsyncSearchStatusResponse.cs
+++ b/src/Nest/XPack/AsyncSearch/Status/AsyncSearchStatusResponse.cs
@@ -4,42 +4,17 @@
 
 using System;
 using System.Runtime.Serialization;
-using Elasticsearch.Net.Utf8Json;
 
 namespace Nest
 {
-	[InterfaceDataContract]
-	public interface IAsyncSearchResponse<TDocument> : IResponse where TDocument : class
+	public class AsyncSearchStatusResponse : ResponseBase
 	{
-		[DataMember(Name = "id")]
-		string Id { get; }
+		[DataMember(Name = "_shards")]
+		public ShardStatistics Shards { get; internal set; }
 
-		[DataMember(Name = "is_partial")]
-		bool IsPartial { get; }
+		[DataMember(Name = "completion_status")]
+		public int? CompletionStatus { get; internal set; }
 
-		[DataMember(Name = "start_time_in_millis")]
-		long StartTimeInMilliseconds { get; }
-
-		[IgnoreDataMember]
-		DateTimeOffset StartTime { get; }
-
-		[DataMember(Name = "is_running")]
-		bool IsRunning { get; }
-
-		[DataMember(Name = "expiration_time_in_millis")]
-		long ExpirationTimeInMilliseconds { get; }
-
-		[IgnoreDataMember]
-		DateTimeOffset ExpirationTime { get; }
-
-		[DataMember(Name = "response")]
-		AsyncSearch<TDocument> Response { get; }
-	}
-
-	[DataContract]
-	public abstract class AsyncSearchResponseBase<TDocument>
-		: ResponseBase, IAsyncSearchResponse<TDocument> where TDocument: class
-	{
 		[DataMember(Name = "id")]
 		public string Id { get; internal set; }
 
@@ -60,8 +35,5 @@ namespace Nest
 
 		[IgnoreDataMember]
 		public DateTimeOffset ExpirationTime => DateTimeUtil.UnixEpoch.AddMilliseconds(ExpirationTimeInMilliseconds);
-
-		[DataMember(Name = "response")]
-		public AsyncSearch<TDocument> Response { get; internal set; }
 	}
 }

--- a/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitRequest.cs
+++ b/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitRequest.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.Serialization;

--- a/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitResponse.cs
+++ b/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitResponse.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
 namespace Nest
 {
 	public class AsyncSearchSubmitResponse<TDocument> : AsyncSearchResponseBase<TDocument>

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -20,6 +20,7 @@ namespace Nest
 	{
 		internal static ApiUrls AsyncSearchDelete = new ApiUrls(new[]{"_async_search/{id}"});
 		internal static ApiUrls AsyncSearchGet = new ApiUrls(new[]{"_async_search/{id}"});
+		internal static ApiUrls AsyncSearchStatus = new ApiUrls(new[]{"_async_search/status/{id}"});
 		internal static ApiUrls AsyncSearchSubmit = new ApiUrls(new[]{"_async_search", "{index}/_async_search"});
 		internal static ApiUrls NoNamespaceBulk = new ApiUrls(new[]{"_bulk", "{index}/_bulk"});
 		internal static ApiUrls CatAliases = new ApiUrls(new[]{"_cat/aliases", "_cat/aliases/{name}"});

--- a/tests/Tests/XPack/AsyncSearch/Status/AsyncSearchStatusUrlTests.cs
+++ b/tests/Tests/XPack/AsyncSearch/Status/AsyncSearchStatusUrlTests.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+using static Tests.Framework.EndpointTests.UrlTester;
+
+namespace Tests.XPack.AsyncSearch.Status
+{
+	public class AsyncSearchStatusUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() => await GET("/_async_search/status/search_id")
+			.Fluent(c => c.AsyncSearch.Status("search_id", f => f))
+			.Request(c => c.AsyncSearch.Status(new AsyncSearchStatusRequest("search_id")))
+			.FluentAsync(c => c.AsyncSearch.StatusAsync("search_id", f => f))
+			.RequestAsync(c => c.AsyncSearch.StatusAsync(new AsyncSearchStatusRequest("search_id")));
+	}
+}


### PR DESCRIPTION
Main change to existing is removing `Response` from `AsyncSearchResponseBase` and making `AsyncSearchResponseBase` non-generic as a result. This allows the base to be used for the status response which differs by not include the response itself.