### PR TITLE
Adjust logic for CI versioning

### DIFF
--- a/build/scripts/Versioning.fs
+++ b/build/scripts/Versioning.fs
@@ -71,7 +71,10 @@ module Versioning =
         | ("canary", _) ->
             let v = GlobalJsonVersion
             let timestampedVersion = (sprintf "ci%s" (DateTime.UtcNow.ToString("yyyyMMddTHHmmss")))
-            let canaryVersion = parse ((sprintf "%d.%d.0-%s" v.Major (v.Minor + 1u) timestampedVersion).Trim())
+            let canaryVersion = 
+                match v.PreRelease with
+                    | Some _ -> parse ((sprintf "%d.%d.%d-%s" v.Major v.Minor v.Patch timestampedVersion).Trim())
+                    | None -> parse ((sprintf "%d.%d.%d-%s" v.Major v.Minor (v.Patch + 1u) timestampedVersion).Trim())
             Some canaryVersion
         | _ -> None
     


### PR DESCRIPTION
The existing logic and branching strategy leads to some confusing versioning on CI packages. When the current version in `global.json` is `8.0.0-beta.1`, the CI package is pushed as `8.1.0-CI{TIMESTAMP}`. Similarly, if the 8.1 branch version were `8.1.0` then the CI package would be `8.2.0-CI{TIMESTAMP}` which would actually belong to the 8.2 branch.

This PR adjusts the logic for canary packages to increment the patch number for standard releases. For pre-releases it removes the pre-release element, keeping the version the same. So if the current release is `8.0.0-beta.1`, the CI package would be `8.0.0-CI{TIMESTAMP}`.