### PR TITLE
Fix weekly schedule deserialisation

### DIFF
--- a/src/Nest/XPack/Watcher/Schedule/Day.cs
+++ b/src/Nest/XPack/Watcher/Schedule/Day.cs
@@ -11,25 +11,25 @@ namespace Nest
 	[StringEnum]
 	public enum Day
 	{
-		[EnumMember(Value = "sunday")]
+		[EnumMember(Value = "SUN")]
 		Sunday,
 
-		[EnumMember(Value = "monday")]
+		[EnumMember(Value = "MON")]
 		Monday,
 
-		[EnumMember(Value = "tuesday")]
+		[EnumMember(Value = "TUE")]
 		Tuesday,
 
-		[EnumMember(Value = "wednesday")]
+		[EnumMember(Value = "WED")]
 		Wednesday,
 
-		[EnumMember(Value = "thursday")]
+		[EnumMember(Value = "THU")]
 		Thursday,
 
-		[EnumMember(Value = "friday")]
+		[EnumMember(Value = "FRI")]
 		Friday,
 
-		[EnumMember(Value = "saturday")]
+		[EnumMember(Value = "SAT")]
 		Saturday
 	}
 }

--- a/src/Nest/XPack/Watcher/Watch.cs
+++ b/src/Nest/XPack/Watcher/Watch.cs
@@ -10,7 +10,7 @@ using Elasticsearch.Net.Utf8Json;
 namespace Nest
 {
 	[InterfaceDataContract]
-	[ReadAsAttribute(typeof(Watch))]
+	[ReadAs(typeof(Watch))]
 	public interface IWatch
 	{
 		[DataMember(Name ="actions")]
@@ -101,6 +101,5 @@ namespace Nest
 		/// <inheritdoc cref="IWatch.Trigger" />
 		public WatchDescriptor Trigger(Func<TriggerDescriptor, TriggerContainer> selector) =>
 			Assign(selector, (a, v) => a.Trigger = v.InvokeOrDefault(new TriggerDescriptor()));
-
 	}
 }

--- a/tests/Tests/XPack/Watcher/PutWatch/PutWatchApiTests.cs
+++ b/tests/Tests/XPack/Watcher/PutWatch/PutWatchApiTests.cs
@@ -193,8 +193,8 @@ namespace Tests.XPack.Watcher.PutWatch
 					{
 						weekly = new[]
 						{
-							new { on = new[] { "monday" }, at = new[] { "noon" } },
-							new { on = new[] { "friday" }, at = new[] { "17:00" } }
+							new { on = new[] { "MON" }, at = new[] { "noon" } },
+							new { on = new[] { "FRI" }, at = new[] { "17:00" } }
 						}
 					}
 				},
@@ -897,8 +897,8 @@ namespace Tests.XPack.Watcher.PutWatch
 					{
 						weekly = new[]
 						{
-							new { on = new[] { "monday" }, at = new[] { "noon" } },
-							new { on = new[] { "friday" }, at = new[] { "17:00" } }
+							new { on = new[] { "MON" }, at = new[] { "noon" } },
+							new { on = new[] { "FRI" }, at = new[] { "17:00" } }
 						}
 					}
 				},

--- a/tests/Tests/XPack/Watcher/WatcherCluster.cs
+++ b/tests/Tests/XPack/Watcher/WatcherCluster.cs
@@ -6,8 +6,10 @@ using Tests.Core.ManagedElasticsearch.Clusters;
 
 namespace Tests.XPack.Watcher
 {
+	/// <summary>
+	/// Used to isolate watcher tests within their own cluster.
+	/// </summary>
 	public class WatcherCluster : XPackCluster
 	{
-
 	}
 }

