### PR TITLE
Add support for datastream rollover api

### DIFF
--- a/src/ApiGenerator/ApiGenerator.csproj
+++ b/src/ApiGenerator/ApiGenerator.csproj
@@ -21,6 +21,5 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="RestSpecification\Core" />
-    <Folder Include="RestSpecification\XPack" />
   </ItemGroup>
 </Project>

--- a/src/ApiGenerator/RestSpecification/XPack/indices.data_stream_rollover.json
+++ b/src/ApiGenerator/RestSpecification/XPack/indices.data_stream_rollover.json
@@ -1,0 +1,31 @@
+﻿{
+  "indices.create_data_stream": {
+    "documentation": {
+      "url": "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html",
+      "description": "Rolls over a data stream"
+    },
+    "stability": "stable",
+    "visibility": "public",
+    "headers": {
+      "accept": [ "application/json" ]
+    },
+    "url": {
+      "paths": [
+        {
+          "path": "/{name}/_rollover/",
+          "methods": [
+            "POST"
+          ],
+          "parts": {
+            "name": {
+              "type": "string",
+              "description": "The name of the data stream"
+            }
+          }
+        }
+      ]
+    },
+    "params": {
+    }
+  }
+}

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Indices.cs
@@ -245,6 +245,11 @@ namespace Elasticsearch.Net.Specification.IndicesApi
 	{
 	}
 
+	///<summary>Request options for CreateDataStream <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
+	public class DataStreamRolloverRequestParameters : RequestParameters<DataStreamRolloverRequestParameters>
+	{
+	}
+
 	///<summary>Request options for DataStreamsStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
 	public class DataStreamsStatsRequestParameters : RequestParameters<DataStreamsStatsRequestParameters>
 	{

--- a/src/Nest/Descriptors.Indices.cs
+++ b/src/Nest/Descriptors.Indices.cs
@@ -281,6 +281,29 @@ namespace Nest
 	// Request parameters
 	}
 
+	///<summary>Descriptor for CreateDataStream <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
+	public partial class DataStreamRolloverDescriptor : RequestDescriptorBase<DataStreamRolloverDescriptor, DataStreamRolloverRequestParameters, IDataStreamRolloverRequest>, IDataStreamRolloverRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesDataStreamRollover;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+		protected override bool SupportsBody => false;
+		///<summary>/{name}/_rollover</summary>
+		///<param name = "name">this parameter is required</param>
+		public DataStreamRolloverDescriptor(Name name): base(r => r.Required("name", name))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected DataStreamRolloverDescriptor(): base()
+		{
+		}
+
+		// values part of the url path
+		Name IDataStreamRolloverRequest.Name => Self.RouteValues.Get<Name>("name");
+	// Request parameters
+	}
+
 	///<summary>Descriptor for DataStreamsStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
 	public partial class DataStreamsStatsDescriptor : RequestDescriptorBase<DataStreamsStatsDescriptor, DataStreamsStatsRequestParameters, IDataStreamsStatsRequest>, IDataStreamsStatsRequest
 	{

--- a/src/Nest/ElasticClient.Indices.cs
+++ b/src/Nest/ElasticClient.Indices.cs
@@ -205,6 +205,30 @@ namespace Nest.Specification.IndicesApi
 		/// </summary>
 		public Task<CreateDataStreamResponse> CreateDataStreamAsync(ICreateDataStreamRequest request, CancellationToken ct = default) => DoRequestAsync<ICreateDataStreamRequest, CreateDataStreamResponse>(request, request.RequestParameters, ct);
 		/// <summary>
+		/// <c>POST</c> request to the <c>indices.data_stream_rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</a>
+		/// </summary>
+		public DataStreamRolloverResponse DataStreamRollover(Name name, Func<DataStreamRolloverDescriptor, IDataStreamRolloverRequest> selector = null) => DataStreamRollover(selector.InvokeOrDefault(new DataStreamRolloverDescriptor(name: name)));
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.data_stream_rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</a>
+		/// </summary>
+		public Task<DataStreamRolloverResponse> DataStreamRolloverAsync(Name name, Func<DataStreamRolloverDescriptor, IDataStreamRolloverRequest> selector = null, CancellationToken ct = default) => DataStreamRolloverAsync(selector.InvokeOrDefault(new DataStreamRolloverDescriptor(name: name)), ct);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.data_stream_rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</a>
+		/// </summary>
+		public DataStreamRolloverResponse DataStreamRollover(IDataStreamRolloverRequest request) => DoRequest<IDataStreamRolloverRequest, DataStreamRolloverResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>POST</c> request to the <c>indices.data_stream_rollover</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</a>
+		/// </summary>
+		public Task<DataStreamRolloverResponse> DataStreamRolloverAsync(IDataStreamRolloverRequest request, CancellationToken ct = default) => DoRequestAsync<IDataStreamRolloverRequest, DataStreamRolloverResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>GET</c> request to the <c>indices.data_streams_stats</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html">https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</a>

--- a/src/Nest/Requests.Indices.cs
+++ b/src/Nest/Requests.Indices.cs
@@ -475,6 +475,41 @@ namespace Nest
 		}
 	}
 
