### PR TITLE
Skip field usage YAML tests

### DIFF
--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -194,4 +194,10 @@ let SkipList = dict<SkipFile,SkipSection> [
     // - Add new alias operation to distinguish intent
     // - Rewrite the test to avoid the use of the aliases
     SkipFile "indices.stats/50_disk_usage.yml", Section "Disk usage stats"
+
+    // TODO Can we handle the set which is essentially an alias?
+    // Options: 
+    // - Add new alias operation to distinguish intent
+    // - Rewrite the test to avoid the use of the aliases
+    SkipFile "indices.stats/60_field_usage.yml", Section "Field usage stats"
 ]


### PR DESCRIPTION
These are failing in CI for the same reason as disk usage. They use set in a way that the YAML runner is not able to handle.