### PR TITLE
Fix AggregateFormatter to read boolean values

### DIFF
--- a/src/DocGenerator/packages.lock.json
+++ b/src/DocGenerator/packages.lock.json
@@ -1653,7 +1653,7 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"

--- a/src/Nest.JsonNetSerializer/packages.lock.json
+++ b/src/Nest.JsonNetSerializer/packages.lock.json
@@ -96,7 +96,7 @@
           "System.Memory": "4.5.4"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
@@ -307,7 +307,7 @@
           "System.Reflection.Emit.Lightweight": "4.3.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"

--- a/src/Nest/Aggregations/AggregateFormatter.cs
+++ b/src/Nest/Aggregations/AggregateFormatter.cs
@@ -1002,7 +1002,13 @@ namespace Nest
 					var keyToken = reader.GetCurrentJsonToken();
 
 					if (keyToken == JsonToken.String)
+					{
 						keyItem = reader.ReadString();
+					}
+					else if (keyToken == JsonToken.True || keyToken == JsonToken.False)
+					{
+						keyItem = reader.ReadBoolean();
+					}
 					else
 					{
 						var numberKey = reader.ReadNumberSegment();

--- a/tests/Tests.Benchmarking/BulkBenchmarkTests.cs
+++ b/tests/Tests.Benchmarking/BulkBenchmarkTests.cs
@@ -31,12 +31,12 @@ namespace Tests.Benchmarking
 				.EnableHttpCompression(false)
 			);
 
-		private static readonly Nest7.IElasticClient ClientV7 =
-			new Nest7.ElasticClient(new Nest7.ConnectionSettings(
-					new Elasticsearch.Net7.InMemoryConnection(Response, 200, null, null))
-				.DefaultIndex("index")
-				.EnableHttpCompression(false)
-			);
+		//private static readonly Nest7.IElasticClient ClientV7 =
+		//	new Nest7.ElasticClient(new Nest7.ConnectionSettings(
+		//			new Elasticsearch.Net7.InMemoryConnection(Response, 200, null, null))
+		//		.DefaultIndex("index")
+		//		.EnableHttpCompression(false)
+		//	);
 
 		[GlobalSetup]
 		public void Setup() { }
@@ -47,8 +47,8 @@ namespace Tests.Benchmarking
 		[Benchmark(Description = "PR no recyclable")]
 		public BulkResponse NoRecyclableMemory() => ClientNoRecyclableMemory.Bulk(b => b.IndexMany(Projects));
 
-		[Benchmark(Description = "7.x")]
-		public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));
+		//[Benchmark(Description = "7.x")]
+		//public Nest7.BulkResponse NestCurrentBulk() => ClientV7.Bulk(b => b.IndexMany(Projects));
 
 		private static object BulkItemResponse(Project project) => new
 		{

--- a/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
+++ b/tests/Tests.Benchmarking/Tests.Benchmarking.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
@@ -14,6 +14,6 @@
     <PackageReference Include="BenchmarkDotNet" Version="0.12.0" />
     <PackageReference Include="Elastic.CommonSchema.BenchmarkDotNetExporter" Version="1.5.0" />
     <PackageReference Include="LibGit2Sharp" Version="0.26.0-preview-0062" />
-    <PackageReference Include="NEST.v7" Version="7.13.0-ci20210301T140449" />
+    <!--<PackageReference Include="NEST.v7" Version="7.13.0-ci20210301T140449" />-->
   </ItemGroup>
 </Project>

--- a/tests/Tests.Benchmarking/packages.lock.json
+++ b/tests/Tests.Benchmarking/packages.lock.json
@@ -46,15 +46,6 @@
         "resolved": "1.0.0-preview.2",
         "contentHash": "m+pJPEO7HyXvrOna5Sr3s77ewXonjYWJTNL6drh8xACnMNxnlqUDKx9HfGeSE9wmfY0lQwppaeZpFTPGaH7kZg=="
       },
-      "NEST.v7": {
-        "type": "Direct",
-        "requested": "[7.13.0-ci20210301T140449, )",
-        "resolved": "7.13.0-ci20210301T140449",
-        "contentHash": "1y9pIH5QADisLjnpbK8ZS4ajbF6uFu5TA6LOfB4ECgI/mjipK4FbKvIydicp0nff4xWqmVzBMBVfZ33zauMYhg==",
-        "dependencies": {
-          "Elasticsearch.Net.v7": "7.13.0-ci20210301T140449"
-        }
-      },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
         "resolved": "0.12.0",
