### PR TITLE
Update to 0.3.1 abstractions

### DIFF
--- a/tests/Tests.ClusterLauncher/packages.lock.json
+++ b/tests/Tests.ClusterLauncher/packages.lock.json
@@ -23,36 +23,36 @@
       },
       "Elastic.Elasticsearch.Ephemeral": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "X+ORplVf4WMNsbXEx0Ed4HXSY9yJNpcZreeVWQ4ec0nMEOVXV2+ov26RwRkdVbD2Yzq2+U5W04VKKrPY+wekQg==",
+        "resolved": "0.3.1",
+        "contentHash": "n7QRXJsCqKznk0HhH+ayAByh3Z6FiBra2kGW6Llm7IuFU8s1aub9ynsLjOPF+Kt6oF41uGtlgH16e2BKlaKbNw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "SharpZipLib.NETStandard": "1.0.7"
         }
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
       },
       "Elastic.Elasticsearch.Xunit": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "VVSdSQAyeiI3t3f5YXCwkm9bremkppAoFDdbHw/p8kLcteb+gnn6PsZ+/EonXNxTLzGMerrjJT2m/xDQJoahdw==",
+        "resolved": "0.3.1",
+        "contentHash": "DuTpxy14mOL02e7D24caI/Kq1Dum3+GCFJNefzT7xMvLgMCE2lRl5kQMxt9uFow0tQ/qa88MJmf5l9Llk7yOaw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Ephemeral": "0.3.0",
+          "Elastic.Elasticsearch.Ephemeral": "0.3.1",
           "xunit": "2.4.1"
         }
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -1218,7 +1218,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       },
       "tests.core": {
@@ -1226,7 +1226,7 @@
         "dependencies": {
           "DiffPlex": "1.4.1",
           "Elastic.Clients.Elasticsearch.JsonNetSerializer": "8.0.0",
-          "Elastic.Elasticsearch.Xunit": "0.3.0",
+          "Elastic.Elasticsearch.Xunit": "0.3.1",
           "FluentAssertions": "5.10.3",
           "JunitXml.TestLogger": "3.0.110",
           "Microsoft.Bcl.HashCode": "1.1.1",
@@ -1242,7 +1242,7 @@
         "dependencies": {
           "Bogus": "22.1.2",
           "Elastic.Clients.Elasticsearch": "8.0.0",
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "Newtonsoft.Json": "12.0.1",
           "Tests.Configuration": "8.0.0"
         }
@@ -1270,36 +1270,36 @@
       },
       "Elastic.Elasticsearch.Ephemeral": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "X+ORplVf4WMNsbXEx0Ed4HXSY9yJNpcZreeVWQ4ec0nMEOVXV2+ov26RwRkdVbD2Yzq2+U5W04VKKrPY+wekQg==",
+        "resolved": "0.3.1",
+        "contentHash": "n7QRXJsCqKznk0HhH+ayAByh3Z6FiBra2kGW6Llm7IuFU8s1aub9ynsLjOPF+Kt6oF41uGtlgH16e2BKlaKbNw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "SharpZipLib.NETStandard": "1.0.7"
         }
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
       },
       "Elastic.Elasticsearch.Xunit": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "VVSdSQAyeiI3t3f5YXCwkm9bremkppAoFDdbHw/p8kLcteb+gnn6PsZ+/EonXNxTLzGMerrjJT2m/xDQJoahdw==",
+        "resolved": "0.3.1",
+        "contentHash": "DuTpxy14mOL02e7D24caI/Kq1Dum3+GCFJNefzT7xMvLgMCE2lRl5kQMxt9uFow0tQ/qa88MJmf5l9Llk7yOaw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Ephemeral": "0.3.0",
+          "Elastic.Elasticsearch.Ephemeral": "0.3.1",
           "xunit": "2.4.1"
         }
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -2469,7 +2469,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       },
       "tests.core": {
@@ -2477,7 +2477,7 @@
         "dependencies": {
           "DiffPlex": "1.4.1",
           "Elastic.Clients.Elasticsearch.JsonNetSerializer": "8.0.0",
-          "Elastic.Elasticsearch.Xunit": "0.3.0",
+          "Elastic.Elasticsearch.Xunit": "0.3.1",
           "FluentAssertions": "5.10.3",
           "JunitXml.TestLogger": "3.0.110",
           "Microsoft.Bcl.HashCode": "1.1.1",
@@ -2493,7 +2493,7 @@
         "dependencies": {
           "Bogus": "22.1.2",
           "Elastic.Clients.Elasticsearch": "8.0.0",
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "Newtonsoft.Json": "12.0.1",
           "Tests.Configuration": "8.0.0"
         }
@@ -2521,36 +2521,36 @@
       },
       "Elastic.Elasticsearch.Ephemeral": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "X+ORplVf4WMNsbXEx0Ed4HXSY9yJNpcZreeVWQ4ec0nMEOVXV2+ov26RwRkdVbD2Yzq2+U5W04VKKrPY+wekQg==",
+        "resolved": "0.3.1",
+        "contentHash": "n7QRXJsCqKznk0HhH+ayAByh3Z6FiBra2kGW6Llm7IuFU8s1aub9ynsLjOPF+Kt6oF41uGtlgH16e2BKlaKbNw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "SharpZipLib.NETStandard": "1.0.7"
         }
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
       },
       "Elastic.Elasticsearch.Xunit": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "VVSdSQAyeiI3t3f5YXCwkm9bremkppAoFDdbHw/p8kLcteb+gnn6PsZ+/EonXNxTLzGMerrjJT2m/xDQJoahdw==",
