### PR TITLE
Fix hourly watcher scheduler serialisation

### DIFF
--- a/src/Nest/XPack/Watcher/Schedule/ScheduleContainer.cs
+++ b/src/Nest/XPack/Watcher/Schedule/ScheduleContainer.cs
@@ -227,6 +227,12 @@ namespace Nest
 				var formatter = formatterResolver.GetFormatter<CronExpression>();
 				formatter.Serialize(ref writer, value.Cron, formatterResolver);
 			}
+			else if (value.Hourly is not null)
+			{
+				writer.WritePropertyName(Parser.Hourly);
+				var formatter = formatterResolver.GetFormatter<IHourlySchedule>();
+				formatter.Serialize(ref writer, value.Hourly, formatterResolver);
+			}
 			else if (value.Daily is not null)
 			{
 				writer.WritePropertyName(Parser.Daily);


### PR DESCRIPTION
A previous PR #5761 improved serialisation and deserialisation of watcher trigger schedules. However, I missed the hourly case which this PR addresses.