@@ -121,16 +112,6 @@
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
-        }
-      },
-      "Elasticsearch.Net.v7": {
-        "type": "Transitive",
-        "resolved": "7.13.0-ci20210301T140449",
-        "contentHash": "/bijZdruoRaQLMy/7niRp8RiJpO95uP7Q8Vxwxxb4jjKSIXcRzgrLaMtWlkhCEQQ3nGZIkdxVEWpapv5pWfrXA==",
-        "dependencies": {
-          "Microsoft.CSharp": "4.6.0",
-          "System.Buffers": "4.5.1",
-          "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
       "FluentAssertions": {
@@ -1410,13 +1391,13 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",

--- a/tests/Tests.ClusterLauncher/packages.lock.json
+++ b/tests/Tests.ClusterLauncher/packages.lock.json
@@ -865,13 +865,13 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",

--- a/tests/Tests.Core/packages.lock.json
+++ b/tests/Tests.Core/packages.lock.json
@@ -1312,13 +1312,13 @@
           "System.Reflection.Emit.Lightweight": "4.3.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",

--- a/tests/Tests.Domain/packages.lock.json
+++ b/tests/Tests.Domain/packages.lock.json
@@ -808,7 +808,7 @@
           "System.Reflection.Emit.Lightweight": "4.3.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"

--- a/tests/Tests.Reproduce/GitHubIssue5962.cs
+++ b/tests/Tests.Reproduce/GitHubIssue5962.cs
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+using Tests.Domain;
+
+namespace Tests.Reproduce
+{
+	public class GitHubIssue5962
+	{
+		private static readonly byte[] ResponseBytes = Encoding.UTF8.GetBytes(@"{
+    ""took"": 2,
+    ""timed_out"": false,
+    ""_shards"": {
+        ""total"": 1,
+        ""successful"": 1,
+        ""skipped"": 0,
+        ""failed"": 0
+    },
+    ""hits"": {
+        ""total"": {
+            ""value"": 6,
+            ""relation"": ""eq""
+        },
+        ""max_score"": null,
+        ""hits"": []
+    },
+    ""aggregations"": {
+        ""multi_terms#multi-terms"": {
+            ""doc_count_error_upper_bound"": 0,
+            ""sum_other_doc_count"": 0,
+            ""buckets"": [
+                {
+                    ""key"": [
+                        ""A title 1"",
+                        true
+                    ],
+                    ""key_as_string"": ""A title 1|true"",
+                    ""doc_count"": 3
+                },
+                {
+                    ""key"": [
+                        ""A title 1"",
+                        false
+                    ],
+                    ""key_as_string"": ""A title 1|false"",
+                    ""doc_count"": 1
+                }
+            ]
+        }
+    }
+}");
+
+		[U] public void MultiTermsShouldHandleBooleanValues()
+		{
+			var pool = new SingleNodeConnectionPool(new Uri($"http://localhost:9200"));
+			var settings = new ConnectionSettings(pool, new InMemoryConnection(ResponseBytes));
+			var client = new ElasticClient(settings);
+
+			var response = client.Search<TestData>(s => s
+				.Size(0)
+				.Index("test")
+				.Aggregations(a => a
+					.MultiTerms("multi-terms", mt => mt.Terms(t1 => t1.Field("title.keyword"), t2 => t2.Field(f2 => f2.IsEnabled)))));
+
+			response.Aggregations.MultiTerms("multi-terms").Buckets.Should().HaveCount(2);
+		}
+
+		private class TestData
+		{
+			public bool IsEnabled { get; set; }
+			public string SubTitle { get; set; }
+			public string Title { get; set; }
+		}
+	}
+}

--- a/tests/Tests.Reproduce/packages.lock.json
+++ b/tests/Tests.Reproduce/packages.lock.json
@@ -1281,13 +1281,13 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",

--- a/tests/Tests.ScratchPad/packages.lock.json
+++ b/tests/Tests.ScratchPad/packages.lock.json
@@ -1397,13 +1397,13 @@
           "System.Diagnostics.DiagnosticSource": "5.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -1337,13 +1337,13 @@
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST": {
+      "nest": {
         "type": "Project",
         "dependencies": {
           "Elasticsearch.Net": "7.0.0"
         }
       },
-      "NEST.JsonNetSerializer": {
+      "nest.jsonnetserializer": {
         "type": "Project",
         "dependencies": {
           "NEST": "7.0.0",


### PR DESCRIPTION
Fixes #5962 by ensuring that a multi-terms bucket containing a boolean value can be read correctly. 