+        "resolved": "0.3.1",
+        "contentHash": "DuTpxy14mOL02e7D24caI/Kq1Dum3+GCFJNefzT7xMvLgMCE2lRl5kQMxt9uFow0tQ/qa88MJmf5l9Llk7yOaw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Ephemeral": "0.3.0",
+          "Elastic.Elasticsearch.Ephemeral": "0.3.1",
           "xunit": "2.4.1"
         }
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -3720,7 +3720,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       },
       "tests.core": {
@@ -3728,7 +3728,7 @@
         "dependencies": {
           "DiffPlex": "1.4.1",
           "Elastic.Clients.Elasticsearch.JsonNetSerializer": "8.0.0",
-          "Elastic.Elasticsearch.Xunit": "0.3.0",
+          "Elastic.Elasticsearch.Xunit": "0.3.1",
           "FluentAssertions": "5.10.3",
           "JunitXml.TestLogger": "3.0.110",
           "Microsoft.Bcl.HashCode": "1.1.1",
@@ -3744,7 +3744,7 @@
         "dependencies": {
           "Bogus": "22.1.2",
           "Elastic.Clients.Elasticsearch": "8.0.0",
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "Newtonsoft.Json": "12.0.1",
           "Tests.Configuration": "8.0.0"
         }

--- a/tests/Tests.Configuration/Tests.Configuration.csproj
+++ b/tests/Tests.Configuration/Tests.Configuration.csproj
@@ -4,6 +4,6 @@
     <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.3.0" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.3.1" />
   </ItemGroup>
 </Project>

--- a/tests/Tests.Configuration/packages.lock.json
+++ b/tests/Tests.Configuration/packages.lock.json
@@ -4,11 +4,11 @@
     ".NETStandard,Version=v2.1": {
       "Elastic.Elasticsearch.Managed": {
         "type": "Direct",
-        "requested": "[0.3.0, )",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "requested": "[0.3.1, )",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
@@ -21,8 +21,8 @@
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"

--- a/tests/Tests.Core/Tests.Core.csproj
+++ b/tests/Tests.Core/Tests.Core.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.0" />
+    <PackageReference Include="Elastic.Elasticsearch.Xunit" Version="0.3.1" />
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="JunitXml.TestLogger" Version="3.0.110" />

--- a/tests/Tests.Core/packages.lock.json
+++ b/tests/Tests.Core/packages.lock.json
@@ -13,11 +13,11 @@
       },
       "Elastic.Elasticsearch.Xunit": {
         "type": "Direct",
-        "requested": "[0.3.0, )",
-        "resolved": "0.3.0",
-        "contentHash": "VVSdSQAyeiI3t3f5YXCwkm9bremkppAoFDdbHw/p8kLcteb+gnn6PsZ+/EonXNxTLzGMerrjJT2m/xDQJoahdw==",
+        "requested": "[0.3.1, )",
+        "resolved": "0.3.1",
+        "contentHash": "DuTpxy14mOL02e7D24caI/Kq1Dum3+GCFJNefzT7xMvLgMCE2lRl5kQMxt9uFow0tQ/qa88MJmf5l9Llk7yOaw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Ephemeral": "0.3.0",
+          "Elastic.Elasticsearch.Ephemeral": "0.3.1",
           "xunit": "2.4.1"
         }
       },
@@ -91,27 +91,27 @@
       },
       "Elastic.Elasticsearch.Ephemeral": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "X+ORplVf4WMNsbXEx0Ed4HXSY9yJNpcZreeVWQ4ec0nMEOVXV2+ov26RwRkdVbD2Yzq2+U5W04VKKrPY+wekQg==",
+        "resolved": "0.3.1",
+        "contentHash": "n7QRXJsCqKznk0HhH+ayAByh3Z6FiBra2kGW6Llm7IuFU8s1aub9ynsLjOPF+Kt6oF41uGtlgH16e2BKlaKbNw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "SharpZipLib.NETStandard": "1.0.7"
         }
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -1528,7 +1528,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       },
       "tests.domain": {
@@ -1536,7 +1536,7 @@
         "dependencies": {
           "Bogus": "22.1.2",
           "Elastic.Clients.Elasticsearch": "8.0.0",
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "Newtonsoft.Json": "12.0.1",
           "Tests.Configuration": "8.0.0"
         }

--- a/tests/Tests.Domain/Tests.Domain.csproj
+++ b/tests/Tests.Domain/Tests.Domain.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="Bogus" Version="22.1.2" />
-    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.3.0" />
+    <PackageReference Include="Elastic.Elasticsearch.Managed" Version="0.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
     <ProjectReference Include="$(SolutionRoot)\tests\Tests.Configuration\Tests.Configuration.csproj" />
     <ProjectReference Include="$(SolutionRoot)\src\Elastic.Clients.Elasticsearch\Elastic.Clients.Elasticsearch.csproj" />

--- a/tests/Tests.Domain/packages.lock.json
+++ b/tests/Tests.Domain/packages.lock.json
@@ -10,11 +10,11 @@
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Direct",
-        "requested": "[0.3.0, )",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "requested": "[0.3.1, )",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
@@ -33,8 +33,8 @@
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -1082,7 +1082,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       }
     }

