### PR TITLE
[6.x] Switch default memory stream factory

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,7 +36,7 @@ jobs:
   strategy:
     maxParallel: 5
     matrix:
-      es682:
+      es6816:
         esVersion: '6.8.16'
       es672:
         esVersion: '6.7.2'
@@ -44,7 +44,7 @@ jobs:
         esVersion: '6.6.2'
       es654:
         esVersion: '6.5.4'
-      es642:
+      es643:
         esVersion: '6.4.3'
       es632:
         esVersion: '6.3.2'
@@ -74,7 +74,7 @@ jobs:
   strategy:
     maxParallel: 5
     matrix:
-      es682:
+      es6816:
         esVersion: '6.8.16'
       es672:
         esVersion: '6.7.2'
@@ -82,7 +82,7 @@ jobs:
         esVersion: '6.6.2'
       es654:
         esVersion: '6.5.4'
-      es642:
+      es643:
         esVersion: '6.4.3'
       es632:
         esVersion: '6.3.2'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
     maxParallel: 5
     matrix:
       es682:
-        esVersion: '6.8.2'
+        esVersion: '6.8.16'
       es672:
         esVersion: '6.7.2'
       es662:
@@ -45,7 +45,7 @@ jobs:
       es654:
         esVersion: '6.5.4'
       es642:
-        esVersion: '6.4.2'
+        esVersion: '6.4.3'
       es632:
         esVersion: '6.3.2'
       es624:
@@ -75,7 +75,7 @@ jobs:
     maxParallel: 5
     matrix:
       es682:
-        esVersion: '6.8.2'
+        esVersion: '6.8.16'
       es672:
         esVersion: '6.7.2'
       es662:
@@ -83,7 +83,7 @@ jobs:
       es654:
         esVersion: '6.5.4'
       es642:
-        esVersion: '6.4.2'
+        esVersion: '6.4.3'
       es632:
         esVersion: '6.3.2'
       es624:

--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -129,6 +129,8 @@ namespace Elasticsearch.Net
 	public abstract class ConnectionConfiguration<T> : IConnectionConfigurationValues, IHideObjectMembers
 		where T : ConnectionConfiguration<T>
 	{
+		public static IMemoryStreamFactory DefaultMemoryStreamFactory { get; } = Elasticsearch.Net.MemoryStreamFactory.Default;
+
 		private readonly IConnection _connection;
 		private readonly IConnectionPool _connectionPool;
 		private readonly NameValueCollection _headers = new NameValueCollection();
@@ -141,9 +143,7 @@ namespace Elasticsearch.Net
 		private Action<IApiCallDetails> _completedRequestHandler = DefaultCompletedRequestHandler;
 		private int _connectionLimit;
 		private TimeSpan? _deadTimeout;
-
 		private bool _disableAutomaticProxyDetection = false;
-
 		private bool _disableDirectStreaming = false;
 		private bool _disableMetaHeader;
 		private bool _disablePings;
@@ -154,12 +154,12 @@ namespace Elasticsearch.Net
 		private TimeSpan? _maxDeadTimeout;
 		private int? _maxRetries;
 		private TimeSpan? _maxRetryTimeout;
+		private IMemoryStreamFactory _memoryStreamFactory = DefaultMemoryStreamFactory;
 		private Func<Node, bool> _nodePredicate = DefaultNodePredicate;
 		private Action<RequestData> _onRequestDataCreated = DefaultRequestDataCreated;
 		private TimeSpan? _pingTimeout;
 		private bool _prettyJson;
 		private string _proxyAddress;
-
 		private string _proxyPassword;
 		private string _proxyUsername;
 		private TimeSpan _requestTimeout;
@@ -217,8 +217,7 @@ namespace Elasticsearch.Net
 		TimeSpan? IConnectionConfigurationValues.MaxDeadTimeout => _maxDeadTimeout;
 		int? IConnectionConfigurationValues.MaxRetries => _maxRetries;
 		TimeSpan? IConnectionConfigurationValues.MaxRetryTimeout => _maxRetryTimeout;
-		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory { get; } = new RecyclableMemoryStreamFactory();
-
+		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory => _memoryStreamFactory;
 		Func<Node, bool> IConnectionConfigurationValues.NodePredicate => _nodePredicate;
 		Action<IApiCallDetails> IConnectionConfigurationValues.OnRequestCompleted => _completedRequestHandler;
 		Action<RequestData> IConnectionConfigurationValues.OnRequestDataCreated => _onRequestDataCreated;
@@ -584,6 +583,11 @@ namespace Elasticsearch.Net
 		/// versions that initiate requests to Elasticsearch
 		/// </summary>
 		public T UserAgent(string userAgent) => Assign(userAgent, (a, v) => a._userAgent = v);
+
+		/// <summary>
+		/// The memory stream factory to use, defaults to <see cref="MemoryStreamFactory.Default"/>.
+		/// </summary>
+		public T MemoryStreamFactory(IMemoryStreamFactory memoryStreamFactory) => Assign(memoryStreamFactory, (a, v) => a._memoryStreamFactory = v);
 
 		protected virtual void DisposeManagedResources()
 		{

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -120,7 +120,7 @@ namespace Elasticsearch.Net
 		/// </summary>
 		TimeSpan? MaxRetryTimeout { get; }
 
-		/// <summary> Provides a memory stream factory</summary>
+		/// <summary> Provides a memory stream factory.</summary>
 		IMemoryStreamFactory MemoryStreamFactory { get; }
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/MemoryStreamFactory.cs
@@ -3,17 +3,19 @@
 namespace Elasticsearch.Net
 {
 	/// <summary>
-	/// A factory for creating memory streams using instances of <see cref="MemoryStream" />
+	/// A factory for creating memory streams using instances of <see cref="MemoryStream" />.
 	/// </summary>
 	public class MemoryStreamFactory : IMemoryStreamFactory
 	{
+		public static MemoryStreamFactory Default { get; } = new MemoryStreamFactory();
+
 		/// <summary>
-		/// Creates a memory stream using <see cref="MemoryStream" />
+		/// Creates a memory stream using <see cref="MemoryStream" />.
 		/// </summary>
 		public MemoryStream Create() => new MemoryStream();
 
 		/// <summary>
-		/// Creates a memory stream using <see cref="MemoryStream" /> with the bytes written to the stream
+		/// Creates a memory stream using <see cref="MemoryStream" /> with the bytes written to the stream.
 		/// </summary>
 		public MemoryStream Create(byte[] bytes) => new MemoryStream(bytes);
 	}

--- a/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
+++ b/src/Elasticsearch.Net/Providers/RecyclableMemoryStreamFactory.cs
@@ -3,10 +3,12 @@
 namespace Elasticsearch.Net
 {
 	/// <summary>
-	/// A factory for creating memory streams using a recyclable pool of <see cref="MemoryStream" /> instances
+	/// A factory for creating memory streams using a recyclable pool of <see cref="MemoryStream" /> instances.
 	/// </summary>
 	public class RecyclableMemoryStreamFactory : IMemoryStreamFactory
 	{
+		public static RecyclableMemoryStreamFactory Default { get; } = new RecyclableMemoryStreamFactory();
+
 		private readonly RecyclableMemoryStreamManager _manager;
 
 		public RecyclableMemoryStreamFactory() =>


### PR DESCRIPTION
Port of change from 7.x.

Provides a saner, more predictable default value that can be configured to enable pooling if the consumer desires.