+	[InterfaceDataContract]
+	public partial interface IDataStreamRolloverRequest : IRequest<DataStreamRolloverRequestParameters>
+	{
+		[IgnoreDataMember]
+		Name Name
+		{
+			get;
+		}
+	}
+
+	///<summary>Request for CreateDataStream <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
+	public partial class DataStreamRolloverRequest : PlainRequestBase<DataStreamRolloverRequestParameters>, IDataStreamRolloverRequest
+	{
+		protected IDataStreamRolloverRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.IndicesDataStreamRollover;
+		protected override HttpMethod HttpMethod => HttpMethod.POST;
+		protected override bool SupportsBody => false;
+		///<summary>/_data_stream/{name}</summary>
+		///<param name = "name">this parameter is required</param>
+		public DataStreamRolloverRequest(Name name): base(r => r.Required("name", name))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected DataStreamRolloverRequest(): base()
+		{
+		}
+
+		// values part of the url path
+		[IgnoreDataMember]
+		Name IDataStreamRolloverRequest.Name => Self.RouteValues.Get<Name>("name");
+	// Request parameters
+	}
+
 	///<summary>Request for DataStreamsStats <para>https://www.elastic.co/guide/en/elasticsearch/reference/master/data-streams.html</para></summary>
 	public partial class DataStreamsStatsRequest : PlainRequestBase<DataStreamsStatsRequestParameters>, IDataStreamsStatsRequest
 	{

--- a/src/Nest/XPack/DataStreams/Rollover/DataStreamRolloverRequest.cs
+++ b/src/Nest/XPack/DataStreams/Rollover/DataStreamRolloverRequest.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nest
+{
+	/// <summary>
+	/// Rolls over a data stream
+	/// </summary>
+	[MapsApi("indices.data_streams_rollover.json")]
+	[ReadAs(typeof(DataStreamRolloverRequest))]
+	public partial interface IDataStreamRolloverRequest
+	{
+	}
+
+	/// <inheritdoc cref="IDataStreamRolloverRequest"/>
+	public partial class DataStreamRolloverRequest
+	{
+	}
+
+	/// <inheritdoc cref="IDataStreamRolloverRequest"/>
+	public partial class DataStreamRolloverDescriptor
+	{
+	}
+}

--- a/src/Nest/XPack/DataStreams/Rollover/DataStreamRolloverResponse.cs
+++ b/src/Nest/XPack/DataStreams/Rollover/DataStreamRolloverResponse.cs
@@ -1,0 +1,8 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Nest
+{
+	public class DataStreamRolloverResponse : AcknowledgedResponseBase { }
+}

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -114,6 +114,7 @@ namespace Nest
 		internal static ApiUrls IndicesClose = new ApiUrls(new[]{"{index}/_close"});
 		internal static ApiUrls IndicesCreate = new ApiUrls(new[]{"{index}"});
 		internal static ApiUrls IndicesCreateDataStream = new ApiUrls(new[]{"_data_stream/{name}"});
+		internal static ApiUrls IndicesDataStreamRollover = new ApiUrls(new[]{"{name}/_rollover"});
 		internal static ApiUrls IndicesDataStreamsStats = new ApiUrls(new[]{"_data_stream/_stats", "_data_stream/{name}/_stats"});
 		internal static ApiUrls IndicesDelete = new ApiUrls(new[]{"{index}"});
 		internal static ApiUrls IndicesDeleteAlias = new ApiUrls(new[]{"{index}/_alias/{name}"});

--- a/tests/Tests/XPack/DataStreams/DataStreamsApiTests.cs
+++ b/tests/Tests/XPack/DataStreams/DataStreamsApiTests.cs
@@ -34,6 +34,7 @@ namespace Tests.XPack.DataStreams
 		private const string GetDataStreamStep = nameof(GetDataStreamStep);
 		private const string PutIndexTemplateStep = nameof(PutIndexTemplateStep);
 		private const string DataStreamsStatsStep = nameof(DataStreamsStatsStep);
+		private const string DataStreamRolloverStep = nameof(DataStreamRolloverStep);
 		private const string DeleteDataStreamStep = nameof(DeleteDataStreamStep);
 
 		public DataStreamsApiTests(WritableCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage, testOnlyOne: true)
@@ -116,6 +117,16 @@ namespace Tests.XPack.DataStreams
 					(v, c, r) => c.Indices.DataStreamsStatsAsync(r)
 				)
 			},
