### PR TITLE
Set no BOM in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,6 +5,7 @@ trim_trailing_whitespace=true
 insert_final_newline=true
 
 [*]
+charset = utf-8
 indent_style = tab
 indent_size = 4
 


### PR DESCRIPTION
The `.editorconfig` change is applied by ReSharper code cleanup and avoid BOM changes affecting the check license headers action.