### PR TITLE
Add experimental config to disable TLS1.3

### DIFF
--- a/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
+++ b/src/Elasticsearch.Net/Configuration/ConnectionConfiguration.cs
@@ -179,6 +179,7 @@ namespace Elasticsearch.Net
 		private bool _enableThreadPoolStats;
 		private bool _enableApiVersioningHeader;
 		private string _certificateFingerprint;
+		private bool _unsafeDisableTls13;
 
 		private string _userAgent = ConnectionConfiguration.DefaultUserAgent;
 		private readonly Func<HttpMethod, int, bool> _statusCodeToResponseSuccess;
@@ -240,7 +241,6 @@ namespace Elasticsearch.Net
 		int? IConnectionConfigurationValues.MaxRetries => _maxRetries;
 		TimeSpan? IConnectionConfigurationValues.MaxRetryTimeout => _maxRetryTimeout;
 		IMemoryStreamFactory IConnectionConfigurationValues.MemoryStreamFactory => _memoryStreamFactory;
-
 		Func<Node, bool> IConnectionConfigurationValues.NodePredicate => _nodePredicate;
 		Action<IApiCallDetails> IConnectionConfigurationValues.OnRequestCompleted => _completedRequestHandler;
 		Action<RequestData> IConnectionConfigurationValues.OnRequestDataCreated => _onRequestDataCreated;
@@ -253,10 +253,8 @@ namespace Elasticsearch.Net
 		IElasticsearchSerializer IConnectionConfigurationValues.RequestResponseSerializer => UseThisRequestResponseSerializer;
 		TimeSpan IConnectionConfigurationValues.RequestTimeout => _requestTimeout;
 		TimeSpan IConnectionConfigurationValues.DnsRefreshTimeout => _dnsRefreshTimeout;
-
 		Func<object, X509Certificate, X509Chain, SslPolicyErrors, bool> IConnectionConfigurationValues.ServerCertificateValidationCallback =>
 			_serverCertificateValidationCallback;
-
 		IReadOnlyCollection<int> IConnectionConfigurationValues.SkipDeserializationForStatusCodes => _skipDeserializationForStatusCodes;
 		TimeSpan? IConnectionConfigurationValues.SniffInformationLifeSpan => _sniffLifeSpan;
 		bool IConnectionConfigurationValues.SniffsOnConnectionFault => _sniffOnConnectionFault;
@@ -268,10 +266,10 @@ namespace Elasticsearch.Net
 		bool IConnectionConfigurationValues.TransferEncodingChunked => _transferEncodingChunked;
 		bool IConnectionConfigurationValues.EnableTcpStats => _enableTcpStats;
 		bool IConnectionConfigurationValues.EnableThreadPoolStats => _enableThreadPoolStats;
-
 		MetaHeaderProvider IConnectionConfigurationValues.MetaHeaderProvider { get; } = new MetaHeaderProvider();
 		bool IConnectionConfigurationValues.EnableApiVersioningHeader => _enableApiVersioningHeader;
 		string IConnectionConfigurationValues.CertificateFingerprint => _certificateFingerprint;
+		bool IConnectionConfigurationValues.UnsafeDisableTls13 => _unsafeDisableTls13;
 
 		void IDisposable.Dispose() => DisposeManagedResources();
 
@@ -624,6 +622,10 @@ namespace Elasticsearch.Net
 		public T EnableTcpStats(bool enableTcpStats = true) => Assign(enableTcpStats, (a, v) => a._enableTcpStats = v);
 
 		public T EnableThreadPoolStats(bool enableThreadPoolStats = true) => Assign(enableThreadPoolStats, (a, v) => a._enableThreadPoolStats = v);
+
+		/// <inheritdoc cref="IConnectionConfigurationValues.UnsafeDisableTls13"/>
+		[Obsolete("This API is temporary, experiemental setting and will be removed in a future minor release.")]
+		public T UnsafeDisableTls13(bool disableTls13 = true) => Assign(disableTls13, (a, v) => a._unsafeDisableTls13 = v);
 
 		protected virtual void DisposeManagedResources()
 		{

--- a/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
+++ b/src/Elasticsearch.Net/Configuration/IConnectionConfigurationValues.cs
@@ -292,5 +292,17 @@ namespace Elasticsearch.Net
 		/// <para> NOTE: You need at least Elasticsearch 7.11 and higher before you can enable this setting on the client</para>
 		/// </summary>
 		bool EnableApiVersioningHeader { get; }
+
+		/// <summary>
+		/// This is an EXPERIMENTAL configuration value which forces the use only of TLS 1.1 and 1.2 during the TLS negotiation. This is a
+		/// temporary workaround for an known TLS negotiation issue with some Cloud regions from Windows 11 for apps targetting .NET 5.0+.
+		/// It should not be used other than to avoid that specific limitation.
+		/// <para>
+		/// This is a temporary, experiemental configuration setting which is likely to be removed in a future release, once the TLS negotiation
+		/// issue is resolved.
+		/// </para>
+		/// </summary>
+		[Obsolete("This API is temporary, experiemental setting and will be removed in a future minor release.")]
+		bool UnsafeDisableTls13 { get; }
 	}
 }

--- a/src/Elasticsearch.Net/Connection/HttpConnection.cs
+++ b/src/Elasticsearch.Net/Connection/HttpConnection.cs
@@ -210,6 +210,14 @@ namespace Elasticsearch.Net
 		{
 			var handler = new HttpClientHandler { AutomaticDecompression = requestData.HttpCompression ? GZip | Deflate : None, };
 
+			// This supports a temporary workaround for https://github.com/elastic/cloud/issues/87734 which disables the use of TLS 1.3.
+#pragma warning disable CS0618 // Type or member is obsolete
+			if (requestData.ConnectionSettings.UnsafeDisableTls13)
+#pragma warning restore CS0618 // Type or member is obsolete
+			{
+				handler.SslProtocols = System.Security.Authentication.SslProtocols.Tls | System.Security.Authentication.SslProtocols.Tls11 | System.Security.Authentication.SslProtocols.Tls12;
+			}
+
 			// same limit as desktop clr
 			if (requestData.ConnectionSettings.ConnectionLimit > 0)
 				try


### PR DESCRIPTION
Workaround for #5951

There is currently an issue for users on Windows 11, targetting .NET 5.0 where TLS negotiation to some cloud regions is failing when TLS 1.3 is enabled. A workaround is to disable TLS 1.3 at the OS level but that is problematic as it affects all client-side apps.

This PR adds a temporary and experimental configuration option that may be used to disable TLS 1.3 in the client directly. This setting affects only .NET Core and .NET 5.0+ targets. It is intended to be used purely as a short term workaround until changes can be made at the cloud proxy layer to resolve the negotiation issue.

Example usage:
```c#
var credentials = new BasicAuthenticationCredentials("elastic", "password"); 
var pool = new CloudConnectionPool("CloudId", credentials); 
var esClient = new ElasticClient(new ConnectionSettings(pool).UnsafeDisableTls13());
```