### PR TITLE
Skip ml.find_file_structure.json

### DIFF
--- a/src/ApiGenerator/Configuration/CodeConfiguration.cs
+++ b/src/ApiGenerator/Configuration/CodeConfiguration.cs
@@ -32,6 +32,9 @@ namespace ApiGenerator.Configuration
 			"indices.upgrade.json",
 			"indices.get_upgrade.json",
 
+			// This was added in 7.12.0 BC1 but the spec was removed before GA, but the API still existed.
+			// This isn't the preferred API so skipping code gen for it.
+			"ml.find_file_structure.json"
 		};
 
 		private static string[] IgnoredApisHighLevel { get; } =


### PR DESCRIPTION
This spec was reintroduced as the API technically still exists but was deprecated before GA of 7.12.0. Since we have generated the newer API already, skipping the generation of the ML endpoint for LL code-gen.