### PR TITLE
[Backport master] Fix GetRoleMappings when multiple distinguished names returned

### DIFF
--- a/src/Nest/XPack/Security/RoleMapping/Rules/Field/DistinguishedNameRule.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Field/DistinguishedNameRule.cs
@@ -2,10 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
+
 namespace Nest
 {
 	public class DistinguishedNameRule : FieldRuleBase
 	{
 		public DistinguishedNameRule(string name) => DistinguishedName = name;
+
+		public DistinguishedNameRule(IEnumerable<string> names) => DistinguishedNames = names;
 	}
 }

--- a/src/Nest/XPack/Security/RoleMapping/Rules/Field/FieldRuleBase.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Field/FieldRuleBase.cs
@@ -21,6 +21,13 @@ namespace Nest
 		}
 
 		[IgnoreDataMember]
+		protected IEnumerable<string> DistinguishedNames
+		{
+			get => BackingDictionary.TryGetValue("dn", out var o) ? (IEnumerable<string>)o : null;
+			set => BackingDictionary.Add("dn", value);
+		}
+
+		[IgnoreDataMember]
 		protected IEnumerable<string> Groups
 		{
 			get => BackingDictionary.TryGetValue("groups", out var o) ? (IEnumerable<string>)o : null;

--- a/src/Nest/XPack/Security/RoleMapping/Rules/Field/FieldRuleBaseFormatter.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Field/FieldRuleBaseFormatter.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Generic;
 using Nest.Utf8Json;
 namespace Nest
@@ -38,6 +39,13 @@ namespace Nest
 							fieldRule = new UsernameRule(username);
 							break;
 						case 1:
+							if (reader.GetCurrentJsonToken() == JsonToken.BeginArray)
+							{
+								var fm = formatterResolver.GetFormatter<IEnumerable<string>>();
+								var dns = fm.Deserialize(ref reader, formatterResolver);
+								fieldRule = new DistinguishedNameRule(dns);
+								break;
+							}
 							var dn = reader.ReadString();
 							fieldRule = new DistinguishedNameRule(dn);
 							break;

--- a/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRulesDescriptor.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRulesDescriptor.cs
@@ -20,6 +20,8 @@ namespace Nest
 			return this;
 		}
 
+		public RoleMappingRulesDescriptor DistinguishedName(IEnumerable<string> names) => Add(new DistinguishedNameRule(names));
+
 		public RoleMappingRulesDescriptor DistinguishedName(string name) => Add(new DistinguishedNameRule(name));
 
 		public RoleMappingRulesDescriptor Username(string username) => Add(new UsernameRule(username));

--- a/tests/Tests.Reproduce/GitHubIssue5270.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5270.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elastic.Transport;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;

--- a/tests/Tests.Reproduce/GitHubIssue5270.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5270.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue5270
+	{
+		private static readonly byte[] ResponseBytes = Encoding.UTF8.GetBytes(@"{
+  ""test admin role mapping"" : {
+    ""enabled"" : true,
+    ""roles"" : [
+      ""apm_user""
+    ],
+    ""rules"" : {
+      ""any"" : [
+        {
+          ""field"" : {
+            ""dn"" : [
+              ""CN=Bloggs Joe abcdef01,OU=Users,OU=_Central,OU=S1000,OU=SG001,DC=ad001,DC=example,DC=net"",
+              ""cn=bloggs joe abcdef02,ou=usersfunctional,ou=_central,ou=accadm,OU=SG001,DC=ad001,DC=example,DC=net""
+            ]
+          }
+        }
+      ]
+    },
+    ""metadata"" : { }
+  }
+}");
+
+		[U]
+		public async Task GetRoleMappings()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri($"http://localhost:9200"));
+			var settings = new ConnectionSettings(pool, new InMemoryConnection(ResponseBytes));
+			var client = new ElasticClient(settings);
+
+			// ReSharper disable once MethodHasAsyncOverload
+			var roleResponse = client.Security.GetRoleMapping();
+			roleResponse.RoleMappings.Count.Should().Be(1);
+			Assert(roleResponse);
+
+			roleResponse = await client.Security.GetRoleMappingAsync();
+			roleResponse.RoleMappings.Count.Should().Be(1);
+			Assert(roleResponse);
+		}
+
+		private static void Assert(GetRoleMappingResponse roleResponse) =>
+			roleResponse.RoleMappings["test admin role mapping"]
+				.Rules.Should()
+				.BeAssignableTo<AnyRoleMappingRule>()
+				.Subject.Any.First()
+				.Should()
+				.BeAssignableTo<FieldRoleMappingRule>()
+				.Subject.Field.Should()
+				.BeAssignableTo<DistinguishedNameRule>()
+				.Subject["dn"].Should().BeAssignableTo<IEnumerable<string>>()
+				.Subject.Count().Should().Be(2);
+	}
+}

--- a/tests/Tests/XPack/Security/RoleMapping/DistinguishedNamesRoleMappingsTests.cs
+++ b/tests/Tests/XPack/Security/RoleMapping/DistinguishedNamesRoleMappingsTests.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
-using Elasticsearch.Net;
+using Elastic.Transport;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Framework.EndpointTests;

--- a/tests/Tests/XPack/Security/RoleMapping/DistinguishedNamesRoleMappingsTests.cs
+++ b/tests/Tests/XPack/Security/RoleMapping/DistinguishedNamesRoleMappingsTests.cs
@@ -1,0 +1,68 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Collections.Generic;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+
+namespace Tests.XPack.Security.RoleMapping
+{
+	[SkipVersion("<5.5.0", "Does not exist in earlier versions")]
+	public class DistinguishedNamesRoleMappingsTests
+		: ApiTestBase<XPackCluster, PutRoleMappingResponse, IPutRoleMappingRequest, PutRoleMappingDescriptor, PutRoleMappingRequest>
+	{
+		public DistinguishedNamesRoleMappingsTests(XPackCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override HttpMethod HttpMethod => HttpMethod.PUT;
+		protected override string UrlPath => "/_security/role_mapping/name";
+		protected override bool SupportsDeserialization => false;
+
+		protected override object ExpectJson => new
+		{
+			enabled = true,
+			roles = new[] { "user_role" },
+			rules = new
+			{
+				any = new object[]
+				{
+					new
+					{
+						field = new {
+							dn = new [] {
+								"a",
+								"b"
+							}
+						}
+					}
+				}
+			}
+		};
+
+		protected override PutRoleMappingRequest Initializer { get; } = new("name")
+		{
+			Enabled = true,
+			Roles = new List<string> { "user_role" },
+			Rules = new AnyRoleMappingRule(new DistinguishedNameRule(new List<string>
+			{
+				"a", "b"
+			}))
+		};
+
+		protected override PutRoleMappingDescriptor NewDescriptor() => new("name");
+
+		protected override Func<PutRoleMappingDescriptor, IPutRoleMappingRequest> Fluent =>
+			d => d.Enabled().Roles("user_role").Rules(r => r.Any(a => a.DistinguishedName(new List<string> { "a", "b" })));
+
+		protected override LazyResponses ClientUsage() => Calls(
+			(client, f) => client.Security.PutRoleMapping("name", f),
+			(client, f) => client.Security.PutRoleMappingAsync("name", f),
+			(client, r) => client.Security.PutRoleMapping(r),
+			(client, r) => client.Security.PutRoleMappingAsync(r));
+	}
+}


### PR DESCRIPTION
Backport c1316d32bc749c35a5ea45f2e74553561d901bd6 from #5271