### PR TITLE
Ensure we dispose of the response stream in all cases

### DIFF
--- a/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpWebRequestConnection.cs
@@ -19,7 +19,8 @@ using Elasticsearch.Net.Diagnostics;
 namespace Elasticsearch.Net
 {
 #if DOTNETCORE
-	[Obsolete("CoreFX HttpWebRequest uses HttpClient under the covers but does not reuse HttpClient instances, do NOT use on .NET core only used as the default on Full Framework")]
+	[Obsolete(
+		"CoreFX HttpWebRequest uses HttpClient under the covers but does not reuse HttpClient instances, do NOT use on .NET core only used as the default on Full Framework")]
 #endif
 	public class HttpWebRequestConnection : IConnection
 	{
@@ -53,8 +54,10 @@ namespace Elasticsearch.Net
 					using (var stream = request.GetRequestStream())
 					{
 						if (requestData.HttpCompression)
+						{
 							using (var zipStream = new GZipStream(stream, CompressionMode.Compress))
 								data.Write(zipStream, requestData.ConnectionSettings);
+						}
 						else
 							data.Write(stream, requestData.ConnectionSettings);
 					}
@@ -69,7 +72,7 @@ namespace Elasticsearch.Net
 
 				//http://msdn.microsoft.com/en-us/library/system.net.httpwebresponse.getresponsestream.aspx
 				//Either the stream or the response object needs to be closed but not both although it won't
-				//throw any errors if both are closed atleast one of them has to be Closed.
+				//throw any errors if both are closed at least one of them has to be Closed.
 				//Since we expose the stream we let closing the stream determining when to close the connection
 				var httpWebResponse = (HttpWebResponse)request.GetResponse();
 				HandleResponse(httpWebResponse, out statusCode, out responseStream, out mimeType);
@@ -79,7 +82,8 @@ namespace Elasticsearch.Net
 					warnings = httpWebResponse.Headers.GetValues("Warning");
 
 				//response.Headers.HasKeys() can return false even if response.Headers.AllKeys has values.
-				if (httpWebResponse.SupportsHeaders && httpWebResponse.Headers.Count > 0 && httpWebResponse.Headers.AllKeys.Contains("X-elastic-product"))
+				if (httpWebResponse.SupportsHeaders && httpWebResponse.Headers.Count > 0
+					&& httpWebResponse.Headers.AllKeys.Contains("X-elastic-product"))
 					productNames = httpWebResponse.Headers.GetValues("X-elastic-product");
 			}
 			catch (WebException e)
@@ -90,7 +94,8 @@ namespace Elasticsearch.Net
 			}
 
 			responseStream ??= Stream.Null;
-			var response = ResponseBuilder.ToResponse<TResponse>(requestData, ex, statusCode, warnings, responseStream, mimeType, productNames.FirstOrDefault());
+			var response = ResponseBuilder.ToResponse<TResponse>(requestData, ex, statusCode, warnings, responseStream, mimeType,
+				productNames?.FirstOrDefault());
 
 			// set TCP and threadpool stats on the response here so that in the event the request fails after the point of
 			// gathering stats, they are still exposed on the call details. Ideally these would be set inside ResponseBuilder.ToResponse,
@@ -131,8 +136,10 @@ namespace Elasticsearch.Net
 						using (var stream = await apmGetRequestStreamTask.ConfigureAwait(false))
 						{
 							if (requestData.HttpCompression)
+							{
 								using (var zipStream = new GZipStream(stream, CompressionMode.Compress))
 									await data.WriteAsync(zipStream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
+							}
 							else
 								await data.WriteAsync(stream, requestData.ConnectionSettings, cancellationToken).ConfigureAwait(false);
 						}
@@ -159,7 +166,8 @@ namespace Elasticsearch.Net
 						warnings = httpWebResponse.Headers.GetValues("Warning");
 
 					//response.Headers.HasKeys() can return false even if response.Headers.AllKeys has values.
-					if (httpWebResponse.SupportsHeaders && httpWebResponse.Headers.Count > 0 && httpWebResponse.Headers.AllKeys.Contains("X-elastic-product"))
+					if (httpWebResponse.SupportsHeaders && httpWebResponse.Headers.Count > 0
+						&& httpWebResponse.Headers.AllKeys.Contains("X-elastic-product"))
 						productNames = httpWebResponse.Headers.GetValues("X-elastic-product");
 				}
 			}
@@ -175,7 +183,7 @@ namespace Elasticsearch.Net
 			}
 			responseStream ??= Stream.Null;
 			var response = await ResponseBuilder.ToResponseAsync<TResponse>
