### PR TITLE
Fix size overflow in StringToDoubleConverter

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
+++ b/src/Elasticsearch.Net/Utf8Json/Internal/DoubleConversion/StringToDoubleConverter.cs
@@ -540,30 +540,24 @@ namespace Elasticsearch.Net.Utf8Json.Internal.DoubleConversion
 
             buffer[buffer_pos] = (byte)'\0';
 
-            double? converted;
-            if (read_as_double)
-            {
-                converted = StringToDouble.Strtod(new Vector(buffer, 0, buffer_pos), exponent);
-            }
-            else
-            {
-                converted = StringToDouble.Strtof(new Vector(buffer, 0, buffer_pos), exponent);
-            }
+			var converted = read_as_double
+				? StringToDouble.Strtod(new Vector(buffer, 0, buffer_pos), exponent)
+				: StringToDouble.Strtof(new Vector(buffer, 0, buffer_pos), exponent);
 
             if (converted == null)
             {
                 // read-again
                 processed_characters_count = (current - input);
 
-                var fallbackbuffer = GetFallbackBuffer();
-                BinaryUtil.EnsureCapacity(ref _fallbackBuffer, 0, processed_characters_count);
+                var fallbackBuffer = GetFallbackBuffer();
+                BinaryUtil.EnsureCapacity(ref fallbackBuffer, 0, processed_characters_count);
                 var fallbackI = 0;
                 while (input != current)
                 {
-                    fallbackbuffer[fallbackI++] = input.Value;
+					fallbackBuffer[fallbackI++] = input.Value;
                     input++;
                 }
-                var laststr = Encoding.UTF8.GetString(fallbackbuffer, 0, fallbackI);
+                var laststr = Encoding.UTF8.GetString(fallbackBuffer, 0, fallbackI);
                 return double.Parse(laststr, CultureInfo.InvariantCulture);
             }
 


### PR DESCRIPTION
Original code resized the static if too small but doesn't use the resized array.

Thanks to @benaadams for reporting this bug.