### PR TITLE
Removed flattened assertion from xpack usage tests

### DIFF
--- a/.ci/test-matrix.yml
+++ b/.ci/test-matrix.yml
@@ -1,7 +1,7 @@
 ---
 
 STACK_VERSION:
-  - 7.x-SNAPSHOT
+  - 7.13.0-SNAPSHOT
 
 TEST_SUITE:
   - free

--- a/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
+++ b/tests/Tests/ClientConcepts/Troubleshooting/DebugMode.doc.cs
@@ -60,7 +60,7 @@ namespace Tests.ClientConcepts.Troubleshooting
 			// hide
 			settings.DefaultIndex(Client.ConnectionSettings.DefaultIndex);
 			// hide
-			settings.PingTimeout(TimeSpan.FromSeconds(5)); // Avoids occasional CI failures
+			settings.PingTimeout(TimeSpan.FromSeconds(10)); // Avoids occasional CI failures
 
 			var client = new ElasticClient(settings);
 

--- a/tests/Tests/XPack/Info/XPackInfoApiTests.cs
+++ b/tests/Tests/XPack/Info/XPackInfoApiTests.cs
@@ -66,9 +66,12 @@ namespace Tests.XPack.Info
 			r.Features.Watcher.Should().NotBeNull();
 			r.License.Should().NotBeNull();
 
+			// Flattened fields were moved from x-pack to core in 7.13.0 (https://github.com/elastic/elasticsearch/pull/68780)
+			if (TestConfiguration.Instance.InRange(">=7.3.0") && TestConfiguration.Instance.InRange("<7.13.0"))
+				r.Features.Flattened.Should().NotBeNull();
+			
 			if (TestConfiguration.Instance.InRange(">=7.3.0"))
 			{
-				r.Features.Flattened.Should().NotBeNull();
 				r.Features.Vectors.Should().NotBeNull();
 
 				if (TestConfiguration.Instance.InRange("<7.5.0"))
@@ -110,9 +113,15 @@ namespace Tests.XPack.Info
 			r.Alerting.Execution.Should().NotBeNull();
 			r.Alerting.Watch.Should().NotBeNull();
 
+			// Flattened fields were moved from x-pack to core in 7.13.0 (https://github.com/elastic/elasticsearch/pull/68780)
+			if (TestConfiguration.Instance.InRange(">=7.3.0") && TestConfiguration.Instance.InRange("<7.13.0"))
+				r.Flattened.Should().NotBeNull();
+
+			if (TestConfiguration.Instance.InRange(">=7.6.0") && TestConfiguration.Instance.InRange("<7.13.0"))
+				r.Flattened.FieldCount.Should().HaveValue();
+
 			if (TestConfiguration.Instance.InRange(">=7.3.0"))
 			{
-				r.Flattened.Should().NotBeNull();
 				r.Vectors.Should().NotBeNull();
 				r.VotingOnly.Should().NotBeNull();
 
@@ -120,9 +129,6 @@ namespace Tests.XPack.Info
 #pragma warning disable 618
 					r.DataFrame.Should().NotBeNull();
 #pragma warning restore 618
-
-				if (TestConfiguration.Instance.InRange(">=7.6.0"))
-					r.Flattened.FieldCount.Should().HaveValue();
 			}
 
 			if (TestConfiguration.Instance.InRange(">=7.5.0"))


### PR DESCRIPTION
In 7.13, flattened fields were moved to core and no longer report in the responses from the X-Pack APIs.

This PR skips those assertions when testing against 7.13.0 and higher.