### PR TITLE
Support stored scripts for update

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Types/Bulk/BulkUpdateOperation.cs
+++ b/src/Elastic.Clients.Elasticsearch/Types/Bulk/BulkUpdateOperation.cs
@@ -98,7 +98,7 @@ public static class BulkUpdateOperationFactory
 
 	public static BulkUpdateOperationWithScript<TDocument> WithScript<TDocument>(Id id, IndexName index, ScriptBase script, TDocument upsert) => new(upsert, id, index, script);
 
-	public static BulkUpdateOperationWithScript<TDocument> WithScript<TDocument>( Id id, ScriptBase script, TDocument upsert) => new(upsert, id, script);
+	public static BulkUpdateOperationWithScript<TDocument> WithScript<TDocument>(Id id, ScriptBase script, TDocument upsert) => new(upsert, id, script);
 
 	public static BulkUpdateOperationWithScript<TDocument> WithScript<TDocument>(ScriptBase script, TDocument upsert) => new(upsert, new Id(upsert), script);
 

--- a/src/Elastic.Clients.Elasticsearch/Types/Bulk/BulkUpdateOperationDescriptor.cs
+++ b/src/Elastic.Clients.Elasticsearch/Types/Bulk/BulkUpdateOperationDescriptor.cs
@@ -29,7 +29,8 @@ public sealed class BulkUpdateOperationDescriptor<TDocument, TPartialDocument> :
 	private ScriptBase _script;
 	private Union<bool, SourceFilter> _source;
 
-	private Action<InlineScriptDescriptor> _scriptAction;
+	private Action<InlineScriptDescriptor> _inlineScriptAction;
+	private Action<StoredScriptIdDescriptor> _storedScriptIdAction;
 
 	protected override string Operation => "update";
 
@@ -49,9 +50,29 @@ public sealed class BulkUpdateOperationDescriptor<TDocument, TPartialDocument> :
 	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> RetriesOnConflict(int? retriesOnConflict) =>
 		Assign(retriesOnConflict, (a, v) => a._retriesOnConflict = v);
 
-	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> Script(Action<InlineScriptDescriptor> configure) => Assign(configure, (a, v) => a._scriptAction = v);
+	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> Script(Action<InlineScriptDescriptor> configure)
+	{
+		_script = null;
+		_storedScriptIdAction = null;
 
-	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> Script(ScriptBase script) => Assign(script, (a, v) => a._script = v);
+		return Assign(configure, (a, v) => a._inlineScriptAction = v);
+	}
+
+	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> Script(Action<StoredScriptIdDescriptor> configure)
+	{
+		_script = null;
+		_inlineScriptAction = null;
+
+		return Assign(configure, (a, v) => a._storedScriptIdAction = v);
+	}
+
+	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> Script(ScriptBase script)
+	{
+		_inlineScriptAction = null;
+		_storedScriptIdAction = null;
+
+		return Assign(script, (a, v) => a._script = v);
+	}
 
 	public BulkUpdateOperationDescriptor<TDocument, TPartialDocument> ScriptedUpsert(bool? scriptedUpsert = true) =>
 		Assign(scriptedUpsert, (a, v) => a._scriptedUpsert = v);
