### PR TITLE
Introduce compatibility header

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
-		<add key="Versioned Clients" value="https://f.feedz.io/elastic/all/nuget/index.json" />
+		<add key="Elastic Abstractions CI" value="https://ci.appveyor.com/nuget/elasticsearch-net-abstractions" />
+		<add key="Versioned Clients" value="https://ci.appveyor.com/nuget/elasticsearch-net" />
 	</packageSources>
 </configuration>

--- a/nuget.config
+++ b/nuget.config
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<packageSources>
-		<add key="Elastic Abstractions CI" value="https://ci.appveyor.com/nuget/elasticsearch-net-abstractions" />
-		<add key="Versioned Clients" value="https://ci.appveyor.com/nuget/elasticsearch-net" />
+		<add key="Versioned Clients" value="https://f.feedz.io/elastic/all/nuget/index.json" />
 	</packageSources>
 </configuration>

--- a/src/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
+++ b/src/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
@@ -73,10 +73,10 @@ namespace Elasticsearch.Net.VirtualizedCluster.Rules
 			return (TRule)this;
 		}
 
-		public TRule ReturnByteResponse(byte[] response, string responseContentType = RequestData.MimeType)
+		public TRule ReturnByteResponse(byte[] response, string responseContentType = null)
 		{
 			Self.ReturnResponse = response;
-			Self.ReturnContentType = responseContentType;
+			Self.ReturnContentType = responseContentType ?? RequestData.MimeType;
 			return (TRule)this;
 		}
 	}

--- a/src/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
+++ b/src/Elasticsearch.Net.VirtualizedCluster/Rules/RuleBase.cs
@@ -69,14 +69,14 @@ namespace Elasticsearch.Net.VirtualizedCluster.Rules
 				r = ms.ToArray();
 			}
 			Self.ReturnResponse = r;
-			Self.ReturnContentType = RequestData.MimeType;
+			Self.ReturnContentType = RequestData.DefaultJsonMimeType;
 			return (TRule)this;
 		}
 
 		public TRule ReturnByteResponse(byte[] response, string responseContentType = null)
 		{
 			Self.ReturnResponse = response;
-			Self.ReturnContentType = responseContentType ?? RequestData.MimeType;
+			Self.ReturnContentType = responseContentType ?? RequestData.DefaultJsonMimeType;
 			return (TRule)this;
 		}
 	}

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -131,6 +131,8 @@ namespace Elasticsearch.Net
 	public abstract class ConnectionConfiguration<T> : IConnectionConfigurationValues
 		where T : ConnectionConfiguration<T>
 	{
+		internal const string ApiVersioningEnvironmentVariableName = "ELASTIC_CLIENT_APIVERSIONING";
+
 		private readonly IConnection _connection;
 		private readonly IConnectionPool _connectionPool;
 		private readonly NameValueCollection _headers = new NameValueCollection();
@@ -206,6 +208,14 @@ namespace Elasticsearch.Net
 				_apiKeyAuthCredentials = cloudPool.ApiKeyCredentials;
 				_enableHttpCompression = true;
 			}
+
+			var apiVersioningEnabled = Environment.GetEnvironmentVariable(ApiVersioningEnvironmentVariableName);
+			_enableApiVersioningHeader = string.IsNullOrEmpty(apiVersioningEnabled) switch
+			{
+				false when bool.TryParse(apiVersioningEnabled, out var isEnabled) => isEnabled,
+				false when int.TryParse(apiVersioningEnabled, out var isEnabledValue) => isEnabledValue == 1,
+				_ => _enableApiVersioningHeader
+			};
 		}
 
 		protected IElasticsearchSerializer UseThisRequestResponseSerializer { get; set; }

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -176,6 +176,7 @@ namespace Elasticsearch.Net
 		//public static IMemoryStreamFactory Default { get; } = RecyclableMemoryStreamFactory.Default;
 		public static IMemoryStreamFactory DefaultMemoryStreamFactory { get; } = Elasticsearch.Net.MemoryStreamFactory.Default;
 		private bool _enableThreadPoolStats;
+		private bool _enableApiVersioningHeader;
 
 		private string _userAgent = ConnectionConfiguration.DefaultUserAgent;
 		private readonly Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -257,8 +258,9 @@ namespace Elasticsearch.Net
 		bool IConnectionConfigurationValues.TransferEncodingChunked => _transferEncodingChunked;
 		bool IConnectionConfigurationValues.EnableTcpStats => _enableTcpStats;
 		bool IConnectionConfigurationValues.EnableThreadPoolStats => _enableThreadPoolStats;
-		
+
 		MetaHeaderProvider IConnectionConfigurationValues.MetaHeaderProvider { get; } = new MetaHeaderProvider();
