### PR TITLE
Update RuntimeField to use IInlineScript

### DIFF
--- a/src/Nest/CommonOptions/Scripting/InlineScript.cs
+++ b/src/Nest/CommonOptions/Scripting/InlineScript.cs
@@ -8,6 +8,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[InterfaceDataContract]
+	[ReadAs(typeof(InlineScript))]
 	public interface IInlineScript : IScript
 	{
 		[DataMember(Name ="source")]

--- a/src/Nest/Mapping/RuntimeFields/RuntimeField.cs
+++ b/src/Nest/Mapping/RuntimeFields/RuntimeField.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information
 
+using System;
 using System.Runtime.Serialization;
 using Elasticsearch.Net.Utf8Json;
 
@@ -22,7 +23,7 @@ namespace Nest
 		/// The script to be evaluated for field calculation at search time.
 		/// </summary>
 		[DataMember(Name = "script")]
-		IStoredScript Script { get; set; }
+		IInlineScript Script { get; set; }
 
 		/// <summary>
 		/// The datatype of the runtime field.
@@ -36,7 +37,7 @@ namespace Nest
 		/// <inheritdoc />
 		public string Format { get; set; }
 		/// <inheritdoc />
-		public IStoredScript Script { get; set; }
+		public IInlineScript Script { get; set; }
 		/// <inheritdoc />
 		public FieldType Type { get; set; }
 	}
@@ -47,13 +48,19 @@ namespace Nest
 		public RuntimeFieldDescriptor(FieldType fieldType) => Self.Type = fieldType;
 
 		string IRuntimeField.Format { get; set; }
-		IStoredScript IRuntimeField.Script { get; set; }
+		IInlineScript IRuntimeField.Script { get; set; }
 		FieldType IRuntimeField.Type { get; set; }
 
+		/// <inheritdoc cref="IRuntimeField.Format" />
 		public RuntimeFieldDescriptor Format(string format) => Assign(format, (a, v) => a.Format = v);
-		
-		public RuntimeFieldDescriptor Script(IStoredScript script) => Assign(script, (a, v) => a.Script = v);
 
-		public RuntimeFieldDescriptor Script(string source) => Assign(source, (a, v) => a.Script = new PainlessScript(source));
+		/// <inheritdoc cref="IRuntimeField.Script" />
+		public RuntimeFieldDescriptor Script(IInlineScript script) => Assign(script, (a, v) => a.Script = v);
+
+		/// <inheritdoc cref="IRuntimeField.Script" />
+		public RuntimeFieldDescriptor Script(string source) => Assign(source, (a, v) => a.Script = new InlineScript(source));
+
+		/// <inheritdoc cref="IRuntimeField.Script" />
+		public RuntimeFieldDescriptor Script(Func<InlineScriptDescriptor, IInlineScript> selector) => Assign(selector, (a, v) => a.Script = v?.Invoke(new InlineScriptDescriptor()));
 	}
 }

--- a/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
+++ b/tests/Tests/Indices/MappingManagement/PutMapping/PutMappingApiTest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information
 
 using System;
+using System.Collections.Generic;
 using Elastic.Elasticsearch.Xunit.XunitPlumbing;
 using Elasticsearch.Net;
 using Nest;
@@ -344,7 +345,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 	{
 		// These test serialisation only. Integration tests take place in RuntimeFieldsTests.cs
 
-		private const string ScriptValue = "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT))";
+		private const string ScriptValue = "emit(doc['@timestamp'].value.dayOfWeekEnum.getDisplayName(TextStyle.FULL, Locale.ROOT) + params.foo";
 
 		public PutMappingWithRuntimeFieldsTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
 
@@ -357,7 +358,10 @@ namespace Tests.Indices.MappingManagement.PutMapping
 			RuntimeFields = new RuntimeFields
 			{
 				{ "runtime_date", new RuntimeField { Type = FieldType.Date, Format = "yyyy-MM-dd" } },
-				{ "runtime_scripted", new RuntimeField { Type = FieldType.Keyword, Script = new PainlessScript(ScriptValue) } }
+				{ "runtime_scripted", new RuntimeField { Type = FieldType.Keyword, Script = new InlineScript(ScriptValue) { Lang = "painless", Params = new Dictionary<string, object>
+				{
+					{ "foo", " is a good day." }
+				}}}}
 			}
 		};
 
