### PR TITLE
[perf] Reduce allocations on some transport paths

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -14,6 +14,7 @@ namespace Elasticsearch.Net
 	public class RequestData
 	{
 		private Uri _requestUri;
+		private Node _node;
 
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
@@ -129,7 +130,19 @@ namespace Elasticsearch.Net
 
 		public HttpMethod Method { get; }
 
-		public Node Node { get; set; }
+		public Node Node 
+		{
+			get
+			{
+				return _node; 
+			}
+			set
+			{
+				_requestUri = null;
+				_node = value;
+			}
+		}
+
 		public AuditEvent OnFailureAuditEvent => MadeItToResponse ? AuditEvent.BadResponse : AuditEvent.BadRequest;
 		public PipelineFailure OnFailurePipelineFailure => MadeItToResponse ? PipelineFailure.BadResponse : PipelineFailure.BadRequest;
 		public string PathAndQuery { get; }

--- a/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/RequestData.cs
@@ -13,6 +13,8 @@ namespace Elasticsearch.Net
 {
 	public class RequestData
 	{
+		private Uri _requestUri;
+
 		public const string OpaqueIdHeader = "X-Opaque-Id";
 		public const string RunAsSecurityHeader = "es-security-runas-user";
 
@@ -149,7 +151,20 @@ namespace Elasticsearch.Net
 		public bool TcpStats { get; }
 		public bool ThreadPoolStats { get; }
 
-		public Uri Uri => Node != null ? new Uri(Node.Uri, PathAndQuery) : null;
+		/// <summary>
+		/// The <see cref="Uri" /> for the request.
+		/// </summary>
+		public Uri Uri
+		{
+			get
+			{
+				if (_requestUri is not null) return _requestUri;
+
+				_requestUri = Node is not null ? new Uri(Node.Uri, PathAndQuery) : null;
+				return _requestUri;
+			}
+		}
+		
 		public TimeSpan DnsRefreshTimeout { get; }
 
 		public MetaHeaderProvider MetaHeaderProvider { get; }


### PR DESCRIPTION
Lazily caches the Uri on RequestData since this property is accessed at least three times and each time was allocating a new Uri. This saves 192 bytes per request.

This optimisation is one of three added to the new `Elastic.Transport` project that was suitable to backport to 7.x.