### PR TITLE
Flight recorder exporter

### DIFF
--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -18,6 +18,8 @@ module Paths =
     
     let InplaceBuildOutput project tfm = 
         sprintf "src/%s/bin/Release/%s" project tfm
+    let InplaceBuildTestOutput project tfm = 
+        sprintf "tests/%s/bin/Release/%s" project tfm
     let MagicDocumentationFile  = 
         "src/Elasticsearch.Net/obj/Release/netstandard2.1/Elasticsearch.Net.csprojAssemblyReference.cache" 
   

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -15,7 +15,7 @@ module ReposTooling =
         let clusterName = Option.defaultValue "" <| match args.CommandArguments with | Cluster c -> Some c.Name | _ -> None
         let clusterVersion = Option.defaultValue "" <|match args.CommandArguments with | Cluster c -> c.Version | _ -> None
         
-        let testsProjectDirectory = Path.Combine(Path.GetFullPath(Paths.Output("Tests.ClusterLauncher")), "net5.0")
+        let testsProjectDirectory = Path.GetFullPath(Paths.InplaceBuildTestOutput "Tests.ClusterLauncher" "net5.0")
         let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         
         printfn "%s" testsProjectDirectory

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -28,8 +28,12 @@ module Main =
         let userYaml = Path.Combine(sourceDir, "tests.yaml");
         let e f = File.Exists f;
         match ((e userYaml), (e defaultYaml)) with
-        | (true, _) -> Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(userYaml))
-        | (_, true) -> Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(defaultYaml))
+        | (true, _) ->
+            Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(userYaml))
+            printfn "%s" <| Environment.environVar "NEST_YAML_FILE"
+        | (_, true) ->
+            Environment.setEnvironVar "NEST_YAML_FILE" (Path.GetFullPath(defaultYaml))
+            printfn "%s" <| Environment.environVar "NEST_YAML_FILE"
         | _ -> failwithf "Expected to find a tests.default.yaml or tests.yaml in %s" sourceDir
         
           

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -38,7 +38,7 @@
     <PackageReference Include="FSharp.Core" Version="5.0.0" />
 
     <PackageReference Include="Bullseye" Version="3.3.0" />
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
     
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -152,6 +152,12 @@ namespace Elasticsearch.Net
 		Action<IApiCallDetails> OnRequestCompleted { get; }
 
 		/// <summary>
+		/// Allows you to register a callback every time a an API call has finished and before its returned to the user.
+		/// Fires at the same time as <see cref="OnRequestCompleted"/> but includes the <see cref="RequestData"/> instance.
+		/// </summary>
+		Action<IApiCallDetails, RequestData> OnBeforeReturn { get; }
+
+		/// <summary>
 		/// An action to run when the <see cref="RequestData" /> for a request has been
 		/// created.
 		/// </summary>

--- a/src/Elasticsearch.Net/Transport/Transport.cs
+++ b/src/Elasticsearch.Net/Transport/Transport.cs
@@ -225,6 +225,7 @@ namespace Elasticsearch.Net
 #endif
 			}
 
+			Settings.OnBeforeReturn?.Invoke(response.ApiCall, data);
 			Settings.OnRequestCompleted?.Invoke(response.ApiCall);
 			if (data != null && (clientException != null && data.ThrowExceptions)) throw clientException;
 		}

--- a/src/Nest/CommonAbstractions/ForAttribute.cs
+++ b/src/Nest/CommonAbstractions/ForAttribute.cs
@@ -14,8 +14,10 @@ namespace Nest
 	[AttributeUsage(AttributeTargets.Interface)]
 	internal class MapsApiAttribute : Attribute
 	{
+		public string Name { get; }
+
 		// ReSharper disable once UnusedParameter.Local
-		public MapsApiAttribute(string restSpecName) { }
+		public MapsApiAttribute(string restSpecName) => Name = restSpecName;
 	}
 
 	/// <summary>

--- a/src/Nest/ElasticClient.cs
+++ b/src/Nest/ElasticClient.cs
@@ -196,7 +196,7 @@ namespace Nest
 			{
 				return;
 			}
-			var testCode = frames
+			var framesFilter = frames
 				.Where(f =>
 				{
 					var path = f.GetFileName();
@@ -204,7 +204,10 @@ namespace Nest
 						&& path.Contains("Tests" + Path.DirectorySeparatorChar)
 						&& !path.Contains("Framework");
 				})
