### PR TITLE
Add NEST support for EQL delete API

### DIFF
--- a/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Eql.cs
+++ b/src/Elasticsearch.Net/Api/RequestParameters/RequestParameters.Eql.cs
@@ -43,7 +43,7 @@ using System.Linq.Expressions;
 namespace Elasticsearch.Net.Specification.EqlApi
 {
 	///<summary>Request options for Delete <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
-	public class DeleteRequestParameters : RequestParameters<DeleteRequestParameters>
+	public class EqlDeleteRequestParameters : RequestParameters<EqlDeleteRequestParameters>
 	{
 		public override HttpMethod DefaultHttpMethod => HttpMethod.DELETE;
 		public override bool SupportsBody => false;

--- a/src/Elasticsearch.Net/ElasticLowLevelClient.Eql.cs
+++ b/src/Elasticsearch.Net/ElasticLowLevelClient.Eql.cs
@@ -64,13 +64,13 @@ namespace Elasticsearch.Net.Specification.EqlApi
 		///<summary>DELETE on /_eql/search/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
 		///<param name = "id">The async search ID</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
-		public TResponse Delete<TResponse>(string id, DeleteRequestParameters requestParameters = null)
+		public TResponse Delete<TResponse>(string id, EqlDeleteRequestParameters requestParameters = null)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequest<TResponse>(DELETE, Url($"_eql/search/{id:id}"), null, RequestParams(requestParameters));
 		///<summary>DELETE on /_eql/search/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
 		///<param name = "id">The async search ID</param>
 		///<param name = "requestParameters">Request specific configuration such as querystring parameters &amp; request specific connection settings.</param>
 		[MapsApi("eql.delete", "id")]
-		public Task<TResponse> DeleteAsync<TResponse>(string id, DeleteRequestParameters requestParameters = null, CancellationToken ctx = default)
+		public Task<TResponse> DeleteAsync<TResponse>(string id, EqlDeleteRequestParameters requestParameters = null, CancellationToken ctx = default)
 			where TResponse : class, IElasticsearchResponse, new() => DoRequestAsync<TResponse>(DELETE, Url($"_eql/search/{id:id}"), ctx, null, RequestParams(requestParameters));
 		///<summary>GET on /_eql/search/{id} <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
 		///<param name = "id">The async search ID</param>

--- a/src/Nest/Descriptors.Eql.cs
+++ b/src/Nest/Descriptors.Eql.cs
@@ -48,6 +48,27 @@ using Elasticsearch.Net.Specification.EqlApi;
 // ReSharper disable RedundantNameQualifier
 namespace Nest
 {
+	///<summary>Descriptor for Delete <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
+	public partial class EqlDeleteDescriptor : RequestDescriptorBase<EqlDeleteDescriptor, EqlDeleteRequestParameters, IEqlDeleteRequest>, IEqlDeleteRequest
+	{
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.EqlDelete;
+		///<summary>/_eql/search/{id}</summary>
+		///<param name = "id">this parameter is required</param>
+		public EqlDeleteDescriptor(Id id): base(r => r.Required("id", id))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected EqlDeleteDescriptor(): base()
+		{
+		}
+
+		// values part of the url path
+		Id IEqlDeleteRequest.Id => Self.RouteValues.Get<Id>("id");
+	// Request parameters
+	}
+
 	///<summary>Descriptor for Get <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
 	public partial class EqlGetDescriptor : RequestDescriptorBase<EqlGetDescriptor, EqlGetRequestParameters, IEqlGetRequest>, IEqlGetRequest
 	{

--- a/src/Nest/ElasticClient.Eql.cs
+++ b/src/Nest/ElasticClient.Eql.cs
@@ -55,6 +55,30 @@ namespace Nest.Specification.EqlApi
 		}
 
 		/// <summary>
+		/// <c>DELETE</c> request to the <c>eql.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</a>
+		/// </summary>
+		public EqlDeleteResponse Delete(Id id, Func<EqlDeleteDescriptor, IEqlDeleteRequest> selector = null) => Delete(selector.InvokeOrDefault(new EqlDeleteDescriptor(id: id)));
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>eql.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</a>
+		/// </summary>
+		public Task<EqlDeleteResponse> DeleteAsync(Id id, Func<EqlDeleteDescriptor, IEqlDeleteRequest> selector = null, CancellationToken ct = default) => DeleteAsync(selector.InvokeOrDefault(new EqlDeleteDescriptor(id: id)), ct);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>eql.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</a>
+		/// </summary>
+		public EqlDeleteResponse Delete(IEqlDeleteRequest request) => DoRequest<IEqlDeleteRequest, EqlDeleteResponse>(request, request.RequestParameters);
+		/// <summary>
+		/// <c>DELETE</c> request to the <c>eql.delete</c> API, read more about this API online:
+		/// <para></para>
+		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</a>
+		/// </summary>
+		public Task<EqlDeleteResponse> DeleteAsync(IEqlDeleteRequest request, CancellationToken ct = default) => DoRequestAsync<IEqlDeleteRequest, EqlDeleteResponse>(request, request.RequestParameters, ct);
+		/// <summary>
 		/// <c>GET</c> request to the <c>eql.get</c> API, read more about this API online:
 		/// <para></para>
 		/// <a href = "https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html">https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</a>

--- a/src/Nest/Requests.Eql.cs
+++ b/src/Nest/Requests.Eql.cs
@@ -50,6 +50,39 @@ using Elasticsearch.Net.Specification.EqlApi;
 namespace Nest
 {
 	[InterfaceDataContract]
+	public partial interface IEqlDeleteRequest : IRequest<EqlDeleteRequestParameters>
+	{
+		[IgnoreDataMember]
+		Id Id
+		{
+			get;
+		}
+	}
+
+	///<summary>Request for Delete <para>https://www.elastic.co/guide/en/elasticsearch/reference/current/eql-search-api.html</para></summary>
+	public partial class EqlDeleteRequest : PlainRequestBase<EqlDeleteRequestParameters>, IEqlDeleteRequest
+	{
+		protected IEqlDeleteRequest Self => this;
+		internal override ApiUrls ApiUrls => ApiUrlsLookups.EqlDelete;
+		///<summary>/_eql/search/{id}</summary>
+		///<param name = "id">this parameter is required</param>
+		public EqlDeleteRequest(Id id): base(r => r.Required("id", id))
+		{
+		}
+
+		///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>
+		[SerializationConstructor]
+		protected EqlDeleteRequest(): base()
+		{
+		}
+
+		// values part of the url path
+		[IgnoreDataMember]
+		Id IEqlDeleteRequest.Id => Self.RouteValues.Get<Id>("id");
+	// Request parameters
+	}
+
+	[InterfaceDataContract]
 	public partial interface IEqlGetRequest : IRequest<EqlGetRequestParameters>
 	{
 		[IgnoreDataMember]

--- a/src/Nest/XPack/Eql/Delete/EqlDeleteRequest.cs
+++ b/src/Nest/XPack/Eql/Delete/EqlDeleteRequest.cs
@@ -1,0 +1,39 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Nest
+{
+	/// <summary>
+	/// Request to deletes an async EQL search or a stored synchronous EQL search.
+	/// The delete API also deletes results for the search.
+	/// </summary>
+	[MapsApi("eql.delete.json")]
+	[ReadAs(typeof(EqlDeleteRequest))]
+	public partial interface IEqlDeleteRequest { }
+
+	/// <inheritdoc cref="IEqlDeleteRequest"/>
+	public partial class EqlDeleteRequest
+	{
+	}
+
+	/// <inheritdoc cref="IEqlDeleteRequest"/>
+	public partial class EqlDeleteDescriptor
+	{
+	}
+}

--- a/src/Nest/XPack/Eql/Delete/EqlDeleteResponse.cs
+++ b/src/Nest/XPack/Eql/Delete/EqlDeleteResponse.cs
@@ -1,0 +1,23 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+namespace Nest
+{
+	public class EqlDeleteResponse : AcknowledgedResponseBase { }
+}

--- a/src/Nest/_Generated/ApiUrlsLookup.generated.cs
+++ b/src/Nest/_Generated/ApiUrlsLookup.generated.cs
@@ -106,6 +106,7 @@ namespace Nest
 		internal static ApiUrls EnrichGetPolicy = new ApiUrls(new[]{"_enrich/policy/{name}", "_enrich/policy/"});
 		internal static ApiUrls EnrichPutPolicy = new ApiUrls(new[]{"_enrich/policy/{name}"});
 		internal static ApiUrls EnrichStats = new ApiUrls(new[]{"_enrich/_stats"});
+		internal static ApiUrls EqlDelete = new ApiUrls(new[]{"_eql/search/{id}"});
 		internal static ApiUrls EqlGet = new ApiUrls(new[]{"_eql/search/{id}"});
 		internal static ApiUrls EqlSearchStatus = new ApiUrls(new[]{"_eql/search/status/{id}"});
 		internal static ApiUrls EqlSearch = new ApiUrls(new[]{"{index}/_eql/search"});

--- a/tests/Tests/XPack/Eql/Delete/EqlDeleteUrlTests.cs
+++ b/tests/Tests/XPack/Eql/Delete/EqlDeleteUrlTests.cs
@@ -1,0 +1,36 @@
+/*
+ * Licensed to Elasticsearch B.V. under one or more contributor
+ * license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright
+ * ownership. Elasticsearch B.V. licenses this file to you under
+ * the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+using static Tests.Framework.EndpointTests.UrlTester;
+
+namespace Tests.XPack.Eql.Delete
+{
+	public class EqlDeleteUrlTests : UrlTestsBase
+	{
+		[U] public override async Task Urls() => await DELETE("/_eql/search/search_id")
+			.Fluent(c => c.Eql.Delete("search_id", f => f))
+			.Request(c => c.Eql.Delete(new EqlDeleteRequest("search_id")))
+			.FluentAsync(c => c.Eql.DeleteAsync("search_id", f => f))
+			.RequestAsync(c => c.Eql.DeleteAsync(new EqlDeleteRequest("search_id")));
+	}
+}


### PR DESCRIPTION
Adds support for deleting a running search using EQL via the NEST client.

Contributes to #5584