### PR TITLE
Disable GeoIP database

### DIFF
--- a/.ci/run-elasticsearch.ps1
+++ b/.ci/run-elasticsearch.ps1
@@ -159,7 +159,8 @@ $environment = @(
   "--env", "bootstrap.memory_lock=true",
   "--env", "node.attr.testattr=test",
   "--env", "path.repo=/tmp",
-  "--env", "repositories.url.allowed_urls=http://snapshot.test*"
+  "--env", "repositories.url.allowed_urls=http://snapshot.test*",
+  "--env", "ingest.geoip.downloader.enabled=false"
 )
 
 $volumes = @(

--- a/.ci/run-elasticsearch.sh
+++ b/.ci/run-elasticsearch.sh
@@ -36,6 +36,7 @@ environment=($(cat <<-END
   --env node.attr.testattr=test
   --env path.repo=/tmp
   --env repositories.url.allowed_urls=http://snapshot.test*
+  --env ingest.geoip.downloader.enabled=false
 END
 ))
 if [[ "$TEST_SUITE" == "platinum" ]]; then


### PR DESCRIPTION
When Elasticsearch CI runs, the geoip database downloader is disabled and as a result, the index is not created. This change matches the configuration when running the .NET YAML tests to avoid assertion failures due to the `.geoip_database` index appearing in `/_cat/*` responses.