+			{DataStreamRolloverStep, u =>
+				u.Calls<DataStreamRolloverDescriptor, DataStreamRolloverRequest, IDataStreamRolloverRequest, DataStreamRolloverResponse>(
+					v => new DataStreamRolloverRequest(v),
+					(v, d) => d,
+					(v, c, f) => c.Indices.DataStreamRollover(v, f),
+					(v, c, f) => c.Indices.DataStreamRolloverAsync(v, f),
+					(v, c, r) => c.Indices.DataStreamRollover(r),
+					(v, c, r) => c.Indices.DataStreamRolloverAsync(r)
+				)
+			},
 			{DeleteDataStreamStep, u =>
 				u.Calls<DeleteDataStreamDescriptor, DeleteDataStreamRequest, IDeleteDataStreamRequest, DeleteDataStreamResponse>(
 					v => new DeleteDataStreamRequest(v),
@@ -173,6 +184,12 @@ namespace Tests.XPack.DataStreams
 			dataStream.MaximumTimestamp.Should().Be(new DateTimeOffset(2020, 8, 3, 14, 0, 0, TimeSpan.Zero).ToUnixTimeMilliseconds());
 			dataStream.MaximumTimestampDateTimeOffset.Should().Be(new DateTimeOffset(2020, 8, 3, 14, 0, 0, TimeSpan.Zero));
 			dataStream.StoreSizeBytes.Should().BeGreaterThan(0);
+		});
+
+		[I] public async Task DataStreamRolloverResponse() => await Assert<DataStreamRolloverResponse>(DataStreamRolloverStep, (v, r) =>
+		{
+			r.ShouldBeValid();
+			r.Acknowledged.Should().BeTrue();
 		});
 
 		[I] public async Task DeleteDataStreamResponse() => await Assert<DeleteDataStreamResponse>(DeleteDataStreamStep, (v, r) =>

--- a/tests/Tests/XPack/DataStreams/Rollover/CreateDataStreamUrlTests.cs
+++ b/tests/Tests/XPack/DataStreams/Rollover/CreateDataStreamUrlTests.cs
@@ -1,0 +1,17 @@
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+using static Tests.Framework.EndpointTests.UrlTester;
+
+namespace Tests.XPack.DataStreams.Create
+{
+	public class DataStreamRolloverUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() => await POST("/stream/_rollover")
+			.Fluent(c => c.Indices.DataStreamRollover("stream", f => f))
+			.Request(c => c.Indices.DataStreamRollover(new DataStreamRolloverRequest("stream")))
+			.FluentAsync(c => c.Indices.DataStreamRolloverAsync("stream", f => f))
+			.RequestAsync(c => c.Indices.DataStreamRolloverAsync(new DataStreamRolloverRequest("stream")));
+	}
+}


### PR DESCRIPTION
Implement [manual datastream rollover API](https://www.elastic.co/guide/en/elasticsearch/reference/current/use-a-data-stream.html#manually-roll-over-a-data-stream)