@@ -63,7 +84,7 @@ public sealed class BulkUpdateOperationDescriptor<TDocument, TPartialDocument> :
 
 	protected override object GetBody()
 	{
-		if (_scriptAction is not null)
+		if (_inlineScriptAction is not null || _storedScriptIdAction is not null)
 			return null;
 
 		return new BulkUpdateBody<TDocument, TPartialDocument>
@@ -118,10 +139,15 @@ public sealed class BulkUpdateOperationDescriptor<TDocument, TPartialDocument> :
 
 	private void WriteBody(IElasticsearchClientSettings settings, Utf8JsonWriter writer, JsonSerializerOptions options)
 	{
-		if (_scriptAction is not null)
+		if (_inlineScriptAction is not null)
 		{
 			writer.WritePropertyName("script");
-			JsonSerializer.Serialize(writer, new InlineScriptDescriptor(_scriptAction), options);
+			JsonSerializer.Serialize(writer, new InlineScriptDescriptor(_inlineScriptAction), options);
+		}
+		else if (_storedScriptIdAction is not null)
+		{
+			writer.WritePropertyName("script");
+			JsonSerializer.Serialize(writer, new StoredScriptIdDescriptor(_storedScriptIdAction), options);
 		}
 
 		if (_document is not null)

--- a/tests/Tests/Serialization/Bulk/BulkOperationCollectionSerializationTests.cs
+++ b/tests/Tests/Serialization/Bulk/BulkOperationCollectionSerializationTests.cs
@@ -9,412 +9,411 @@ using Tests.Core.Xunit;
 using VerifyTests;
 using VerifyXunit;
 
-namespace Tests.Serialization.Bulk
+namespace Tests.Serialization.Bulk;
+
+[UsesVerify]
+[SystemTextJsonOnly]
+// These use verify and the order of properties differs between STJ and Newtonsoft JSON - TODO - Resolve this somehow. Maybe have a set of tests specific to Newtonsoft? or fall back to old method of comparing JSON.
+public class BulkRequestOperationsSerializationTests
 {
-	[UsesVerify]
-	[SystemTextJsonOnly]
-	// These use verify and the order of properties differs between STJ and Newtonsoft JSON - TODO - Resolve this somehow. Maybe have a set of tests specific to Newtonsoft? or fall back to old method of comparing JSON.
-	public class BulkRequestOperationsSerializationTests
+	// NOTE: The verified output from these tests should be valid if pasted into a bulk API call via Kibana.
+	// Although it may fail due to version concurrency not being the expected values, it should be parsed correctly.
+	// Use: POST configured-index/_bulk
+
+	private readonly VerifySettings _verifySettings;
+
+	public BulkRequestOperationsSerializationTests()
 	{
-		// NOTE: The verified output from these tests should be valid if pasted into a bulk API call via Kibana.
-		// Although it may fail due to version concurrency not being the expected values, it should be parsed correctly.
-		// Use: POST configured-index/_bulk
+		_verifySettings = new VerifySettings();
+		_verifySettings.DisableRequireUniquePrefix();
+	}
 
-		private readonly VerifySettings _verifySettings;
+	[U]
+	public async Task BulkRequestWithIndexOperations_ObjectInitializer_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
 
-		public BulkRequestOperationsSerializationTests()
+		var ms = new MemoryStream();
+
+		var request = new BulkRequest("index-from-request")
 		{
-			_verifySettings = new VerifySettings();
-			_verifySettings.DisableRequireUniquePrefix();
-		}
-
-		[U]
-		public async Task BulkRequestWithIndexOperations_ObjectInitializer_SerializesCorrectly()
-		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
-
-			var ms = new MemoryStream();
-
-			var request = new BulkRequest("index-from-request")
+			Operations = new BulkOperationsCollection
 			{
-				Operations = new BulkOperationsCollection
+				new BulkIndexOperation<Inferrable>(Inferrable.Instance),
+				new BulkIndexOperation<Inferrable>(Inferrable.Instance)
 				{
-					new BulkIndexOperation<Inferrable>(Inferrable.Instance),
-					new BulkIndexOperation<Inferrable>(Inferrable.Instance)
-					{
-						Id = "OverriddenId",
-						Routing = "OverriddenRoute",
-						Index = "overridden-index",
-						Pipeline = "my-pipeline",
-						RequireAlias = false,
-						Version = 1,
-						VersionType = VersionType.External,
-						DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
-					},
-					new BulkIndexOperation<NonInferrable>(NonInferrable.Instance),
-					new BulkIndexOperation<NonInferrable>(NonInferrable.Instance, index: "configured-index"),
-					new BulkIndexOperation<NonInferrable>(NonInferrable.Instance)
-					{
-						Id = "ConfiguredId",
-						Routing = "ConfiguredRoute",
-						Index = "configured-index",
-						IfPrimaryTerm = 100,
-						IfSequenceNumber = 10,
-						Pipeline = "my-pipeline",
-						RequireAlias = false,
-						DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
-					}
+					Id = "OverriddenId",
+					Routing = "OverriddenRoute",
+					Index = "overridden-index",
+					Pipeline = "my-pipeline",
+					RequireAlias = false,
+					Version = 1,
+					VersionType = VersionType.External,
+					DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
+				},
+				new BulkIndexOperation<NonInferrable>(NonInferrable.Instance),
+				new BulkIndexOperation<NonInferrable>(NonInferrable.Instance, index: "configured-index"),
+				new BulkIndexOperation<NonInferrable>(NonInferrable.Instance)
+				{
+					Id = "ConfiguredId",
+					Routing = "ConfiguredRoute",
+					Index = "configured-index",
+					IfPrimaryTerm = 100,
+					IfSequenceNumber = 10,
+					Pipeline = "my-pipeline",
+					RequireAlias = false,
+					DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
 				}
-			};
+			}
+		};
 
-			await request.SerializeAsync(ms, settings);
+		await request.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			request.Serialize(ms, settings);
+		ms = new MemoryStream();
+		request.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithDeleteOperations_ObjectInitializer_SerializesCorrectly()
+	[U]
+	public async Task BulkRequestWithDeleteOperations_ObjectInitializer_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+
+		var ms = new MemoryStream();
+
+		var request = new BulkRequest("index-from-request")
 		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
-
-			var ms = new MemoryStream();
-
-			var request = new BulkRequest("index-from-request")
+			Operations = new BulkOperationsCollection
 			{
-				Operations = new BulkOperationsCollection
+				new BulkDeleteOperation("123"),
+				new BulkDeleteOperation("123")
 				{
-					new BulkDeleteOperation("123"),
-					new BulkDeleteOperation("123")
-					{
-						Routing = "ConfiguredRoute",
-						Index = "configured-index",
-						RequireAlias = false,
-						Version = 1,
-						VersionType = VersionType.External
-					},
-					new BulkDeleteOperation<Inferrable>(Inferrable.Instance),
-					new BulkDeleteOperation<Inferrable>(Inferrable.Instance)
-					{
-						Id = "OverriddenId",
-						Routing = "OverriddenRoute",
-						Index = "overridden-index",
-						IfPrimaryTerm = 100,
-						IfSequenceNumber = 10,
-						RequireAlias = false,
-					}
+					Routing = "ConfiguredRoute",
+					Index = "configured-index",
+					RequireAlias = false,
+					Version = 1,
+					VersionType = VersionType.External
+				},
+				new BulkDeleteOperation<Inferrable>(Inferrable.Instance),
+				new BulkDeleteOperation<Inferrable>(Inferrable.Instance)
+				{
+					Id = "OverriddenId",
+					Routing = "OverriddenRoute",
+					Index = "overridden-index",
+					IfPrimaryTerm = 100,
+					IfSequenceNumber = 10,
+					RequireAlias = false,
 				}
-			};
+			}
+		};
 
