### PR TITLE
Tweak code-gen to skip historically ignored URLs

### DIFF
--- a/src/ApiGenerator/Configuration/SkippedUrls.cs
+++ b/src/ApiGenerator/Configuration/SkippedUrls.cs
@@ -1,0 +1,13 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Collections.Generic;
+
+namespace ApiGenerator.Configuration
+{
+	public static class GeneralSkipList
+	{
+		public static IReadOnlyCollection<string> SkippedUrls => new[] { "/_search/scroll/{scroll_id}" };
+	}
+}

--- a/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
+++ b/src/ApiGenerator/Domain/Code/HighLevel/Requests/Constructor.cs
@@ -47,10 +47,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 		{
 			var ctors = new List<Constructor>();
 
-			// Include deprecated paths to ensure these are not removed (a breaking change) during 7.x releases.
-			// For historical reasons, constructors for deprecated paths which specified a type where removed in 7.0 and
-			// therefore we don't include those in generation to avoid them being re-added.
-			var paths = url.Paths.ToList().Union(url.PathsWithDeprecations.Where(x => x.Parts.All(p => p.Name != "type")));
+			var paths = url.FinalPaths;
 
 			if (url.IsPartless) return ctors;
 
@@ -100,6 +97,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 			}
 			var constructors = ctors.GroupBy(c => c.Generated.Split(new[] { ':' }, 2)[0]).Select(g => g.Last()).ToList();
 			if (!constructors.Any(c => c.Parameterless))
+			{
 				constructors.Add(new Constructor
 				{
 					Parameterless = true,
@@ -107,6 +105,7 @@ namespace ApiGenerator.Domain.Code.HighLevel.Requests
 					Description =
 						$"///<summary>Used for serialization purposes, making sure we have a parameterless constructor</summary>{Indent}[SerializationConstructor]",
 				});
+			}
 			return constructors;
 		}
 	}


### PR DESCRIPTION
Now that we generate deprecated URLs to avoid breaking changes in minors, this adds a quite low-tech way to skip URLs that were ignored since 7.0.0 and for which we don't want to re-add actors and properties.

This could have been bolted onto the overrides but I decided on a simpler approach since we expect to replace this code-gen for vNext anyway.