### PR TITLE
Support case_insensitive on term-based queries

### DIFF
--- a/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
+++ b/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
@@ -21,15 +21,18 @@ namespace Nest
 	{
 		public object Value { get; set; }
 		
-		protected override bool Conditionless => TermQuery.IsConditionless(this);
+		protected override bool Conditionless => IsConditionless(this);
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.SpanTerm = this;
+
+		internal static bool IsConditionless(ISpanTermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
 	}
 
 	public class SpanTermQueryDescriptor<T> : FieldNameQueryDescriptorBase<SpanTermQueryDescriptor<T>, ISpanTermQuery, T>, ISpanTermQuery
 		where T : class
 	{
-		protected override bool Conditionless => TermQuery.IsConditionless(this);
+		protected override bool Conditionless => SpanTermQuery.IsConditionless(this);
+		
 		object ISpanTermQuery.Value { get; set; }
 
 		public SpanTermQueryDescriptor<T> Value(object value) =>

--- a/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
+++ b/src/Nest/QueryDsl/Span/Term/SpanTermQuery.cs
@@ -9,18 +9,30 @@ namespace Nest
 {
 	[InterfaceDataContract]
 	[JsonFormatter(typeof(FieldNameQueryFormatter<SpanTermQuery, ISpanTermQuery>))]
-	public interface ISpanTermQuery : ITermQuery, ISpanSubQuery { }
+	public interface ISpanTermQuery : ISpanSubQuery, IFieldNameQuery
+	{
+		[DataMember(Name = "value")]
+		[JsonFormatter(typeof(SourceWriteFormatter<object>))]
+		object Value { get; set; }
+	}
 
 	[DataContract]
 	public class SpanTermQuery : FieldNameQueryBase, ISpanTermQuery
 	{
 		public object Value { get; set; }
-
+		
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.SpanTerm = this;
 	}
 
-	public class SpanTermQueryDescriptor<T> : TermQueryDescriptorBase<SpanTermQueryDescriptor<T>, ISpanTermQuery, T>, ISpanTermQuery
-		where T : class { }
+	public class SpanTermQueryDescriptor<T> : FieldNameQueryDescriptorBase<SpanTermQueryDescriptor<T>, ISpanTermQuery, T>, ISpanTermQuery
+		where T : class
+	{
+		protected override bool Conditionless => TermQuery.IsConditionless(this);
+		object ISpanTermQuery.Value { get; set; }
+
+		public SpanTermQueryDescriptor<T> Value(object value) =>
+			Assign(value, (a, v) => a.Value = v);
+	}
 }

--- a/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Prefix/PrefixQuery.cs
@@ -20,6 +20,7 @@ namespace Nest
 	{
 		public MultiTermQueryRewrite Rewrite { get; set; }
 		public object Value { get; set; }
+		public bool? CaseInsensitive { get; set; }
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Prefix = this;

--- a/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -14,18 +14,29 @@ namespace Nest
 		[DataMember(Name = "value")]
 		[JsonFormatter(typeof(SourceWriteFormatter<object>))]
 		object Value { get; set; }
+
+		[DataMember(Name = "case_insensitive")]
+		bool? CaseInsensitive { get; set; }
 	}
 
 	[DataContract]
 	public class TermQuery : FieldNameQueryBase, ITermQuery
 	{
 		public object Value { get; set; }
+		
+		public bool? CaseInsensitive { get; set; }
 
 		protected override bool Conditionless => IsConditionless(this);
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Term = this;
 
 		internal static bool IsConditionless(ITermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
+
+		internal static bool IsConditionless(ISpanTermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
+
+		internal static bool IsConditionless(IWildcardQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
+
+		internal static bool IsConditionless(IPrefixQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
 	}
 
 	public abstract class TermQueryDescriptorBase<TDescriptor, TInterface, T>
@@ -37,10 +48,17 @@ namespace Nest
 	{
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 		object ITermQuery.Value { get; set; }
+		bool? ITermQuery.CaseInsensitive { get; set; }
 
 		public TDescriptor Value(object value)
 		{
 			Self.Value = value;
+			return (TDescriptor)this;
+		}
+
+		public TDescriptor CaseInsensitive(bool? caseInsensitive = true)
+		{
+			Self.CaseInsensitive = caseInsensitive;
 			return (TDescriptor)this;
 		}
 	}

--- a/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Term/TermQuery.cs
@@ -31,12 +31,6 @@ namespace Nest
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Term = this;
 
 		internal static bool IsConditionless(ITermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
-
-		internal static bool IsConditionless(ISpanTermQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
-
-		internal static bool IsConditionless(IWildcardQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
-
-		internal static bool IsConditionless(IPrefixQuery q) => q.Value == null || q.Value.ToString().IsNullOrEmpty() || q.Field.IsConditionless();
 	}
 
 	public abstract class TermQueryDescriptorBase<TDescriptor, TInterface, T>

--- a/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
+++ b/src/Nest/QueryDsl/TermLevel/Wildcard/WildcardQuery.cs
@@ -27,6 +27,7 @@ namespace Nest
 	{
 		public MultiTermQueryRewrite Rewrite { get; set; }
 		public object Value { get; set; }
+		public bool? CaseInsensitive { get; set; }
 		protected override bool Conditionless => TermQuery.IsConditionless(this);
 
 		internal override void InternalWrapInContainer(IQueryContainer c) => c.Wildcard = this;


### PR DESCRIPTION
Resolves #5407

Note that `ISpanTermQuery` can no longer derive from `ITermQuery` as it doesn't support the `case_insenstive` option. This now manually includes and implements the value property.