-			await request.SerializeAsync(ms, settings);
+		await request.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			request.Serialize(ms, settings);
+		ms = new MemoryStream();
+		request.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithCreateOperations_ObjectInitializer_SerializesCorrectly()
+	[U]
+	public async Task BulkRequestWithCreateOperations_ObjectInitializer_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+
+		var ms = new MemoryStream();
+
+		var request = new BulkRequest("index-from-request")
 		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
-
-			var ms = new MemoryStream();
-
-			var request = new BulkRequest("index-from-request")
+			Operations = new BulkOperationsCollection
 			{
-				Operations = new BulkOperationsCollection
+				new BulkCreateOperation<Inferrable>(Inferrable.Instance),
+				new BulkCreateOperation<Inferrable>(Inferrable.Instance)
 				{
-					new BulkCreateOperation<Inferrable>(Inferrable.Instance),
-					new BulkCreateOperation<Inferrable>(Inferrable.Instance)
-					{
-						Id = "OverriddenId",
-						Routing = "OverriddenRoute",
-						Index = "overridden-index",
-						Pipeline = "my-pipeline",
-						RequireAlias = false,
-						Version = 1,
-						VersionType = VersionType.External,
-						DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
-					},
-					new BulkCreateOperation<NonInferrable>(NonInferrable.Instance),
-					new BulkCreateOperation<NonInferrable>(NonInferrable.Instance, index: "configured-index"),
-					new BulkCreateOperation<NonInferrable>(NonInferrable.Instance)
-					{
-						Id = "ConfiguredId",
-						Routing = "ConfiguredRoute",
-						Index = "configured-index",
-						IfPrimaryTerm = 100,
-						IfSequenceNumber = 10,
-						Pipeline = "my-pipeline",
-						RequireAlias = false,
-						DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
-					}
+					Id = "OverriddenId",
+					Routing = "OverriddenRoute",
+					Index = "overridden-index",
+					Pipeline = "my-pipeline",
+					RequireAlias = false,
+					Version = 1,
+					VersionType = VersionType.External,
+					DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
+				},
+				new BulkCreateOperation<NonInferrable>(NonInferrable.Instance),
+				new BulkCreateOperation<NonInferrable>(NonInferrable.Instance, index: "configured-index"),
+				new BulkCreateOperation<NonInferrable>(NonInferrable.Instance)
+				{
+					Id = "ConfiguredId",
+					Routing = "ConfiguredRoute",
+					Index = "configured-index",
+					IfPrimaryTerm = 100,
+					IfSequenceNumber = 10,
+					Pipeline = "my-pipeline",
+					RequireAlias = false,
+					DynamicTemplates = new Dictionary<string, string>{ { "t1", "v1" } }
 				}
-			};
+			}
+		};
 
