### PR TITLE
[DOCS] Adds new Intro and Install chapters

### DIFF
--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -1,7 +1,7 @@
 :title-separator: |
 
 [[elasticsearch-net-reference]]
-= Elasticsearch .NET Clients
+= Elasticsearch .NET Client
 
 ////
 IMPORTANT NOTE
@@ -13,9 +13,9 @@ please modify the original csharp file found at the link and submit the PR with 
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]
 
-include::introduction.asciidoc[]
+include::intro.asciidoc[]
 
-include::installation.asciidoc[]
+include::install.asciidoc[]
 
 include::breaking-changes.asciidoc[]
 

--- a/docs/install.asciidoc
+++ b/docs/install.asciidoc
@@ -1,0 +1,57 @@
+[[installation]]
+== Installation
+
+This page shows you how to install the .NET client for {es}.
+
+[discrete]
+[[dot-net-client]]
+=== Installing the .NET client
+
+For SDK style projects, you can install the {es} client by running the following 
+.NET CLI command in your terminal:
+
+[source,shell]
+----
+dotnet add package Elastic.Clients.Elasticsearch
+----
+
+This command adds a package reference to your project (csproj) file for the 
+latest stable version of the client.
+
+If you prefer, you may also manually add a package reference inside your project 
+file:
+
+[source,shell]
+----
+<PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.0.0" />
+----
+
+To install a different version, modify the version as necessary.
+
+For Visual Studio users, the .NET client can also be installed from the Package
+Manager Console inside Visual Studio using the following command:
+
+[source,shell]
+----
+Install-Package Elastic.Clients.Elasticsearch
+----
+
+Alternatively, search for `Elastic.Clients.Elasticsearch` in the NuGet Package 
+Manager UI.
+
+// To learn how to connect the {es} client, refer to the Connecting section.
+
+[discrete]
+[[compatibility]]
+=== Compatibility
+
+The {es} client is compatible with currently maintained .NET runtime versions. 
+Compatibility with EOL runtimes is not guaranteed or supported.
+
+Language clients are forward compatible; meaning that clients support 
+communicating with greater or equal minor versions of {es}. {es} language 
+clients are only backward compatible with default distributions and without 
+guarantees made.
+
+Refer to the https://www.elastic.co/support/eol[end-of-life policy] for more 
+information.

--- a/docs/installation.asciidoc
+++ b/docs/installation.asciidoc
@@ -6,7 +6,7 @@ If you wish to submit a PR for any spelling mistakes, typos or grammatical error
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
 
-[[installation]]
+[[installation-old]]
 == Installation
 
 This page is about about how to install the `Elasticsearch.Net` and the `NEST`

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -1,0 +1,23 @@
+[[introduction]]
+== Introduction
+
+This is the documentation for the .NET client for {es}. This page gives you a 
+quick overview of the main features of the client.
+
+// For breaking changes, refer to this page.
+
+[discrete]
+[[features]]
+=== Features
+
+* One-to-one mapping with REST API.
+* Strongly typed requests and responses for {es} APIs.
+* Fluent API for building requests.
+* Helpers for common tasks such as bulk indexing of documents. 
+* Pluggable serialization of requests and responses based on System.Text.Json.
+* Diagnostics, auditing, and .NET activity integration.
+
+The .NET {es} client is built upon the Elastic Transport library which provides:
+
+* Connection management and load balancing across all available nodes.
+* Request retries and dead connections handling.

--- a/docs/introduction.asciidoc
+++ b/docs/introduction.asciidoc
@@ -10,7 +10,7 @@ If you wish to submit a PR for any spelling mistakes, typos or grammatical error
 please modify the original csharp file found at the link and submit the PR with that change. Thanks!
 ////
 
-[[introduction]]
+[[introduction-old]]
 == Introduction
 
 This is the documentation page for `Elasticsearch.Net` and `NEST`, the two 


### PR DESCRIPTION
## Overview

This PR adds two new pages to the .NET documentation:
* Introduction
* Installation.

It also modifies: 
* the index file to point to the new pages instead of the old ones
* the section IDs in the old pages.

### Preview

* [Introduction]()
* [Installation]()

