### PR TITLE
[DOCS] Fixes links that point to the Configuration section

### DIFF
--- a/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
@@ -33,7 +33,7 @@ but by exiting the pipeline.
 
 By default, the client won't throw on any `TransportException` but instead return an invalid response
 that can be detected by checking the `.IsValid` property on the response. You can change this behaviour with
-by using `ThrowExceptions()` on <<configuration-options, `ConnectionSettings`>>.
+by using `ThrowExceptions()` on <<configuration, `ConnectionSettings`>>.
 
 [source,csharp]
 ----

--- a/docs/client-concepts/high-level/getting-started.asciidoc
+++ b/docs/client-concepts/high-level/getting-started.asciidoc
@@ -41,7 +41,7 @@ var client = new ElasticClient(settings);
 ----
 
 In this example, a default index was also specified to use if no other index is supplied for the request or can be inferred for the
-POCO generic type parameter in the request. There are many other <<configuration-options,Configuration options>> on `ConnectionSettings`.
+POCO generic type parameter in the request. There are many other <<configuration,configuration options>> on `ConnectionSettings`.
 
 TIP: Specifying a default index is _optional_ but NEST may throw an exception if no index can be inferred for a given request. To understand more around how
 an index can be specified for a request, see <<index-name-inference,Index name inference>>.


### PR DESCRIPTION
## Overview

This PR fixes two links that point to the `Configuration` section. Currently, these inks are breaking the docs build.