### PR TITLE
Fix ReSharper's "Convert 'as' expression type check and the following…

### DIFF
--- a/src/DocGenerator/XmlDocs/XmlDocsVisitor.cs
+++ b/src/DocGenerator/XmlDocs/XmlDocsVisitor.cs
@@ -42,9 +42,7 @@ namespace DocGenerator.XmlDocs
 					_labeledListItem.Add(new Paragraph(content));
 				else
 				{
-					var literal = paragraph.Last() as TextLiteral;
-
-					if (literal != null && literal.Text == ListItemContinuation)
+					if (paragraph.Last() is TextLiteral literal && literal.Text == ListItemContinuation)
 						paragraph.Add(new TextLiteral(content));
 					else
 						paragraph.Add(new TextLiteral(" " + content));
@@ -138,9 +136,7 @@ namespace DocGenerator.XmlDocs
 				if (member.Info.DeclaringType == _type &&
 					member.Info.MemberType.HasFlag(MemberTypes.Method))
 				{
-					var methodInfo = member.Info as MethodInfo;
-
-					if (methodInfo != null && methodInfo.IsPublic)
+					if (member.Info is MethodInfo methodInfo && methodInfo.IsPublic)
 					{
 						if (_labeledListItem != null)
 							LabeledListItems.Add(_labeledListItem);

--- a/src/Nest/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
+++ b/src/Nest/QueryDsl/MultiTermQueryRewrite/RewriteMultiTerm.cs
@@ -214,8 +214,7 @@ namespace Nest
 			if (ReferenceEquals(null, obj)) return false;
 			if (ReferenceEquals(this, obj)) return true;
 
-			var value = obj as string;
-			if (value != null)
+			if (obj is string value)
 				return string.Equals(value, _value);
 
 			return obj.GetType() == GetType() && Equals((MultiTermQueryRewrite)obj);

--- a/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRuleBase.cs
+++ b/src/Nest/XPack/Security/RoleMapping/Rules/Role/RoleMappingRuleBase.cs
@@ -54,14 +54,12 @@ namespace Nest
 
 		public static IEnumerable<RoleMappingRuleBase> AllOrSelf(RoleMappingRuleBase rule)
 		{
-			var all = rule as AllRoleMappingRule;
-			return all != null ? all.AllRules : new[] { rule };
+			return rule is AllRoleMappingRule all ? all.AllRules : new[] { rule };
 		}
 
 		public static IEnumerable<RoleMappingRuleBase> AnyOrSelf(RoleMappingRuleBase rule)
 		{
-			var all = rule as AnyRoleMappingRule;
-			return all != null ? all.AnyRules : new[] { rule };
+			return rule is AnyRoleMappingRule all ? all.AnyRules : new[] { rule };
 		}
 
 		public static implicit operator RoleMappingRuleBase(UsernameRule rule) => new FieldRoleMappingRule(rule);

--- a/src/Nest/XPack/Watcher/Action/Actions.cs
+++ b/src/Nest/XPack/Watcher/Action/Actions.cs
@@ -27,8 +27,7 @@ namespace Nest
 			var reducedActions = new Dictionary<string, IAction>(actions.Count);
 			foreach (var action in actions)
 			{
-				var combinator = action.Value as ActionCombinator;
-				if (combinator != null)
+				if (action.Value is ActionCombinator combinator)
 				{
 					foreach (var combinatorAction in combinator.Actions)
 					{


### PR DESCRIPTION
Hello,

This pull request is _very simple_ and aims to reduce the technical debt. It specifically targets the "Convert 'as' expression type check and the following null check into pattern matching" [rule](https://www.jetbrains.com/help/resharper/UsePatternMatching.html) reported by ReSharper.

Let me know if you are interested in similar contributions.

