### PR TITLE
Support version on ingest pipelines

### DIFF
--- a/build/scripts/ReleaseNotes.fs
+++ b/build/scripts/ReleaseNotes.fs
@@ -53,7 +53,7 @@ module ReleaseNotes =
             ("Uncategorized", "Uncategorized")
         ]
         uncategorized = "Uncategorized"
-    };
+    }
         
     let groupByLabel (config: Config) (items: List<GitHubItem>) =
         let dict = Dictionary<string, GitHubItem list>()     

--- a/build/scripts/XmlDocPatcher.fs
+++ b/build/scripts/XmlDocPatcher.fs
@@ -32,7 +32,7 @@ module InheritDoc =
         relatedInterfaceDescriptorRequest;
         relatedInterfaceDescriptorGeneric;
         manualMapping
-    ];
+    ]
     
     let private documentedApis (file:string) =
         use reader = XmlReader.Create file

--- a/src/Nest/Ingest/Pipeline.cs
+++ b/src/Nest/Ingest/Pipeline.cs
@@ -21,6 +21,9 @@ namespace Nest
 
 		[DataMember(Name ="processors")]
 		IEnumerable<IProcessor> Processors { get; set; }
+
+		[DataMember(Name = "version")]
+		long Version { get; set; }
 	}
 
 	public class Pipeline : IPipeline
@@ -30,6 +33,8 @@ namespace Nest
 		public IEnumerable<IProcessor> OnFailure { get; set; }
 
 		public IEnumerable<IProcessor> Processors { get; set; }
+
+		public long Version { get; set; }
 	}
 
 	public class PipelineDescriptor : DescriptorBase<PipelineDescriptor, IPipeline>, IPipeline
@@ -37,6 +42,7 @@ namespace Nest
 		string IPipeline.Description { get; set; }
 		IEnumerable<IProcessor> IPipeline.OnFailure { get; set; }
 		IEnumerable<IProcessor> IPipeline.Processors { get; set; }
+		long IPipeline.Version { get; set; }
 
 		/// <inheritdoc />
 		public PipelineDescriptor Description(string description) => Assign(description, (a, v) => a.Description = v);
@@ -54,5 +60,8 @@ namespace Nest
 		/// <inheritdoc />
 		public PipelineDescriptor OnFailure(Func<ProcessorsDescriptor, IPromise<IList<IProcessor>>> selector) =>
 			Assign(selector, (a, v) => a.OnFailure = v?.Invoke(new ProcessorsDescriptor())?.Value);
+
+		/// <inheritdoc />
+		public PipelineDescriptor Version(long version) => Assign(version, (a, v) => a.Version = v);
 	}
 }

--- a/src/Nest/Ingest/Pipeline.cs
+++ b/src/Nest/Ingest/Pipeline.cs
@@ -23,7 +23,7 @@ namespace Nest
 		IEnumerable<IProcessor> Processors { get; set; }
 
 		[DataMember(Name = "version")]
-		long Version { get; set; }
+		long? Version { get; set; }
 	}
 
 	public class Pipeline : IPipeline
@@ -34,7 +34,7 @@ namespace Nest
 
 		public IEnumerable<IProcessor> Processors { get; set; }
 
-		public long Version { get; set; }
+		public long? Version { get; set; }
 	}
 
 	public class PipelineDescriptor : DescriptorBase<PipelineDescriptor, IPipeline>, IPipeline
@@ -42,7 +42,7 @@ namespace Nest
 		string IPipeline.Description { get; set; }
 		IEnumerable<IProcessor> IPipeline.OnFailure { get; set; }
 		IEnumerable<IProcessor> IPipeline.Processors { get; set; }
-		long IPipeline.Version { get; set; }
+		long? IPipeline.Version { get; set; }
 
 		/// <inheritdoc />
 		public PipelineDescriptor Description(string description) => Assign(description, (a, v) => a.Description = v);
@@ -62,6 +62,6 @@ namespace Nest
 			Assign(selector, (a, v) => a.OnFailure = v?.Invoke(new ProcessorsDescriptor())?.Value);
 
 		/// <inheritdoc />
-		public PipelineDescriptor Version(long version) => Assign(version, (a, v) => a.Version = v);
+		public PipelineDescriptor Version(long? version = null) => Assign(version, (a, v) => a.Version = v);
 	}
 }

--- a/src/Nest/Ingest/Processor.cs
+++ b/src/Nest/Ingest/Processor.cs
@@ -100,7 +100,5 @@ namespace Nest
 
 		/// <inheritdoc cref="IProcessor.IgnoreFailure"/>
 		public TProcessorDescriptor IgnoreFailure(bool? ignoreFailure = true) => Assign(ignoreFailure, (a, v) => a.IgnoreFailure = v);
-
 	}
-
 }

--- a/src/Nest/Ingest/PutPipeline/PutPipelineRequest.cs
+++ b/src/Nest/Ingest/PutPipeline/PutPipelineRequest.cs
@@ -15,6 +15,7 @@ namespace Nest
 		public string Description { get; set; }
 		public IEnumerable<IProcessor> OnFailure { get; set; }
 		public IEnumerable<IProcessor> Processors { get; set; }
