### PR TITLE
Check _cleanupTimer is not null when disposing (backport fix/4818 to 6.x)

### DIFF
--- a/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
+++ b/src/Elasticsearch.Net/Connection/HandlerTracking/RequestDataHttpClientFactory.cs
@@ -154,7 +154,7 @@ namespace Elasticsearch.Net
 		{
 			lock (_cleanupTimerLock)
 			{
-				_cleanupTimer.Dispose();
+				_cleanupTimer?.Dispose();
 				_cleanupTimer = null;
 			}
 		}


### PR DESCRIPTION
Backporting fix for #4818
This commit checks that _cleanupTimer is not null when disposing, which it may be if no requests have been made.

Fixes #5529