### PR TITLE
Introduce automated scheduled codegeneration

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -42,6 +42,11 @@ case $CMD in
         TASK=release
         TASK_ARGS=("$VERSION" "$output_folder" "skiptests")
         ;;
+    codegen)
+        TASK=codegen
+        # VERSION is BRANCH here for now
+        TASK_ARGS=("$VERSION") 
+        ;;
     *)
         echo -e "\nUsage:\n\t $CMD is not supported right now\n"
         exit 1

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -29,10 +29,10 @@ jobs:
       matrix:
         branch: ${{ fromJson(needs.active-branches.outputs.matrix) }}
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: "${{ matrix.branch }}"
-    - run: "echo ${{ matrix.branch }}"
-      name: Code Gen ${{ matrix.branch }}
-    #- run: "./.ci/make.sh codegen ${{ matrix.branch }}"
-    #  name: Code Gen ${{ matrix.stack_version }}
+      - uses: actions/checkout@v2
+        with:
+          ref: "${{ matrix.branch }}"
+      - run: "echo ${{ matrix.branch }}"
+        name: Code Gen ${{ matrix.branch }}
+      # - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
+      #  name: Code Gen ${{ matrix.stack_version }}

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -4,7 +4,7 @@ on:
     - cron: "0 0/2 * * *"
   push:
     branches:
-      - 'feature/master/automate-codegen
+      - 'feature/master/automate-codegen'
 
 
 jobs:

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -33,7 +33,18 @@ jobs:
       - uses: actions/checkout@v2
         with:
           ref: "${{ matrix.branch }}"
-      - run: "echo ${{ matrix.branch }}"
-        name: ${{ matrix.branch }}
-      # - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
-      #  name: Code Gen ${{ matrix.stack_version }}
+      - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
+        name: "code-gen ${{ matrix.branch }}"
+      - name: "PR ${{ matrix.branch }}"
+        # fixate to known release. 
+        uses: peter-evans/create-pull-request@5ea31358e901bfaf28ca19849903d802fd0a891b
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: "fix/${{ matrix.branch }}/code-gen"
+          delete-branch: true
+          base: "${{ matrix.branch }}"
+          commit-message: "[codegen] ${{ matrix.branch }} synchronization" 
+          title: '[codegen] ${{ matrix.branch }} synchronization'
+          body: |
+            This synchronizes the client's ${{ matrix.branch }} branch with the server. 
+          labels: "infra,code-gen"

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -2,9 +2,6 @@ name: Code Generation
 on:
   schedule:
     - cron: "0 0/2 * * *"
-  push:
-    branches:
-      - 'feature/master/automate-codegen'
 
 
 jobs:

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -1,0 +1,27 @@
+name: Code Generation 
+on:
+  schedule:
+    - cron: "*/5 * * * *"
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: some-branch
+
+
+jobs:
+  codegen:
+    name: Assemble
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [ 'master', '7.x']
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        ref: "${{ matrix.branch }}"
+    - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
+      name: Code Gen ${{ matrix.stack_version }}

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -13,15 +13,16 @@ jobs:
 
     steps:
       - id: dump-branches
-        run: 
-          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" > branches.json
+        run:
+          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output
+          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output > branches.json
       - id: set-matrix
         run: echo "::set-output name=matrix::$(cat branches.json)"
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
       
   codegen:
-    name: Assemble
+    name: Sync
     needs: active-branches
     runs-on: ubuntu-latest
     strategy:
@@ -33,6 +34,6 @@ jobs:
         with:
           ref: "${{ matrix.branch }}"
       - run: "echo ${{ matrix.branch }}"
-        name: Code Gen ${{ matrix.branch }}
+        name: ${{ matrix.branch }}
       # - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
       #  name: Code Gen ${{ matrix.stack_version }}

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -13,9 +13,9 @@ jobs:
 
     steps:
       - id: dump-branches
