### PR TITLE
Rename `IndexManagement` client property to `Indices`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Helpers/BulkAllObservable.cs
+++ b/src/Elastic.Clients.Elasticsearch/Helpers/BulkAllObservable.cs
@@ -103,7 +103,7 @@ public class BulkAllObservable<T> : IDisposable, IObservable<BulkAllResponse>
 		if (rc is not null)
 			request.RequestConfiguration = new RequestConfiguration { RequestMetaData = rc };
 
-		var refresh = _client.IndexManagement.Refresh(request);
+		var refresh = _client.Indices.Refresh(request);
 
 		if (!refresh.IsValid)
 			throw Throw($"Refreshing after all documents have indexed failed", refresh.ApiCall);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
@@ -22,9 +22,9 @@ using System.Threading.Tasks;
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.IndexManagement
 {
-	public class IndexManagementNamespace : NamespacedClientProxy
+	public class IndicesNamespace : NamespacedClientProxy
 	{
-		internal IndexManagementNamespace(ElasticsearchClient client) : base(client)
+		internal IndicesNamespace(ElasticsearchClient client) : base(client)
 		{
 		}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.g.cs
@@ -52,7 +52,7 @@ namespace Elastic.Clients.Elasticsearch
 
 		public IlmNamespace Ilm { get; private set; }
 
-		public IndexManagementNamespace IndexManagement { get; private set; }
+		public IndicesNamespace Indices { get; private set; }
 
 		public IngestNamespace Ingest { get; private set; }
 
@@ -75,7 +75,7 @@ namespace Elastic.Clients.Elasticsearch
 			Eql = new EqlNamespace(this);
 			Graph = new GraphNamespace(this);
 			Ilm = new IlmNamespace(this);
-			IndexManagement = new IndexManagementNamespace(this);
+			Indices = new IndicesNamespace(this);
 			Ingest = new IngestNamespace(this);
 			Nodes = new NodesNamespace(this);
 			SearchableSnapshots = new SearchableSnapshotsNamespace(this);

--- a/tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
+++ b/tests/Tests.Core/ManagedElasticsearch/NodeSeeders/DefaultSeeder.cs
@@ -154,9 +154,9 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 		{
 			var tasks = new List<Task>
 			{
-				Client.IndexManagement.DeleteAsync(typeof(Project)),
-				Client.IndexManagement.DeleteAsync(typeof(Developer)),
-				Client.IndexManagement.DeleteAsync(typeof(ProjectPercolation))
+				Client.Indices.DeleteAsync(typeof(Project)),
+				Client.Indices.DeleteAsync(typeof(Developer)),
+				Client.Indices.DeleteAsync(typeof(ProjectPercolation))
 			};
 
 			if (alreadySeeded)
@@ -422,7 +422,7 @@ namespace Tests.Core.ManagedElasticsearch.NodeSeeders
 
 			await Task.WhenAll(tasks).ConfigureAwait(false);
 
-			await Client.IndexManagement.RefreshAsync(new RefreshRequest(Indices.Index(typeof(Project)))).ConfigureAwait(false);
+			await Client.Indices.RefreshAsync(new RefreshRequest(Indices.Index(typeof(Project)))).ConfigureAwait(false);
 		}
 
 		//		private Task<PutIndexTemplateResponse> CreateIndexTemplateAsync() => Client.Indices.PutTemplateAsync(


### PR DESCRIPTION
While the IndexManagement namespace is still required to avoid type/namespace conflicts from code generation, this PR ensures that we maintain better compatibility with the naming of the client property used to access the indices APIs. Previously this picked up the "IndexManagement" naming but now matches `7.x` using "Indices".