### PR TITLE
Update get token response to include auth info

### DIFF
--- a/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
+++ b/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
@@ -2,7 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System.Collections.Generic;
 using System.Runtime.Serialization;
+using Elasticsearch.Net;
 
 namespace Nest
 {
@@ -24,7 +26,7 @@ namespace Nest
 		public Authentication Authentication { get; set; }
 	}
 
-	public class Authentication : ResponseBase
+	public class Authentication
 	{
 		[DataMember(Name = "email")]
 		public string Email { get; internal set; }
@@ -44,12 +46,21 @@ namespace Nest
 		public string Username { get; internal set; }
 
 		[DataMember(Name = "authentication_realm")]
-		public RealmInfo AuthenticationRealm { get; internal set; }
+		public AuthenticationRealmInfo AuthenticationRealm { get; internal set; }
 
 		[DataMember(Name = "lookup_realm")]
-		public RealmInfo LookupRealm { get; internal set; }
+		public AuthenticationRealmInfo LookupRealm { get; internal set; }
 
 		[DataMember(Name = "authentication_type")]
 		public string AuthenticationType { get; internal set; }
+	}
+
+	public class AuthenticationRealmInfo
+	{
+		[DataMember(Name = "name")]
+		public string Name { get; internal set; }
+
+		[DataMember(Name = "type")]
+		public string Type { get; internal set; }
 	}
 }

--- a/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
+++ b/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
@@ -19,5 +19,8 @@ namespace Nest
 
 		[DataMember(Name ="type")]
 		public string Type { get; set; }
+
+		[DataMember(Name = "authentication")]
+		public AuthenticateResponse Authentication { get; set; }
 	}
 }

--- a/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
+++ b/src/Nest/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenResponse.cs
@@ -21,6 +21,35 @@ namespace Nest
 		public string Type { get; set; }
 
 		[DataMember(Name = "authentication")]
-		public AuthenticateResponse Authentication { get; set; }
+		public Authentication Authentication { get; set; }
+	}
+
+	public class Authentication : ResponseBase
+	{
+		[DataMember(Name = "email")]
+		public string Email { get; internal set; }
+
+		[DataMember(Name = "full_name")]
+		public string FullName { get; internal set; }
+
+		[DataMember(Name = "metadata")]
+		public IReadOnlyDictionary<string, object> Metadata { get; internal set; }
+			= EmptyReadOnly<string, object>.Dictionary;
+
+		[DataMember(Name = "roles")]
+		public IReadOnlyCollection<string> Roles { get; internal set; }
+			= EmptyReadOnly<string>.Collection;
+
+		[DataMember(Name = "username")]
+		public string Username { get; internal set; }
+
+		[DataMember(Name = "authentication_realm")]
+		public RealmInfo AuthenticationRealm { get; internal set; }
+
+		[DataMember(Name = "lookup_realm")]
+		public RealmInfo LookupRealm { get; internal set; }
+
+		[DataMember(Name = "authentication_type")]
+		public string AuthenticationType { get; internal set; }
 	}
 }

--- a/tests/Tests/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenApiTests.cs
+++ b/tests/Tests/XPack/Security/User/GetUserAccessToken/GetUserAccessTokenApiTests.cs
@@ -7,6 +7,8 @@ using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using FluentAssertions;
 using Nest;
+using Tests.Configuration;
+using Tests.Core.Extensions;
 using Tests.Framework.EndpointTests;
 using Tests.Framework.EndpointTests.TestState;
 using static Elastic.Elasticsearch.Ephemeral.ClusterAuthentication;
@@ -63,6 +65,13 @@ namespace Tests.XPack.Security.User.GetUserAccessToken
 			response.Type.Should().NotBeNullOrEmpty().And.Be("Bearer");
 			response.ExpiresIn.Should().BeGreaterThan(0);
 			response.Scope.Should().Be("full");
+
+			if (TestConfiguration.Instance.InRange(">=7.11.0"))
+			{
+				response.Authentication.Should().NotBeNull();
+				response.Authentication.Username.Should().NotBeNullOrEmpty();
+				response.Authentication.Roles.Count.Should().BeGreaterThan(0);
+			}
 		}
 	}
 


### PR DESCRIPTION
Updates the response as a result of this enhancement - https://github.com/elastic/elasticsearch/pull/62490

I've taken a similar approach as the server-side implementation by reusing the `AuthenticateResponse` type.