### PR TITLE
Add searchable snapshot action for ILM

### DIFF
--- a/src/Nest/XPack/Ilm/Actions/SearchableSnapshotAction.cs
+++ b/src/Nest/XPack/Ilm/Actions/SearchableSnapshotAction.cs
@@ -1,0 +1,54 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.Runtime.Serialization;
+
+namespace Nest
+{
+	/// <summary>
+	/// This action takes a snapshot of the managed index in the configured repository and mounts it as a
+	/// searchable snapshot. If the index is part of a data stream, the mounted index replaces the original
+	/// index in the stream.
+	/// </summary>
+	public interface ISearchableSnapshotAction : ILifecycleAction
+	{
+		/// <summary>
+		/// The repository used to store the snapshot.
+		/// </summary>
+		[DataMember(Name = "snapshot_repository")]
+		string SnapshotRepository { get; set; }
+
+		/// <summary>
+		/// Force merges the managed index to one segment.
+		/// </summary>
+		[DataMember(Name = "force_merge_index")]
+		bool? ForceMergeIndex { get; set; }
+	}
+
+	public class SearchableSnapshotAction : ISearchableSnapshotAction
+	{
+		/// <inheritdoc />
+		public string SnapshotRepository { get; set; }
+
+		/// <inheritdoc />
+		public bool? ForceMergeIndex { get; set; }
+	}
+
+	public class SearchableSnapshotActionDescriptor : DescriptorBase<SearchableSnapshotActionDescriptor, ISearchableSnapshotAction>, ISearchableSnapshotAction
+	{
+		/// <inheritdoc cref="ISearchableSnapshotAction.SnapshotRepository" />
+		string ISearchableSnapshotAction.SnapshotRepository { get; set; }
+
+		/// <inheritdoc cref="ISearchableSnapshotAction.ForceMergeIndex" />
+		bool? ISearchableSnapshotAction.ForceMergeIndex { get; set; }
+
+		/// <inheritdoc cref="ISearchableSnapshotAction.SnapshotRepository" />
+		public SearchableSnapshotActionDescriptor SnapshotRepository(string snapshotRespository) =>
+			Assign(snapshotRespository, (a, v) => a.SnapshotRepository = snapshotRespository);
+
+		/// <inheritdoc cref="ISearchableSnapshotAction.ForceMergeIndex" />
+		public SearchableSnapshotActionDescriptor ForceMergeIndex(bool? forceMergeIndex = true) =>
+			Assign(forceMergeIndex, (a, v) => a.ForceMergeIndex = forceMergeIndex);
+	}
+}

--- a/src/Nest/XPack/Ilm/LifecycleActions.cs
+++ b/src/Nest/XPack/Ilm/LifecycleActions.cs
@@ -37,6 +37,9 @@ namespace Nest
 		/// <inheritdoc cref="IRolloverLifecycleAction"/>
 		public void Add(IRolloverLifecycleAction action) => BackingDictionary.Add("rollover", action);
 
+		/// <inheritdoc cref="ISearchableSnapshotAction"/>
+		public void Add(ISearchableSnapshotAction action) => BackingDictionary.Add("searchable_snapshot", action);
+
 		/// <inheritdoc cref="ISetPriorityLifecycleAction"/>
 		public void Add(ISetPriorityLifecycleAction action) => BackingDictionary.Add("set_priority", action);
 
@@ -64,6 +67,7 @@ namespace Nest
 			{ "shrink", 7 },
 			{ "unfollow", 8 },
 			{ "wait_for_snapshot", 9 },
+			{ "searchable_snapshot", 10 },
 		};
 
 		public ILifecycleActions Deserialize(ref JsonReader reader, IJsonFormatterResolver formatterResolver)
@@ -125,6 +129,10 @@ namespace Nest
 							lifecycleAction = formatterResolver.GetFormatter<WaitForSnapshotLifecycleAction>()
 								.Deserialize(ref reader, formatterResolver);
 							break;
+						case 10:
+							lifecycleAction = formatterResolver.GetFormatter<SearchableSnapshotAction>()
+								.Deserialize(ref reader, formatterResolver);
+							break;
 					}
 
 					lifecycles.Add(type.Utf8String(), lifecycleAction);
@@ -172,6 +180,9 @@ namespace Nest
 						break;
 					case "rollover":
 						Serialize<IRolloverLifecycleAction>(ref writer, action.Value, formatterResolver);
+						break;
+					case "searchable_snapshot":
+						Serialize<ISearchableSnapshotAction>(ref writer, action.Value, formatterResolver);
 						break;
 					case "set_priority":
 						Serialize<ISetPriorityLifecycleAction>(ref writer, action.Value, formatterResolver);
@@ -228,6 +239,10 @@ namespace Nest
 		/// <inheritdoc cref="IRolloverLifecycleAction"/>
 		public LifecycleActionsDescriptor Rollover(Func<RolloverLifecycleActionDescriptor, IRolloverLifecycleAction> selector) =>
 			Assign("rollover", selector.InvokeOrDefault(new RolloverLifecycleActionDescriptor()));
+
+		/// <inheritdoc cref="ISearchableSnapshotAction"/>
+		public LifecycleActionsDescriptor SearchableSnapshot(Func<SearchableSnapshotAction, ISearchableSnapshotAction> selector) =>
+			Assign("searchable_snapshot", selector.InvokeOrDefault(new SearchableSnapshotAction()));
 
 		/// <inheritdoc cref="ISetPriorityLifecycleAction"/>
 		public LifecycleActionsDescriptor SetPriority(Func<SetPriorityLifecycleActionDescriptor, ISetPriorityLifecycleAction> selector) =>


### PR DESCRIPTION
Fixes #6262 by adding the missing `searchable_snapshot` index lifecycle action.