+		bool IConnectionConfigurationValues.EnableApiVersioningHeader => _enableApiVersioningHeader;
 
 		void IDisposable.Dispose() => DisposeManagedResources();
 
@@ -342,7 +344,7 @@ namespace Elasticsearch.Net
 		public T DisableAutomaticProxyDetection(bool disable = true) => Assign(disable, (a, v) => a._disableAutomaticProxyDetection = v);
 
 		/// <summary>
-		/// Disables the meta header which is included on all requests by default. This header contains lightweight information 
+		/// Disables the meta header which is included on all requests by default. This header contains lightweight information
 		/// about the client and runtime.
 		/// </summary>
 		public T DisableMetaHeader(bool disable = true) => Assign(disable, (a, v) => a._disableMetaHeader = v);
@@ -601,6 +603,9 @@ namespace Elasticsearch.Net
 		/// The memory stream factory to use, defaults to <see cref="RecyclableMemoryStreamFactory.Default"/>
 		/// </summary>
 		public T MemoryStreamFactory(IMemoryStreamFactory memoryStreamFactory) => Assign(memoryStreamFactory, (a, v) => a._memoryStreamFactory = v);
+
+		/// <inheritdoc cref="IConnectionConfigurationValues.EnableApiVersioningHeader"/>
+		public T EnableApiVersioningHeader(bool enable = true) => Assign(enable, (a, v) => a._enableApiVersioningHeader = v);
 
 		public T EnableTcpStats(bool enableTcpStats = true) => Assign(enableTcpStats, (a, v) => a._enableTcpStats = v);
 

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -280,5 +280,11 @@ namespace Elasticsearch.Net
 		/// Produces the client meta header for a request.
 		/// </summary>
 		MetaHeaderProvider MetaHeaderProvider { get; }
+
+		/// <summary>
+		/// Enables the client to start sending the API versioning header. This allows a `7.x` client to talk to `8.x` Elasticsearch.
+		/// <para> NOTE: You need at least Elasticsearch 7.11 and higher before you can enable this setting on the client</para>
+		/// </summary>
+		bool EnableApiVersioningHeader { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
+++ b/src/Elasticsearch.Net/Connection/Content/RequestDataContent.cs
@@ -30,7 +30,7 @@ namespace Elasticsearch.Net
 		public RequestDataContent(RequestData requestData)
 		{
 			_requestData = requestData;
-			Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
+			Headers.ContentType = MediaTypeHeaderValue.Parse(requestData.RequestMimeType);
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 
@@ -50,7 +50,7 @@ namespace Elasticsearch.Net
 		public RequestDataContent(RequestData requestData, CancellationToken token)
 		{
 			_requestData = requestData;
-			Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
+			Headers.ContentType = MediaTypeHeaderValue.Parse(requestData.RequestMimeType);
 			if (requestData.HttpCompression)
 				Headers.ContentEncoding.Add("gzip");
 

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -95,7 +95,7 @@ namespace Elasticsearch.Net
 
 				requestData.MadeItToResponse = true;
 				responseMessage.Headers.TryGetValues("Warning", out warnings);
-				mimeType = responseMessage.Content.Headers.ContentType?.MediaType;
+				mimeType = responseMessage.Content.Headers.ContentType?.ToString();
 
 				if (responseMessage.Content != null)
 				{
@@ -162,7 +162,7 @@ namespace Elasticsearch.Net
 				}
 
 				requestData.MadeItToResponse = true;
-				mimeType = responseMessage.Content.Headers.ContentType?.MediaType;
+				mimeType = responseMessage.Content.Headers.ContentType?.ToString();
 				responseMessage.Headers.TryGetValues("Warning", out warnings);
 
 				if (responseMessage.Content != null)
@@ -323,8 +323,6 @@ namespace Elasticsearch.Net
 			requestMessage.Headers.Connection.Clear();
 			requestMessage.Headers.ConnectionClose = false;
 			requestMessage.Headers.TryAddWithoutValidation("Accept", requestData.Accept);
-
-			//requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(requestData.Accept));
 
 			if (!string.IsNullOrWhiteSpace(requestData.UserAgent))
 			{

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -322,7 +322,9 @@ namespace Elasticsearch.Net
 
 			requestMessage.Headers.Connection.Clear();
 			requestMessage.Headers.ConnectionClose = false;
-			requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(requestData.Accept));
+			requestMessage.Headers.TryAddWithoutValidation("Accept", requestData.Accept);
+
+			//requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue(requestData.Accept));
 
 			if (!string.IsNullOrWhiteSpace(requestData.UserAgent))
 			{
@@ -372,7 +374,7 @@ namespace Elasticsearch.Net
 				if (requestData.HttpCompression)
 					message.Content.Headers.ContentEncoding.Add("gzip");
 
-				message.Content.Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
+				message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(requestData.RequestMimeType);
 			}
 		}
 
@@ -409,7 +411,7 @@ namespace Elasticsearch.Net
 				if (requestData.HttpCompression)
 					message.Content.Headers.ContentEncoding.Add("gzip");
 
-				message.Content.Headers.ContentType = new MediaTypeHeaderValue(requestData.RequestMimeType);
+				message.Content.Headers.ContentType = MediaTypeHeaderValue.Parse(requestData.RequestMimeType);
 			}
 		}
 