--- a/tests/Tests/XPack/Watcher/WatcherCoordinatedTests.cs
+++ b/tests/Tests/XPack/Watcher/WatcherCoordinatedTests.cs
@@ -1,0 +1,85 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Threading.Tasks;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Nest;
+using Tests.Framework.EndpointTests;
+using Tests.Framework.EndpointTests.TestState;
+using FluentAssertions;
+using Tests.Core.Extensions;
+
+namespace Tests.XPack.Watcher
+{
+	public class WatcherWeeklyScheduleoCoordinatedTests : CoordinatedIntegrationTestBase<WatcherCluster>
+	{
+		private const string CreateWeeklyScheduleWatcher = nameof(CreateWeeklyScheduleWatcher);
+		private const string GetWeeklyScheduleWatcher = nameof(GetWeeklyScheduleWatcher);
+		private const string DeleteWeeklyScheduleWatcher = nameof(DeleteWeeklyScheduleWatcher);
+
+		public WatcherWeeklyScheduleoCoordinatedTests(WatcherCluster cluster, EndpointUsage usage) : base(new CoordinatedUsage(cluster, usage)
+		{
+			{CreateWeeklyScheduleWatcher, u =>
+				u.Calls<PutWatchDescriptor, PutWatchRequest, IPutWatchRequest, PutWatchResponse>(
+					v => new PutWatchRequest(v){
+						Trigger = new ScheduleContainer
+						{
+							Weekly = new WeeklySchedule
+							{
+								new TimeOfWeek(Day.Monday, "17:00"),
+								new TimeOfWeek(Day.Tuesday, "17:00"),
+								new TimeOfWeek(Day.Wednesday, "17:00"),
+								new TimeOfWeek(Day.Thursday, "17:00"),
+								new TimeOfWeek(Day.Friday, "17:00"),
+								new TimeOfWeek(Day.Saturday, "17:00"),
+								new TimeOfWeek(Day.Sunday, "17:00"),
+							}
+						}},
+					(v, d) => d.Trigger(t => t.Schedule(s => s.Weekly(w => w
+						.Add(tow => tow.On(Day.Monday).At("17:00"))
+						.Add(tow => tow.On(Day.Tuesday).At("17:00"))
+						.Add(tow => tow.On(Day.Wednesday).At("17:00"))
+						.Add(tow => tow.On(Day.Thursday).At("17:00"))
+						.Add(tow => tow.On(Day.Friday).At("17:00"))
+						.Add(tow => tow.On(Day.Saturday).At("17:00"))
+						.Add(tow => tow.On(Day.Sunday).At("17:00"))
+					))),
+					(v, c, f) => c.Watcher.Put(v, f),
+					(v, c, f) => c.Watcher.PutAsync(v, f),
+					(v, c, r) => c.Watcher.Put(r),
+					(v, c, r) => c.Watcher.PutAsync(r)
+				)
+			},
+			{GetWeeklyScheduleWatcher, u =>
+				u.Calls<GetWatchDescriptor, GetWatchRequest, IGetWatchRequest, GetWatchResponse>(
+					v => new GetWatchRequest(v),
+					(v, d) => d,
+					(v, c, f) => c.Watcher.Get(v, f),
+					(v, c, f) => c.Watcher.GetAsync(v, f),
+					(v, c, r) => c.Watcher.Get(r),
+					(v, c, r) => c.Watcher.GetAsync(r)
+				)
+			},
+			{DeleteWeeklyScheduleWatcher, u =>
+				u.Calls<DeleteWatchDescriptor, DeleteWatchRequest, IDeleteWatchRequest, DeleteWatchResponse>(
+					v => new DeleteWatchRequest(v),
+					(v, d) => d,
+					(v, c, f) => c.Watcher.Delete(v, f),
+					(v, c, f) => c.Watcher.DeleteAsync(v, f),
+					(v, c, r) => c.Watcher.Delete(r),
+					(v, c, r) => c.Watcher.DeleteAsync(r)
+				)
+			}
+		})
+		{ }
+
+		[I] public async Task GetWeeklyScheduleWatcherResponse() => await Assert<GetWatchResponse>(GetWeeklyScheduleWatcher, (v, r) =>
+		{
+			r.ShouldBeValid();
+			r.Id.Should().Be(v);
+			r.Found.Should().BeTrue();
+			r.Watch.Trigger.Should().BeAssignableTo<ITriggerContainer>().Subject.Schedule.Weekly.Should().NotBeNullOrEmpty().And.HaveCount(7);
+		});
+	}
+}


### PR DESCRIPTION
Relates to #5725 by fixing the `Day` enum JSON strings such that they can be deserialised correctly. Watcher in general may need more work to make working with the `GetWatch` response easier but that is difficult without breaking the models. This will be improved in vNext with code-gen.