--- a/tests/Tests/packages.lock.json
+++ b/tests/Tests/packages.lock.json
@@ -143,36 +143,36 @@
       },
       "Elastic.Elasticsearch.Ephemeral": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "X+ORplVf4WMNsbXEx0Ed4HXSY9yJNpcZreeVWQ4ec0nMEOVXV2+ov26RwRkdVbD2Yzq2+U5W04VKKrPY+wekQg==",
+        "resolved": "0.3.1",
+        "contentHash": "n7QRXJsCqKznk0HhH+ayAByh3Z6FiBra2kGW6Llm7IuFU8s1aub9ynsLjOPF+Kt6oF41uGtlgH16e2BKlaKbNw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "SharpZipLib.NETStandard": "1.0.7"
         }
       },
       "Elastic.Elasticsearch.Managed": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "vzRuSJgZWdOMV8fOpGSShkBUDTxzFZE3CiicBW8/y6PJwWCfgw325gSrQndG57KbL8I1EfhV5XF4EWpDdrGviA==",
+        "resolved": "0.3.1",
+        "contentHash": "kEQe4lJdY6iInC487RLXFl3hKJhnVkvZActfYefDvEZpxz8k9+41R3vvLD2ouO1LEpj9INOZHt5VG92axizXvA==",
         "dependencies": {
-          "Elastic.Stack.ArtifactsApi": "0.3.0",
+          "Elastic.Stack.ArtifactsApi": "0.3.1",
           "Proc": "0.6.1",
           "System.Net.Http": "4.3.1"
         }
       },
       "Elastic.Elasticsearch.Xunit": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "VVSdSQAyeiI3t3f5YXCwkm9bremkppAoFDdbHw/p8kLcteb+gnn6PsZ+/EonXNxTLzGMerrjJT2m/xDQJoahdw==",
+        "resolved": "0.3.1",
+        "contentHash": "DuTpxy14mOL02e7D24caI/Kq1Dum3+GCFJNefzT7xMvLgMCE2lRl5kQMxt9uFow0tQ/qa88MJmf5l9Llk7yOaw==",
         "dependencies": {
-          "Elastic.Elasticsearch.Ephemeral": "0.3.0",
+          "Elastic.Elasticsearch.Ephemeral": "0.3.1",
           "xunit": "2.4.1"
         }
       },
       "Elastic.Stack.ArtifactsApi": {
         "type": "Transitive",
-        "resolved": "0.3.0",
-        "contentHash": "bJ5YI/YkejOAzpo2Vq/M3bDHartZgDxui4V8CTLGmuU9vddt0tmmXgBiAPCxiaVeNzjjhzxku3yun34VxdG/fQ==",
+        "resolved": "0.3.1",
+        "contentHash": "/zrZNOCCk6Nach1gAk8FkRqgNxlx9BFHchSGOZLQWdU3FwQ80uV+06oXCu4klX07Wma8P3AHBHrpb1LByn62XQ==",
         "dependencies": {
           "SemanticVersioning": "0.8.0",
           "System.Text.Json": "4.6.0"
@@ -1459,7 +1459,7 @@
       "tests.configuration": {
         "type": "Project",
         "dependencies": {
-          "Elastic.Elasticsearch.Managed": "0.3.0"
+          "Elastic.Elasticsearch.Managed": "0.3.1"
         }
       },
       "tests.core": {
@@ -1467,7 +1467,7 @@
         "dependencies": {
           "DiffPlex": "1.4.1",
           "Elastic.Clients.Elasticsearch.JsonNetSerializer": "8.0.0",
-          "Elastic.Elasticsearch.Xunit": "0.3.0",
+          "Elastic.Elasticsearch.Xunit": "0.3.1",
           "FluentAssertions": "5.10.3",
           "JunitXml.TestLogger": "3.0.110",
           "Microsoft.Bcl.HashCode": "1.1.1",
@@ -1483,7 +1483,7 @@
         "dependencies": {
           "Bogus": "22.1.2",
           "Elastic.Clients.Elasticsearch": "8.0.0",
-          "Elastic.Elasticsearch.Managed": "0.3.0",
+          "Elastic.Elasticsearch.Managed": "0.3.1",
           "Newtonsoft.Json": "12.0.1",
           "Tests.Configuration": "8.0.0"
         }


### PR DESCRIPTION
The v0.3.1 `Elastic.Elasticsearch.Managed` library includes a change to account for a change in the 8.3.0 log messages that resulted in a started node not being identified during integration testing. This PR updates the tests to use the fixed version.