--- a/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
+++ b/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
@@ -25,7 +25,7 @@ namespace Elasticsearch.Net
 		/// </summary>
 		public InMemoryConnection() => _statusCode = 200;
 
-		public InMemoryConnection(byte[] responseBody, int statusCode = 200, Exception exception = null, string contentType = RequestData.MimeType)
+		public InMemoryConnection(byte[] responseBody, int statusCode = 200, Exception exception = null, string contentType = null)
 		{
 			_responseBody = responseBody;
 			_statusCode = statusCode;

--- a/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
+++ b/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
@@ -27,10 +27,11 @@ namespace Elasticsearch.Net
 
 		public InMemoryConnection(byte[] responseBody, int statusCode = 200, Exception exception = null, string contentType = null)
 		{
+
 			_responseBody = responseBody;
 			_statusCode = statusCode;
 			_exception = exception;
-			_contentType = contentType;
+			_contentType = contentType ?? RequestData.MimeType;
 		}
 
 		public virtual TResponse Request<TResponse>(RequestData requestData)

--- a/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
+++ b/src/Elasticsearch.Net/Connection/InMemoryConnection.cs
@@ -31,7 +31,7 @@ namespace Elasticsearch.Net
 			_responseBody = responseBody;
 			_statusCode = statusCode;
 			_exception = exception;
-			_contentType = contentType ?? RequestData.MimeType;
+			_contentType = contentType ?? RequestData.DefaultJsonMimeType;
 		}
 
 		public virtual TResponse Request<TResponse>(RequestData requestData)
@@ -66,7 +66,7 @@ namespace Elasticsearch.Net
 
 			var sc = statusCode ?? _statusCode;
 			Stream s = body != null ? requestData.MemoryStreamFactory.Create(body) : requestData.MemoryStreamFactory.Create(EmptyBody);