-				.FirstOrDefault();
+				.OrderByDescending(f=>f.GetFileName()?.Length ?? 0)
+				.ToArray();
+
+			var testCode = framesFilter.FirstOrDefault();
 
 			if (testCode != null)
 			{

--- a/tests/Tests.Configuration/ConfigurationLoader.cs
+++ b/tests/Tests.Configuration/ConfigurationLoader.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Threading;
 
@@ -26,19 +27,25 @@ namespace Tests.Configuration
 		/// </summary>
 		private static EnvironmentConfiguration LoadCommandLineConfiguration()
 		{
+			Console.WriteLine(">>>> cmd");
 			var yamlFile = Environment.GetEnvironmentVariable("NEST_YAML_FILE");
 			if (string.IsNullOrWhiteSpace(yamlFile))
 				throw new Exception("expected NEST_YAML_FILE to be set when calling build.bat or build.sh");
 			if (!File.Exists(yamlFile))
 				throw new Exception($"expected {yamlFile} to exist on disk NEST_YAML_FILE seems misconfigured");
 
+			Console.WriteLine($">>>> {yamlFile}");
 			//load the test seed from the explicitly passed yaml file when running from FAKE
 			var tempYamlConfiguration = new YamlConfiguration(yamlFile);
-			return new EnvironmentConfiguration(tempYamlConfiguration);
+			Console.WriteLine($"new EnvironmentConfig {yamlFile}");
+			var x = new EnvironmentConfiguration(tempYamlConfiguration);
+			Console.WriteLine($"return EnvironmentConfig {yamlFile}");
+			return x;
 		}
 
 		public static string LocateTestYamlFile()
 		{
+			Console.WriteLine(">>>> yaml");
 			var directory = new DirectoryInfo(Directory.GetCurrentDirectory());
 			var testsConfigurationFolder = FindTestsConfigurationFolder(directory);
 			if (testsConfigurationFolder == null)

--- a/tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -16,7 +16,9 @@ namespace Tests.Configuration
 			TestFilter = Environment.GetEnvironmentVariable("NEST_TEST_FILTER");
 
 			var version = Environment.GetEnvironmentVariable("NEST_INTEGRATION_VERSION");
+			Console.WriteLine($">>> cmd version {version}");
 			ElasticsearchVersion = string.IsNullOrWhiteSpace(version) ? yamlConfiguration.ElasticsearchVersion : version;
+			Console.WriteLine($">>> version {ElasticsearchVersion}");
 			if (ElasticsearchVersion == null)
 				throw new Exception("Elasticsearch Version could not be determined from env var NEST_INTEGRATION_VERSION nor the test yaml configuration");
 
@@ -26,6 +28,7 @@ namespace Tests.Configuration
 					? yamlConfiguration.Seed
 					: (int?)null;
 			SetExternalSeed(externalSeed, out var randomizer);
+			Console.WriteLine($">>> EnvironmentConfig {ElasticsearchVersion}");
 
 			TestOnlyOne = RandomBoolConfig("TEST_ONLY_ONE", randomizer, false);
 			Random = new RandomConfiguration

--- a/tests/Tests.Configuration/Tests.Configuration.csproj
+++ b/tests/Tests.Configuration/Tests.Configuration.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Configuration/YamlConfiguration.cs
+++ b/tests/Tests.Configuration/YamlConfiguration.cs
@@ -17,10 +17,12 @@ namespace Tests.Configuration
 		{
 			if (!File.Exists(configurationFile)) return;
 
+			Console.WriteLine($">>>> >>>> {configurationFile}");
 			_config = File.ReadAllLines(configurationFile)
 				.Where(l => !l.Trim().StartsWith("#") && !string.IsNullOrWhiteSpace(l))
 				.ToDictionary(ConfigName, ConfigValue);
 
+			Console.WriteLine($">>>> 1 {configurationFile}");
 			Mode = GetTestMode(_config["mode"]);
 			var version = _config["elasticsearch_version"];
 			ElasticsearchVersion = version;

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -13,7 +13,7 @@ elasticsearch_version: latest-7
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
-#force_reseed: true
+# force_reseed: true
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
@@ -25,4 +25,4 @@ test_against_already_running_elasticsearch: true
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.
 # Can also help keep the noise down in case of test failures
-#test_only_one: false
+test_only_one: true

--- a/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
+++ b/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
@@ -5,6 +5,7 @@
 using System.IO;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using Elasticsearch.Net;
 using Nest;
 using Tests.Core.Xunit;
@@ -13,9 +14,10 @@ namespace Tests.Core.Client.Settings
 {
 	public class FlightRecorderExporter
 	{
+		private static int _unique = 1;
 		public static void OnBeforeReturn(IApiCallDetails response, RequestData requestData)
 		{
-			//if (!response.ResponseMimeType.StartsWith("application/json")) return;
+			if (!response.ResponseMimeType.StartsWith("application/json")) return;
 
 			var args = CreateArgsJson(requestData.Headers.Get("x-api-args")); //key=value;....
 			var apiName = requestData.Headers.Get("x-api-name"); //count
@@ -25,11 +27,12 @@ namespace Tests.Core.Client.Settings
 			var tokens = fileName.Split('$');
 			if (tokens.Length != 3) return;
 
+			var unique = Interlocked.Increment(ref _unique);
 			var path = tokens[0].Replace(".cs", "");
 			var testDirectory = Path.Combine(XunitRunState.TemporaryDirectory.FullName, apiName, path);
 			var @class = string.Join("_", tokens[1].Split(Path.GetInvalidFileNameChars()));
 			var @cmethod = string.Join("_", tokens[2].Split(Path.GetInvalidFileNameChars().Concat(new[] { '<', '>' }).ToArray()));
-			var fileNamePrefix = $"{@class}_{@cmethod}_";
+			var fileNamePrefix = $"{@class}_{@cmethod}_{unique}_";
 
 			Directory.CreateDirectory(testDirectory);
 
@@ -44,31 +47,44 @@ namespace Tests.Core.Client.Settings
 
 		public static string CreateArgsJson(string args)
 		{
+			if (args == null) return string.Empty;
 			var argsJson = string.Join(",", args.Split(';')
 				.Select(a => a.Split('='))
 				.Where(a=>a.Length == 2)
 				.Select(tokens => $"    \"{tokens[0]}\": \"{tokens[1]}\"")
 				.ToArray());
-			if (!string.IsNullOrEmpty(argsJson)) argsJson += ",";
 			return argsJson;
 
 		}
-		public static string BytesToJson(byte[] bytes)
+		public static string BytesToJson(byte[] bytes, bool isNdJsonApi = false)
 		{
 			if (bytes == null || bytes.Length <= 0) return string.Empty;
-			var body = $"\"body\": {Encoding.UTF8.GetString(bytes)}";
-			return body;
+
+			var body = Encoding.UTF8.GetString(bytes);
+			if (isNdJsonApi)
+			{
+				body = new StringBuilder()
+					.Append("[")
+					.Append(body.Replace("\n", "\n,").TrimEnd(','))
+					.Append("]")
+					.ToString();
+			}
+
+			var property = $"\"body\": {body}";
+			return property;
 		}
 
 		public static string CreateResponse(string apiName, byte[] responseBytes, string args, int statusCode)
 		{
 			var error = (statusCode < 300 && statusCode >= 200) || statusCode == 404 ? "false" : "true";
+			var body = BytesToJson(responseBytes);
+			if (!string.IsNullOrEmpty(args) && !string.IsNullOrEmpty(body)) args += ",";
 			var contents = $@"{{
   ""api"": ""{apiName}"",
   ""origin"": [""nest-integration-tests""],
   ""args"": {{
 {args}
-    {BytesToJson(responseBytes)}
+    {body}
   }},
   ""error"": {error},
   ""statusCode"": [{statusCode}]
@@ -80,12 +96,20 @@ namespace Tests.Core.Client.Settings
 		public static string CreateRequest(string apiName, byte[] requestBytes, string args, int statusCode)
 		{
 			var error = (statusCode < 300 && statusCode >= 200) || statusCode == 404 ? "false" : "true";
+			var ndJsonApis = new[]
+			{
+				"bulk", "msearch", "msearch_template", "ml.find_file_structure", "monitoring.bulk", "xpack.ml.find_file_structure",
+				"xpack.monitoring.bulk"
+			};
+			var isNdJsonApi = ndJsonApis.Contains(apiName);
+			var body = BytesToJson(requestBytes, isNdJsonApi);
+			if (!string.IsNullOrEmpty(args) && !string.IsNullOrEmpty(body)) args += ",";
 			var contents = $@"{{
   ""api"": ""{apiName}"",
   ""origin"": [""nest-integration-tests""],
   ""args"": {{
 {args}
-    {BytesToJson(requestBytes)}
+    {body}
   }},
   ""error"": {error},
   ""statusCode"": [{statusCode}]

--- a/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
+++ b/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
@@ -78,12 +78,10 @@ namespace Tests.Core.Client.Settings
 		{
 			var error = (statusCode < 300 && statusCode >= 200) || statusCode == 404 ? "false" : "true";
 			var body = BytesToJson(responseBytes);
-			if (!string.IsNullOrEmpty(args) && !string.IsNullOrEmpty(body)) args += ",";
 			var contents = $@"{{
   ""api"": ""{apiName}"",
   ""origin"": [""nest-integration-tests""],
-  ""args"": {{
-{args}
+  ""payload"": {{
     {body}
   }},
   ""error"": {error},

--- a/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
+++ b/tests/Tests.Core/Client/Settings/FlightRecorderExporter.cs
@@ -1,0 +1,97 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Linq;
+using System.Text;
+using Elasticsearch.Net;
+using Nest;
+using Tests.Core.Xunit;
+
+namespace Tests.Core.Client.Settings
+{
+	public class FlightRecorderExporter
+	{
+		public static void OnBeforeReturn(IApiCallDetails response, RequestData requestData)
+		{
+			//if (!response.ResponseMimeType.StartsWith("application/json")) return;
+
+			var args = CreateArgsJson(requestData.Headers.Get("x-api-args")); //key=value;....
+			var apiName = requestData.Headers.Get("x-api-name"); //count
+			var fileName = requestData.Headers.Get("x-test-name"); //Search/Count/CountApiTests.cs-CountApiTests-<ClientUsage>b__15_2
+			if (fileName == null) return;
+
+			var tokens = fileName.Split('$');
+			if (tokens.Length != 3) return;
+
+			var path = tokens[0].Replace(".cs", "");
+			var testDirectory = Path.Combine(XunitRunState.TemporaryDirectory.FullName, apiName, path);
+			var @class = string.Join("_", tokens[1].Split(Path.GetInvalidFileNameChars()));
+			var @cmethod = string.Join("_", tokens[2].Split(Path.GetInvalidFileNameChars().Concat(new[] { '<', '>' }).ToArray()));
+			var fileNamePrefix = $"{@class}_{@cmethod}_";
+
+			Directory.CreateDirectory(testDirectory);
+
+			var requestRecordingJson = CreateRequest(apiName, response.RequestBodyInBytes, args, response.HttpStatusCode.GetValueOrDefault());
+			var requestFile = Path.Combine(testDirectory, fileNamePrefix + "_request.json");
+			File.WriteAllText(requestFile, requestRecordingJson);
+
+			var responseRecordingJson = CreateResponse(apiName, response.ResponseBodyInBytes, args, response.HttpStatusCode.GetValueOrDefault());
+			var responseFile = Path.Combine(testDirectory, fileNamePrefix + "_response.json");
+			File.WriteAllText(responseFile, responseRecordingJson);
+		}
+
+		public static string CreateArgsJson(string args)
+		{
+			var argsJson = string.Join(",", args.Split(';')
+				.Select(a => a.Split('='))
+				.Where(a=>a.Length == 2)
+				.Select(tokens => $"    \"{tokens[0]}\": \"{tokens[1]}\"")
+				.ToArray());
+			if (!string.IsNullOrEmpty(argsJson)) argsJson += ",";
+			return argsJson;
+
+		}
+		public static string BytesToJson(byte[] bytes)
+		{
+			if (bytes == null || bytes.Length <= 0) return string.Empty;
+			var body = $"\"body\": {Encoding.UTF8.GetString(bytes)}";
+			return body;
+		}
+
+		public static string CreateResponse(string apiName, byte[] responseBytes, string args, int statusCode)
+		{
+			var error = (statusCode < 300 && statusCode >= 200) || statusCode == 404 ? "false" : "true";
+			var contents = $@"{{
+  ""api"": ""{apiName}"",
+  ""origin"": [""nest-integration-tests""],
+  ""args"": {{
+{args}
+    {BytesToJson(responseBytes)}
+  }},
+  ""error"": {error},
+  ""statusCode"": [{statusCode}]
+}}
+";
+			return contents;
+		}
+
+		public static string CreateRequest(string apiName, byte[] requestBytes, string args, int statusCode)
+		{
+			var error = (statusCode < 300 && statusCode >= 200) || statusCode == 404 ? "false" : "true";
+			var contents = $@"{{
+  ""api"": ""{apiName}"",
+  ""origin"": [""nest-integration-tests""],
+  ""args"": {{
+{args}
+    {BytesToJson(requestBytes)}
+  }},
+  ""error"": {error},
+  ""statusCode"": [{statusCode}]
+}}
+";
+			return contents;
+		}
+	}
+}

--- a/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using Elasticsearch.Net;
 using Nest;
@@ -53,6 +54,10 @@ namespace Tests.Core.Client.Settings
 			.EnableDebugMode()
 #endif
 			.ConnectionLimit(ConnectionLimitDefault)
+			.OnBeforeReturn((response, requestData) =>
+			{
+				FlightRecorderExporter.OnBeforeReturn(response, requestData);
+			})
 			.OnRequestCompleted(r =>
 			{
 				if (!r.DeprecationWarnings.Any()) return;

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.5" />
     
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
     <PackageReference Include="coverlet.collector" Version="1.1.0" />

--- a/tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -18,6 +18,7 @@ namespace Tests.Core.Xunit
 	{
 		public NestXunitRunOptions()
 		{
+			Console.WriteLine("asdasdasdaxxxx");
 			RunIntegrationTests = TestConfiguration.Instance.RunIntegrationTests;
 			RunUnitTests = TestConfiguration.Instance.RunUnitTests;
 			ClusterFilter = TestConfiguration.Instance.ClusterFilter;
@@ -26,11 +27,12 @@ namespace Tests.Core.Xunit
 			IntegrationTestsMayUseAlreadyRunningNode = TestConfiguration.Instance.TestAgainstAlreadyRunningElasticsearch;
 
 			Generators.Initialize();
+			Console.WriteLine("2");
 		}
 
 		public override void OnBeforeTestsRun()
 		{
-			//TestConfiguration.Instance.DumpConfiguration();
+			TestConfiguration.Instance.DumpConfiguration();
 		}
 
 		public override void OnTestsFinished(Dictionary<string, Stopwatch> clusterTotals, ConcurrentBag<Tuple<string, string>> failedCollections)

--- a/tests/Tests.Core/Xunit/XunitRunState.cs
+++ b/tests/Tests.Core/Xunit/XunitRunState.cs
@@ -2,12 +2,31 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Collections.Concurrent;
+using System.IO;
 
 namespace Tests.Core.Xunit
 {
 	internal static class XunitRunState
 	{
 		public static ConcurrentBag<string> SeenDeprecations { get; } = new ConcurrentBag<string>();
+
+
+		private static DirectoryInfo _tempDir;
+		public static DirectoryInfo TemporaryDirectory
+		{
+			get
+			{
+				if (_tempDir != null) return _tempDir;
+				var dir = Path.GetTempPath();
+				//var testDir = Path.Combine(dir, "nest-tests-" + Guid.NewGuid().ToString("N").Substring(0, 8));
+				var testDir = Path.Combine(dir, "nest-tests");
+				_tempDir = Directory.CreateDirectory(testDir);
+				return _tempDir;
+
+
+			}
+		}
 	}
 }

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>

--- a/tests/Tests/Aggregations/AggregationMetaUsageTests.cs
+++ b/tests/Tests/Aggregations/AggregationMetaUsageTests.cs
@@ -20,6 +20,9 @@ namespace Tests.Aggregations
 	{
 		public AggregationMetaUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			min_last_activity = new

--- a/tests/Tests/Aggregations/AggregationUsageTestBase.cs
+++ b/tests/Tests/Aggregations/AggregationUsageTestBase.cs
@@ -83,11 +83,22 @@ namespace Tests.Aggregations
 			(client, r) => client.Search<Project>(r),
 			(client, r) => client.SearchAsync<Project>(r)
 		);
+
+		protected LazyResponses SetupCalls() => Calls(
+			(client, f) => client.Search(f),
+			(client, f) => client.SearchAsync(f),
+			(client, r) => client.Search<Project>(r),
+			(client, r) => client.SearchAsync<Project>(r)
+		);
+
 	}
 
 	public abstract class ProjectsOnlyAggregationUsageTestBase : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		protected ProjectsOnlyAggregationUsageTestBase(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override Nest.Indices AgainstIndex => DefaultSeeder.ProjectsAliasFilter;
 		protected override string UrlPath => $"/{DefaultSeeder.ProjectsAliasFilter}/_search";

--- a/tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/AdjacencyMatrix/AdjacencyMatrixUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Bucket.AdjacencyMatrix
 	{
 		public AdjacencyMatrixUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			interactions = new

--- a/tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Children/ChildrenAggregationUsageTests.cs
@@ -20,6 +20,9 @@ namespace Tests.Aggregations.Bucket.Children
 	{
 		public ChildrenAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			name_of_child_agg = new

--- a/tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateRange/DateRangeAggregationUsageTests.cs
@@ -28,6 +28,9 @@ namespace Tests.Aggregations.Bucket.DateRange
 	{
 		public DateRangeAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_date_ranges = new

--- a/tests/Tests/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DiversifiedSampler/DiversifiedSamplerAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Bucket.DiversifiedSampler
 	{
 		public DiversifiedSamplerAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			diversified_sample = new

--- a/tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Filter/FilterAggregationUsageTests.cs
@@ -28,6 +28,9 @@ namespace Tests.Aggregations.Bucket.Filter
 
 		public FilterAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			bethels_projects = new
@@ -91,6 +94,9 @@ namespace Tests.Aggregations.Bucket.Filter
 	{
 		public EmptyFilterAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			empty_filter = new
@@ -131,6 +137,9 @@ namespace Tests.Aggregations.Bucket.Filter
 		private readonly string _ctxNumberofCommits = "doc['numberOfCommits'].value > 0";
 
 		public InlineScriptFilterAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Filters/FiltersAggregationUsageTests.cs
@@ -193,6 +193,9 @@ namespace Tests.Aggregations.Bucket.Filters
 	{
 		public EmptyFiltersAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			empty_filters = new
@@ -227,6 +230,9 @@ namespace Tests.Aggregations.Bucket.Filters
 	public class ConditionlessFiltersAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public ConditionlessFiltersAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoDistance/GeoDistanceAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Bucket.GeoDistance
 	{
 		public GeoDistanceAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			rings_around_amsterdam = new

--- a/tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoHashGrid/GeoHashGridAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Bucket.GeoHashGrid
 	{
 		public GeoHashGridAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			my_geohash_grid = new
@@ -62,6 +65,9 @@ namespace Tests.Aggregations.Bucket.GeoHashGrid
 	public class GeoHashGridAggregationWithBoundsUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public GeoHashGridAggregationWithBoundsUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/GeoTileGrid/GeoTileGridAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Bucket.GeoTileGrid
 	{
 		public GeoTileGridAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			my_geotile = new

--- a/tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Global/GlobalAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Bucket.Global
 	{
 		public GlobalAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			all_projects = new

--- a/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Histogram/HistogramAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Bucket.Histogram
 	{
 		public HistogramAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commits = new
@@ -76,6 +79,9 @@ namespace Tests.Aggregations.Bucket.Histogram
 		private const double HardBoundsMaximum = 300;
 
 		public HistogramAggregationWithHardBoundsUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/IpRange/IpRangeAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Bucket.IpRange
 	{
 		public IpRangeAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			ip_ranges = new

--- a/tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Missing/MissingAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Bucket.Missing
 	{
 		public MissingAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_without_a_description = new

--- a/tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Nested/NestedAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Bucket.Nested
 	{
 		public NestedAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			tags = new

--- a/tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Range/RangeAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Bucket.Range
 	{
 		public RangeAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commit_ranges = new

--- a/tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/RareTerms/RareTermsAggregationUsageTests.cs
@@ -29,6 +29,9 @@ namespace Tests.Aggregations.Bucket.RareTerms
 	{
 		public RareTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			names = new

--- a/tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/ReverseNested/ReverseNestedAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Bucket.ReverseNested
 	{
 		public ReverseNestedAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			tags = new

--- a/tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Sampler/SamplerAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Bucket.Sampler
 	{
 		public SamplerAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			sample = new

--- a/tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/SignificantTerms/SignificantTermsAggregationUsageTests.cs
@@ -29,6 +29,9 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 	{
 		public SignificantTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			significant_names = new
@@ -87,6 +90,9 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 	public class SignificantTermsIncludePatternAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public SignificantTermsIncludePatternAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{
@@ -150,6 +156,9 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 	{
 		public SignificantTermsExcludeExactValuesAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			significant_names = new
@@ -211,6 +220,9 @@ namespace Tests.Aggregations.Bucket.SignificantTerms
 	public class NumericSignificantTermsAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public NumericSignificantTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/SignificantText/SignificantTextAggregationUsageTests.cs
@@ -40,6 +40,9 @@ namespace Tests.Aggregations.Bucket.SignificantText
 
 		public SignificantTextAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			significant_descriptions = new

--- a/tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/Terms/TermsAggregationUsageTests.cs
@@ -24,6 +24,9 @@ namespace Tests.Aggregations.Bucket.Terms
 	{
 		public TermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			states = new
@@ -124,6 +127,9 @@ namespace Tests.Aggregations.Bucket.Terms
 	{
 		public TermsAggregationIncludePatternUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			states = new
@@ -219,6 +225,9 @@ namespace Tests.Aggregations.Bucket.Terms
 	public class TermsAggregationIncludeExactValuesUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public TermsAggregationIncludeExactValuesUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{
@@ -320,6 +329,9 @@ namespace Tests.Aggregations.Bucket.Terms
 	public class PartitionTermsAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public PartitionTermsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Matrix/MatrixStats/MatrixStatsAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Matrix.MatrixStats
 	{
 		public MatrixStatsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			matrixstats = new

--- a/tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Average/AverageAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Metric.Average
 	{
 		public AverageAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => base.ClientUsage();
+
 		protected override object AggregationJson => new
 		{
 			average_commits = new

--- a/tests/Tests/Aggregations/Metric/Boxplot/BoxplotAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Boxplot/BoxplotAggregationUsageTests.cs
@@ -29,6 +29,9 @@ namespace Tests.Aggregations.Metric.Boxplot
 	{
 		public BoxplotAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			boxplot_commits = new

--- a/tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Cardinality/CardinalityAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Cardinality
 	{
 		public CardinalityAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			state_count = new

--- a/tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/ExtendedStats/ExtendedStatsAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Metric.ExtendedStats
 	{
 		public ExtendedStatsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commit_stats = new
@@ -80,6 +83,9 @@ namespace Tests.Aggregations.Metric.ExtendedStats
 	public class ExtendedStatsAggregationUsageDocCountZeroTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public ExtendedStatsAggregationUsageDocCountZeroTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		// a query that no docs will match
 		protected override QueryContainer QueryScope => base.QueryScope &&

--- a/tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/GeoBounds/GeoBoundsAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.GeoBounds
 	{
 		public GeoBoundsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			viewport = new

--- a/tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/GeoCentroid/GeoCentroidAggregationUsageTests.cs
@@ -23,6 +23,9 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 	{
 		public GeoCentroidAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			centroid = new
@@ -65,6 +68,9 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 	public class NestedGeoCentroidAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public NestedGeoCentroidAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{
@@ -127,6 +133,9 @@ namespace Tests.Aggregations.Metric.GeoCentroid
 	public class GeoCentroidNoResultsAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public GeoCentroidNoResultsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/GeoLine/GeoLineAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/GeoLine/GeoLineAggregationUsageTests.cs
@@ -15,7 +15,7 @@ using static Nest.Infer;
 namespace Tests.Aggregations.Metric.GeoLine
 {
 	/**
-	 * The geo_line aggregation aggregates all geo_point values within a bucket into a LineString ordered by the chosen sort field. 
+	 * The geo_line aggregation aggregates all geo_point values within a bucket into a LineString ordered by the chosen sort field.
 	 *
 	 * Be sure to read the Elasticsearch documentation on {ref_current}/search-aggregations-metrics-geo-line.html[Geo-Line Aggregation].
 	*/
@@ -23,6 +23,9 @@ namespace Tests.Aggregations.Metric.GeoLine
 	public class GeoLineAggregationUsageTests : AggregationUsageTestBase<XPackCluster>
 	{
 		public GeoLineAggregationUsageTests(XPackCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Max/MaxAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Max
 	{
 		public MaxAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			max_commits = new

--- a/tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/MedianAbsoluteDeviation/MedianAbsoluteDeviationAggregationUsageTests.cs
@@ -30,6 +30,9 @@ namespace Tests.Aggregations.Metric.MedianAbsoluteDeviation
 	{
 		public MedianAbsoluteDeviationAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			average_commits = new

--- a/tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Min/MinAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Min
 	{
 		public MinAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			min_last_activity = new

--- a/tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/PercentileRanks/PercentileRanksAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Metric.PercentileRanks
 	{
 		public PercentileRanksAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commits_outlier = new
@@ -79,6 +82,9 @@ namespace Tests.Aggregations.Metric.PercentileRanks
 	public class PercentileRanksAggregationNonKeyedValuesUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public PercentileRanksAggregationNonKeyedValuesUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Percentiles/PercentilesAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Percentiles
 	{
 		public PercentilesAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commits_outlier = new
@@ -78,6 +81,9 @@ namespace Tests.Aggregations.Metric.Percentiles
 	public class PercentilesAggregationNonKeyedValuesUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public PercentilesAggregationNonKeyedValuesUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/Rate/RateAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Rate/RateAggregationUsageTests.cs
@@ -25,6 +25,9 @@ namespace Tests.Aggregations.Metric.Rate
 	{
 		public RateAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			by_date = new
@@ -94,6 +97,9 @@ namespace Tests.Aggregations.Metric.Rate
 	public class RateAggregationWithoutModeUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public RateAggregationWithoutModeUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Stats/StatsAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Stats
 	{
 		public StatsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commit_stats = new

--- a/tests/Tests/Aggregations/Metric/StringStats/StringStatsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/StringStats/StringStatsAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Metric.StringStats
 	{
 		public StringStatsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			name_stats = new
@@ -56,6 +59,9 @@ namespace Tests.Aggregations.Metric.StringStats
 	public class StringStatsWithDistributionAggregationUsageTests : AggregationUsageTestBase<ReadOnlyCluster>
 	{
 		public StringStatsWithDistributionAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
 
 		protected override object AggregationJson => new
 		{

--- a/tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/Sum/SumAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.Sum
 	{
 		public SumAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commits_sum = new

--- a/tests/Tests/Aggregations/Metric/TTest/TTestAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/TTest/TTestAggregationUsageTests.cs
@@ -29,6 +29,9 @@ namespace Tests.Aggregations.Metric.TTest
 	{
 		public TTestAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commits_visibility = new

--- a/tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/TopHits/TopHitsAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Metric.TopHits
 	{
 		public TopHitsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			states = new

--- a/tests/Tests/Aggregations/Metric/TopMetrics/TopMetricsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/TopMetrics/TopMetricsAggregationUsageTests.cs
@@ -28,6 +28,9 @@ namespace Tests.Aggregations.Metric.TopMetrics
 	{
 		public TopMetricsAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			tm = new

--- a/tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/ValueCount/ValueCountAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Metric.ValueCount
 	{
 		public ValueCountAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			commit_count = new

--- a/tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Metric/WeightedAverage/WeightedAverageAggregationUsageTests.cs
@@ -31,6 +31,9 @@ namespace Tests.Aggregations.Metric.WeightedAverage
 	{
 		public WeightedAverageAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			weighted_avg_commits = new

--- a/tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/AverageBucket/AverageBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.AverageBucket
 	{
 		public AverageBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketScript/BucketScriptAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.BucketScript
 	{
 		public BucketScriptAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketSelector/BucketSelectorAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.BucketSelector
 	{
 		public BucketSelectorAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/BucketSort/BucketSortAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Pipeline.BucketSort
 	{
 		public BucketSortAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/CumulativeCardinality/CumulativeCardinalityAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/CumulativeCardinality/CumulativeCardinalityAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Pipeline.CumulativeCardinality
 	{
 		public CumulativeCardinalityAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/CumulativeSum/CumulativeSumAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.CumulativeSum
 	{
 		public CumulativeSumAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/Derivative/DerivativeAggregationUsageTests.cs
@@ -17,6 +17,9 @@ namespace Tests.Aggregations.Pipeline.Derivative
 	{
 		public DerivativeAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/ExtendedStatsBucket/ExtendedStatsBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.ExtendedStatsBucket
 	{
 		public ExtendedStatsBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MaxBucket/MaxBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.MaxBucket
 	{
 		public MaxBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MinBucket/MinBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.MinBucket
 	{
 		public MinBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageEwmaAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 	{
 		public MovingAverageEwmaAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltLinearAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 	{
 		public MovingAverageHoltLinearAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageHoltWintersAggregationUsageTests.cs
@@ -18,6 +18,9 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 	{
 		public MovingAverageHoltWintersUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageLinearAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 	{
 		public MovingAverageLinearAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingAverage/MovingAverageSimpleAggregationUsageTests.cs
@@ -19,6 +19,9 @@ namespace Tests.Aggregations.Pipeline.MovingAverage
 	{
 		public MovingAverageSimpleAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingFunction/MovingFunctionAggregationUsageTests.cs
@@ -30,6 +30,9 @@ namespace Tests.Aggregations.Pipeline.MovingFunction
 	{
 		public MovingFunctionAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/MovingPercentiles/MovingPercentilesAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/MovingPercentiles/MovingPercentilesAggregationUsageTests.cs
@@ -27,6 +27,9 @@ namespace Tests.Aggregations.Pipeline.MovingPercentiles
 	{
 		public MovingPercentilesAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/Normalize/NormalizeAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/Normalize/NormalizeAggregationUsageTests.cs
@@ -24,6 +24,9 @@ namespace Tests.Aggregations.Pipeline.Normalize
 	{
 		public NormalizeAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/PercentilesBucket/PercentilesBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.PercentilesBucket
 	{
 		public PercentilesBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/SerialDifferencing/SerialDifferencingAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.SerialDifferencing
 	{
 		public SerialDifferencingAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/StatsBucket/StatsBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.StatsBucket
 	{
 		public StatsBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Pipeline/SumBucket/SumBucketAggregationUsageTests.cs
@@ -16,6 +16,9 @@ namespace Tests.Aggregations.Pipeline.SumBucket
 	{
 		public SumBucketAggregationUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
+		// ReSharper disable once RedundantOverriddenMember
+		protected override LazyResponses ClientUsage() => SetupCalls();
+
 		protected override object AggregationJson => new
 		{
 			projects_started_per_month = new

--- a/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
+++ b/tests/Tests/ClientConcepts/Connection/ConnectionReuseAndBalancing.cs
@@ -33,6 +33,7 @@ namespace Tests.ClientConcepts.Connection
 				yield return new Project { Name = $"project-{i}" };
 		}
 
+		[SkipVersion("<8.0.0", "Skipping for flight recorder export generates too much of the same")]
 		[I] public async Task IndexAndSearchABunch()
 		{
 			const int requestsPerIteration = 1000;


### PR DESCRIPTION
This is a total hack but keeping it up as a draft PR so we can update as needed over time. 

This exports the in flight request and response from our integration tests to json files in a temp folder. These json format are in the format our typescript specification model checker tooling requires.

