### PR TITLE
Fix bug in AutoExpandReplicas.Create

### DIFF
--- a/src/Nest/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
+++ b/src/Nest/IndexModules/IndexSettings/Settings/AutoExpandReplicas.cs
@@ -98,6 +98,9 @@ namespace Nest
 			if (value.IsNullOrEmpty())
 				throw new ArgumentException("cannot be null or empty", nameof(value));
 
+			if (value.Equals("false", StringComparison.OrdinalIgnoreCase))
+				return Disabled;
+			
 			var expandReplicaParts = value.Split('-');
 			if (expandReplicaParts.Length != 2)
 				throw new ArgumentException("must contain a 'from' and 'to' value", nameof(value));

--- a/tests/Tests/CommonOptions/AutoExpandReplicas/AutoExpandReplicasTests.cs
+++ b/tests/Tests/CommonOptions/AutoExpandReplicas/AutoExpandReplicasTests.cs
@@ -78,6 +78,17 @@ namespace Tests.CommonOptions.AutoExpandReplicas
 		}
 
 		[U]
+		public void CreateWithFalse()
+		{
+			var autoExpandReplicas = Nest.AutoExpandReplicas.Create("false");
+			autoExpandReplicas.Should().NotBeNull();
+			autoExpandReplicas.Enabled.Should().BeFalse();
+			autoExpandReplicas.MinReplicas.Should().BeNull();
+			autoExpandReplicas.MaxReplicas.Should().BeNull();
+			autoExpandReplicas.ToString().Should().Be("false");
+		}
+
+		[U]
 		public void Disabled()
 		{
 			var autoExpandReplicas = Nest.AutoExpandReplicas.Disabled;


### PR DESCRIPTION
The create method was not allowing the valid value of "false".

Fixes #5258