### PR TITLE
Reintroduce AssemblyInfos target

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -15,5 +15,23 @@
     <CopyLocalLockFileAssemblies Condition="'$(TargetFramework)'=='netstandard2.0'">true</CopyLocalLockFileAssemblies>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>
+
+  <Target Name="AssemblyInfos"
+        BeforeTargets="CoreGenerateAssemblyInfo"
+        Inputs="@InternalsVisibleTo" Outputs="%(InternalsVisibleTo.Identity)"
+        Condition="$(IsPackable) == True">
+    <PropertyGroup>
+      <ExposedAssembly>%(InternalsVisibleTo.Identity)</ExposedAssembly>
+      <VersionNamespaced>$(ExposedAssembly.Replace("Nest", "Nest$(MajorVersion)").Replace("Elasticsearch.Net","Elasticsearch.Net$(MajorVersion)"))</VersionNamespaced>
+    </PropertyGroup>
+    <ItemGroup>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>%(InternalsVisibleTo.Identity), PublicKey=$(ExposedPublicKey)</_Parameter1>
+      </AssemblyAttribute>
+      <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+        <_Parameter1>$(VersionNamespaced), PublicKey=$(ExposedPublicKey)</_Parameter1>
+      </AssemblyAttribute>
+    </ItemGroup>
+  </Target>
   
 </Project>


### PR DESCRIPTION
This target was [removed](https://github.com/elastic/elasticsearch-net/commit/900088a947a461fcd64a891694c09ec385bc8a26#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dc) as part of the .NET 5 upgrade which appears to be an error. Reintroducing the target which should hopefully resolve the issue.