### PR TITLE
Respond to transport refactoring

### DIFF
--- a/benchmarks/Benchmarks/packages.lock.json
+++ b/benchmarks/Benchmarks/packages.lock.json
@@ -52,8 +52,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -1129,7 +1129,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       }
     }

--- a/benchmarks/Profiling/packages.lock.json
+++ b/benchmarks/Profiling/packages.lock.json
@@ -16,8 +16,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -65,7 +65,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       }
     }

--- a/src/Elastic.Clients.Elasticsearch.JsonNetSerializer/packages.lock.json
+++ b/src/Elastic.Clients.Elasticsearch.JsonNetSerializer/packages.lock.json
@@ -35,8 +35,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -148,7 +148,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       }
     },
@@ -192,8 +192,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -400,7 +400,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1",
+          "Elastic.Transport": "0.3.2",
           "System.Reflection.Emit": "4.3.0",
           "System.Reflection.Emit.Lightweight": "4.3.0"
         }

--- a/src/Elastic.Clients.Elasticsearch/Common/ElasticsearchClientProductRegistration.cs
+++ b/src/Elastic.Clients.Elasticsearch/Common/ElasticsearchClientProductRegistration.cs
@@ -15,7 +15,7 @@ internal sealed class ElasticsearchClientProductRegistration : ElasticsearchProd
 	public static ElasticsearchClientProductRegistration DefaultForElasticsearchClientsElasticsearch { get; } = new(typeof(ElasticsearchClient));
 
 	/// <summary>
-	///     Elastic.Clients.Elasticsearch handles 404 in its <see cref="ResponseBase.IsValid" />, we do not want the low level client throwing
+	///     Elastic.Clients.Elasticsearch handles 404 in its <see cref="ElasticsearchResponseBase.IsValid" />, we do not want the low level client throwing
 	///     exceptions
 	///     when <see cref="ITransportConfiguration.ThrowExceptions" /> is enabled for 404's. The client is in charge of
 	///     composing paths
@@ -25,12 +25,12 @@ internal sealed class ElasticsearchClientProductRegistration : ElasticsearchProd
 		statusCode is >= 200 and < 300 or 404;
 
 	/// <summary>
-	///     Makes the low level transport aware of Elastic.Clients.Elasticsearch's <see cref="ResponseBase" />
+	///     Makes the low level transport aware of Elastic.Clients.Elasticsearch's <see cref="ElasticsearchResponseBase" />
 	///     so that it can peek in to its exposed error when reporting failures.
 	/// </summary>
 	public override bool TryGetServerErrorReason<TResponse>(TResponse response, out string? reason)
 	{
-		if (response is not ResponseBase r)
+		if (response is not ElasticsearchResponseBase r)
 			return base.TryGetServerErrorReason(response, out reason);
 		reason = r.ServerError?.Error?.ToString();
 		return !string.IsNullOrEmpty(reason);

--- a/src/Elastic.Clients.Elasticsearch/Common/Infer/Inferrer.cs
+++ b/src/Elastic.Clients.Elasticsearch/Common/Infer/Inferrer.cs
@@ -39,7 +39,7 @@ namespace Elastic.Clients.Elasticsearch
 			//		Action<MultiGetResponseFormatter.MultiHitTuple, IJsonFormatterResolver, ICollection<IMultiGetHit<object>>>>();
 			//CreateSearchResponseDelegates =
 			//	new ConcurrentDictionary<Type,
-			//		Action<MultiSearchResponseFormatter.SearchHitTuple, IJsonFormatterResolver, IDictionary<string, IResponse>>>();
+			//		Action<MultiSearchResponseFormatter.SearchHitTuple, IJsonFormatterResolver, IDictionary<string, IElasticsearchResponse>>>();
 		}
 
 		//internal ConcurrentDictionary<Type, Action<MultiGetResponseFormatter.MultiHitTuple, IJsonFormatterResolver, ICollection<IMultiGetHit<object>>>
@@ -47,7 +47,7 @@ namespace Elastic.Clients.Elasticsearch
 		//	CreateMultiHitDelegates { get; }
 
 		//internal ConcurrentDictionary<Type,
