### PR TITLE
Adds back additional information when running our tests

### DIFF
--- a/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -55,6 +55,9 @@ namespace Tests.Core.Client.Settings
 			.ConnectionLimit(ConnectionLimitDefault)
 			.OnRequestCompleted(r =>
 			{
+				//r.HttpMethod;
+
+
 				if (!r.DeprecationWarnings.Any()) return;
 
 				var q = r.Uri.Query;


### PR DESCRIPTION
Dumps all the configuration bits at the beginning of the run including
test mode and random seed information.

At the end of the run this now again produces an overview of how long
testing each cluster took.

And produce a reproduce command line that you can use to only rerun
failed collections/tests using the exact same configuration.
