### PR TITLE
Patch preview ML datafeed spec and re-gen code

### DIFF
--- a/src/ApiGenerator/RestSpecification/_Patches/ml.preview_datafeed.patch.json
+++ b/src/ApiGenerator/RestSpecification/_Patches/ml.preview_datafeed.patch.json
@@ -1,0 +1,7 @@
+{
+  "ml.preview_datafeed": {
+    "methods": [
+      "GET"
+    ]
+  }
+}

--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.MachineLearning.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.MachineLearning.cs
@@ -681,7 +681,7 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 	///<summary>Request options for PreviewDatafeed <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 	public class PreviewDatafeedRequestParameters : RequestParameters<PreviewDatafeedRequestParameters>
 	{
-		public override HttpMethod DefaultHttpMethod => HttpMethod.POST;
+		public override HttpMethod DefaultHttpMethod => HttpMethod.GET;
 		public override bool SupportsBody => true;
 	}
 

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.MachineLearning.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.MachineLearning.cs
@@ -721,30 +721,30 @@ namespace Elasticsearch.Net.Specification.MachineLearningApi
 		[MapsApi("ml.preview_data_frame_analytics", "id, body")]
 		public Task<TResponse> PreviewDataFrameAnalyticsAsync<TResponse>(string id, PostData body, PreviewDataFrameAnalyticsRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"_ml/data_frame/analytics/{id:id}/_preview"), ctx, body, RequestParams(requestParameters));
-		///<summary>POST on /_ml/datafeeds/{datafeed_id}/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
+		///<summary>GET on /_ml/datafeeds/{datafeed_id}/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 		///<param name = "datafeedId">The ID of the datafeed to preview</param>
 		///<param name = "body">The datafeed config and job config with which to execute the preview</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse PreviewDatafeed<TResponse>(string datafeedId, PostData body, PreviewDatafeedRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, Url($"_ml/datafeeds/{datafeedId:datafeedId}/_preview"), body, RequestParams(requestParameters));
-		///<summary>POST on /_ml/datafeeds/{datafeed_id}/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(GET, Url($"_ml/datafeeds/{datafeedId:datafeedId}/_preview"), body, RequestParams(requestParameters));
+		///<summary>GET on /_ml/datafeeds/{datafeed_id}/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 		///<param name = "datafeedId">The ID of the datafeed to preview</param>
 		///<param name = "body">The datafeed config and job config with which to execute the preview</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("ml.preview_datafeed", "datafeed_id, body")]
 		public Task<TResponse> PreviewDatafeedAsync<TResponse>(string datafeedId, PostData body, PreviewDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, Url($"_ml/datafeeds/{datafeedId:datafeedId}/_preview"), ctx, body, RequestParams(requestParameters));
-		///<summary>POST on /_ml/datafeeds/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(GET, Url($"_ml/datafeeds/{datafeedId:datafeedId}/_preview"), ctx, body, RequestParams(requestParameters));
+		///<summary>GET on /_ml/datafeeds/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 		///<param name = "body">The datafeed config and job config with which to execute the preview</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		public TResponse PreviewDatafeed<TResponse>(PostData body, PreviewDatafeedRequestParameters requestParameters = null)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(POST, "_ml/datafeeds/_preview", body, RequestParams(requestParameters));
-		///<summary>POST on /_ml/datafeeds/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
+			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(GET, "_ml/datafeeds/_preview", body, RequestParams(requestParameters));
+		///<summary>GET on /_ml/datafeeds/_preview <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-preview-datafeed.html</para></summary>
 		///<param name = "body">The datafeed config and job config with which to execute the preview</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("ml.preview_datafeed", "body")]
 		public Task<TResponse> PreviewDatafeedAsync<TResponse>(PostData body, PreviewDatafeedRequestParameters requestParameters = null, CancellationToken ctx = default)
-			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(POST, "_ml/datafeeds/_preview", ctx, body, RequestParams(requestParameters));
+			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(GET, "_ml/datafeeds/_preview", ctx, body, RequestParams(requestParameters));
 		///<summary>PUT on /_ml/calendars/{calendar_id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/ml-put-calendar.html</para></summary>
 		///<param name = "calendarId">The ID of the calendar to create</param>
 		///<param name = "body">The calendar details</param>


### PR DESCRIPTION
This was failing in YAML tests after the recent code-gen. The API supports only get but the spec included POST which was being preferred by the generator. If this all works locally I will submit a PR to fix the main spec.

We will also need to port the patch to master.