-		//		Action<MultiSearchResponseFormatter.SearchHitTuple, IJsonFormatterResolver, IDictionary<string, IResponse>>>
+		//		Action<MultiSearchResponseFormatter.SearchHitTuple, IJsonFormatterResolver, IDictionary<string, IElasticsearchResponse>>>
 		//	CreateSearchResponseDelegates { get; }
 
 		private FieldResolver FieldResolver { get; }

--- a/src/Elastic.Clients.Elasticsearch/Common/Response/ExistsResponseBase.cs
+++ b/src/Elastic.Clients.Elasticsearch/Common/Response/ExistsResponseBase.cs
@@ -6,7 +6,7 @@ using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Clients.Elasticsearch
 {
-	public abstract class ExistsResponseBase : ResponseBase
+	public abstract class ExistsResponseBase : ElasticsearchResponseBase
 	{
 		public bool Exists => ApiCall is {Success: true, HttpStatusCode: 200};
 	}

--- a/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
+++ b/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
@@ -17,7 +17,7 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport" Version="0.3.1" />
+    <PackageReference Include="Elastic.Transport" Version="0.3.2" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit" Version="4.3.0" />
     <PackageReference Condition="'$(TargetFramework)' == 'netstandard2.0'" Include="System.Reflection.Emit.Lightweight" Version="4.3.0" />
   </ItemGroup>

--- a/src/Elastic.Clients.Elasticsearch/Helpers/BulkAllObservable.cs
+++ b/src/Elastic.Clients.Elasticsearch/Helpers/BulkAllObservable.cs
@@ -238,7 +238,7 @@ public class BulkAllObservable<T> : IDisposable, IObservable<BulkAllResponse>
 		return await BulkAsync(retryDocuments, page, backOffRetries).ConfigureAwait(false);
 	}
 
