### PR TITLE
Implement unsigned long numeric field

### DIFF
--- a/src/Nest/Mapping/Types/Core/Number/NumberType.cs
+++ b/src/Nest/Mapping/Types/Core/Number/NumberType.cs
@@ -34,7 +34,10 @@ namespace Nest
 		Short,
 
 		[EnumMember(Value = "byte")]
-		Byte
+		Byte,
+
+		[EnumMember(Value = "unsigned_long")]
+		UnsignedLong
 	}
 
 	internal static class NumberTypeExtensions
@@ -51,6 +54,7 @@ namespace Nest
 				case NumberType.Long: return FieldType.Long;
 				case NumberType.Short: return FieldType.Short;
 				case NumberType.Byte: return FieldType.Byte;
+				case NumberType.UnsignedLong: return FieldType.UnsignedLong;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(numberType), numberType, null);
 			}

--- a/src/Nest/Mapping/Types/FieldType.cs
+++ b/src/Nest/Mapping/Types/FieldType.cs
@@ -89,6 +89,9 @@ namespace Nest
 		[EnumMember(Value = "long")]
 		Long,
 
+		[EnumMember(Value = "unsigned_long")]
+		UnsignedLong,
+
 		[EnumMember(Value = "short")]
 		Short,
 

--- a/src/Nest/Mapping/Types/PropertyFormatter.cs
+++ b/src/Nest/Mapping/Types/PropertyFormatter.cs
@@ -68,6 +68,7 @@ namespace Nest
 				case FieldType.Long:
 				case FieldType.ScaledFloat:
 				case FieldType.HalfFloat:
+				case FieldType.UnsignedLong:
 					var numberProperty = Deserialize<NumberProperty>(ref segmentReader, formatterResolver);
 					((IProperty)numberProperty).Type = typeString;
 					return numberProperty;

--- a/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
+++ b/tests/Tests/Mapping/Types/Core/Number/NumberPropertyTests.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Nest;
 using Tests.Core.ManagedElasticsearch.Clusters;
 using Tests.Domain;
@@ -114,6 +115,53 @@ namespace Tests.Mapping.Types.Core.Number
 					NullValue = 0.0,
 					IgnoreMalformed = true,
 					Coerce = true
+				}
+			}
+		};
+	}
+
+	[SkipVersion("<7.10.0", "Introduced in 7.10.0")]
+	public class UnsignedLongNumberPropertyTests : PropertyTestsBase
+	{
+		public UnsignedLongNumberPropertyTests(WritableCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override object ExpectJson => new
+		{
+			properties = new
+			{
+				numberOfCommits = new
+				{
+					type = "unsigned_long",
+					doc_values = true,
+					similarity = "BM25",
+					store = true,
+					index = false,
+					ignore_malformed = true
+				}
+			}
+		};
+
+		protected override Func<PropertiesDescriptor<Project>, IPromise<IProperties>> FluentProperties => f => f
+			.Number(n => n
+				.Name(p => p.NumberOfCommits)
+				.Type(NumberType.UnsignedLong)
+				.DocValues()
+				.Similarity("BM25")
+				.Store()
+				.Index(false)
+				.IgnoreMalformed()
+			);
+		
+		protected override IProperties InitializerProperties => new Properties
+		{
+			{
+				"numberOfCommits", new NumberProperty(NumberType.UnsignedLong)
+				{
+					DocValues = true,
+					Similarity = "BM25",
+					Store = true,
+					Index = false,
+					IgnoreMalformed = true
 				}
 			}
 		};


### PR DESCRIPTION
Add support for mapping an unsigned_long field. There is an issue currently with any mapping where the `null_value` needs to be provided. This is because we store that value in a `double?` property and currently, this causes a mapper_parser_exception. This has been raised for the ES team in https://github.com/elastic/elasticsearch/issues/67565

Contributes #5198