### PR TITLE
Remove vectors feature check in 7.15+

### DIFF
--- a/tests/Tests/XPack/Info/XPackInfoApiTests.cs
+++ b/tests/Tests/XPack/Info/XPackInfoApiTests.cs
@@ -72,7 +72,10 @@ namespace Tests.XPack.Info
 			
 			if (TestConfiguration.Instance.InRange(">=7.3.0"))
 			{
-				r.Features.Vectors.Should().NotBeNull();
+				if (TestConfiguration.Instance.InRange("<7.15.0"))
+				{
+					r.Features.Vectors.Should().NotBeNull();
+				}
 
 				if (TestConfiguration.Instance.InRange("<7.5.0"))
 #pragma warning disable 618
@@ -122,7 +125,10 @@ namespace Tests.XPack.Info
 
 			if (TestConfiguration.Instance.InRange(">=7.3.0"))
 			{
-				r.Vectors.Should().NotBeNull();
+				if (TestConfiguration.Instance.InRange("<7.15.0"))
+				{
+					r.Vectors.Should().NotBeNull();
+				}
 				r.VotingOnly.Should().NotBeNull();
 
 				if (TestConfiguration.Instance.InRange("<7.5.0"))


### PR DESCRIPTION
This is removed in 7.15.0 - See https://github.com/elastic/elasticsearch/pull/76068