### PR TITLE
Deserialise analyzers without a type

### DIFF
--- a/src/Nest/Analysis/Analyzers/AnalyzerFormatter.cs
+++ b/src/Nest/Analysis/Analyzers/AnalyzerFormatter.cs
@@ -32,10 +32,7 @@ namespace Nest
 						break;
 				}
 			}
-
-			if (analyzerType == null)
-				return null;
-
+			
 			segmentReader = new JsonReader(arraySegment.Array, arraySegment.Offset);
 
 			switch (analyzerType)

--- a/tests/Tests.Reproduce/GitHubIssue5432.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5432.cs
@@ -1,0 +1,105 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Linq;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+using Tests.Core.Client;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue5432
+	{
+		[U]
+		public void DeserializesAnalyzers()
+		{
+			const string json = @"{
+    ""analyzer-test"": {
+        ""aliases"": {},
+        ""mappings"": {},
+        ""settings"": {
+            ""index"": {
+                ""routing"": {
+                    ""allocation"": {
+                        ""include"": {
+                            ""_tier_preference"": ""data_content""
+                        }
+                    }
+                },
+                ""number_of_shards"": ""1"",
+                ""provided_name"": ""analyzer-test"",
+                ""creation_date"": ""1616482422981"",
+                ""analysis"": {
+                    ""filter"": {
+                        ""autocomplete_ngram"": {
+                            ""type"": ""edge_ngram"",
+                            ""min_gram"": ""3"",
+                            ""max_gram"": ""20""
+                        }
+                    },
+                    ""analyzer"": {
+                        ""search_autocomplete"": {
+                            ""filter"": [
+                                ""lowercase""
+                            ],
+                            ""tokenizer"": ""keyword""
+                        },
+                        ""index_autocomplete"": {
+                            ""filter"": [
+                                ""lowercase"",
+                                ""autocomplete_ngram""
+                            ],
+                            ""tokenizer"": ""keyword""
+                        }
+                    }
+                },
+                ""number_of_replicas"": ""1"",
+                ""uuid"": ""g8qnTA5wTveRCQnQN6xa3A"",
+                ""version"": {
+                    ""created"": ""7110099""
+                }
+            }
+        }
+    }
+}";
+
+			var bytes = Encoding.UTF8.GetBytes(json);
+			var client = TestClient.FixedInMemoryClient(bytes);
+			var response = client.Indices.Get("analyzer-test");
+
+			var analyzers = response.Indices.Values.First().Settings.Analysis.Analyzers.Values;
+			analyzers.Count.Should().Be(2);
+
+			foreach(var a in analyzers)
+			{
+				a.Should().NotBeNull();
+			}
+
+			if (response.Indices.Values.First().Settings.Analysis.Analyzers.TryGetValue("search_autocomplete", out var analyzerOne))
+			{
+				var customAnalyzer = analyzerOne as CustomAnalyzer;
+				customAnalyzer.Should().NotBeNull();
+				customAnalyzer!.Filter.Count().Should().Be(1);
+			}
+			else
+			{
+				throw new Exception("Expected index_autocomplete analyzer was not found.");
+			}
+
+			if (response.Indices.Values.First().Settings.Analysis.Analyzers.TryGetValue("index_autocomplete", out var analyzerTwo))
+			{
+				var customAnalyzer = analyzerTwo as CustomAnalyzer;
+				customAnalyzer.Should().NotBeNull();
+				customAnalyzer!.Filter.Count().Should().Be(2);
+			}
+			else
+			{
+				throw new Exception("Expected index_autocomplete analyzer was not found.");
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #5435 

Although it is recommended to define custom analyzers with `"type": "custom"` it's possible to not provide a type. This resulted in the `AnalyzerFormatter` skipping the deserialisation. This change removes the type check so that we deserialise such analyzers as custom.