### PR TITLE
enhancement/ienumerable searchafter descriptor

### DIFF
--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -453,6 +453,9 @@ namespace Nest
 			Assign(selector, (a, v) => a.Sort = v?.Invoke(new SortDescriptor<TInferDocument>())?.Value);
 
 		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
+		public SearchDescriptor<TInferDocument> SearchAfter(IEnumerable<object> searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v?.ToListOrNullIfEmpty());
+
+		/// <inheritdoc cref="ISearchRequest.SearchAfter" />
 		public SearchDescriptor<TInferDocument> SearchAfter(IList<object> searchAfter) => Assign(searchAfter, (a, v) => a.SearchAfter = v);
 
 		/// <inheritdoc cref="ISearchRequest.SearchAfter" />


### PR DESCRIPTION
Fixes #5416.

Since the sort from a previous search is represented as `IReadOnlyCollection<object>` it's reasonable that consumers may want to pass this unaltered into the next search. The `SearchRequest` defines this property as an `IList<object>` which we can't address without breaking changes. However, this PR can improve the fluent usage by providing an `IEnumerable<object>` overload, avoiding the need to call `ToList()` or `ToArray()` on the previous sort.