+		public long Version { get; set; }
 	}
 
 	public partial class PutPipelineDescriptor
@@ -22,6 +23,7 @@ namespace Nest
 		string IPipeline.Description { get; set; }
 		IEnumerable<IProcessor> IPipeline.OnFailure { get; set; }
 		IEnumerable<IProcessor> IPipeline.Processors { get; set; }
+		long IPipeline.Version { get; set; }
 
 		/// <inheritdoc />
 		public PutPipelineDescriptor Description(string description) => Assign(description, (a, v) => a.Description = v);
@@ -39,5 +41,8 @@ namespace Nest
 		/// <inheritdoc />
 		public PutPipelineDescriptor OnFailure(Func<ProcessorsDescriptor, IPromise<IList<IProcessor>>> selector) =>
 			Assign(selector, (a, v) => a.OnFailure = v?.Invoke(new ProcessorsDescriptor())?.Value);
+
+		/// <inheritdoc />
+		public PutPipelineDescriptor Version(long version) => Assign(version, (a, v) => a.Version = v);
 	}
 }

--- a/src/Nest/Ingest/PutPipeline/PutPipelineRequest.cs
+++ b/src/Nest/Ingest/PutPipeline/PutPipelineRequest.cs
@@ -15,7 +15,7 @@ namespace Nest
 		public string Description { get; set; }
 		public IEnumerable<IProcessor> OnFailure { get; set; }
 		public IEnumerable<IProcessor> Processors { get; set; }
-		public long Version { get; set; }
+		public long? Version { get; set; }
 	}
 
 	public partial class PutPipelineDescriptor
@@ -23,7 +23,7 @@ namespace Nest
 		string IPipeline.Description { get; set; }
 		IEnumerable<IProcessor> IPipeline.OnFailure { get; set; }
 		IEnumerable<IProcessor> IPipeline.Processors { get; set; }
-		long IPipeline.Version { get; set; }
+		long? IPipeline.Version { get; set; }
 
 		/// <inheritdoc />
 		public PutPipelineDescriptor Description(string description) => Assign(description, (a, v) => a.Description = v);
@@ -43,6 +43,6 @@ namespace Nest
 			Assign(selector, (a, v) => a.OnFailure = v?.Invoke(new ProcessorsDescriptor())?.Value);
 
 		/// <inheritdoc />
-		public PutPipelineDescriptor Version(long version) => Assign(version, (a, v) => a.Version = v);
+		public PutPipelineDescriptor Version(long? version = null) => Assign(version, (a, v) => a.Version = v);
 	}
 }

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: u
+mode: i
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype

--- a/tests/Tests.YamlRunner/SkipList.fs
+++ b/tests/Tests.YamlRunner/SkipList.fs
@@ -28,6 +28,9 @@ let SkipList = dict<SkipFile,SkipSection> [
     SkipFile "search.aggregation/180_percentiles_tdigest_metric.yml", Section "Invalid params test"
     SkipFile "search.aggregation/190_percentiles_hdr_metric.yml", Section "Invalid params test"
 
+    // New range test fails to parse - SharpYaml.SyntaxErrorException: (Lin: 15, Col: 26, Chr: 352) - (Lin: 15, Col: 39, Chr: 365): While scanning a plain scalar, find unexpected ':'.
+    SkipFile "search.aggregation/40_range.yml", Section "Range aggregation on date field"
+
     // Test looks for "testnode.crt", but "ca.crt" is returned first
     SkipFile "ssl/10_basic.yml", Section "Test get SSL certificates"
     

--- a/tests/Tests/Ingest/PipelineCrudTests.cs
+++ b/tests/Tests/Ingest/PipelineCrudTests.cs
@@ -38,6 +38,7 @@ namespace Tests.Ingest
 
 			var pipeline = kv.Value;
 			pipeline.Description.Should().NotBeNull();
+			pipeline.Version.Should().BeGreaterOrEqualTo(1);
 
 			var processors = pipeline.Processors;
 			processors.Should().NotBeNull().And.HaveCount(2);
@@ -66,7 +67,8 @@ namespace Tests.Ingest
 					Field = Infer.Field<Project>(p => p.NumberOfCommits),
 					Value = 0
 				}
-			}
+			},
+			Version = 1
 		};
 
 		private IPutPipelineRequest CreateFluent(string pipelineId, PutPipelineDescriptor d) => d
@@ -79,7 +81,8 @@ namespace Tests.Ingest
 					.Field(p => p.NumberOfCommits)
 					.Value(0)
 				)
-			);
+			)
+			.Version(1);
 
 		protected override LazyResponses Read() => Calls<GetPipelineDescriptor, GetPipelineRequest, IGetPipelineRequest, GetPipelineResponse>(
 			id => new GetPipelineRequest(id),


### PR DESCRIPTION
Fixes #6082

The version field was missing from our `IPipeline` model.

- Unrelated F# cleanup to fix compiler errors
- Support version of ingest pipelines
- Skip YAML test which cannot be parsed

