### PR TITLE
Disable translate API test

### DIFF
--- a/tests/Tests/XPack/Sql/TranslateSql/TranslateSqlQueryApiTests.cs
+++ b/tests/Tests/XPack/Sql/TranslateSql/TranslateSqlQueryApiTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elastic.Transport;
 using FluentAssertions;
 using Nest;
@@ -14,6 +15,8 @@ using Tests.Framework.EndpointTests.TestState;
 
 namespace Tests.XPack.Sql.TranslateSql
 {
+	// TODO: Remove skip when https://github.com/elastic/elasticsearch/issues/67163 is fixed
+	[SkipVersion(">1.0.0", "Open issue https://github.com/elastic/elasticsearch/issues/67163")]
 	public class TranslateSqlApiTests
 		: ApiIntegrationTestBase<XPackCluster, TranslateSqlResponse, ITranslateSqlRequest, TranslateSqlDescriptor, TranslateSqlRequest>
 	{


### PR DESCRIPTION
Due to a [regression in 7.11](https://github.com/elastic/elasticsearch/issues/67163) currently this test fails. Once the server is fixed we can re-enable this test.

Fixes #5185