### PR TITLE
Support `wildcard` field in `WildcardQuery`

### DIFF
--- a/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardQueryUsageTests.cs
@@ -52,4 +52,48 @@ namespace Tests.QueryDsl.TermLevel.Wildcard
 				.Rewrite(MultiTermQueryRewrite.TopTermsBoost(10))
 			);
 	}
+
+	public class WildcardQueryUsingWildcardFieldUsageTests : QueryDslUsageTestsBase
+	{
+		public WildcardQueryUsingWildcardFieldUsageTests(ReadOnlyCluster cluster, EndpointUsage usage) : base(cluster, usage) { }
+
+		protected override ConditionlessWhen ConditionlessWhen => new ConditionlessWhen<IWildcardQuery>(a => a.Wildcard)
+		{
+			q => q.Field = null,
+			q => { q.Value = null; q.Wildcard = null; },
+			q => { q.Value = string.Empty; q.Wildcard = string.Empty; }
+		};
+
+		protected override QueryContainer QueryInitializer => new WildcardQuery
+		{
+			Name = "named_query",
+			Boost = 1.1,
+			Field = "description",
+			Wildcard = "p*oj",
+			Rewrite = MultiTermQueryRewrite.TopTermsBoost(10)
+		};
+
+		protected override object QueryJson => new
+		{
+			wildcard = new
+			{
+				description = new
+				{
+					_name = "named_query",
+					boost = 1.1,
+					rewrite = "top_terms_boost_10",
+					wildcard = "p*oj"
+				}
+			}
+		};
+
+		protected override QueryContainer QueryFluent(QueryContainerDescriptor<Project> q) => q
+			.Wildcard(c => c
+				.Name("named_query")
+				.Boost(1.1)
+				.Field(p => p.Description)
+				.Wildcard("p*oj")
+				.Rewrite(MultiTermQueryRewrite.TopTermsBoost(10))
+			);
+	}
 }

--- a/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardSerialisationTests.cs
+++ b/tests/Tests/QueryDsl/TermLevel/Wildcard/WildcardSerialisationTests.cs
@@ -1,0 +1,49 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using Elasticsearch.Net;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.QueryDsl.TermLevel.Wildcard
+{
+	public class WildcardSerialisationTests
+	{
+		[U]
+		public void DeserialisesAndSerialises()
+		{
+			// This test validates that a response from SQL translate can be used in the seubsequent query
+			// The WildcardQueryBuilder prefers the `wildcard` field over the `value` field.
+
+			var translateResponse = @"{""size"":1000,""query"":{""bool"":{""must"":[{""wildcard"":{""customershortnm.keyword"":{""wildcard"":""*B*"",""boost"":1}}}],""adjust_pure_negative"":true,""boost"":1}}}";
+
+			var pool = new SingleNodeConnectionPool(new Uri($"http://localhost:9200"));
+			var settings = new ConnectionSettings(pool, new InMemoryConnection(Encoding.UTF8.GetBytes(translateResponse)));
+			var client = new ElasticClient(settings);
+
+			var response = client.Sql.Translate();
+
+			IQueryContainer queryContainer = response.Result.Query;
+
+			queryContainer.Bool.Should().NotBeNull();
+			var clauses = queryContainer.Bool.Must.ToList();
+			queryContainer = clauses.Single();
+			queryContainer.Wildcard.Wildcard.Should().Be("*B*");
+
+			var stream = new MemoryStream();
+			client.ConnectionSettings.RequestResponseSerializer.Serialize(response.Result, stream);
+			stream.Position = 0;
+			var reader = new StreamReader(stream);
+			var json = reader.ReadToEnd();
+
+			// note: adjust_pure_negative is not recommended
+			json.Should().Be(@"{""query"":{""bool"":{""must"":[{""wildcard"":{""customershortnm.keyword"":{""wildcard"":""*B*"",""boost"":1.0}}}],""boost"":1.0}},""size"":1000}");
+		}
+	}
+}


### PR DESCRIPTION
Fixes #6033

The `WildcardQueryBuilder` used by the SQL translate API returns wildcard queries without a `value` field, and instead uses a `wildcard` field. This PR ensures that we can deserialise an `ISearchRequest` in such cases and that the conditionless checks consider the query valid when either the `Value` or `Wildcard` property is set.
