### PR TITLE
Adjust delete alias test to specify the index

### DIFF
--- a/tests/Tests/Indices/AliasManagement/DeleteAlias/AliasDeleteApiTests.cs
+++ b/tests/Tests/Indices/AliasManagement/DeleteAlias/AliasDeleteApiTests.cs
@@ -21,22 +21,20 @@ namespace Tests.Indices.AliasManagement.DeleteAlias
 
 		protected override Func<DeleteAliasDescriptor, IDeleteAliasRequest> Fluent => null;
 		protected override HttpMethod HttpMethod => HttpMethod.DELETE;
-		protected override DeleteAliasRequest Initializer => new DeleteAliasRequest(Infer.AllIndices, Names);
+		protected override DeleteAliasRequest Initializer => new(CallIsolatedValue, Names);
 		protected override bool SupportsDeserialization => false;
-		protected override string UrlPath => $"/_all/_alias/{CallIsolatedValue + "-alias"}";
+		protected override string UrlPath => $"/{CallIsolatedValue}/_alias/{CallIsolatedValue + "-alias"}";
 		private Names Names => Infer.Names(CallIsolatedValue + "-alias");
 
 		protected override void IntegrationSetup(IElasticClient client, CallUniqueValues values)
 		{
 			foreach (var index in values.Values)
-				client.Indices.Create(index, c => c
-					.Aliases(aa => aa.Alias(index + "-alias"))
-				);
+				client.Indices.Create(index, c => c.Aliases(aa => aa.Alias(index + "-alias")));
 		}
 
 		protected override LazyResponses ClientUsage() => Calls(
-			(client, f) => client.Indices.DeleteAlias(Infer.AllIndices, Names),
-			(client, f) => client.Indices.DeleteAliasAsync(Infer.AllIndices, Names),
+			(client, f) => client.Indices.DeleteAlias(CallIsolatedValue, Names),
+			(client, f) => client.Indices.DeleteAliasAsync(CallIsolatedValue, Names),
 			(client, r) => client.Indices.DeleteAlias(r),
 			(client, r) => client.Indices.DeleteAliasAsync(r)
 		);


### PR DESCRIPTION
With the addition of aliases for data streams, the server validates whether the index expression. If the expression matches both data streams and regular indices then a validation error is returned. This behaviour may yet be adjusted but these changes limit the test such that it targets a specific index.