### PR TITLE
[Api Generator] Add mechanism to escape C# keywords for path parts

### DIFF
--- a/src/ApiGenerator/Domain/Code/LowLevel/LowLevelClientMethod.cs
+++ b/src/ApiGenerator/Domain/Code/LowLevel/LowLevelClientMethod.cs
@@ -33,9 +33,8 @@ namespace ApiGenerator.Domain.Code.LowLevel
 			{
 				string Evaluator(Match m)
 				{
-
 					var arg = m.Groups[^1].Value.ToCamelCase();
-					return $"{{{arg}:{arg}}}";
+					return $"{{{arg.ReservedKeywordReplacer()}:{arg}}}";
 				}
 
 				var url = Path.TrimStart('/');

--- a/src/ApiGenerator/Domain/Specification/UrlPart.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPart.cs
@@ -139,17 +139,14 @@ namespace ApiGenerator.Domain.Specification
 		}
 
 		public string Name { get; set; }
-		public string NameAsArgument => Name.ToCamelCase();
+		public string NameAsArgument => Name.ToCamelCase().ReservedKeywordReplacer();
 		public IEnumerable<string> Options { get; set; }
 		public bool Required { get; set; }
 		public bool Deprecated { get; set; }
 		public string Type { get; set; }
 
-		private string CleanUpDescription(string value)
-		{
-			if (string.IsNullOrWhiteSpace(value)) return value;
 
-			return value.Replace("use `_all` or empty string", "use the special string `_all` or Indices.All");
-		}
+
+		private static string CleanUpDescription(string value) => string.IsNullOrWhiteSpace(value) ? value : value.Replace("use `_all` or empty string", "use the special string `_all` or Indices.All");
 	}
 }

--- a/src/ApiGenerator/Domain/Specification/UrlPath.cs
+++ b/src/ApiGenerator/Domain/Specification/UrlPath.cs
@@ -55,17 +55,16 @@ namespace ApiGenerator.Domain.Specification
 
 		public string TypedSubClassBaseArguments => string.Join(", ", Parts.Select(p => p.NameAsArgument));
 
-		private static string[] ResolvabeFromT = { "index"};
+		private static readonly string[] ResolvableFromT = { "index"};
 
+		public bool HasResolvableArguments => Parts.Any(p => ResolvableFromT.Contains(p.Name));
+		public string AutoResolveConstructorArguments => string.Join(", ", Parts.Where(p  => !ResolvableFromT.Contains(p.Name)).Select(p => $"{p.HighLevelTypeName} {p.NameAsArgument}"));
 
-		public bool HasResolvableArguments => Parts.Any(p => ResolvabeFromT.Contains(p.Name));
-		public string AutoResolveConstructorArguments => string.Join(", ", Parts.Where(p  => !ResolvabeFromT.Contains(p.Name)).Select(p => $"{p.HighLevelTypeName} {p.NameAsArgument}"));
-
-		public string AutoResolveBaseArguments(string generic) => string.Join(", ", Parts.Select(p => !ResolvabeFromT.Contains(p.Name) ? p.Name : $"typeof({generic})"));
+		public string AutoResolveBaseArguments(string generic) => string.Join(", ", Parts.Select(p => !ResolvableFromT.Contains(p.Name) ? p.Name : $"typeof({generic})"));
 
 		public string DocumentPathBaseArgument(string generic) => string.Join(", ",
 			_additionalPartsForConstructor.Select(p => p.Name =="id" ? $"id ?? Nest.Id.From(documentWithId)"
-				: ResolvabeFromT.Contains(p.Name) ? $"{p.Name} ?? typeof({generic})" : p.Name));
+				: ResolvableFromT.Contains(p.Name) ? $"{p.Name} ?? typeof({generic})" : p.Name));
 
 		public string DocumentPathConstructorArgument(string generic) => string.Join(", ",
 			new [] { $"{generic} documentWithId" }.Concat(_additionalPartsForConstructor.Select(p => $"{p.HighLevelTypeName} {p.NameAsArgument} = null")));
@@ -73,7 +72,7 @@ namespace ApiGenerator.Domain.Specification
 		public string GetXmlDocs(string indent, bool skipResolvable = false, bool documentConstructor = false)
 		{
 			var doc = $@"///<summary>{Path}</summary>";
-			var parts = Parts.Where(p => !skipResolvable || !ResolvabeFromT.Contains(p.Name)).ToList();
+			var parts = Parts.Where(p => !skipResolvable || !ResolvableFromT.Contains(p.Name)).ToList();
 			if (!parts.Any()) return doc;
 
 			doc += indent;

--- a/src/ApiGenerator/Extensions.cs
+++ b/src/ApiGenerator/Extensions.cs
@@ -43,7 +43,10 @@ namespace ApiGenerator
 			return pascal[0].ToLower() + pascal.Substring(1);
 		}
 
-		public static string SplitPascalCase(this string s) =>
-			Regex.Replace(s, "([A-Z]+[a-z]*)", " $1").Trim();
+		private static readonly Dictionary<string, string> ReservedNames = new() { { "namespace", "@namespace" } };
+
+		public static string ReservedKeywordReplacer(this string name) => ReservedNames.ContainsKey(name) ? ReservedNames[name] : name;
+		
+		public static string SplitPascalCase(this string s) => Regex.Replace(s, "([A-Z]+[a-z]*)", " $1").Trim();
 	}
 }


### PR DESCRIPTION
Some recent additions to the API spec (for example security.clear_cached_service_tokens.json), include a path part named `namespace`. Since this is a C# keyword, the generated code does not compile. This change addresses this and provides a mechanism for this and future replacements via an extension method. This method adjusts the name if it matches any reserved keywords defined in the dictionary. The variable name and the URL code call this extension to adjust accordingly.