### PR TITLE
Enable more CI integration test clusters

### DIFF
--- a/.github/workflows/integration-jobs.yml
+++ b/.github/workflows/integration-jobs.yml
@@ -44,7 +44,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-elastic-managed-
             
-      - run: "./build.sh integrate ${{ matrix.stack_version }} readonly,writable random:test_only_one --report"
+      - run: "./build.sh integrate ${{ matrix.stack_version }} random:test_only_one --report"
         name: ${{ matrix.stack_version }}
       - name: Results ${{ matrix.stack_version }}
         # only report on if the previous run failed, otherwise this ends up being too noisy


### PR DESCRIPTION
Historically in v7 we only ran read-only and writeable tests in CI. Other test clusters tended to be too brittle but ran fine locally. This PR re-enables all tests in CI as we're adding things back and can hopefully remove/fix unstable tests.