-			await request.SerializeAsync(ms, settings);
+		await request.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			request.Serialize(ms, settings);
+		ms = new MemoryStream();
+		request.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithUpdateOperations_ObjectInitializer_SerializesCorrectly()
+	[U]
+	public async Task BulkRequestWithUpdateOperations_ObjectInitializer_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+
+		var ms = new MemoryStream();
+
+		var request = new BulkRequest("index-from-request")
 		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
-
-			var ms = new MemoryStream();
-
-			var request = new BulkRequest("index-from-request")
+			Operations = new BulkOperationsCollection
 			{
-				Operations = new BulkOperationsCollection
+				BulkUpdateOperationFactory.WithScript("123", "test-index", new StoredScriptId("my-script-id")
 				{
-					BulkUpdateOperationFactory.WithScript("123", "test-index", new StoredScriptId("my-script-id")
-					{
-						Params = new Dictionary<string, object> { { "param1", "paramvalue1" } }
-					}),
-					BulkUpdateOperationFactory.WithScript("123", new InlineScript("ctx._source.counter += params.param1")
-					{
-						Language = ScriptLanguage.Painless,
-						Params = new Dictionary<string, object>{ { "param1", 1 } },
-						Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
-					}),
-					BulkUpdateOperationFactory.WithScript("123", new InlineScript("ctx._source.counter += params.param1")
-					{
-						Language = ScriptLanguage.Painless,
-						Params = new Dictionary<string, object>{ { "param1", 1 } },
-						Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
-					}, Inferrable.Instance),
-					BulkUpdateOperationFactory.WithScript("123", "configured-index", new InlineScript("ctx._source.counter += params.param1")
-					{
-						Language = ScriptLanguage.Painless,
-						Params = new Dictionary<string, object>{ { "param1", 1 } },
-						Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
-					}, Inferrable.Instance),
-					// TODO - Partial
-					// TODO - Full operation
-				}
-			};
+					Params = new Dictionary<string, object> { { "param1", "paramvalue1" } }
+				}),
+				BulkUpdateOperationFactory.WithScript("123", new InlineScript("ctx._source.counter += params.param1")
+				{
+					Language = ScriptLanguage.Painless,
+					Params = new Dictionary<string, object>{ { "param1", 1 } },
+					Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
+				}),
+				BulkUpdateOperationFactory.WithScript("123", new InlineScript("ctx._source.counter += params.param1")
+				{
+					Language = ScriptLanguage.Painless,
+					Params = new Dictionary<string, object>{ { "param1", 1 } },
+					Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
+				}, Inferrable.Instance),
+				BulkUpdateOperationFactory.WithScript("123", "configured-index", new InlineScript("ctx._source.counter += params.param1")
+				{
+					Language = ScriptLanguage.Painless,
+					Params = new Dictionary<string, object>{ { "param1", 1 } },
+					Options = new Dictionary<string, string>{ { "option1", "optionvalue1" } }
+				}, Inferrable.Instance),
+				// TODO - Partial
+				// TODO - Full operation
+			}
+		};
 
