### PR TITLE
Support configuring a certificate fingerprint

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -178,6 +178,7 @@ namespace Elasticsearch.Net
 		public static IMemoryStreamFactory DefaultMemoryStreamFactory { get; } = Elasticsearch.Net.MemoryStreamFactory.Default;
 		private bool _enableThreadPoolStats;
 		private bool _enableApiVersioningHeader;
+		private string _certificateFingerprint;
 
 		private string _userAgent = ConnectionConfiguration.DefaultUserAgent;
 		private readonly Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -270,6 +271,7 @@ namespace Elasticsearch.Net
 
 		MetaHeaderProvider IConnectionConfigurationValues.MetaHeaderProvider { get; } = new MetaHeaderProvider();
 		bool IConnectionConfigurationValues.EnableApiVersioningHeader => _enableApiVersioningHeader;
+		string IConnectionConfigurationValues.CertificateFingerprint => _certificateFingerprint;
 
 		void IDisposable.Dispose() => DisposeManagedResources();
 
@@ -303,6 +305,9 @@ namespace Elasticsearch.Net
 
 		/// <summary> The maximum number of retries for a given request </summary>
 		public T MaximumRetries(int maxRetries) => Assign(maxRetries, (a, v) => a._maxRetries = v);
+
+		/// <inheritdoc cref="IConnectionConfigurationValues.CertificateFingerprint"/>
+		public T CertificateFingerprint(string fingerprint) => Assign(fingerprint, (a, v) => a._certificateFingerprint = v);
 
 		/// <summary>
 		/// Limits the number of concurrent connections that can be opened to an endpoint. Defaults to <c>80</c> for all IConnection

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -34,6 +34,12 @@ namespace Elasticsearch.Net
 		SemaphoreSlim BootstrapLock { get; }
 
 		/// <summary>
+		/// During development, the server certificate fingerprint may be provided. When present, it is used to validate the
+		/// certificate sent by the server. The fingerprint is expected to be the hex string representing the SHA256 public key fingerprint.
+		/// </summary>
+		string CertificateFingerprint { get; }
+
+		/// <summary>
 		/// Use the following certificates to authenticate all HTTP requests. You can also set them on individual
 		/// request using <see cref="RequestConfiguration.ClientCertificates" />
 		/// </summary>

--- a/src/Elasticsearch.Net/Connection/CertificateHelpers.cs
+++ b/src/Elasticsearch.Net/Connection/CertificateHelpers.cs
@@ -1,0 +1,52 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.Security.Cryptography;
+using System.Security.Cryptography.X509Certificates;
+
+namespace Elasticsearch.Net
+{
+	internal static class CertificateHelpers
+	{
+		private const string _colon = ":";
+		private const string _hyphen = "-";
+
+		/// <summary>
+		/// Returns the result of validating the fingerprint of a certificate against an expected fingerprint string.
+		/// </summary>
+		public static bool ValidateCertificateFingerprint(X509Certificate certificate, string expectedFingerprint)
+		{
+			string sha256Fingerprint;
+
+#if DOTNETCORE && !NETSTANDARD2_0
+			sha256Fingerprint = certificate.GetCertHashString(HashAlgorithmName.SHA256);
+#else
+			using var alg = SHA256.Create();
+
+			var sha256FingerprintBytes = alg.ComputeHash(certificate.GetRawCertData());
+			sha256Fingerprint = BitConverter.ToString(sha256FingerprintBytes);
+#endif
+
+			sha256Fingerprint = ComparableFingerprint(sha256Fingerprint);
+			return expectedFingerprint.Equals(sha256Fingerprint, StringComparison.OrdinalIgnoreCase);
+		}
+
+		/// <summary>
+		/// Cleans the fingerprint by removing colons and dashes so that a comparison can be made
+		/// without such characters affecting the result.
+		/// </summary>
+		public static string ComparableFingerprint(string fingerprint)
+		{
+			var finalFingerprint = fingerprint;
+
+			if (fingerprint.Contains(_colon))
+				finalFingerprint = fingerprint.Replace(_colon, string.Empty);
+			else if (fingerprint.Contains(_hyphen))
+				finalFingerprint = fingerprint.Replace(_hyphen, string.Empty);
+
+			return finalFingerprint;
+		}
+	}
+}


### PR DESCRIPTION
When using compatibility mode against an `8.0` server, the server will be configured with security enabled and a self-signed cert. The fingerprint of that certificate can be used to connect. This is not expected to be used during production.

- Add configuration option to provide a fingerprint
- Update connections to validate the certificate using the fingerprint when present