### PR TITLE
Improve warning for transient product check failures

### DIFF
--- a/src/Elasticsearch.Net/Transport/Pipeline/ProductCheckStatus.cs
+++ b/src/Elasticsearch.Net/Transport/Pipeline/ProductCheckStatus.cs
@@ -12,6 +12,7 @@ namespace Elasticsearch.Net
 		NotChecked,
 		ValidProduct,
 		InvalidProduct,
-		UndeterminedProduct
+		UndeterminedProduct,
+		TransientFailure
 	}
 }


### PR DESCRIPTION
When a transient error occurs during the product check, we add a warning to the debug information. This PR makes the warning clearer and explains the actual failure.