-			return ResponseBuilder.ToResponse<TResponse>(requestData, _exception, sc, null, s, contentType ?? _contentType ?? RequestData.MimeType);
+			return ResponseBuilder.ToResponse<TResponse>(requestData, _exception, sc, null, s, contentType ?? _contentType ?? RequestData.DefaultJsonMimeType);
 		}
 
 		protected async Task<TResponse> ReturnConnectionStatusAsync<TResponse>(RequestData requestData, CancellationToken cancellationToken,

--- a/src/Elasticsearch.Net/Connection/MetaData/ClientVersionInfo.cs
+++ b/src/Elasticsearch.Net/Connection/MetaData/ClientVersionInfo.cs
@@ -15,6 +15,8 @@ namespace Elasticsearch.Net
 
 		public static readonly ClientVersionInfo Empty = new ClientVersionInfo { Version = new Version(0, 0, 0), IsPrerelease = false };
 
+		public static readonly ClientVersionInfo LowLevelClientVersionInfo = Create<IElasticLowLevelClient>();
+
 		private ClientVersionInfo() { }
 
 		public static ClientVersionInfo Create<T>()

--- a/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
+++ b/src/Elasticsearch.Net/Responses/ElasticsearchResponse.cs
@@ -74,7 +74,7 @@ namespace Elasticsearch.Net
 		{
 			serverError = null;
 			var bytes = ApiCall.ResponseBodyInBytes;
-			if (bytes == null || ResponseMimeType != RequestData.MimeType)
+			if (bytes == null || RequestData.IsJsonMimeType(ResponseMimeType))
 				return false;
 
 			using(var stream = ConnectionConfiguration.MemoryStreamFactory.Create(bytes))

--- a/src/Elasticsearch.Net/Responses/Special/BytesResponse.cs
+++ b/src/Elasticsearch.Net/Responses/Special/BytesResponse.cs
@@ -13,7 +13,7 @@ namespace Elasticsearch.Net
 		public override bool TryGetServerError(out ServerError serverError)
 		{
 			serverError = null;
-			if (Body == null || Body.Length == 0 || ResponseMimeType != RequestData.MimeType)
+			if (Body == null || Body.Length == 0 || !RequestData.IsJsonMimeType(ResponseMimeType))
 				return false;
 
 			using(var stream = ConnectionConfiguration.MemoryStreamFactory.Create(Body))

--- a/src/Elasticsearch.Net/Responses/Special/StringResponse.cs
+++ b/src/Elasticsearch.Net/Responses/Special/StringResponse.cs
@@ -15,7 +15,7 @@ namespace Elasticsearch.Net
 		public override bool TryGetServerError(out ServerError serverError)
 		{
 			serverError = null;
-			if (string.IsNullOrEmpty(Body) || ResponseMimeType != RequestData.MimeType)
+			if (string.IsNullOrEmpty(Body) || !RequestData.IsJsonMimeType(ResponseMimeType))
 				return false;
 
 			using(var stream = ConnectionConfiguration.MemoryStreamFactory.Create(Encoding.UTF8.GetBytes(Body)))

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -13,10 +13,12 @@ namespace Elasticsearch.Net
 {
 	public class RequestData
 	{
-		public const string MimeType = "application/json";
-		public const string MimeTypeTextPlain = "text/plain";
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
+
+		public const string MimeTypeOld = "application/json";
+		public const string MimeTypeTextPlain = "text/plain";
+		public const string MimeType = "application/vnd.elasticsearch+json;compatible-with=7";
 
 		public RequestData(HttpMethod method, string path, PostData data, IConnectionConfigurationValues global, IRequestParameters local,
 			IMemoryStreamFactory memoryStreamFactory

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -18,7 +18,7 @@ namespace Elasticsearch.Net
 
 		public const string MimeTypeTextPlain = "text/plain";
 		private const string MimeTypeOld = "application/json";
-		private static readonly string MimeType = "application/vnd.elasticsearch+json;compatible-with=" + ClientVersionInfo.LowLevelClientVersionInfo.Version.Major;
+		private static readonly string MimeType = "application/vnd.elasticsearch+json; compatible-with=" + ClientVersionInfo.LowLevelClientVersionInfo.Version.Major;
 
 		public static readonly string DefaultJsonMimeType =
 			ClientVersionInfo.LowLevelClientVersionInfo.Version.Major >= 8 ? MimeType : MimeTypeOld;

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -18,7 +18,7 @@ namespace Elasticsearch.Net
 
 		public const string MimeTypeOld = "application/json";
 		public const string MimeTypeTextPlain = "text/plain";
-		public const string MimeType = "application/vnd.elasticsearch+json;compatible-with=7";
+		public static readonly string MimeType = "application/vnd.elasticsearch+json;compatible-with=" + ClientVersionInfo.LowLevelClientVersionInfo.Version.Major;
 
 		public RequestData(HttpMethod method, string path, PostData data, IConnectionConfigurationValues global, IRequestParameters local,
 			IMemoryStreamFactory memoryStreamFactory

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -175,7 +175,7 @@ namespace Elasticsearch.Net
 			// we a startswith check because the response can return charset information
 			// e.g: application/json; charset=UTF-8
 			if (acceptMimeType == RequestData.MimeTypeOld)
-				return responseMimeType.StartsWith(RequestData.MimeTypeOld);
+				return responseMimeType.StartsWith(RequestData.MimeTypeOld, StringComparison.OrdinalIgnoreCase);
 
 			//vendored check
 			if (acceptMimeType == RequestData.MimeType)
@@ -184,10 +184,10 @@ namespace Elasticsearch.Net
 				return
 					responseMimeType == RequestData.MimeType
 					|| responseMimeType == RequestData.MimeTypeOld
-					|| responseMimeType.StartsWith(RequestData.MimeTypeOld)
-					|| responseMimeType.StartsWith(RequestData.MimeType);
+					|| responseMimeType.StartsWith(RequestData.MimeTypeOld, StringComparison.OrdinalIgnoreCase)
+					|| responseMimeType.StartsWith(RequestData.MimeType, StringComparison.OrdinalIgnoreCase);
 
-			return responseMimeType.StartsWith(acceptMimeType);
+			return responseMimeType.StartsWith(acceptMimeType, StringComparison.OrdinalIgnoreCase);
 		}
 
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -23,7 +23,6 @@ namespace Elasticsearch.Net
 		public static readonly string DefaultJsonMimeType =
 			ClientVersionInfo.LowLevelClientVersionInfo.Version.Major >= 8 ? MimeType : MimeTypeOld;
 
-
 		public string JsonContentMimeType { get; }
 
 		public RequestData(HttpMethod method, string path, PostData data, IConnectionConfigurationValues global, IRequestParameters local,

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -165,7 +165,7 @@ namespace Elasticsearch.Net
 
 
 		public static bool IsJsonMimeType(string mimeType) =>
-			ValidResponseContentType(MimeType, mimeType) || !ValidResponseContentType(MimeTypeOld, mimeType);
+			ValidResponseContentType(MimeType, mimeType) || ValidResponseContentType(MimeTypeOld, mimeType);
 
 		public static bool ValidResponseContentType(string acceptMimeType, string responseMimeType)
 		{

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -16,9 +16,15 @@ namespace Elasticsearch.Net
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
 
-		public const string MimeTypeOld = "application/json";
 		public const string MimeTypeTextPlain = "text/plain";
-		public static readonly string MimeType = "application/vnd.elasticsearch+json;compatible-with=" + ClientVersionInfo.LowLevelClientVersionInfo.Version.Major;
+		private const string MimeTypeOld = "application/json";
+		private static readonly string MimeType = "application/vnd.elasticsearch+json;compatible-with=" + ClientVersionInfo.LowLevelClientVersionInfo.Version.Major;
+
+		public static readonly string DefaultJsonMimeType =
+			ClientVersionInfo.LowLevelClientVersionInfo.Version.Major >= 8 ? MimeType : MimeTypeOld;
+
+
+		public string JsonContentMimeType { get; }
 
 		public RequestData(HttpMethod method, string path, PostData data, IConnectionConfigurationValues global, IRequestParameters local,
 			IMemoryStreamFactory memoryStreamFactory
@@ -43,13 +49,15 @@ namespace Elasticsearch.Net
 			Method = method;
 			PostData = data;
 
+			JsonContentMimeType = DefaultJsonBasedOnConfigurationSettings(ConnectionSettings);
+
 			if (data != null)
 				data.DisableDirectStreaming = local?.DisableDirectStreaming ?? global.DisableDirectStreaming;
 
 			Pipelined = local?.EnableHttpPipelining ?? global.HttpPipeliningEnabled;
 			HttpCompression = global.EnableHttpCompression;
-			RequestMimeType = local?.ContentType ?? MimeType;
-			Accept = local?.Accept ?? MimeType;
+			RequestMimeType = local?.ContentType ?? JsonContentMimeType;
+			Accept = local?.Accept ?? JsonContentMimeType;
 
 			if (global.Headers != null)
 				Headers = new NameValueCollection(global.Headers);
@@ -152,6 +160,37 @@ namespace Elasticsearch.Net
 		public bool IsAsync { get; internal set; }
 
 		public override string ToString() => $"{Method.GetStringValue()} {_path}";
+
+		public static string DefaultJsonBasedOnConfigurationSettings(IConnectionConfigurationValues settings) =>
+			settings.EnableApiVersioningHeader ? MimeType : MimeTypeOld;
+
+
+		public static bool IsJsonMimeType(string mimeType) =>
+			ValidResponseContentType(MimeType, mimeType) || !ValidResponseContentType(MimeTypeOld, mimeType);
+
+		public static bool ValidResponseContentType(string acceptMimeType, string responseMimeType)
+		{
+			if (string.IsNullOrEmpty(acceptMimeType)) return false;
+			if (string.IsNullOrEmpty(responseMimeType)) return false;
+
+			// we a startswith check because the response can return charset information
+			// e.g: application/json; charset=UTF-8
+			if (acceptMimeType == RequestData.MimeTypeOld)
+				return responseMimeType.StartsWith(RequestData.MimeTypeOld);
+
+			//vendored check
+			if (acceptMimeType == RequestData.MimeType)
+				// we check both vendored and nonvendored since on 7.x the response does not return a
+				// vendored Content-Type header on the response
+				return
+					responseMimeType == RequestData.MimeType
+					|| responseMimeType == RequestData.MimeTypeOld
+					|| responseMimeType.StartsWith(RequestData.MimeTypeOld)
+					|| responseMimeType.StartsWith(RequestData.MimeType);
+
+			return responseMimeType.StartsWith(acceptMimeType);
+		}
+
 
 		// TODO This feels like its in the wrong place
 		private string CreatePathWithQueryStrings(string path, IConnectionConfigurationValues global, IRequestParameters request)

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestPipeline.cs
@@ -142,7 +142,7 @@ namespace Elasticsearch.Net
 			{
 				//make sure we copy over the error body in case we disabled direct streaming.
 				var s = callDetails?.ResponseBodyInBytes == null ? Stream.Null : _memoryStreamFactory.Create(callDetails.ResponseBodyInBytes);
-				var m = callDetails?.ResponseMimeType ?? RequestData.MimeType;
+				var m = callDetails?.ResponseMimeType ?? RequestData.DefaultJsonMimeType;
 				response = ResponseBuilder.ToResponse<TResponse>(data, exception, callDetails?.HttpStatusCode, null, s, m);
 			}
 

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -192,7 +192,7 @@ namespace Elasticsearch.Net
 			else if (responseType == typeof(DynamicResponse))
 			{
 				//if not json store the result under "body"
-				if (mimeType == null || !mimeType.StartsWith(RequestData.MimeType))
+				if (!ValidResponseContentType(RequestData.MimeType, mimeType) || !ValidResponseContentType(RequestData.MimeTypeOld, mimeType))
 				{
 					var dictionary = new DynamicDictionary();
 					dictionary["body"] = new DynamicValue(bytes.Utf8String());

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -25,7 +25,7 @@ namespace Elasticsearch.Net
 			int? statusCode,
 			IEnumerable<string> warnings,
 			Stream responseStream,
-			string mimeType = RequestData.MimeType
+			string mimeType = null
 		)
 			where TResponse : class, IElasticsearchResponse, new()
 		{
@@ -43,7 +43,7 @@ namespace Elasticsearch.Net
 			int? statusCode,
 			IEnumerable<string> warnings,
 			Stream responseStream,
-			string mimeType = RequestData.MimeType,
+			string mimeType = null,
 			CancellationToken cancellationToken = default
 		)
 			where TResponse : class, IElasticsearchResponse, new()

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -91,6 +91,7 @@ namespace Elasticsearch.Net
 		private static bool ValidResponseContentType(string acceptMimeType, string responseMimeType)
 		{
 			if (string.IsNullOrEmpty(acceptMimeType)) return false;
+			if (string.IsNullOrEmpty(responseMimeType)) return false;
 
 			// we a startswith check because the response can return charset information
 			// e.g: application/json; charset=UTF-8

--- a/tests/Tests.Configuration/EnvironmentConfiguration.cs
+++ b/tests/Tests.Configuration/EnvironmentConfiguration.cs
@@ -33,6 +33,7 @@ namespace Tests.Configuration
 				SourceSerializer = RandomBoolConfig("SOURCESERIALIZER", randomizer),
 				TypedKeys = RandomBoolConfig("TYPEDKEYS", randomizer),
 				HttpCompression = RandomBoolConfig("HTTPCOMPRESSION", randomizer),
+				ApiVersioning = ElasticsearchVersion.InRange("<7.12.0") ? false : RandomBoolConfig("APIVERSIONING", randomizer),
 			};
 		}
 

--- a/tests/Tests.Configuration/TestConfigurationBase.cs
+++ b/tests/Tests.Configuration/TestConfigurationBase.cs
@@ -76,5 +76,8 @@ namespace Tests.Configuration
 
 		/// <summary> Randomly enable compression on the http requests</summary>
 		public bool HttpCompression { get; set; }
+
+		/// <summary> Randomly enable compression on the http requests</summary>
+		public bool ApiVersioning { get; set; }
 	}
 }

--- a/tests/Tests.Configuration/TestConfigurationExtensions.cs
+++ b/tests/Tests.Configuration/TestConfigurationExtensions.cs
@@ -29,6 +29,7 @@ namespace Tests.Configuration
 			Console.WriteLine($" \t- {nameof(config.Random.SourceSerializer)}: {config.Random.SourceSerializer}");
 			Console.WriteLine($" \t- {nameof(config.Random.TypedKeys)}: {config.Random.TypedKeys}");
 			Console.WriteLine($" \t- {nameof(config.Random.HttpCompression)}: {config.Random.HttpCompression}");
+			Console.WriteLine($" \t- {nameof(config.Random.ApiVersioning)}: {config.Random.ApiVersioning}");
 			Console.WriteLine(new string('-', 20));
 		}
 	}

--- a/tests/Tests.Configuration/YamlConfiguration.cs
+++ b/tests/Tests.Configuration/YamlConfiguration.cs
@@ -39,6 +39,7 @@ namespace Tests.Configuration
 				SourceSerializer = RandomBool("source_serializer", randomizer),
 				TypedKeys = RandomBool("typed_keys", randomizer),
 				HttpCompression = RandomBool("http_compression", randomizer),
+				ApiVersioning = ElasticsearchVersion.InRange("<7.12.0") ? false : RandomBool("api_versioning", randomizer),
 			};
 		}
 

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -9,7 +9,7 @@ mode: i
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
-elasticsearch_version: latest-7
+elasticsearch_version: latest
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
@@ -21,7 +21,7 @@ test_against_already_running_elasticsearch: true
 #random_source_serializer: true
 #random_old_connection: true
 #random_http_compresssion: true
-#random_api_versioning: true
+random_api_versioning: true
 #seed: 74337
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -13,7 +13,7 @@ elasticsearch_version: latest
 # cluster filter allows you to only run the integration tests of a particular cluster (cluster suffix not needed)
 # cluster_filter:
 # whether we want to forcefully reseed on the node, if you are starting the tests with a node already running
-#force_reseed: true
+force_reseed: true
 # do not spawn nodes as part of the test setup if we find a node is already running
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -21,6 +21,7 @@ test_against_already_running_elasticsearch: true
 #random_source_serializer: true
 #random_old_connection: true
 #random_http_compresssion: true
+#random_api_versioning: true
 #seed: 74337
 
 # Can be helpful to speed up tests runs as setting this to true only randomly tests a single overload of the api rather than all 4.

--- a/tests/Tests.Core/Client/FixedResponseClient.cs
+++ b/tests/Tests.Core/Client/FixedResponseClient.cs
@@ -15,7 +15,7 @@ namespace Tests.Core.Client
 			object response,
 			int statusCode = 200,
 			Func<ConnectionSettings, ConnectionSettings> modifySettings = null,
-			string contentType = RequestData.MimeType,
+			string contentType = null,
 			Exception exception = null
 		)
 		{
@@ -27,10 +27,11 @@ namespace Tests.Core.Client
 			object response,
 			int statusCode = 200,
 			Func<ConnectionSettings, ConnectionSettings> modifySettings = null,
-			string contentType = RequestData.MimeType,
+			string contentType = null,
 			Exception exception = null
 		)
 		{
+			contentType ??= RequestData.MimeType;
 			var serializer = TestClient.Default.RequestResponseSerializer;
 			byte[] responseBytes;
 			switch (response)

--- a/tests/Tests.Core/Client/FixedResponseClient.cs
+++ b/tests/Tests.Core/Client/FixedResponseClient.cs
@@ -31,7 +31,6 @@ namespace Tests.Core.Client
 			Exception exception = null
 		)
 		{
-			contentType ??= RequestData.MimeType;
 			var serializer = TestClient.Default.RequestResponseSerializer;
 			byte[] responseBytes;
 			switch (response)
@@ -44,7 +43,7 @@ namespace Tests.Core.Client
 					break;
 				default:
 				{
-					responseBytes = contentType == RequestData.MimeType
+					responseBytes = RequestData.IsJsonMimeType(contentType)
 						? serializer.SerializeToBytes(response, TestClient.Default.ConnectionSettings.MemoryStreamFactory)
 						: Encoding.UTF8.GetBytes(response.ToString());
 					break;

--- a/tests/Tests.Core/Client/FixedResponseClient.cs
+++ b/tests/Tests.Core/Client/FixedResponseClient.cs
@@ -31,6 +31,7 @@ namespace Tests.Core.Client
 			Exception exception = null
 		)
 		{
+			contentType ??= RequestData.DefaultJsonMimeType;
 			var serializer = TestClient.Default.RequestResponseSerializer;
 			byte[] responseBytes;
 			switch (response)

--- a/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
+++ b/tests/Tests.Core/Client/Settings/TestConnectionSettings.cs
@@ -49,6 +49,7 @@ namespace Tests.Core.Client.Settings
 			RerouteToProxyIfNeeded()
 			.EnableDebugMode()
 			.EnableHttpCompression(TestConfiguration.Instance.Random.HttpCompression)
+			.EnableApiVersioningHeader(TestConfiguration.Instance.Random.ApiVersioning)
 #if DEBUG
 			.EnableDebugMode()
 #endif

--- a/tests/Tests.Core/Xunit/NestXunitRunOptions.cs
+++ b/tests/Tests.Core/Xunit/NestXunitRunOptions.cs
@@ -112,6 +112,7 @@ namespace Tests.Core.Xunit
 			AppendConfig(nameof(RandomConfiguration.SourceSerializer), config.Random.SourceSerializer, sb);
 			AppendConfig(nameof(RandomConfiguration.TypedKeys), config.Random.TypedKeys, sb);
 			AppendConfig(nameof(RandomConfiguration.HttpCompression), config.Random.HttpCompression, sb);
+			AppendConfig(nameof(RandomConfiguration.ApiVersioning), config.Random.ApiVersioning, sb);
 
 			if (runningIntegrations)
 				sb.Append("integrate ")

--- a/tests/Tests.YamlRunner/OperationExecutor.fs
+++ b/tests/Tests.YamlRunner/OperationExecutor.fs
@@ -108,7 +108,8 @@ type OperationExecutor(client:IElasticLowLevelClient) =
             
             let responseMimeType = r.ApiCall.ResponseMimeType
             match responseMimeType with
-            | RequestData.MimeType -> ignore() //json
+            | s when s.StartsWith(RequestData.MimeType) -> ignore() //json
+            | s when s.StartsWith(RequestData.MimeTypeOld) -> ignore() //json
             // not json set $body to the response body string
             | _ -> op.Stashes.[StashedId.Body] <- r.Get<String>("body")
             

--- a/tests/Tests.YamlRunner/OperationExecutor.fs
+++ b/tests/Tests.YamlRunner/OperationExecutor.fs
@@ -108,8 +108,7 @@ type OperationExecutor(client:IElasticLowLevelClient) =
             
             let responseMimeType = r.ApiCall.ResponseMimeType
             match responseMimeType with
-            | s when s.StartsWith(RequestData.MimeType) -> ignore() //json
-            | s when s.StartsWith(RequestData.MimeTypeOld) -> ignore() //json
+            | s when s.StartsWith(RequestData.DefaultJsonBasedOnConfigurationSettings(r.ConnectionConfiguration)) -> ignore() //json
             // not json set $body to the response body string
             | _ -> op.Stashes.[StashedId.Body] <- r.Get<String>("body")
             

--- a/tests/Tests/XPack/Watcher/GetWatch/GetWatchApiTests.cs
+++ b/tests/Tests/XPack/Watcher/GetWatch/GetWatchApiTests.cs
@@ -150,7 +150,7 @@ namespace Tests.XPack.Watcher.GetWatch
 							.Attachments(ea => ea
 								.HttpAttachment("http_attachment", ha => ha
 									.Inline()
-									.ContentType(RequestData.MimeType)
+									.ContentType(RequestData.DefaultJsonMimeType)
 									.Request(r => r
 										.Url("http://localhost:8080/http_attachment")
 									)

--- a/tests/Tests/XPack/Watcher/PutWatch/PutWatchApiTests.cs
+++ b/tests/Tests/XPack/Watcher/PutWatch/PutWatchApiTests.cs
@@ -217,7 +217,7 @@ namespace Tests.XPack.Watcher.PutWatch
 									http = new
 									{
 										inline = true,
-										content_type = RequestData.MimeType,
+										content_type = RequestData.DefaultJsonMimeType,
 										request = new
 										{
 											url = "http://localhost:8080/http_attachment"
@@ -438,7 +438,7 @@ namespace Tests.XPack.Watcher.PutWatch
 					.Attachments(ea => ea
 						.HttpAttachment("http_attachment", ha => ha
 							.Inline()
-							.ContentType(RequestData.MimeType)
+							.ContentType(RequestData.DefaultJsonMimeType)
 							.Request(r => r
 								.Url("http://localhost:8080/http_attachment")
 							)
@@ -631,7 +631,7 @@ namespace Tests.XPack.Watcher.PutWatch
 							"http_attachment", new HttpAttachment
 							{
 								Inline = true,
-								ContentType = RequestData.MimeType,
+								ContentType = RequestData.DefaultJsonMimeType,
 								Request = new HttpInputRequest
 								{
 									Url = "http://localhost:8080/http_attachment"
@@ -717,7 +717,7 @@ namespace Tests.XPack.Watcher.PutWatch
 			response.Id.Should().Be(CallIsolatedValue);
 		}
 	}
-	
+
 	[SkipVersion("<7.10.1", "Support for multiple expand wildcards added in 7.10.1")]
 	public class PutWatchApiWithMultipleExpandWildcardsTests : ApiIntegrationTestBase<WatcherCluster, PutWatchResponse, IPutWatchRequest, PutWatchDescriptor, PutWatchRequest>
 	{
@@ -921,7 +921,7 @@ namespace Tests.XPack.Watcher.PutWatch
 									http = new
 									{
 										inline = true,
-										content_type = RequestData.MimeType,
+										content_type = RequestData.DefaultJsonMimeType,
 										request = new
 										{
 											url = "http://localhost:8080/http_attachment"
@@ -1142,7 +1142,7 @@ namespace Tests.XPack.Watcher.PutWatch
 					.Attachments(ea => ea
 						.HttpAttachment("http_attachment", ha => ha
 							.Inline()
-							.ContentType(RequestData.MimeType)
+							.ContentType(RequestData.DefaultJsonMimeType)
 							.Request(r => r
 								.Url("http://localhost:8080/http_attachment")
 							)
@@ -1335,7 +1335,7 @@ namespace Tests.XPack.Watcher.PutWatch
 							"http_attachment", new HttpAttachment
 							{
 								Inline = true,
-								ContentType = RequestData.MimeType,
+								ContentType = RequestData.DefaultJsonMimeType,
 								Request = new HttpInputRequest
 								{
 									Url = "http://localhost:8080/http_attachment"


### PR DESCRIPTION
Changes our default `Accept` and `Content-Type` request headers over to
the new vendor specific headers that includes compatible with
informations to start powering structurally versioned API's

```
Accept:       application/vnd.elasticsearch+json;compatible-with=7
Content-Type: application/vnd.elasticsearch+json; compatible-with=7
```

On 7.x Elasticsearch does not return the vendor type we send for
`Accept` but is still hardwired to return:

```
content-type: application/json; charset=UTF-8
```

We are therefor lenient in our Accept to Response ContentType
validations.

We do these assertions to prevent the client from de-serializing HTML
from possible proxies in the middle of the client and server.

NOTE this is for `7.13`