### PR TITLE
Avoid global state in snapshot

### DIFF
--- a/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CoordinatedSnapshotTests.cs
+++ b/tests/Tests/Modules/SnapshotAndRestore/Snapshot/CoordinatedSnapshotTests.cs
@@ -40,8 +40,8 @@ namespace Tests.Modules.SnapshotAndRestore.Snapshot
 			{
 				CreateSnapshotStep, u => u
 					.Calls<SnapshotDescriptor, SnapshotRequest, ISnapshotRequest, SnapshotResponse>(
-						v => new SnapshotRequest($"{v}-repository", $"{v}-source") { Indices = $"{v}-index", WaitForCompletion = true },
-						(v, d) => d.Index($"{v}-index").WaitForCompletion(true),
+						v => new SnapshotRequest($"{v}-repository", $"{v}-source") { Indices = $"{v}-index", WaitForCompletion = true, IncludeGlobalState = false },
+						(v, d) => d.Index($"{v}-index").WaitForCompletion(true).IncludeGlobalState(false),
 						(v, c, f) => c.Snapshot.Snapshot($"{v}-repository", $"{v}-source", f),
 						(v, c, f) => c.Snapshot.SnapshotAsync($"{v}-repository", $"{v}-source", f),
 						(_, c, r) => c.Snapshot.Snapshot(r),


### PR DESCRIPTION
A change in 7.12 may result in system indices such as ".tasks" being included in the snapshot which makes the assertions less deterministic. The best option is to disable the global state so that only our expected index is in the snapshot.