### PR TITLE
Fix duplicate object serialization of aggregations

### DIFF
--- a/src/Nest/Aggregations/AggregationContainer.cs
+++ b/src/Nest/Aggregations/AggregationContainer.cs
@@ -306,12 +306,16 @@ namespace Nest
 	{
 		public IAdjacencyMatrixAggregation AdjacencyMatrix { get; set; }
 
+		private AggregationDictionary _aggs;
+
 		// This is currently used to support deserializing the response from SQL Translate,
 		// which forms a response which uses "aggregations", rather than "aggs". Longer term
 		// it would be preferred to address that in Elasticsearch itself.
 		[DataMember(Name = "aggregations")]
-		private AggregationDictionary _aggs;
-		
+#pragma warning disable IDE0051 // Remove unused private members
+		private AggregationDictionary AggregationsProxy { set => _aggs = value; }
+#pragma warning restore IDE0051 // Remove unused private members
+
 		// ReSharper disable once ConvertToAutoProperty
 		public AggregationDictionary Aggregations { get => _aggs; set => _aggs = value; }
 		

--- a/src/Nest/Search/Search/SearchRequest.cs
+++ b/src/Nest/Search/Search/SearchRequest.cs
@@ -194,14 +194,17 @@ namespace Nest
 	[DataContract]
 	public partial class SearchRequest
 	{
+		private AggregationDictionary _aggs;
+
 		// This is currently used to support deserializing the response from SQL Translate,
 		// which forms a response which uses "aggregations", rather than "aggs". Longer term
 		// it would be preferred to address that in Elasticsearch itself.
 		[DataMember(Name = "aggregations")]
-		private AggregationDictionary _aggs;
+#pragma warning disable IDE0051 // Remove unused private members
+		private AggregationDictionary AggregationsProxy { set => _aggs = value; }
+#pragma warning restore IDE0051 // Remove unused private members
 
 		/// <inheritdoc />
-		// ReSharper disable once ConvertToAutoProperty
 		public AggregationDictionary Aggregations { get => _aggs; set => _aggs = value; }
 		/// <inheritdoc />
 		public IFieldCollapse Collapse { get; set; }

--- a/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitRequest.cs
+++ b/src/Nest/XPack/AsyncSearch/Submit/AsyncSearchSubmitRequest.cs
@@ -121,8 +121,18 @@ namespace Nest
 	[DataContract]
 	public partial class AsyncSearchSubmitRequest
 	{
+		private AggregationDictionary _aggs;
+
+		// This is currently used to support deserializing the response from SQL Translate,
+		// which forms a response which uses "aggregations", rather than "aggs". Longer term
+		// it would be preferred to address that in Elasticsearch itself.
+		[DataMember(Name = "aggregations")]
+#pragma warning disable IDE0051 // Remove unused private members
+		private AggregationDictionary AggregationsProxy { set => _aggs = value; }
+#pragma warning restore IDE0051 // Remove unused private members
+
 		/// <inheritdoc />
-		public AggregationDictionary Aggregations { get; set; }
+		public AggregationDictionary Aggregations { get => _aggs; set => _aggs = value; }
 		/// <inheritdoc />
 		public IFieldCollapse Collapse { get; set; }
 		/// <inheritdoc />

--- a/tests/Tests.Configuration/tests.default.yaml
+++ b/tests/Tests.Configuration/tests.default.yaml
@@ -5,7 +5,7 @@
 # tracked by git).
 
 # mode either u (unit test), i (integration test) or m (mixed mode)
-mode: i
+mode: u
 
 # the elasticsearch version that should be started
 # Can be a snapshot version of sonatype or "latest" to get the latest snapshot of sonatype
@@ -18,7 +18,7 @@ force_reseed: true
 # this is opt in during development in CI we never want to see our tests running against an already running node
 test_against_already_running_elasticsearch: true
 
-random_source_serializer: true
+#random_source_serializer: true
 #random_old_connection: true
 #random_http_compresssion: true
 #random_api_versioning: true

--- a/tests/Tests/Aggregations/SearchAggregationSerializationTests.cs
+++ b/tests/Tests/Aggregations/SearchAggregationSerializationTests.cs
@@ -1,0 +1,106 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information
+
+using System.IO;
+using System.Text;
+using Elastic.Elasticsearch.Xunit.XunitPlumbing;
+using FluentAssertions;
+using Nest;
+
+namespace Tests.Aggregations
+{
+	public class SearchAggregationSerializationTests
+	{
+		private const string ExpectedAggsJson = @"{""aggs"":{""test-agg"":{""terms"":{""field"":""my-field""}}}}";
+		private const string AggregationsJson = @"{""aggregations"":{""test-agg"":{""terms"":{""field"":""my-field""}}}}";
+
+		[U] public void SerializesAsExpected()
+		{
+			var client = new ElasticClient();
+
+			var request = new SearchRequest
+			{
+				Aggregations = new TermsAggregation("test-agg")
+				{
+					Field = "my-field"
+				}
+			};
+
+			var stream = new MemoryStream();
+			client.RequestResponseSerializer.Serialize(request, stream);
+
+			stream.Position = 0;
+			var reader = new StreamReader(stream);
+			var json = reader.ReadToEnd();
+
+			json.Should().Be(ExpectedAggsJson);
+		}
+
+		[U]
+		public void DeserializesAggsAsExpected()
+		{
+			var client = new ElasticClient();
+			var stream = new MemoryStream(Encoding.UTF8.GetBytes(ExpectedAggsJson));
+			var request = client.RequestResponseSerializer.Deserialize<SearchRequest>(stream);
+			request.Aggregations.Should().HaveCount(1);
+		}
+
+		[U]
+		public void DeserializesAggregationsAsExpected()
+		{
+			var client = new ElasticClient();
+			var stream = new MemoryStream(Encoding.UTF8.GetBytes(AggregationsJson));
+			var request = client.RequestResponseSerializer.Deserialize<SearchRequest>(stream);
+			request.Aggregations.Should().HaveCount(1);
+		}
+	}
+
+	public class AggregationContainer_AggregationSerializationTests
+	{
+		private const string ExpectedAggsJson = @"{""aggs"":{""sub-agg"":{""terms"":{""field"":""my-field""}}},""terms"":{""field"":""my-field""}}";
+		private const string AggregationsJson = @"{""aggregations"":{""sub-agg"":{""terms"":{""field"":""my-field""}}},""terms"":{""field"":""my-field""}}";
+
+		[U]
+		public void SerializesAsExpected()
+		{
+			var client = new ElasticClient();
+
+			AggregationContainer aggsDictionary = new TermsAggregation("test-agg")
+			{
+				Field = "my-field",
+				Aggregations = new TermsAggregation("sub-agg")
+				{
+					Field = "my-field"
+				}
+			};
+
+			var stream = new MemoryStream();
+			client.RequestResponseSerializer.Serialize(aggsDictionary, stream);
+
+			stream.Position = 0;
+			var reader = new StreamReader(stream);
+			var json = reader.ReadToEnd();
+
+			json.Should().Be(ExpectedAggsJson);
+		}
+
+		[U]
+		public void DeserializesAggsAsExpected()
+		{
+			var client = new ElasticClient();
+			var stream = new MemoryStream(Encoding.UTF8.GetBytes(ExpectedAggsJson));
+			var request = client.RequestResponseSerializer.Deserialize<AggregationContainer>(stream);
+			request.Aggregations.Should().HaveCount(1);
+		}
+
+		[U]
+		public void DeserializesAggregationsAsExpected()
+		{
+			var client = new ElasticClient();
+			var stream = new MemoryStream(Encoding.UTF8.GetBytes(AggregationsJson));
+			var request = client.RequestResponseSerializer.Deserialize<AggregationContainer>(stream);
+			request.Aggregations.Should().HaveCount(1);
+		}
+	}
+}


### PR DESCRIPTION
When using the object initializer syntax, aggregations can appear in the request twice. This is harmless but wastes bytes and has an added serialization overhead.

This PR ensures we retain the ability to deserialize from either name ("aggs" or "aggregations") but all serialization using "aggs" as standard.