### PR TITLE
Fix field name query converter

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
@@ -4,6 +4,8 @@
 
 using System;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Elastic.Transport;
@@ -14,6 +16,8 @@ namespace Elastic.Clients.Elasticsearch;
 public sealed partial class ElasticsearchClient
 {
 	private readonly ITransport<IElasticsearchClientSettings> _transport;
+
+	internal static ConditionalWeakTable<JsonSerializerOptions, IElasticsearchClientSettings> SettingsTable { get; } = new();
 
 	/// <summary>
 	///     Creates a client configured to connect to localhost:9200.

--- a/src/Elastic.Clients.Elasticsearch/Serialization/CustomizedNamingPolicy.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/CustomizedNamingPolicy.cs
@@ -1,0 +1,17 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Text.Json;
+
+namespace Elastic.Clients.Elasticsearch;
+
+internal class CustomizedNamingPolicy : JsonNamingPolicy
+{
+	private readonly Func<string, string> _namingAction;
+
+	public CustomizedNamingPolicy(Func<string, string> namingAction) => _namingAction = namingAction;
+
+	public override string ConvertName(string name) => _namingAction(name);
+}

--- a/src/Elastic.Clients.Elasticsearch/Serialization/DefaultRequestResponseSerializer.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/DefaultRequestResponseSerializer.cs
@@ -13,15 +13,6 @@ using Elastic.Transport;
 
 namespace Elastic.Clients.Elasticsearch;
 
-internal class CustomizedNamingPolicy : JsonNamingPolicy
-{
-	private readonly Func<string, string> _namingAction;
-
-	public CustomizedNamingPolicy(Func<string, string> namingAction) => _namingAction = namingAction;
-
-	public override string ConvertName(string name) => _namingAction(name);
-}
-
 /// <summary>
 /// The built in internal serializer that the high level client Elastic.Clients.Elasticsearch uses.
 /// </summary>
@@ -64,6 +55,8 @@ internal class DefaultRequestResponseSerializer : SystemTextJsonSerializer
 				},
 			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
 		};
+
+		ElasticsearchClient.SettingsTable.Add(Options, settings);
 
 		_settings = settings;
 	}

--- a/src/Elastic.Clients.Elasticsearch/Serialization/FieldNameQueryConverterBase.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/FieldNameQueryConverterBase.cs
@@ -41,10 +41,16 @@ namespace Elastic.Clients.Elasticsearch
 			if (value.Field is null)
 				writer.WriteNullValue();
 
-			writer.WriteStartObject();
-			writer.WritePropertyName(value.Field.ToString());
-			WriteInternal(writer, value, options);
-			writer.WriteEndObject();
+			if (options.TryGetClientSettings(out var settings))
+			{
+				writer.WriteStartObject();
+				writer.WritePropertyName(settings.Inferrer.Field(value.Field));
+				WriteInternal(writer, value, options);
+				writer.WriteEndObject();
+				return;
+			}
+
+			throw new JsonException("Unable to retrieve client settings to infer field.");
 		}
 
 		internal abstract T? ReadInternal(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options);

--- a/src/Elastic.Clients.Elasticsearch/Serialization/JsonSerializerOptionsExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/JsonSerializerOptionsExtensions.cs
@@ -1,0 +1,13 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+namespace Elastic.Clients.Elasticsearch;
+
+internal static class JsonSerializerOptionsExtensions
+{
+	public static bool TryGetClientSettings(this JsonSerializerOptions options, out IElasticsearchClientSettings settings) =>
+		ElasticsearchClient.SettingsTable.TryGetValue(options, out settings);
+}

--- a/tests/Tests/Serialization/Queries/SearchSerializationTests.cs
+++ b/tests/Tests/Serialization/Queries/SearchSerializationTests.cs
@@ -1,0 +1,28 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch.QueryDsl;
+using Tests.Domain;
+using VerifyXunit;
+
+namespace Tests.Serialization.Queries;
+
+[UsesVerify]
+public class SearchSerializationTests : SerializerTestBase
+{
+	[U]
+	public async Task Search_WithMatchQuery_SerializesInferredField_ForObjectInitializer()
+	{
+		var container = QueryContainer.Match(new MatchQuery
+		{
+			Field = Infer.Field<Project>(d => d.Description),
+			Query = "testing"
+		});
+
+		var json = SerializeAndGetJsonString(container);
+
+		await Verifier.VerifyJson(json);
+	}
+}

--- a/tests/Tests/_VerifySnapshots/SearchSerializationTests.Search_WithMatchQuery_SerializesInferredField_ForObjectInitializer.verified.txt
+++ b/tests/Tests/_VerifySnapshots/SearchSerializationTests.Search_WithMatchQuery_SerializesInferredField_ForObjectInitializer.verified.txt
@@ -1,0 +1,7 @@
+{
+  match: {
+    description: {
+      query: testing
+    }
+  }
+}


### PR DESCRIPTION
Fixes #6557 

- Add `ConditionalWeakTable` to client.
- Updates `FieldNameQueryConverterBase` to use inferrer from settings, retrieved from `ConditionalWeakTable`.