-        run:
-          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output
-          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output > branches.json
+        run: |
+          curl -s "https://artifacts-api.elastic.co/v1/branches"  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output
+          curl -s "https://artifacts-api.elastic.co/v1/branches"  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" --compact-output > branches.json
       - id: set-matrix
         run: echo "::set-output name=matrix::$(cat branches.json)"
     outputs:

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -1,27 +1,38 @@
 name: Code Generation 
 on:
   schedule:
-    - cron: "*/5 * * * *"
+    - cron: "0 0/2 * * *"
+  push:
+    branches:
+      - 'feature/master/automate-codegen
+
+
 jobs:
-  build:
+  active-branches:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v2
-        with:
-          ref: some-branch
-
-
-jobs:
+      - id: dump-branches
+        run: 
+          curl -s https://artifacts-api.elastic.co/v1/branches  | jq "[ .branches[] | select(. | startswith(\"6\") | not) ]" > branches.json
+      - id: set-matrix
+        run: echo "::set-output name=matrix::$(cat branches.json)"
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+      
   codegen:
     name: Assemble
+    needs: active-branches
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        branch: [ 'master', '7.x']
+        branch: ${{ fromJson(needs.active-branches.outputs.matrix) }}
     steps:
     - uses: actions/checkout@v2
       with:
         ref: "${{ matrix.branch }}"
-    - run: "./.ci/make.sh codegen ${{ matrix.branch }}"
-      name: Code Gen ${{ matrix.stack_version }}
+    - run: "echo ${{ matrix.branch }}"
+      name: Code Gen ${{ matrix.branch }}
+    #- run: "./.ci/make.sh codegen ${{ matrix.branch }}"
+    #  name: Code Gen ${{ matrix.stack_version }}

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -197,9 +197,7 @@ Execution hints can be provided anywhere on the command line
         | ["profile"] -> parsed
         | "rest-spec-tests" :: tail -> { parsed with RemainingArguments = tail }
         
-        | ["codegen"; branch]  ->
-            { parsed with CommandArguments = CodeGen { Branch = branch } }
-        | ("codegen" & branch) :: tail ->
+        | "codegen" :: branch :: tail  ->
             { parsed with CommandArguments = CodeGen { Branch = branch }; RemainingArguments = tail }
         
         | ["release"; version] -> { parsed with CommandArguments = SetVersion { Version = version; OutputLocation = None }; }

--- a/build/scripts/Commandline.fs
+++ b/build/scripts/Commandline.fs
@@ -38,8 +38,9 @@ Targets:
 * benchmark [non-interactive] [url] [username] [password] 
   - Runs a benchmark from Tests.Benchmarking and indexes the results to [url] when provided.
     If non-interactive runs all benchmarks without prompting
-* codegen
-  - runs the code generator interactively
+* codegen <branch> [arguments]
+  - runs the code generator, the first argument is required and dictates the branch to sync from.
+  - Any other arguments are passed down to the tool directly
 * documentation
   - runs the doc generation, without running any tests
   
@@ -87,6 +88,7 @@ Execution hints can be provided anywhere on the command line
 
     type BenchmarkArguments = { Endpoint: string; Username: string option; Password: string option; }
     type ClusterArguments = { Name: string; Version: string option; }
+    type CodeGenArguments = { Branch: string; }
     type CommandArguments =
         | Unknown
         | SetVersion of VersionArguments
@@ -94,6 +96,7 @@ Execution hints can be provided anywhere on the command line
         | Integration of IntegrationArguments
         | Benchmark of BenchmarkArguments
         | Cluster of ClusterArguments