-					(requestData, ex, statusCode, warnings, responseStream, mimeType, productNames.FirstOrDefault(), cancellationToken)
+					(requestData, ex, statusCode, warnings, responseStream, mimeType, productNames?.FirstOrDefault(), cancellationToken)
 				.ConfigureAwait(false);
 
 			// set TCP and thread pool stats on the response here so that in the event the request fails after the point of
@@ -215,7 +223,7 @@ namespace Elasticsearch.Net
 #else
 				if (callback != null)
 					throw new Exception("Mono misses ServerCertificateValidationCallback on HttpWebRequest");
-			#endif
+#endif
 		}
 
 		protected virtual HttpWebRequest CreateWebRequest(RequestData requestData)
@@ -321,8 +329,10 @@ namespace Elasticsearch.Net
 			if (!string.IsNullOrEmpty(requestData.Uri.UserInfo))
 				userInfo = Uri.UnescapeDataString(requestData.Uri.UserInfo);
 			else if (requestData.BasicAuthorizationCredentials != null)
+			{
 				userInfo =
 					$"{requestData.BasicAuthorizationCredentials.Username}:{requestData.BasicAuthorizationCredentials.Password.CreateString()}";
+			}
 
 			if (string.IsNullOrWhiteSpace(userInfo))
 				return;
@@ -346,7 +356,6 @@ namespace Elasticsearch.Net
 
 			request.Headers["Authorization"] = $"ApiKey {apiKey}";
 			return true;
-
 		}
 
 		/// <summary>

--- a/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ResponseBuilder.cs
@@ -43,6 +43,8 @@ namespace Elasticsearch.Net
 			// Only attempt to set the body if the response may have content
 			if (MayHaveBody(statusCode, requestData.Method))
 				response = SetBody<TResponse>(details, requestData, responseStream, mimeType);
+			else
+				responseStream.Dispose();
 
 			response ??= new TResponse();
 
@@ -73,6 +75,8 @@ namespace Elasticsearch.Net
 			// Only attempt to set the body if the response may have content
 			if (MayHaveBody(statusCode, requestData.Method))
 				response = await SetBodyAsync<TResponse>(details, requestData, responseStream, mimeType, cancellationToken).ConfigureAwait(false);
+			else
+				responseStream.Dispose();
 
 			response ??= new TResponse();
 
@@ -84,7 +88,7 @@ namespace Elasticsearch.Net
 		/// A helper which returns true if the response could potentially have a body.
 		/// </summary>
 		private static bool MayHaveBody(int? statusCode, HttpMethod httpMethod) =>
-			!statusCode.HasValue || (statusCode.Value != 204 && httpMethod != HttpMethod.HEAD);
+			!statusCode.HasValue || statusCode.Value != 204 && httpMethod != HttpMethod.HEAD;
 
 		private static ApiCallDetails Initialize(
 			RequestData requestData,
@@ -92,7 +96,8 @@ namespace Elasticsearch.Net
 			int? statusCode,
 			IEnumerable<string> warnings,
 			string mimeType,
-			string productName)
+			string productName
+		)
 		{
 			var success = false;
 			var allowedStatusCodes = requestData.AllowedStatusCodes;
@@ -101,8 +106,10 @@ namespace Elasticsearch.Net
 				if (allowedStatusCodes.Contains(-1) || allowedStatusCodes.Contains(statusCode.Value))
 					success = true;
 				else
+				{
 					success = requestData.ConnectionSettings
 						.StatusCodeToResponseSuccess(requestData.Method, statusCode.Value);
+				}
 			}
 
 			// We don't validate the content-type (MIME type) for HEAD requests or responses that have no content (204 status code).
@@ -181,8 +188,10 @@ namespace Elasticsearch.Net
 
 				var serializer = requestData.ConnectionSettings.RequestResponseSerializer;
 				if (requestData.CustomResponseBuilder != null)
+				{
 					return await requestData.CustomResponseBuilder.DeserializeResponseAsync(serializer, details, responseStream, cancellationToken)
 						.ConfigureAwait(false) as TResponse;
+				}
 
 				return !RequestData.ValidResponseContentType(requestData.Accept, mimeType)
 					? null
@@ -210,10 +219,7 @@ namespace Elasticsearch.Net
 				//if not json store the result under "body"
 				if (!RequestData.IsJsonMimeType(mimeType))
 				{
-					var dictionary = new DynamicDictionary
-					{
-						["body"] = new(bytes.Utf8String())
-					};
+					var dictionary = new DynamicDictionary { ["body"] = new(bytes.Utf8String()) };
 
 					cs = new DynamicResponse(dictionary) as TResponse;
 				}


### PR DESCRIPTION
Repeat calls to ExistsAsync can cause the connection limit to be reached as the optimized code which ensures we correctly handle cloud responses may not always run, leaving the response stream and therefore the connection open. This causes the default connection limit of 80 to be reached.

This fix ensures we correctly dispose of the response stream in all code paths.

Fixes #5775