### PR TITLE
Correct the JSON name for the position length on tokens

### DIFF
--- a/src/Nest/Indices/Analyze/AnalyzeToken.cs
+++ b/src/Nest/Indices/Analyze/AnalyzeToken.cs
@@ -15,7 +15,7 @@ namespace Nest
 		[DataMember(Name ="position")]
 		public long Position { get; internal set; }
 
-		[DataMember(Name ="position_length")]
+		[DataMember(Name ="positionLength")]
 		public long? PositionLength { get; internal set; }
 
 		[DataMember(Name ="start_offset")]


### PR DESCRIPTION
Fixes #5498.

After [checking the ES repo](https://github.com/elastic/elasticsearch/blob/780f27306777399db574b9f9a9f44e77f41779f3/server/src/main/java/org/elasticsearch/action/admin/indices/analyze/AnalyzeAction.java#L387), this looks like it will always be returned as `positionLength`.