### PR TITLE
Bump testing abstraction and fix cluster run command

### DIFF
--- a/build/scripts/Paths.fs
+++ b/build/scripts/Paths.fs
@@ -18,6 +18,8 @@ module Paths =
     
     let InplaceBuildOutput project tfm = 
         sprintf "src/%s/bin/Release/%s" project tfm
+    let InplaceBuildTestOutput project tfm = 
+        sprintf "tests/%s/bin/Release/%s" project tfm
     let MagicDocumentationFile  = 
         "src/Elasticsearch.Net/obj/Release/netstandard2.1/Elasticsearch.Net.csprojAssemblyReference.cache" 
   

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -15,7 +15,7 @@ module ReposTooling =
         let clusterName = Option.defaultValue "" <| match args.CommandArguments with | Cluster c -> Some c.Name | _ -> None
         let clusterVersion = Option.defaultValue "" <|match args.CommandArguments with | Cluster c -> c.Version | _ -> None
         
-        let testsProjectDirectory = Path.Combine(Path.GetFullPath(Paths.Output("Tests.ClusterLauncher")), "net5.0")
+        let testsProjectDirectory = Path.GetFullPath(Paths.InplaceBuildTestOutput "Tests.ClusterLauncher" "net5.0")
         let tempDir = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
         
         printfn "%s" testsProjectDirectory

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -38,7 +38,7 @@
     <PackageReference Include="FSharp.Core" Version="5.0.0" />
 
     <PackageReference Include="Bullseye" Version="3.3.0" />
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
     
     <PackageReference Include="Fake.Core.Environment" Version="5.15.0" />
     <PackageReference Include="Fake.Core.SemVer" Version="5.15.0" />

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
-		<add key="Elastic Abstractions CI" value="https://ci.appveyor.com/nuget/elasticsearch-net-abstractions" />
 		<add key="Versioned Clients" value="https://ci.appveyor.com/nuget/elasticsearch-net" />
 	</packageSources>
 </configuration>

--- a/tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
+++ b/tests/Tests.ClusterLauncher/ClusterLaunchProgram.cs
@@ -38,8 +38,8 @@ namespace Tests.ClusterLauncher
 			if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable("NEST_YAML_FILE")))
 			{
 				// build always sets previous argument, assume we are running from the IDE or dotnet run
-                var yamlFile = TestConfiguration.LocateTestYamlFile();
-                Environment.SetEnvironmentVariable("NEST_YAML_FILE", yamlFile, EnvironmentVariableTarget.Process);
+				var yamlFile = TestConfiguration.LocateTestYamlFile();
+				Environment.SetEnvironmentVariable("NEST_YAML_FILE", yamlFile, EnvironmentVariableTarget.Process);
 			}
 
 			// if version is passed this will take precedence over the version in the yaml file
@@ -61,12 +61,19 @@ namespace Tests.ClusterLauncher
 			AppDomain.CurrentDomain.ProcessExit += (s, ev) => Instance?.Dispose();
 			Console.CancelKeyPress += (s, ev) => Instance?.Dispose();
 
-			if (!TryStartClientTestClusterBaseImplementation(cluster) && !TryStartXPackClusterImplementation(cluster))
+			try
 			{
+				if (TryStartClientTestClusterBaseImplementation(cluster) || TryStartXPackClusterImplementation(cluster)) return 0;
+
 				Console.Error.WriteLine($"Could not create an instance of '{cluster.FullName}");
 				return 1;
 			}
-			return 0;
+			catch (Exception e)
+			{
+				Console.WriteLine(e);
+				Instance?.Dispose();
+				throw;
+			}
 		}
 
 		private static bool TryStartXPackClusterImplementation(Type cluster)
@@ -91,7 +98,7 @@ namespace Tests.ClusterLauncher
 		private static bool Run(ICluster<EphemeralClusterConfiguration> instance)
 		{
 			TestConfiguration.Instance.DumpConfiguration();
-			instance.Start();
+			using var start = instance.Start();
 			if (!instance.Started)
 			{
 				Console.Error.WriteLine($"Failed to start cluster: '{instance.GetType().FullName}");
@@ -118,7 +125,7 @@ namespace Tests.ClusterLauncher
 
 			return types
 				.Where(t => t.Implements(typeof(IEphemeralCluster)))
-				.Where(t=> !t.IsAbstract)
+				.Where(t => !t.IsAbstract)
 				.ToArray();
 		}
 	}

--- a/tests/Tests.Configuration/Tests.Configuration.csproj
+++ b/tests/Tests.Configuration/Tests.Configuration.csproj
@@ -3,6 +3,6 @@
     <TargetFramework>netstandard2.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -16,7 +16,7 @@
     
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.5.0" />
-    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.2.5" />
     
     <PackageReference Include="Nullean.VsTest.Pretty.TestLogger" Version="0.3.0" />
     <PackageReference Include="coverlet.collector" Version="1.1.0" />

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.1.0-canary.0.244" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.2.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />
   </ItemGroup>


### PR DESCRIPTION
- update to latest libs from elastic/elasticsearch-net-abstractions and remove nightlies from nuget.config
- Update cluster build command so you can run clusters

You should now be able to call e.g `./build.sh cluster readonly latest-7` in a terminal and use as the cluster to run your scoped integration tests against as your developing them.

Greatly reducing the time you have to wait for the cluster to start.