-			await request.SerializeAsync(ms, settings);
+		await request.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			request.Serialize(ms, settings);
+		ms = new MemoryStream();
+		request.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithIndexOperations_Descriptor_SerializesCorrectly()
-		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+	[U]
+	public async Task BulkRequestWithIndexOperations_Descriptor_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
 
-			var ms = new MemoryStream();
+		var ms = new MemoryStream();
 
-			var fluentRequest = new BulkRequestDescriptor(b => b
-				.Index("index-from-request")
-				.Index(Inferrable.Instance)
-				.Index(Inferrable.Instance, i => i
-					.Id("OverriddenId")
-					.Routing("OverriddenRoute")
-					.Index("overridden-index")
-					.Pipeline("my-pipeline")
-					.RequireAlias(false)
-					.Version(1)
-					.VersionType(VersionType.External)
-					.DynamicTemplates(d => d.Add("t1","v1")))
-				.Index(NonInferrable.Instance)
-				.Index(NonInferrable.Instance, "configured-index")
-				.Index(NonInferrable.Instance, i => i
-					.Id("ConfiguredId")
-					.Routing("ConfiguredRoute")
-					.Index("configured-index")
-					.IfPrimaryTerm(100)
-					.IfSequenceNumber(10)
-					.Pipeline("my-pipeline")
-					.RequireAlias(false)
-					.DynamicTemplates(d => d.Add("t1", "v1"))));
+		var fluentRequest = new BulkRequestDescriptor(b => b
+			.Index("index-from-request")
+			.Index(Inferrable.Instance)
+			.Index(Inferrable.Instance, i => i
+				.Id("OverriddenId")
+				.Routing("OverriddenRoute")
+				.Index("overridden-index")
+				.Pipeline("my-pipeline")
+				.RequireAlias(false)
+				.Version(1)
+				.VersionType(VersionType.External)
+				.DynamicTemplates(d => d.Add("t1","v1")))
+			.Index(NonInferrable.Instance)
+			.Index(NonInferrable.Instance, "configured-index")
+			.Index(NonInferrable.Instance, i => i
+				.Id("ConfiguredId")
+				.Routing("ConfiguredRoute")
+				.Index("configured-index")
+				.IfPrimaryTerm(100)
+				.IfSequenceNumber(10)
+				.Pipeline("my-pipeline")
+				.RequireAlias(false)
+				.DynamicTemplates(d => d.Add("t1", "v1"))));
 
-			await fluentRequest.SerializeAsync(ms, settings);
+		await fluentRequest.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			fluentRequest.Serialize(ms, settings);
+		ms = new MemoryStream();
+		fluentRequest.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithDeleteOperations_Descriptor_SerializesCorrectly()
-		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+	[U]
+	public async Task BulkRequestWithDeleteOperations_Descriptor_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
 
-			var ms = new MemoryStream();
+		var ms = new MemoryStream();
 
