### PR TITLE
Skip disk usage test

### DIFF
--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -188,4 +188,10 @@ let SkipList = dict<SkipFile,SkipSection> [
     // TODO investigate
     // May need to trim the incoming regex string
     SkipFile "analytics/histogram.yml", Section "Histogram requires values in increasing order"
+
+    // TODO Can we handle the set which is essentially an alias?
+    // Options: 
+    // - Add new alias operation to distinguish intent
+    // - Rewrite the test to avoid the use of the aliases
+    SkipFile "indices.stats/50_disk_usage.yml", Section "Disk usage stats"
 ]


### PR DESCRIPTION
This test uses set operations as a way to alias into the response, however, the YAML runner doesn't handle this right now as it stores the Dictionary of entries from that location resulting in an invalid path string that cannot be resolved from the response.

We may be able to tweak the runner to handle this but this needs further review.