### PR TITLE
Always include ReferenceAssemblies

### DIFF
--- a/.ci/packages.lock.json
+++ b/.ci/packages.lock.json
@@ -1,6 +1,13 @@
 {
   "version": 1,
   "dependencies": {
-    ".NETCoreApp,Version=v5.0": {}
+    ".NETCoreApp,Version=v5.0": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      }
+    }
   }
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -42,7 +42,8 @@
     <ExposedPublicKey>002400000480000094000000060200000024000052534131000400000100010025d3a22bf3781ba85067374ad832dfcba3c4fa8dd89227e36121ba17b2c33ad6b6ce03e45e562050a031e2ff7fe12cff9060a50acbc6a0eef9ef32dc258d90f874b2e76b581938071ccc4b4d98204d1d6ca7a1988d7a211f9fc98efd808cf85f61675b11007d0eb0461dc86a968d6af8ebba7e6b540303b54f1c1f5325c252be</ExposedPublicKey>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(OS)' != 'Windows_NT' and $(DefineConstants.Contains(FULLFRAMEWORK))" Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2"/>
+    <!-- Include unconditionally due to difference in how dotnet cli and design time builds generate package.lock.json -->
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" PrivateAssets="All" Version="1.0.0-preview.2"/>
   </ItemGroup>
 
 </Project>

--- a/build/scripts/packages.lock.json
+++ b/build/scripts/packages.lock.json
@@ -84,6 +84,12 @@
         "resolved": "5.0.0",
         "contentHash": "iHoYXA0VaSQUONGENB1aVafjDDZDZpwu39MtaRCTrmwFW/cTcK0b2yKNVYneFHJMc3ChtsSoM9lNtJ1dYXkHfA=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.1, )",

--- a/src/ApiGenerator/packages.lock.json
+++ b/src/ApiGenerator/packages.lock.json
@@ -21,6 +21,12 @@
           "Microsoft.CodeAnalysis.Common": "[3.1.0-beta3-final]"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.1, )",

--- a/src/DocGenerator/packages.lock.json
+++ b/src/DocGenerator/packages.lock.json
@@ -113,6 +113,12 @@
           "NETStandard.Library": "1.6.1"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.1, )",

--- a/tests/Tests.Benchmarking/packages.lock.json
+++ b/tests/Tests.Benchmarking/packages.lock.json
@@ -40,6 +40,12 @@
           "LibGit2Sharp.NativeBinaries": "[1.0.245]"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "NEST.v7": {
         "type": "Direct",
         "requested": "[7.13.0-ci20210301T140449, )",

--- a/tests/Tests.ClusterLauncher/packages.lock.json
+++ b/tests/Tests.ClusterLauncher/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v5.0": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Bogus": {
         "type": "Transitive",
         "resolved": "22.1.2",

--- a/tests/Tests.Configuration/packages.lock.json
+++ b/tests/Tests.Configuration/packages.lock.json
@@ -13,6 +13,12 @@
           "System.Net.Http": "4.3.1"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/tests/Tests.Core/packages.lock.json
+++ b/tests/Tests.Core/packages.lock.json
@@ -42,6 +42,12 @@
         "resolved": "16.5.0",
         "contentHash": "yHZOhVSPuGqgHi+KhHiAZqNY08avkQraXKvgKgDU8c/ztmGzw7gmukkv49EaTq6T3xmp4XroWk3gAlbJHMxl8w=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/tests/Tests.Domain/packages.lock.json
+++ b/tests/Tests.Domain/packages.lock.json
@@ -19,6 +19,12 @@
           "System.Net.Http": "4.3.1"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "NETStandard.Library": {
         "type": "Direct",
         "requested": "[2.0.3, )",

--- a/tests/Tests.Reproduce/packages.lock.json
+++ b/tests/Tests.Reproduce/packages.lock.json
@@ -2,6 +2,12 @@
   "version": 1,
   "dependencies": {
     ".NETCoreApp,Version=v5.0": {
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "System.Reactive": {
         "type": "Direct",
         "requested": "[3.1.1, )",

--- a/tests/Tests.ScratchPad/packages.lock.json
+++ b/tests/Tests.ScratchPad/packages.lock.json
@@ -25,6 +25,12 @@
           "System.ValueTuple": "4.5.0"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "System.Diagnostics.DiagnosticSource": {
         "type": "Direct",
         "requested": "[5.0.0, )",

--- a/tests/Tests.YamlRunner/packages.lock.json
+++ b/tests/Tests.YamlRunner/packages.lock.json
@@ -27,6 +27,12 @@
           "FSharp.Core": "4.3.4"
         }
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.1, )",

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -23,6 +23,12 @@
         "resolved": "4.7.0",
         "contentHash": "6Bf2qzSCaJoP6tTfO+a5muUS7QbyJANqSut73zQvwQ9It5P0ITz9VKseeia2ofco30c55EQ0jA2wf2+A2gpGnw=="
       },
+      "Microsoft.NETFramework.ReferenceAssemblies": {
+        "type": "Direct",
+        "requested": "[1.0.0-preview.2, )",
+        "resolved": "1.0.0-preview.2",
+        "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[12.0.1, )",


### PR DESCRIPTION
Due to difference in how design time and the dotnet CLI produce
package.json files.

This stabalizes the package json between builds
