### PR TITLE
Optimise RouteValues

### DIFF
--- a/src/Nest/CommonAbstractions/Request/RouteValues.cs
+++ b/src/Nest/CommonAbstractions/Request/RouteValues.cs
@@ -10,24 +10,30 @@ namespace Nest
 {
 	internal class ResolvedRouteValues : Dictionary<string, string>
 	{
+		internal static ResolvedRouteValues Empty = new(0);
 
+		public ResolvedRouteValues(int size) : base(size) { }
 	}
 
 	public class RouteValues : Dictionary<string, IUrlParameter>
 	{
-		// Not too happy with this, only exists because IndexRequest needs a resolved
-		// id to know if it has to send a PUT or POST.
-		internal ResolvedRouteValues Resolved { get; private set; }
+		/// <summary>
+		/// Used specifically by index requests to determine whether to use PUT or POST.
+		/// </summary>
+		internal bool ContainsId { get; private set;}
 
 		internal ResolvedRouteValues Resolve(IConnectionSettingsValues configurationValues)
 		{
-			var resolved = new ResolvedRouteValues();
+			if (Count == 0) return ResolvedRouteValues.Empty;
+			
+			var resolved = new ResolvedRouteValues(Count);
 			foreach (var kv in this)
 			{
 				var value = this[kv.Key].GetString(configurationValues);
-				if (!value.IsNullOrEmpty()) resolved[kv.Key] = value;
+				if (value.IsNullOrEmpty()) continue;
+				resolved[kv.Key] = value;
+				if (IsId(kv.Key)) ContainsId = true;
 			}
-			Resolved = resolved;
 			return resolved;
 		}
 
@@ -36,18 +42,19 @@ namespace Nest
 			switch (routeValue) {
 				case null when !required: {
 					if (!ContainsKey(name)) return this;
-
 					Remove(name);
-					Resolved = null; //invalidate cache
+					if (IsId(name)) ContainsId = false; // invalidate cache
 					return this;
 				}
 				case null: throw new ArgumentNullException(name, $"{name} is required to build a url to this API");
 				default:
 					this[name] = routeValue;
-					Resolved = null; //invalidate cache
+					if (IsId(name)) ContainsId = false; // invalidate cache
 					return this;
 			}
 		}
+
+		private static bool IsId(string key) => key.Equals("id", StringComparison.OrdinalIgnoreCase);
 
 		internal RouteValues Required(string route, IUrlParameter value) => Route(route, value);
 

--- a/src/Nest/Document/Single/Index/IndexRequest.cs
+++ b/src/Nest/Document/Single/Index/IndexRequest.cs
@@ -26,7 +26,7 @@ namespace Nest
 			sourceSerializer.Serialize(Document, stream, formatting);
 
 		internal static HttpMethod GetHttpMethod(IIndexRequest<TDocument> request) =>
-			request.Id?.StringOrLongValue != null || (request.RouteValues.Resolved?.ContainsKey("id") ?? false) ? HttpMethod.PUT : HttpMethod.POST;
+			request.Id?.StringOrLongValue != null || request.RouteValues.ContainsId ? HttpMethod.PUT : HttpMethod.POST;
 
 		partial void DocumentFromPath(TDocument document) => Document = document;
 	}


### PR DESCRIPTION
Adds a reusable `ResolvedRouteValues` instance for all requests where there are no `RouteValues`. 

This reduces allocs and improves perf slightly.
```
|           Method |      Mean |    Error |    StdDev |    Median |  Gen 0 | Gen 1 | Gen 2 | Allocated |
|----------------- |----------:|---------:|----------:|----------:|-------:|------:|------:|----------:|
|              Old | 222.59 ns | 9.174 ns | 26.616 ns | 212.48 ns | 0.0496 |     - |     - |     208 B |
| OldParameterless |  88.45 ns | 1.761 ns |  2.582 ns |  88.09 ns | 0.0172 |     - |     - |      72 B |
|              New | 202.92 ns | 5.285 ns |  9.117 ns | 201.08 ns | 0.0496 |     - |     - |     208 B |
| NewParameterless |  11.94 ns | 0.273 ns |  0.570 ns |  11.79 ns |      - |     - |     - |         - |
```

Gets rid of the Resolved `ResolvedRouteValues` on `RouteValues` in favour of a lighter `bool` which still supports the `IndexRequest` requirement.