### PR TITLE
Command line to add package is incorrect.

### DIFF
--- a/docs/install.asciidoc
+++ b/docs/install.asciidoc
@@ -19,7 +19,7 @@ For SDK style projects, you can install the {es} client by running the following
 
 [source,text]
 ----
-dotnet add package Elastic.Clients.Elasticsearch -prerelease
+dotnet add package Elastic.Clients.Elasticsearch --prerelease
 ----
 
 This command adds a package reference to your project (csproj) file for the 


### PR DESCRIPTION
dotnet add package Elastic.Clients.Elasticsearch -prerelease
Unrecognized command or argument '-prerelease'

Correct command is --prerelease