### PR TITLE
Reintroduce set for JsonParsingException.ActualChar (#5090)

### DIFF
--- a/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
+++ b/src/Elasticsearch.Net/Utf8Json/JsonReader.cs
@@ -1168,7 +1168,7 @@ namespace Elasticsearch.Net.Utf8Json
 		private readonly WeakReference _underlyingBytes;
 		private readonly int _limit;
         public int Offset { get; }
-        public string ActualChar { get; }
+        public string ActualChar { get; set; }
 
         public JsonParsingException(string message)
             : base(message)


### PR DESCRIPTION
(cherry picked from commit 5f937c1b3f8196306a2dbdd66ac8c66b2a9418b9)

NOTE: This should have been backported to 7.x (after fixing for 7.10) but got missed and brought back into 7.11 when I cut the branch. Will also backport to 7.x this time!