@@ -365,7 +369,7 @@ namespace Tests.Indices.MappingManagement.PutMapping
 			.Index(CallIsolatedValue)
 			.RuntimeFields(rtf => rtf
 				.RuntimeField("runtime_date", FieldType.Date, rf => rf.Format("yyyy-MM-dd"))
-				.RuntimeField("runtime_scripted", FieldType.Keyword, rf=> rf.Script(new PainlessScript(ScriptValue))));
+				.RuntimeField("runtime_scripted", FieldType.Keyword, rf=> rf.Script(s => s.Source(ScriptValue).Lang(ScriptLang.Painless).Params(p => p.Add("foo", " is a good day.")))));
 
 		protected override LazyResponses ClientUsage() => Calls(
 			(client, f) => client.Indices.PutMapping(f),
@@ -388,8 +392,12 @@ namespace Tests.Indices.MappingManagement.PutMapping
 					type = "keyword",
 					script = new
 					{
+						source = ScriptValue,
 						lang = "painless",
-						source = ScriptValue
+						@params = new Dictionary<string, string>
+						{
+							{ "foo", " is a good day." }
+						}
 					}
 				}
 			}

--- a/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
+++ b/tests/Tests/Mapping/RuntimeFields/RuntimeFieldsTests.cs
@@ -44,7 +44,7 @@ namespace Tests.Mapping.RuntimeFields
 									{RuntimeFieldNameOne, new RuntimeField
 									{
 										Type = FieldType.Keyword,
-										Script = new PainlessScript(ScriptValue)
+										Script = new InlineScript(ScriptValue)
 									}},
 									{RuntimeFieldNameTwo, new RuntimeField
 									{
@@ -108,7 +108,7 @@ namespace Tests.Mapping.RuntimeFields
 								{RuntimeFieldNameOne, new RuntimeField
 								{
 									Type = FieldType.Keyword,
-									Script = new PainlessScript(ScriptValue)
+									Script = new InlineScript(ScriptValue)
 								}},
 								{RuntimeFieldNameTwo, new RuntimeField
 								{

--- a/tests/Tests/Search/Search/SearchApiTests.cs
+++ b/tests/Tests/Search/Search/SearchApiTests.cs
@@ -681,7 +681,6 @@ namespace Tests.Search.Search
 				{
 					script = new
 					{
-						lang = "painless",
 						source = RuntimeFieldScript
 					},
 					type = "keyword"
@@ -710,10 +709,11 @@ namespace Tests.Search.Search
 				.And(RuntimeFieldName),
 			RuntimeFields = new RuntimeFields
 			{
-				{ RuntimeFieldName, new RuntimeField
+				{
+					RuntimeFieldName, new RuntimeField
 					{
 						Type = FieldType.Keyword,
-						Script = new PainlessScript(RuntimeFieldScript)
+						Script = new InlineScript(RuntimeFieldScript)
 					}
 				}
 			}

--- a/tests/Tests/Search/SearchingRuntimeFields.doc.cs
+++ b/tests/Tests/Search/SearchingRuntimeFields.doc.cs
@@ -129,7 +129,6 @@ namespace Tests.Search
 					{
 						script = new
 						{
-							lang = "painless",
 							source = "if (doc['type'].size() != 0) {emit(doc['type'].value.toUpperCase())}"
 						},
 						type = "keyword"
@@ -155,7 +154,7 @@ namespace Tests.Search
 					{ "search_runtime_field", new RuntimeField
 						{
 							Type = FieldType.Keyword,
-							Script = new PainlessScript("if (doc['type'].size() != 0) {emit(doc['type'].value.toUpperCase())}")
+							Script = new InlineScript("if (doc['type'].size() != 0) {emit(doc['type'].value.toUpperCase())}")
 						}
 					}
 				}

--- a/tests/Tests/XPack/Transform/TransformApiWithSettingsTests.cs
+++ b/tests/Tests/XPack/Transform/TransformApiWithSettingsTests.cs
@@ -347,7 +347,6 @@ namespace Tests.XPack.Transform
 						{
 							script = new
 							{
-								lang = "painless",
 								source = RuntimeFieldScript
 							},
 							type = "keyword"
@@ -410,7 +409,7 @@ namespace Tests.XPack.Transform
 						{ RuntimeFieldName, new RuntimeField
 							{
 								Type = FieldType.Keyword,
-								Script = new PainlessScript(RuntimeFieldScript)
+								Script = new InlineScript(RuntimeFieldScript)
 							}
 						}
 					}


### PR DESCRIPTION
Runtime fields now support parameters in their scripts which the current `IStoredScript` interface does not support. This change updates to prefer `IInlineScript` which better aligns to the functionality of scripts in runtime fields.

This is a breaking change but should have a limited impact on existing users and ultimately is worth making to allow consumers to fully utilise runtime fields. Only code currently using runtime fields and the object initialiser syntax will need to be updated. The change is required is to create an instance of `InlineScript` rather than `PainlessScript`.