-			var fluentRequest = new BulkRequestDescriptor(b => b
-				.Index("index-from-request")
-				.Delete("123")
-				.Delete("123", i => i
-					.Id("ConfiguredId")
-					.Routing("ConfiguredRoute")
-					.Index("configured-index")
-					.IfPrimaryTerm(100)
-					.IfSequenceNumber(10)
-					.RequireAlias(false)
-					.Version(1)
-					.VersionType(VersionType.External))
-				.Delete(Inferrable.Instance)
-				.Delete(Inferrable.Instance, i => i
-					.Id("OverriddenId")
-					.Routing("OverriddenRoute")
-					.Index("overridden-index")
-					.IfPrimaryTerm(100)
-					.IfSequenceNumber(10)
-					.RequireAlias(false)
-					.Version(1)
-					.VersionType(VersionType.External))
-				);
+		var fluentRequest = new BulkRequestDescriptor(b => b
+			.Index("index-from-request")
+			.Delete("123")
+			.Delete("123", i => i
+				.Id("ConfiguredId")
+				.Routing("ConfiguredRoute")
+				.Index("configured-index")
+				.IfPrimaryTerm(100)
+				.IfSequenceNumber(10)
+				.RequireAlias(false)
+				.Version(1)
+				.VersionType(VersionType.External))
+			.Delete(Inferrable.Instance)
+			.Delete(Inferrable.Instance, i => i
+				.Id("OverriddenId")
+				.Routing("OverriddenRoute")
+				.Index("overridden-index")
+				.IfPrimaryTerm(100)
+				.IfSequenceNumber(10)
+				.RequireAlias(false)
+				.Version(1)
+				.VersionType(VersionType.External))
+			);
 
-			await fluentRequest.SerializeAsync(ms, settings);
+		await fluentRequest.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			fluentRequest.Serialize(ms, settings);
+		ms = new MemoryStream();
+		fluentRequest.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		[U]
-		public async Task BulkRequestWithCreateOperations_Descriptor_SerializesCorrectly()
-		{
-			var settings = new ElasticsearchClientSettings();
-			settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
+	[U]
+	public async Task BulkRequestWithCreateOperations_Descriptor_SerializesCorrectly()
+	{
+		var settings = new ElasticsearchClientSettings();
+		settings.DefaultMappingFor<Inferrable>(m => m.IdProperty(p => p.Name).RoutingProperty(r => r.Name).IndexName("test-index"));
 
-			var ms = new MemoryStream();
+		var ms = new MemoryStream();
 
-			var fluentRequest = new BulkRequestDescriptor(b => b
-				.Index("index-from-request")
-				.Create(Inferrable.Instance)
-				.Create(Inferrable.Instance, i => i
-					.Id("OverriddenId")
-					.Routing("OverriddenRoute")
-					.Index("overridden-index")
-					.Pipeline("my-pipeline")
-					.RequireAlias(false)
-					.Version(1)
-					.VersionType(VersionType.External)
-					.DynamicTemplates(d => d.Add("t1", "v1")))
-				.Create(NonInferrable.Instance)
-				.Create(NonInferrable.Instance, "configured-index")
-				.Create(NonInferrable.Instance, i => i
-					.Id("ConfiguredId")
-					.Routing("ConfiguredRoute")
-					.Index("configured-index")
-					.IfPrimaryTerm(100)
-					.IfSequenceNumber(10)
-					.Pipeline("my-pipeline")
-					.RequireAlias(false)
-					.DynamicTemplates(d => d.Add("t1", "v1"))));
+		var fluentRequest = new BulkRequestDescriptor(b => b
+			.Index("index-from-request")
+			.Create(Inferrable.Instance)
+			.Create(Inferrable.Instance, i => i
+				.Id("OverriddenId")
+				.Routing("OverriddenRoute")
+				.Index("overridden-index")
+				.Pipeline("my-pipeline")
+				.RequireAlias(false)
+				.Version(1)
+				.VersionType(VersionType.External)
+				.DynamicTemplates(d => d.Add("t1", "v1")))
+			.Create(NonInferrable.Instance)
+			.Create(NonInferrable.Instance, "configured-index")
+			.Create(NonInferrable.Instance, i => i
+				.Id("ConfiguredId")
+				.Routing("ConfiguredRoute")
+				.Index("configured-index")
+				.IfPrimaryTerm(100)
+				.IfSequenceNumber(10)
+				.Pipeline("my-pipeline")
+				.RequireAlias(false)
+				.DynamicTemplates(d => d.Add("t1", "v1"))));
 
-			await fluentRequest.SerializeAsync(ms, settings);
+		await fluentRequest.SerializeAsync(ms, settings);
 
-			ms.Position = 0;
-			var reader = new StreamReader(ms);
-			var ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		var reader = new StreamReader(ms);
+		var ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
+		await Verifier.Verify(ndjson, _verifySettings);
 
-			ms = new MemoryStream();
-			fluentRequest.Serialize(ms, settings);
+		ms = new MemoryStream();
+		fluentRequest.Serialize(ms, settings);
 
-			ms.Position = 0;
-			reader = new StreamReader(ms);
-			ndjson = reader.ReadToEnd();
+		ms.Position = 0;
+		reader = new StreamReader(ms);
+		ndjson = reader.ReadToEnd();
 
-			await Verifier.Verify(ndjson, _verifySettings);
-		}
+		await Verifier.Verify(ndjson, _verifySettings);
+	}
 
