### PR TITLE
Extend ping timeout in EnableDebugMode test

### DIFF
--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
@@ -59,6 +59,8 @@ namespace Tests.ClientConcepts.Troubleshooting
 
 			// hide
 			settings.DefaultIndex(Client.ConnectionSettings.DefaultIndex);
+			// hide
+			settings.PingTimeout(TimeSpan.FromSeconds(5)); // Avoids occasional CI failures
 
 			var client = new ElasticClient(settings);
 


### PR DESCRIPTION
Attempting to reduce the number of intermittent test failures from the `EnableDebugMode` tests by extending the ping timeout.