### PR TITLE
[Backport master] Reorder cleanup steps for YAML tests

### DIFF
--- a/tests/Tests.YamlRunner/TestSuiteBootstrap.fs
+++ b/tests/Tests.YamlRunner/TestSuiteBootstrap.fs
@@ -86,9 +86,8 @@ let DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
         let e = start.AddSeconds(30.)
         while (call() > 0 && DateTime.UtcNow < e) do ignore()
         
-        
     let waitForPendingRollupTasks () = waitForPendingTasks "xpack/rollup/job"
-    
+
     let deleteAllSLMPolicies () =
         getAndDelete
            (fun _ -> client.SnapshotLifecycleManagement.GetSnapshotLifecycle<DynamicResponse>())
@@ -233,12 +232,12 @@ let DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
             waitForPendingRollupTasks()
             yield! deleteAllSLMPolicies()
         
-        yield! wipeSnapshots()
-        
         if suite = Platinum then
             yield wipeDataStreams()
         
         yield wipeAllIndices()
+
+        yield! wipeSnapshots()
         
         yield! wipeTemplateForXPack()
         
@@ -266,5 +265,4 @@ let DefaultSetup : Operation list = [Actions("Setup", fun (client, suite) ->
         
         waitForClusterStateUpdatesToFinish()
     }
-    
 )]


### PR DESCRIPTION
Backport 6399e07e1c1738b0606fb7f05d10648266a6fb91 from #5729