-	private Exception ThrowOnBadBulk(IResponse response, string message)
+	private Exception ThrowOnBadBulk(IElasticsearchResponse response, string message)
 	{
 		_incrementFailed();
 		_partitionedBulkRequest.BackPressure?.Release();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/AsyncSearchStatusResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/AsyncSearchStatusResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.AsyncSearch
 {
-	public partial class AsyncSearchStatusResponse : ResponseBase
+	public partial class AsyncSearchStatusResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("completion_status")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/DeleteAsyncSearchResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/DeleteAsyncSearchResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.AsyncSearch
 {
-	public partial class DeleteAsyncSearchResponse : ResponseBase
+	public partial class DeleteAsyncSearchResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("acknowledged")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/BulkResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/BulkResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class BulkResponse : ResponseBase
+	public partial class BulkResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("errors")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/ClosePointInTimeResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/ClosePointInTimeResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class ClosePointInTimeResponse : ResponseBase
+	public partial class ClosePointInTimeResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("num_freed")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterAllocationExplainResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterAllocationExplainResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Cluster
 {
-	public partial class ClusterAllocationExplainResponse : ResponseBase
+	public partial class ClusterAllocationExplainResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("allocate_explanation")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterHealthResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterHealthResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Cluster
 {
-	public partial class ClusterHealthResponse : ResponseBase
+	public partial class ClusterHealthResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("active_primary_shards")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterPendingTasksResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterPendingTasksResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Cluster
 {
-	public partial class ClusterPendingTasksResponse : ResponseBase
+	public partial class ClusterPendingTasksResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("tasks")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterStateResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterStateResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Cluster
 {
-	public partial class ClusterStateResponse : ResponseBase
+	public partial class ClusterStateResponse : ElasticsearchResponseBase
 	{
 	}
 }

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class CountResponse : ResponseBase
+	public partial class CountResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("count")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/CreateResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/CreateResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class CreateResponse : ResponseBase
+	public partial class CreateResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("forced_refresh")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/DeleteResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/DeleteResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class DeleteResponse : ResponseBase
+	public partial class DeleteResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("forced_refresh")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/DeleteEqlResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/DeleteEqlResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Eql
 {
-	public partial class DeleteEqlResponse : ResponseBase
+	public partial class DeleteEqlResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("acknowledged")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/EqlGetStatusResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/EqlGetStatusResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Eql
 {
-	public partial class EqlGetStatusResponse : ResponseBase
+	public partial class EqlGetStatusResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("completion_status")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/GetResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/GetResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class GetResponse<TDocument> : ResponseBase
+	public partial class GetResponse<TDocument> : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("fields")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.IndexManagement
 {
-	public partial class DeleteResponse : ResponseBase
+	public partial class DeleteResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("acknowledged")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.IndexManagement
 {
-	public partial class RefreshResponse : ResponseBase
+	public partial class RefreshResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("_shards")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class IndexResponse : ResponseBase
+	public partial class IndexResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("forced_refresh")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/OpenPointInTimeResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/OpenPointInTimeResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class OpenPointInTimeResponse : ResponseBase
+	public partial class OpenPointInTimeResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("id")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/PingResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/PingResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class PingResponse : ResponseBase
+	public partial class PingResponse : ElasticsearchResponseBase
 	{
 	}
 }

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class SearchResponse<TDocument> : ResponseBase
+	public partial class SearchResponse<TDocument> : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("aggregations")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SourceResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SourceResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class SourceResponse<TDocument> : ResponseBase
+	public partial class SourceResponse<TDocument> : ElasticsearchResponseBase
 	{
 	}
 }

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlClearCursorResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlClearCursorResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql
 {
-	public partial class SqlClearCursorResponse : ResponseBase
+	public partial class SqlClearCursorResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("succeeded")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlDeleteAsyncResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlDeleteAsyncResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql
 {
-	public partial class SqlDeleteAsyncResponse : ResponseBase
+	public partial class SqlDeleteAsyncResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("acknowledged")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlGetAsyncResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlGetAsyncResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql
 {
-	public partial class SqlGetAsyncResponse : ResponseBase
+	public partial class SqlGetAsyncResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("columns")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlGetAsyncStatusResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlGetAsyncStatusResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql
 {
-	public partial class SqlGetAsyncStatusResponse : ResponseBase
+	public partial class SqlGetAsyncStatusResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("completion_status")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlQueryResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Sql/SqlQueryResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql
 {
-	public partial class SqlQueryResponse : ResponseBase
+	public partial class SqlQueryResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("columns")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/GetTasksResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/GetTasksResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Tasks
 {
-	public partial class GetTasksResponse : ResponseBase
+	public partial class GetTasksResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("completed")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/TasksCancelResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/TasksCancelResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Tasks
 {
-	public partial class TasksCancelResponse : ResponseBase
+	public partial class TasksCancelResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("node_failures")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/TasksListResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Tasks/TasksListResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Tasks
 {
-	public partial class TasksListResponse : ResponseBase
+	public partial class TasksListResponse : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("node_failures")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/UpdateResponse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/UpdateResponse.g.cs
@@ -22,7 +22,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch
 {
-	public partial class UpdateResponse<TDocument> : ResponseBase
+	public partial class UpdateResponse<TDocument> : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("forced_refresh")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/AsyncSearch/AsyncSearchResponseBase.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/AsyncSearch/AsyncSearchResponseBase.g.cs
@@ -25,7 +25,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.AsyncSearch
 {
-	public abstract partial class AsyncSearchResponseBase : ResponseBase
+	public abstract partial class AsyncSearchResponseBase : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("expiration_time_in_millis")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Eql/EqlSearchResponseBase.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Eql/EqlSearchResponseBase.g.cs
@@ -25,7 +25,7 @@ using System.Text.Json.Serialization;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Eql
 {
-	public abstract partial class EqlSearchResponseBase<TEvent> : ResponseBase
+	public abstract partial class EqlSearchResponseBase<TEvent> : ElasticsearchResponseBase
 	{
 		[JsonInclude]
 		[JsonPropertyName("hits")]

--- a/src/Elastic.Clients.Elasticsearch/packages.lock.json
+++ b/src/Elastic.Clients.Elasticsearch/packages.lock.json
@@ -10,9 +10,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -99,9 +99,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -239,9 +239,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -482,9 +482,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -605,9 +605,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -688,9 +688,9 @@
       },
       "Elastic.Transport": {
         "type": "Direct",
-        "requested": "[0.3.1, )",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "requested": "[0.3.2, )",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",

--- a/src/Playground/packages.lock.json
+++ b/src/Playground/packages.lock.json
@@ -16,8 +16,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -65,7 +65,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {

--- a/tests/Tests.ClusterLauncher/packages.lock.json
+++ b/tests/Tests.ClusterLauncher/packages.lock.json
@@ -60,8 +60,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -1205,7 +1205,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {
@@ -1307,8 +1307,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -2456,7 +2456,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {
@@ -2558,8 +2558,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -3707,7 +3707,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {

--- a/tests/Tests.Core/Extensions/ShouldExtensions.cs
+++ b/tests/Tests.Core/Extensions/ShouldExtensions.cs
@@ -12,19 +12,19 @@ namespace Tests.Core.Extensions
 {
 	public static class ShouldExtensions
 	{
-		public static void ShouldHaveExpectedIsValid(this IResponse response, bool expectedIsValid) =>
+		public static void ShouldHaveExpectedIsValid(this IElasticsearchResponse response, bool expectedIsValid) =>
 			response.IsValid.Should().Be(expectedIsValid, "{0}", response.DebugInformation);
 
-		public static void ShouldBeValid(this IResponse response) =>
+		public static void ShouldBeValid(this IElasticsearchResponse response) =>
 			response.IsValid.Should().BeTrue("{0}", response.DebugInformation);
 
-		public static void ShouldBeValid(this IResponse response, string message) =>
+		public static void ShouldBeValid(this IElasticsearchResponse response, string message) =>
 			response.IsValid.Should().BeTrue("{1} {0}", response.DebugInformation, message);
 
-		public static void ShouldNotBeValid(this IResponse response) =>
+		public static void ShouldNotBeValid(this IElasticsearchResponse response) =>
 			response.IsValid.Should().BeFalse("{0}", response.DebugInformation);
 
-		public static void ShouldBeSuccess(this IResponse response) =>
+		public static void ShouldBeSuccess(this IElasticsearchResponse response) =>
 			response.ApiCall.Success.Should().BeTrue("{0}", response.DebugInformation);
 
 

--- a/tests/Tests.Core/Serialization/JsonRoundTripper.cs
+++ b/tests/Tests.Core/Serialization/JsonRoundTripper.cs
@@ -48,13 +48,13 @@ namespace Tests.Core.Serialization
 			return deserializationResult.Result;
 		}
 
-		public void FromRequest(IResponse response) => ToSerializeTo(response.ApiCall.RequestBodyInBytes);
+		public void FromRequest(IElasticsearchResponse response) => ToSerializeTo(response.ApiCall.RequestBodyInBytes);
 
-		public void FromRequest<T>(Func<ElasticsearchClient, T> call) where T : IResponse => FromRequest(call(Tester.Client));
+		public void FromRequest<T>(Func<ElasticsearchClient, T> call) where T : IElasticsearchResponse => FromRequest(call(Tester.Client));
 
-		public void FromResponse(IResponse response) => ToSerializeTo(response.ApiCall.ResponseBodyInBytes);
+		public void FromResponse(IElasticsearchResponse response) => ToSerializeTo(response.ApiCall.ResponseBodyInBytes);
 
-		public void FromResponse<T>(Func<ElasticsearchClient, T> call) where T : IResponse => FromResponse(call(Tester.Client));
+		public void FromResponse<T>(Func<ElasticsearchClient, T> call) where T : IElasticsearchResponse => FromResponse(call(Tester.Client));
 
 		private void ToSerializeTo(byte[] json)
 		{

--- a/tests/Tests.Core/packages.lock.json
+++ b/tests/Tests.Core/packages.lock.json
@@ -119,8 +119,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -1515,7 +1515,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {

--- a/tests/Tests.Domain/packages.lock.json
+++ b/tests/Tests.Domain/packages.lock.json
@@ -42,8 +42,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -1076,7 +1076,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "tests.configuration": {

--- a/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiIntegrationTestBase.cs
@@ -18,7 +18,7 @@ namespace Tests.Framework.EndpointTests
 	public abstract class ApiIntegrationTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		: ApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		where TCluster : IEphemeralCluster<EphemeralClusterConfiguration>, ITestCluster, new()
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 		where TDescriptor : class
 		where TInitializer : class
 	{
@@ -64,7 +64,7 @@ namespace Tests.Framework.EndpointTests
 	public abstract class NdJsonApiIntegrationTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		: NdJsonApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		where TCluster : IEphemeralCluster<EphemeralClusterConfiguration>, ITestCluster, new()
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 		where TDescriptor : class
 		where TInitializer : class
 	{
@@ -111,10 +111,10 @@ namespace Tests.Framework.EndpointTests
 
 	public class ResponseAssertionException : Exception
 	{
-		public ResponseAssertionException(Exception innerException, IResponse response)
+		public ResponseAssertionException(Exception innerException, IElasticsearchResponse response)
 			: base(ResponseInMessage(innerException.Message, response), innerException) { }
 
-		private static string ResponseInMessage(string innerExceptionMessage, IResponse r) => $@"{innerExceptionMessage}
+		private static string ResponseInMessage(string innerExceptionMessage, IElasticsearchResponse r) => $@"{innerExceptionMessage}
 Response Under Test:
 {r.DebugInformation}";
 	}

--- a/tests/Tests/Framework/EndpointTests/ApiTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/ApiTestBase.cs
@@ -20,7 +20,7 @@ namespace Tests.Framework.EndpointTests
 	public abstract class ApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		: RequestResponseApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		where TCluster : IEphemeralCluster<EphemeralClusterConfiguration>, ITestCluster, new()
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 		where TDescriptor : class
 		where TInitializer : class
 	{
@@ -84,7 +84,7 @@ namespace Tests.Framework.EndpointTests
 	public abstract class NdJsonApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		: RequestResponseApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		where TCluster : IEphemeralCluster<EphemeralClusterConfiguration>, ITestCluster, new()
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 		where TDescriptor : class
 		where TInitializer : class
 	{

--- a/tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/CoordinatedIntegrationTestBase.cs
@@ -26,7 +26,7 @@ public abstract class CoordinatedIntegrationTestBase<TCluster>
 	protected CoordinatedIntegrationTestBase(CoordinatedUsage coordinatedUsage) => _coordinatedUsage = coordinatedUsage;
 
 	protected async Task Assert<TResponse>(string name, Action<TResponse> assert)
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 	{
 		if (_coordinatedUsage.Skips(name))
 			return;
@@ -39,7 +39,7 @@ public abstract class CoordinatedIntegrationTestBase<TCluster>
 	}
 
 	protected async Task Assert<TResponse>(string name, Action<string, TResponse> assert)
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 	{
 		if (_coordinatedUsage.Skips(name))
 			return;
@@ -59,7 +59,7 @@ public abstract class CoordinatedIntegrationTestBase<TCluster>
 	}
 
 	private async Task AssertOnAllResponses<TResponse>(string name, LazyResponses responses, Action<string, TResponse> assert)
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 	{
 		foreach (var (key, value) in await responses)
 		{

--- a/tests/Tests/Framework/EndpointTests/CoordinatedUsage.cs
+++ b/tests/Tests/Framework/EndpointTests/CoordinatedUsage.cs
@@ -16,7 +16,7 @@ namespace Tests.Framework.EndpointTests
 {
 	public class CoordinatedUsage : KeyedCollection<string, LazyResponses>
 	{
-		public static readonly IResponse VoidResponse = new PingResponse();
+		public static readonly IElasticsearchResponse VoidResponse = new PingResponse();
 
 		private readonly ITestCluster _cluster;
 
@@ -85,7 +85,7 @@ namespace Tests.Framework.EndpointTests
 			Action<TResponse, CallUniqueValues> onResponse = null,
 			Func<CallUniqueValues, string> uniqueValueSelector = null
 		)
-			where TResponse : class, IResponse
+			where TResponse : class, IElasticsearchResponse
 			where TDescriptor : class
 			where TInitializer : class
 		{
@@ -112,13 +112,13 @@ namespace Tests.Framework.EndpointTests
 				return VoidResponse;
 			});
 
-		public Func<string, LazyResponses> Call<TResponse>(Func<string, ElasticsearchClient, Task<TResponse>> call) where TResponse : IResponse
+		public Func<string, LazyResponses> Call<TResponse>(Func<string, ElasticsearchClient, Task<TResponse>> call) where TResponse : IElasticsearchResponse
 		{
 			var client = Client;
 			return k => Usage.CallOnce(
 				() => new LazyResponses(k, async () =>
 				{
-					var dict = new Dictionary<ClientMethod, IResponse>();
+					var dict = new Dictionary<ClientMethod, IElasticsearchResponse>();
 					foreach (var (m, v) in _values)
 					{
 						var response = await call(v, client);
@@ -132,7 +132,7 @@ namespace Tests.Framework.EndpointTests
 
 		private string Sanitize(string value) => string.IsNullOrEmpty(Prefix) ? value : $"{Prefix}-{value}";
 
-		private async ValueTask<Dictionary<ClientMethod, IResponse>> CallAllClientMethodsOverloads<TDescriptor, TInitializer, TResponse>(
+		private async ValueTask<Dictionary<ClientMethod, IElasticsearchResponse>> CallAllClientMethodsOverloads<TDescriptor, TInitializer, TResponse>(
 			EndpointUsage usage,
 			Func<string, TInitializer> initializerBody,
 			Func<string, TDescriptor, TDescriptor> fluentBody,
@@ -144,11 +144,11 @@ namespace Tests.Framework.EndpointTests
 			Func<CallUniqueValues, string> uniqueValueSelector,
 			ElasticsearchClient client
 		)
-			where TResponse : class, IResponse
+			where TResponse : class, IElasticsearchResponse
 			where TDescriptor : class
 			where TInitializer : class
 		{
-			var dict = new Dictionary<ClientMethod, IResponse>();
+			var dict = new Dictionary<ClientMethod, IElasticsearchResponse>();
 			async Task InvokeApiCall(
 				ClientMethod method,
 				Func<string, ElasticsearchClient, ValueTask<TResponse>> invoke

--- a/tests/Tests/Framework/EndpointTests/RequestResponseApiTestBase.cs
+++ b/tests/Tests/Framework/EndpointTests/RequestResponseApiTestBase.cs
@@ -21,7 +21,7 @@ namespace Tests.Framework.EndpointTests
 	public abstract class RequestResponseApiTestBase<TCluster, TResponse, TDescriptor, TInitializer>
 		: ExpectJsonTestBase, IClusterFixture<TCluster>, IClassFixture<EndpointUsage>
 		where TCluster : IEphemeralCluster<EphemeralClusterConfiguration>, ITestCluster, new()
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 		where TDescriptor : class
 		where TInitializer : class
 	{
@@ -99,7 +99,7 @@ namespace Tests.Framework.EndpointTests
 
 			static (ClientMethod, Func<ValueTask<TResponse>>) Api(ClientMethod method, Func<ValueTask<TResponse>> action) => (method, action);
 
-			var dict = new Dictionary<ClientMethod, IResponse>();
+			var dict = new Dictionary<ClientMethod, IElasticsearchResponse>();
 			var views = new[]
 			{
 				Api(ClientMethod.Initializer, () => new ValueTask<TResponse>(request(client, Initializer))),

--- a/tests/Tests/Framework/EndpointTests/TestState/EndpointUsage.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/EndpointUsage.cs
@@ -49,7 +49,7 @@ namespace Tests.Framework.EndpointTests.TestState
 	}
 
 	public class SingleEndpointUsage<TResponse> : EndpointUsage
-		where TResponse : class, IResponse
+		where TResponse : class, IElasticsearchResponse
 	{
 		private readonly Func<string, ElasticsearchClient, TResponse> _fluent;
 		private readonly Func<string, ElasticsearchClient, Task<TResponse>> _fluentAsync;
@@ -91,7 +91,7 @@ namespace Tests.Framework.EndpointTests.TestState
 
 				var randomCall = Random.Number(0, 3);
 
-				var dict = new Dictionary<ClientMethod, IResponse>();
+				var dict = new Dictionary<ClientMethod, IElasticsearchResponse>();
 
 				if (!oneRandomCall || randomCall == 0)
 					Call(client, dict, ClientMethod.Fluent, v => _fluent(v, client));
@@ -115,7 +115,7 @@ namespace Tests.Framework.EndpointTests.TestState
 				return dict;
 			}));
 
-		private void Call(ElasticsearchClient client, IDictionary<ClientMethod, IResponse> dict, ClientMethod method, Func<string, TResponse> call)
+		private void Call(ElasticsearchClient client, IDictionary<ClientMethod, IElasticsearchResponse> dict, ClientMethod method, Func<string, TResponse> call)
 		{
 			CallUniqueValues.CurrentView = method;
 			OnBeforeCall?.Invoke(client);
@@ -123,7 +123,7 @@ namespace Tests.Framework.EndpointTests.TestState
 			OnAfterCall?.Invoke(client);
 		}
 
-		private async Task CallAsync(ElasticsearchClient client, IDictionary<ClientMethod, IResponse> dict, ClientMethod method,
+		private async Task CallAsync(ElasticsearchClient client, IDictionary<ClientMethod, IElasticsearchResponse> dict, ClientMethod method,
 			Func<string, Task<TResponse>> call
 		)
 		{

--- a/tests/Tests/Framework/EndpointTests/TestState/LazyResponses.cs
+++ b/tests/Tests/Framework/EndpointTests/TestState/LazyResponses.cs
@@ -9,17 +9,17 @@ using Elastic.Transport.Products.Elasticsearch;
 
 namespace Tests.Framework.EndpointTests.TestState
 {
-	public class LazyResponses : AsyncLazy<Dictionary<ClientMethod, IResponse>>
+	public class LazyResponses : AsyncLazy<Dictionary<ClientMethod, IElasticsearchResponse>>
 	{
-		public LazyResponses(Func<Dictionary<ClientMethod, IResponse>> factory) : this("__ignored__", factory) {}
+		public LazyResponses(Func<Dictionary<ClientMethod, IElasticsearchResponse>> factory) : this("__ignored__", factory) {}
 
-		public LazyResponses(Func<Task<Dictionary<ClientMethod, IResponse>>> factory) : this("__ignored__", factory) {}
+		public LazyResponses(Func<Task<Dictionary<ClientMethod, IElasticsearchResponse>>> factory) : this("__ignored__", factory) {}
 
-		public LazyResponses(string name, Func<Dictionary<ClientMethod, IResponse>> factory) : base(factory) => Name = name;
+		public LazyResponses(string name, Func<Dictionary<ClientMethod, IElasticsearchResponse>> factory) : base(factory) => Name = name;
 
-		public LazyResponses(string name, Func<Task<Dictionary<ClientMethod, IResponse>>> factory) : base(factory) => Name = name;
+		public LazyResponses(string name, Func<Task<Dictionary<ClientMethod, IElasticsearchResponse>>> factory) : base(factory) => Name = name;
 
-		public static LazyResponses Empty { get; } = new("__empty__", () => new Dictionary<ClientMethod, IResponse>());
+		public static LazyResponses Empty { get; } = new("__empty__", () => new Dictionary<ClientMethod, IElasticsearchResponse>());
 
 		public string Name { get; }
 	}

--- a/tests/Tests/Framework/EndpointTests/UrlTester.cs
+++ b/tests/Tests/Framework/EndpointTests/UrlTester.cs
@@ -34,18 +34,18 @@ namespace Tests.Framework.EndpointTests
 
 		public static string EscapeUriString(string s) => Uri.EscapeDataString(s);
 
-		public UrlTester Fluent<TResponse>(Func<ElasticsearchClient, TResponse> call) where TResponse : IResponse =>
+		public UrlTester Fluent<TResponse>(Func<ElasticsearchClient, TResponse> call) where TResponse : IElasticsearchResponse =>
 			WhenCalling(call, "fluent");
 
-		public UrlTester Request<TResponse>(Func<ElasticsearchClient, TResponse> call) where TResponse : IResponse =>
+		public UrlTester Request<TResponse>(Func<ElasticsearchClient, TResponse> call) where TResponse : IElasticsearchResponse =>
 			WhenCalling(call, "request");
 
 		public Task<UrlTester> FluentAsync<TResponse>(Func<ElasticsearchClient, Task<TResponse>> call)
-			where TResponse : IResponse =>
+			where TResponse : IElasticsearchResponse =>
 			WhenCallingAsync(call, "fluent async");
 
 		public Task<UrlTester> RequestAsync<TResponse>(Func<ElasticsearchClient, Task<TResponse>> call)
-			where TResponse : IResponse =>
+			where TResponse : IElasticsearchResponse =>
 			WhenCallingAsync(call, "request async");
 
 		//public UrlTester LowLevel(Func<IElasticLowLevelClient, IApiCallDetails> call)
@@ -60,7 +60,7 @@ namespace Tests.Framework.EndpointTests
 		//}
 
 		private UrlTester WhenCalling<TResponse>(Func<ElasticsearchClient, TResponse> call, string typeOfCall)
-			where TResponse : IResponse
+			where TResponse : IElasticsearchResponse
 		{
 			var callDetails = call(Client);
 			return Assert(typeOfCall, callDetails.ApiCall);
@@ -68,7 +68,7 @@ namespace Tests.Framework.EndpointTests
 
 		internal async Task<UrlTester> WhenCallingAsync<TResponse>(Func<ElasticsearchClient, Task<TResponse>> call,
 			string typeOfCall)
-			where TResponse : IResponse
+			where TResponse : IElasticsearchResponse
 		{
 			var callDetails = (await call(Client)).ApiCall;
 			return Assert(typeOfCall, callDetails);

--- a/tests/Tests/Framework/EndpointTests/UrlTesterExtensions.cs
+++ b/tests/Tests/Framework/EndpointTests/UrlTesterExtensions.cs
@@ -11,9 +11,9 @@ namespace Tests.Framework.EndpointTests
 	public static class UrlTesterExtensions
 	{
 		public static async Task<UrlTester> RequestAsync<TResponse>(this Task<UrlTester> tester, Func<ElasticsearchClient, Task<TResponse>> call)
-			where TResponse : IResponse => await (await tester).WhenCallingAsync(call, "request async");
+			where TResponse : IElasticsearchResponse => await (await tester).WhenCallingAsync(call, "request async");
 
 		public static async Task<UrlTester> FluentAsync<TResponse>(this Task<UrlTester> tester, Func<ElasticsearchClient, Task<TResponse>> call)
-			where TResponse : IResponse => await (await tester).WhenCallingAsync(call, "fluent async");
+			where TResponse : IElasticsearchResponse => await (await tester).WhenCallingAsync(call, "fluent async");
 	}
 }

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -180,8 +180,8 @@
       },
       "Elastic.Transport": {
         "type": "Transitive",
-        "resolved": "0.3.1",
-        "contentHash": "zjY9FwRW77/jDctjIOZecuvRrGRuLg0IDMulT8jQr0ycsU4Ikde8uj5pUTkkkWyEmGRgjzf477QkeKGyq8AqVQ==",
+        "resolved": "0.3.2",
+        "contentHash": "saT+26tm2xsXEbCnZHP0bsQNUQbWrLQ2J9tlzAnxPHKsrnNbcuegNDTfZy8GJdrQNbg4tsnLerzThgkU8rYHbA==",
         "dependencies": {
           "Microsoft.CSharp": "4.7.0",
           "System.Buffers": "4.5.1",
@@ -1440,7 +1440,7 @@
       "elastic.clients.elasticsearch": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Transport": "0.3.1"
+          "Elastic.Transport": "0.3.2"
         }
       },
       "elastic.clients.elasticsearch.jsonnetserializer": {


### PR DESCRIPTION
Responds to the following changes in Transport:

> Rename `IResponse` to `IElasticsearchResponse` for clarity as this belongs in the product-specific folder.
> Rename `ResponseBase` to `ElasticsearchResponseBase` for clarity as this belongs in the product-specific folder.