-		private class Inferrable
-		{
-			public static Inferrable Instance = new() { Name = "TestName" };
+	private class Inferrable
+	{
+		public static Inferrable Instance = new() { Name = "TestName" };
 
-			public string Name { get; set; }
-		}
+		public string Name { get; set; }
+	}
 
-		private class NonInferrable
-		{
-			public static NonInferrable Instance = new() { Forename = "Steve" };
+	private class NonInferrable
+	{
+		public static NonInferrable Instance = new() { Forename = "Steve" };
 
-			public string Forename { get; set; }
-		}
+		public string Forename { get; set; }
 	}
 }

--- a/tests/Tests/Serialization/Bulk/BulkUpdateOperationSerializationTests.cs
+++ b/tests/Tests/Serialization/Bulk/BulkUpdateOperationSerializationTests.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using Tests.Domain;
+using VerifyXunit;
+
+namespace Tests.Serialization.Bulk;
+
+[UsesVerify]
+public class BulkUpdateOperationSerializationTests : SerializerTestBase
+{
+	[U]
+	public async Task Serializes_With_StoredScriptId()
+	{
+		var operation = new BulkUpdateOperationDescriptor<Project, Project>("doc-id")
+			.Script(s => s
+				.Id("script-id")
+				.Params(p => p.Add("param1", "value1").Add("param2", "value2")));
+
+		var jsonString = SerializeAndGetJsonString(operation);
+
+		await Verifier.Verify(jsonString);
+	}
+}

--- a/tests/Tests/Serialization/Bulk/BulkUpdateOperationSerializationTests.cs
+++ b/tests/Tests/Serialization/Bulk/BulkUpdateOperationSerializationTests.cs
@@ -1,3 +1,7 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
 using System.Threading.Tasks;
 using Tests.Domain;
 using VerifyXunit;

--- a/tests/Tests/_VerifySnapshots/BulkUpdateOperationSerializationTests.Serializes_With_StoredScriptId.verified.txt
+++ b/tests/Tests/_VerifySnapshots/BulkUpdateOperationSerializationTests.Serializes_With_StoredScriptId.verified.txt
@@ -1,0 +1,2 @@
+{"update":{"_id":"doc-id"}}
+{"script":{"id":"script-id","params":{"param1":"value1","param2":"value2"}}}


### PR DESCRIPTION
Adds overload to the update operation descriptor to support providing an `Action<StoredScriptIdDescriptor>`.

Fixes #6554