### PR TITLE
Bump Newtonsoft.Json version

### DIFF
--- a/build/scripts/scripts.fsproj
+++ b/build/scripts/scripts.fsproj
@@ -74,7 +74,7 @@
     <PackageReference Include="Fake.IO.Zip" Version="5.15.0" />
     <PackageReference Include="ILRepack" Version="2.1.0-beta1" />
     <PackageReference Include="FSharp.Core" Version="4.6.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="NuGet.CommandLine" Version="4.9.4" />
     <PackageReference Include="Octokit" Version="0.32.0" />
     <PackageReference Include="Proc" Version="0.6.1" />

--- a/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
+++ b/src/CodeGeneration/ApiGenerator/ApiGenerator.csproj
@@ -10,7 +10,7 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <PackageReference Include="ShellProgressBar" Version="4.0.0" />
     <PackageReference Include="CsQuery.Core" Version="2.0.1" />
 

--- a/src/CodeGeneration/DocGenerator/DocGenerator.csproj
+++ b/src/CodeGeneration/DocGenerator/DocGenerator.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="AsciiDocNet" Version="1.0.0-alpha6" />
     <PackageReference Include="Microsoft.Build.Runtime" Version="15.7.179" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="1.1.2" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
     <ProjectReference Include="..\..\Nest\Nest.csproj" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="2.3.2" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="2.3.2" />

--- a/src/Nest/Nest.csproj
+++ b/src/Nest/Nest.csproj
@@ -9,6 +9,6 @@
     <ProjectReference Include="..\Elasticsearch.Net\Elasticsearch.Net.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 </Project>

--- a/src/Tests/Tests.Domain/Tests.Domain.csproj
+++ b/src/Tests/Tests.Domain/Tests.Domain.csproj
@@ -5,7 +5,7 @@
   </PropertyGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'!=''">
     <PackageReference Include="NEST" Version="$(TestPackageVersion)" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(TestPackageVersion)'==''">
     <ProjectReference Include="..\..\Nest\Nest.csproj" />


### PR DESCRIPTION
Upgrade Newtonsoft.Json to latest version
[Changelog](https://github.com/JamesNK/Newtonsoft.Json/releases/tag/13.0.1)

Add ability to use old elasticsearch and client version in new projects