### PR TITLE
Fixes the passing of args to assemble

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -66,3 +66,12 @@ docker run \
  --rm \
  elastic/elasticsearch-net \
  /bin/bash -c "./build.sh $TASK ${TASK_ARGS[*]} && chown -R $(id -u):$(id -g) ."
+ 
+if [[ "$CMD" == "assemble" ]]; then
+	if compgen -G ".ci/output/*" > /dev/null; then
+		echo "Output was produced!"
+	else 
+		echo "Assemble did not produce output to $output_folder"
+		exit 1
+	fi	
+fi

--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -58,10 +58,11 @@ esac
 
 # -u does not work need to be root inside the container, the chown hack at the end ensures
 # we still own any new files at the end of this run
+
 docker run \
-  --env "DOTNET_VERSION" \
-  --name test-runner \
-  --volume $REPO_BINDING \
-  --rm \
-  elastic/elasticsearch-net \
-  /bin/bash -c "./build.sh $TASK ${TASK_ARGS[@]} && chown -R $(id -u):$(id -g) ."
+ --env "DOTNET_VERSION" \
+ --name test-runner \
+ --volume $REPO_BINDING \
+ --rm \
+ elastic/elasticsearch-net \
+ /bin/bash -c "./build.sh $TASK ${TASK_ARGS[*]} && chown -R $(id -u):$(id -g) ."

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -34,9 +34,3 @@ jobs:
             
       - run: "./.ci/make.sh assemble ${{ matrix.stack_version }}"
         name: Assemble ${{ matrix.stack_version }}
-
-      - name: Produced output
-        uses: dothq/file-or-directory-exists@3b28438692d2f228bcd001a883d1003d3768a8c9
-        with:
-            input: |
-              .ci/output

--- a/.github/workflows/unified-release.yml
+++ b/.github/workflows/unified-release.yml
@@ -34,4 +34,9 @@ jobs:
             
       - run: "./.ci/make.sh assemble ${{ matrix.stack_version }}"
         name: Assemble ${{ matrix.stack_version }}
-          
+
+      - name: Produced output
+        uses: dothq/file-or-directory-exists@3b28438692d2f228bcd001a883d1003d3768a8c9
+        with:
+            input: |
+              .ci/output


### PR DESCRIPTION
The difference a character makes.

Also added an assertion to our github action that `.ci/output` is
actually created