+        | CodeGen of CodeGenArguments
 
     type PassedArguments = {
         NonInteractive: bool;
@@ -190,10 +193,14 @@ Execution hints can be provided anywhere on the command line
         | ["build"]
         | ["clean"]
         | ["benchmark"]
-        | ["codegen"; ] 
         | ["documentation"; ] 
         | ["profile"] -> parsed
         | "rest-spec-tests" :: tail -> { parsed with RemainingArguments = tail }
+        
+        | ["codegen"; branch]  ->
+            { parsed with CommandArguments = CodeGen { Branch = branch } }
+        | ("codegen" & branch) :: tail ->
+            { parsed with CommandArguments = CodeGen { Branch = branch }; RemainingArguments = tail }
         
         | ["release"; version] -> { parsed with CommandArguments = SetVersion { Version = version; OutputLocation = None }; }
         | ["release"; version; path] ->

--- a/build/scripts/ReposTooling.fs
+++ b/build/scripts/ReposTooling.fs
@@ -29,13 +29,13 @@ module ReposTooling =
         
         Shell.deleteDir tempDir
         
-    let GenerateApi () =
-        //TODO allow branch name to be passed for CI
+    let GenerateApi args =
+        let branch = match args.CommandArguments with | CodeGen a -> a.Branch | _ -> raise <| Exception("Branch is required")
         let folder = Path.getDirectory (Paths.ProjFile "ApiGenerator")
         let timeout = TimeSpan.FromMinutes(120.)
-        // Building to make sure XML docs files are there, faster then relying on the ApiGenerator to emit these
-        // from a compilation unit
-        Tooling.DotNet.ExecInWithTimeout folder ["run"; "-c"; " Release"; ] timeout  |> ignore
+        Tooling.DotNet.ExecInWithTimeout folder
+            (["run"; "-c"; " Release"; "--"; "--branch"; branch; "--download"] @ args.RemainingArguments) timeout
+            |> ignore
         
     let RestSpecTests args =
         let folder = Path.getDirectory (Paths.TestProjFile "Tests.YamlRunner")

--- a/build/scripts/Targets.fs
+++ b/build/scripts/Targets.fs
@@ -109,7 +109,7 @@ module Main =
         command "cluster" [ "restore"; "full-build" ] <| fun _ ->
             ReposTooling.LaunchCluster parsed
         
-        command "codegen" [ ] ReposTooling.GenerateApi
+        command "codegen" [ ] <| fun _ -> ReposTooling.GenerateApi parsed
         
         command "rest-spec-tests" [ ] <| fun _ ->
             ReposTooling.RestSpecTests parsed.RemainingArguments

--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -31,6 +31,9 @@
     <Content Include="..\..\.github\workflows\unified-release.yml">
       <Link>unified-release.yml</Link>
     </Content>
+    <Content Include="..\..\.github\workflows\make-codegen.yml">
+      <Link>make-codegen.yml</Link>
+    </Content>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="5.0.0" />

--- a/src/ApiGenerator/Configuration/GeneratorLocations.cs
+++ b/src/ApiGenerator/Configuration/GeneratorLocations.cs
@@ -10,11 +10,11 @@ namespace ApiGenerator.Configuration
 	public static class GeneratorLocations
 	{
 		// @formatter:off — disable formatter after this line
-		public static string EsNetFolder { get; } = $@"{Root}/../../src/Elasticsearch.Net/";
+		public static string EsNetFolder { get; } = $@"{Root}../../src/Elasticsearch.Net/";
 		public static string LastDownloadedRef { get; } = Path.Combine(Root, "last_downloaded_version.txt");
 
-		public static string NestFolder { get; } = $@"{Root}/../../src/Nest/";
-		public static string RestSpecificationFolder { get; } = $@"{Root}/RestSpecification/";
+		public static string NestFolder { get; } = $@"{Root}../../src/Nest/";
+		public static string RestSpecificationFolder { get; } = $@"{Root}RestSpecification/";
 		// @formatter:on — enable formatter after this line
 
 		public static string HighLevel(params string[] paths) => NestFolder + string.Join("/", paths);
@@ -35,7 +35,7 @@ namespace ApiGenerator.Configuration
 				var pathFromSolutionRoot = Path.Combine(directoryInfo.FullName, "src", "ApiGenerator");
 				if (Directory.Exists(pathFromSolutionRoot))
 				{
-					_root = pathFromSolutionRoot;
+					_root = pathFromSolutionRoot + "/";
 					return _root;
 				}
 

--- a/src/ApiGenerator/Configuration/GeneratorLocations.cs
+++ b/src/ApiGenerator/Configuration/GeneratorLocations.cs
@@ -10,11 +10,11 @@ namespace ApiGenerator.Configuration
 	public static class GeneratorLocations
 	{
 		// @formatter:off — disable formatter after this line
-		public static string EsNetFolder { get; } = $@"{Root}../../src/Elasticsearch.Net/";
+		public static string EsNetFolder { get; } = $@"{Root}/../../src/Elasticsearch.Net/";
 		public static string LastDownloadedRef { get; } = Path.Combine(Root, "last_downloaded_version.txt");
 
-		public static string NestFolder { get; } = $@"{Root}../../src/Nest/";
-		public static string RestSpecificationFolder { get; } = $@"{Root}RestSpecification/";
+		public static string NestFolder { get; } = $@"{Root}/../../src/Nest/";
+		public static string RestSpecificationFolder { get; } = $@"{Root}/RestSpecification/";
 		// @formatter:on — enable formatter after this line
 
 		public static string HighLevel(params string[] paths) => NestFolder + string.Join("/", paths);
@@ -30,6 +30,14 @@ namespace ApiGenerator.Configuration
 				if (_root != null) return _root;
 
 				var directoryInfo = new DirectoryInfo(Directory.GetCurrentDirectory());
+
+				//If we run this tool using dotnet run --project src/ApiGenerator
+				var pathFromSolutionRoot = Path.Combine(directoryInfo.FullName, "src", "ApiGenerator");
+				if (Directory.Exists(pathFromSolutionRoot))
+				{
+					_root = pathFromSolutionRoot;
+					return _root;
+				}
 
 				var dotnetRun =
 					directoryInfo.Name == "ApiGenerator" &&

--- a/src/ApiGenerator/Configuration/ViewLocations.cs
+++ b/src/ApiGenerator/Configuration/ViewLocations.cs
@@ -2,14 +2,14 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
-namespace ApiGenerator.Configuration 
+namespace ApiGenerator.Configuration
 {
 	public static class ViewLocations
 	{
-		public static string Root { get; } = $@"{GeneratorLocations.Root}Views/";
+		public static string Root { get; } = $@"{GeneratorLocations.Root}/Views/";
 		private static string HighLevelRoot { get; } = $@"{Root}/HighLevel/";
 		public static string HighLevel(params string[] paths) => HighLevelRoot + string.Join("/", paths);
-		
+
 		private static string LowLevelRoot { get; } = $@"{Root}/LowLevel/";
 		public static string LowLevel(params string[] paths) => LowLevelRoot + string.Join("/", paths);
 	}

--- a/src/ApiGenerator/Configuration/ViewLocations.cs
+++ b/src/ApiGenerator/Configuration/ViewLocations.cs
@@ -6,7 +6,7 @@ namespace ApiGenerator.Configuration
 {
 	public static class ViewLocations
 	{
-		public static string Root { get; } = $@"{GeneratorLocations.Root}/Views/";
+		public static string Root { get; } = $@"{GeneratorLocations.Root}Views/";
 		private static string HighLevelRoot { get; } = $@"{Root}/HighLevel/";
 		public static string HighLevel(params string[] paths) => HighLevelRoot + string.Join("/", paths);
 


### PR DESCRIPTION
- Allow codegenerator to be run from the root
- Allow codegen to be controlled through build.sh
- update command line argument parsing
- Paths are resolved relative so make sure we have a trailing / for absolute root
- Add github scheduled tasks to regenerate integration branches
- experiment with dynamic matrix
