### PR TITLE
[7.x] [DOCS] Retitle Elasticsearch .NET Clients doc book

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,7 @@
 :title-separator: |
 
 [[elasticsearch-net-reference]]
-= Elasticsearch.Net and NEST:  the .NET clients
+= Elasticsearch .NET Clients
 
 ////
 IMPORTANT NOTE


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch-net/pull/6016