### PR TITLE
[7.x] [DOCS] Retitle Elasticsearch .NET Clients doc book (#6016)

### DIFF
--- a/tests/Tests/index.asciidoc
+++ b/tests/Tests/index.asciidoc
@@ -1,7 +1,7 @@
 ﻿:title-separator: |
 
 [[elasticsearch-net-reference]]
-= Elasticsearch.Net and NEST: the .NET clients
+= Elasticsearch .NET Clients
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 


### PR DESCRIPTION
7.x backport of https://github.com/elastic/elasticsearch-net/pull/6016

Similar to https://github.com/elastic/elasticsearch-net/pull/6017, but applies the change to the right file. 😄 