### PR TITLE
Support PIT, Fields and RuntimeFields on AsyncSearch

### DIFF
--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -39,8 +39,7 @@ namespace Nest
 		bool? Explain { get; set; }
 
 		/// <summary>
-		/// BETA: Allows for retrieving a list of document fields in the search response.
-		/// <para>This functionality is in beta and is subject to change. </para>
+		/// Allows for retrieving a list of document fields in the search response.
 		/// </summary>
 		[DataMember(Name = "fields")]
 		Fields Fields { get; set; }


### PR DESCRIPTION
Async search should accept the same options as regular search and is missing support for PIT, Fields and Runtime fields. This PR ports those to AsyncSearch.

Skipped ISlicedScroll Slice as this is a deprecated choice going forward.

Closes #5988 