### PR TITLE
Reset to branch based test matrix

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -1,7 +1,7 @@
 ---
 
 STACK_VERSION:
-  - 7.12.0-SNAPSHOT
+  - 7.x-SNAPSHOT
 
 TEST_SUITE:
   - free


### PR DESCRIPTION
We previously hardcoded this due to a bug that prevented tagging the Docker images with the branch name. This has been resolved so we can return to using 7.x for this integration branch.