### PR TITLE
Reintroduce sub-aggregations for bucket aggs

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AdjacencyMatrixAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AdjacencyMatrixAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -103,11 +120,104 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Dictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filters { get; set; }
 
 		public Dictionary<string, object>? Meta { get; set; }
 
 		public override string? Name { get; internal set; }
+	}
+
+	public sealed partial class AdjacencyMatrixAggregationDescriptor<TDocument> : SerializableDescriptorBase<AdjacencyMatrixAggregationDescriptor<TDocument>>
+	{
+		internal AdjacencyMatrixAggregationDescriptor(Action<AdjacencyMatrixAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
+		public AdjacencyMatrixAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
+		private Dictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FiltersValue { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public AdjacencyMatrixAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor<TDocument> Filters(Func<FluentDictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>, FluentDictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>> selector)
+		{
+			FiltersValue = selector?.Invoke(new FluentDictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>());
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("adjacency_matrix");
+			writer.WriteStartObject();
+			if (FiltersValue is not null)
+			{
+				writer.WritePropertyName("filters");
+				JsonSerializer.Serialize(writer, FiltersValue, options);
+			}
+
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
 	}
 
 	public sealed partial class AdjacencyMatrixAggregationDescriptor : SerializableDescriptorBase<AdjacencyMatrixAggregationDescriptor>
@@ -117,9 +227,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FiltersValue { get; set; }
 
 		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public AdjacencyMatrixAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public AdjacencyMatrixAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public AdjacencyMatrixAggregationDescriptor Filters(Func<FluentDictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>, FluentDictionary<string, Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>> selector)
 		{
@@ -149,6 +289,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AggregationContainer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AggregationContainer.g.cs
@@ -290,7 +290,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
-		public AggregationContainerDescriptor<TDocument> AdjacencyMatrix(string name, Action<AdjacencyMatrixAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> AdjacencyMatrix(string name, Action<AdjacencyMatrixAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("adjacency_matrix", configure));
 		}
@@ -315,12 +315,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("cardinality", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Children(string name, Action<ChildrenAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Children(string name, Action<ChildrenAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("children", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Composite(string name, Action<CompositeAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Composite(string name, Action<CompositeAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("composite", configure));
 		}
@@ -355,12 +355,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("extended_stats_bucket", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Filters(string name, Action<FiltersAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Filters(string name, Action<FiltersAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("filters", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Global(string name, Action<GlobalAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Global(string name, Action<GlobalAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("global", configure));
 		}
@@ -415,7 +415,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("nested", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Parent(string name, Action<ParentAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Parent(string name, Action<ParentAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("parent", configure));
 		}
@@ -440,7 +440,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("reverse_nested", configure));
 		}
 
-		public AggregationContainerDescriptor<TDocument> Sampler(string name, Action<SamplerAggregationDescriptor> configure)
+		public AggregationContainerDescriptor<TDocument> Sampler(string name, Action<SamplerAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("sampler", configure));
 		}
@@ -518,6 +518,11 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("adjacency_matrix", configure));
 		}
 
+		public AggregationContainerDescriptor AdjacencyMatrix<TDocument>(string name, Action<AdjacencyMatrixAggregationDescriptor<TDocument>> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("adjacency_matrix", configure));
+		}
+
 		public AggregationContainerDescriptor AutoDateHistogram(string name, Action<AutoDateHistogramAggregationDescriptor> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("auto_date_histogram", configure));
@@ -563,7 +568,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("children", configure));
 		}
 
+		public AggregationContainerDescriptor Children<TDocument>(string name, Action<ChildrenAggregationDescriptor<TDocument>> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("children", configure));
+		}
+
 		public AggregationContainerDescriptor Composite(string name, Action<CompositeAggregationDescriptor> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("composite", configure));
+		}
+
+		public AggregationContainerDescriptor Composite<TDocument>(string name, Action<CompositeAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("composite", configure));
 		}
@@ -618,7 +633,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("filters", configure));
 		}
 
+		public AggregationContainerDescriptor Filters<TDocument>(string name, Action<FiltersAggregationDescriptor<TDocument>> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("filters", configure));
+		}
+
 		public AggregationContainerDescriptor Global(string name, Action<GlobalAggregationDescriptor> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("global", configure));
+		}
+
+		public AggregationContainerDescriptor Global<TDocument>(string name, Action<GlobalAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("global", configure));
 		}
@@ -728,6 +753,11 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			return SetContainer(name, AggregationContainer.CreateWithAction("parent", configure));
 		}
 
+		public AggregationContainerDescriptor Parent<TDocument>(string name, Action<ParentAggregationDescriptor<TDocument>> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("parent", configure));
+		}
+
 		public AggregationContainerDescriptor PercentilesBucket(string name, Action<PercentilesBucketAggregationDescriptor> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("percentiles_bucket", configure));
@@ -764,6 +794,11 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		}
 
 		public AggregationContainerDescriptor Sampler(string name, Action<SamplerAggregationDescriptor> configure)
+		{
+			return SetContainer(name, AggregationContainer.CreateWithAction("sampler", configure));
+		}
+
+		public AggregationContainerDescriptor Sampler<TDocument>(string name, Action<SamplerAggregationDescriptor<TDocument>> configure)
 		{
 			return SetContainer(name, AggregationContainer.CreateWithAction("sampler", configure));
 		}

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AutoDateHistogramAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AutoDateHistogramAggregation.g.cs
@@ -163,6 +163,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -235,6 +246,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -246,6 +263,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal AutoDateHistogramAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public int? Buckets { get; set; }
 
@@ -277,6 +296,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private int? BucketsValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
@@ -296,6 +321,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public AutoDateHistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public AutoDateHistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public AutoDateHistogramAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public AutoDateHistogramAggregationDescriptor<TDocument> Buckets(int? buckets)
 		{
@@ -429,6 +478,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -439,6 +504,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public AutoDateHistogramAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private int? BucketsValue { get; set; }
 
@@ -459,6 +530,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public AutoDateHistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public AutoDateHistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public AutoDateHistogramAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public AutoDateHistogramAggregationDescriptor Buckets(int? buckets)
 		{
@@ -596,6 +691,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ChildrenAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ChildrenAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -103,11 +120,104 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Dictionary<string, object>? Meta { get; set; }
 
 		public override string? Name { get; internal set; }
 
 		public string? Type { get; set; }
+	}
+
+	public sealed partial class ChildrenAggregationDescriptor<TDocument> : SerializableDescriptorBase<ChildrenAggregationDescriptor<TDocument>>
+	{
+		internal ChildrenAggregationDescriptor(Action<ChildrenAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
+		public ChildrenAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		private string? TypeValue { get; set; }
+
+		public ChildrenAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor<TDocument> Type(string? type)
+		{
+			TypeValue = type;
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("children");
+			writer.WriteStartObject();
+			if (TypeValue is not null)
+			{
+				writer.WritePropertyName("type");
+				JsonSerializer.Serialize(writer, TypeValue, options);
+			}
+
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
 	}
 
 	public sealed partial class ChildrenAggregationDescriptor : SerializableDescriptorBase<ChildrenAggregationDescriptor>
@@ -117,9 +227,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private string? TypeValue { get; set; }
+
+		public ChildrenAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ChildrenAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public ChildrenAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -149,6 +289,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregation.g.cs
@@ -187,6 +187,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -271,6 +282,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -282,6 +299,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal DateHistogramAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Aggregations.CalendarInterval? CalendarInterval { get; set; }
 
@@ -318,6 +337,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Aggregations.CalendarInterval? CalendarIntervalValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
@@ -341,6 +366,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public DateHistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public DateHistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public DateHistogramAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public DateHistogramAggregationDescriptor<TDocument> CalendarInterval(Elastic.Clients.Elasticsearch.Aggregations.CalendarInterval? calendarInterval)
 		{
@@ -498,6 +547,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -508,6 +573,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public DateHistogramAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Aggregations.CalendarInterval? CalendarIntervalValue { get; set; }
 
@@ -532,6 +603,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public DateHistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public DateHistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public DateHistogramAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public DateHistogramAggregationDescriptor CalendarInterval(Elastic.Clients.Elasticsearch.Aggregations.CalendarInterval? calendarInterval)
 		{
@@ -693,6 +788,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregation.g.cs
@@ -103,6 +103,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -145,6 +156,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -156,6 +173,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal DateRangeAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Field? Field { get; set; }
 
@@ -177,6 +196,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private string? FormatValue { get; set; }
@@ -192,6 +217,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<DateRangeExpressionDescriptor>[] RangesDescriptorActions { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public DateRangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public DateRangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public DateRangeAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public DateRangeAggregationDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -320,6 +369,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -330,6 +395,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public DateRangeAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
@@ -346,6 +417,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<DateRangeExpressionDescriptor>[] RangesDescriptorActions { get; set; }
 
 		private string? TimeZoneValue { get; set; }
+
+		public DateRangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public DateRangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public DateRangeAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public DateRangeAggregationDescriptor Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -478,6 +573,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/FiltersAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/FiltersAggregation.g.cs
@@ -91,6 +91,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -127,6 +138,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -139,6 +156,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filters { get; set; }
 
 		public Dictionary<string, object>? Meta { get; set; }
@@ -150,12 +169,18 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public string? OtherBucketKey { get; set; }
 	}
 
-	public sealed partial class FiltersAggregationDescriptor : SerializableDescriptorBase<FiltersAggregationDescriptor>
+	public sealed partial class FiltersAggregationDescriptor<TDocument> : SerializableDescriptorBase<FiltersAggregationDescriptor<TDocument>>
 	{
-		internal FiltersAggregationDescriptor(Action<FiltersAggregationDescriptor> configure) => configure.Invoke(this);
+		internal FiltersAggregationDescriptor(Action<FiltersAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
 		public FiltersAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FiltersValue { get; set; }
 
@@ -164,6 +189,149 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private bool? OtherBucketValue { get; set; }
 
 		private string? OtherBucketKeyValue { get; set; }
+
+		public FiltersAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> Filters(Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filters)
+		{
+			FiltersValue = filters;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> OtherBucket(bool? otherBucket = true)
+		{
+			OtherBucketValue = otherBucket;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor<TDocument> OtherBucketKey(string? otherBucketKey)
+		{
+			OtherBucketKeyValue = otherBucketKey;
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("filters");
+			writer.WriteStartObject();
+			if (FiltersValue is not null)
+			{
+				writer.WritePropertyName("filters");
+				JsonSerializer.Serialize(writer, FiltersValue, options);
+			}
+
+			if (OtherBucketValue.HasValue)
+			{
+				writer.WritePropertyName("other_bucket");
+				writer.WriteBooleanValue(OtherBucketValue.Value);
+			}
+
+			if (!string.IsNullOrEmpty(OtherBucketKeyValue))
+			{
+				writer.WritePropertyName("other_bucket_key");
+				writer.WriteStringValue(OtherBucketKeyValue);
+			}
+
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
+	}
+
+	public sealed partial class FiltersAggregationDescriptor : SerializableDescriptorBase<FiltersAggregationDescriptor>
+	{
+		internal FiltersAggregationDescriptor(Action<FiltersAggregationDescriptor> configure) => configure.Invoke(this);
+		public FiltersAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FiltersValue { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		private bool? OtherBucketValue { get; set; }
+
+		private string? OtherBucketKeyValue { get; set; }
+
+		public FiltersAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public FiltersAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public FiltersAggregationDescriptor Filters(Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filters)
 		{
@@ -217,6 +385,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/GlobalAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/GlobalAggregation.g.cs
@@ -56,6 +56,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -74,6 +85,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -86,9 +103,88 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Dictionary<string, object>? Meta { get; set; }
 
 		public override string? Name { get; internal set; }
+	}
+
+	public sealed partial class GlobalAggregationDescriptor<TDocument> : SerializableDescriptorBase<GlobalAggregationDescriptor<TDocument>>
+	{
+		internal GlobalAggregationDescriptor(Action<GlobalAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
+		public GlobalAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public GlobalAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public GlobalAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public GlobalAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public GlobalAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("global");
+			writer.WriteStartObject();
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
 	}
 
 	public sealed partial class GlobalAggregationDescriptor : SerializableDescriptorBase<GlobalAggregationDescriptor>
@@ -98,7 +194,37 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public GlobalAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public GlobalAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public GlobalAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public GlobalAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -116,6 +242,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregation.g.cs
@@ -151,6 +151,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -217,6 +228,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -228,6 +245,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal HistogramAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Field? Field { get; set; }
 
@@ -258,6 +277,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private string? FormatValue { get; set; }
@@ -275,6 +300,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
+
+		public HistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public HistogramAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public HistogramAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public HistogramAggregationDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -396,6 +445,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -406,6 +471,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public HistogramAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
@@ -424,6 +495,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
+
+		public HistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public HistogramAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public HistogramAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public HistogramAggregationDescriptor Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -549,6 +644,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregation.g.cs
@@ -79,6 +79,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -109,6 +120,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -120,6 +137,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal IpRangeAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Field? Field { get; set; }
 
@@ -137,6 +156,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private Dictionary<string, object>? MetaValue { get; set; }
@@ -148,6 +173,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<IpRangeAggregationRangeDescriptor> RangesDescriptorAction { get; set; }
 
 		private Action<IpRangeAggregationRangeDescriptor>[] RangesDescriptorActions { get; set; }
+
+		public IpRangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public IpRangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public IpRangeAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public IpRangeAggregationDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -252,6 +301,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -262,6 +327,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public IpRangeAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
@@ -274,6 +345,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<IpRangeAggregationRangeDescriptor> RangesDescriptorAction { get; set; }
 
 		private Action<IpRangeAggregationRangeDescriptor>[] RangesDescriptorActions { get; set; }
+
+		public IpRangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public IpRangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public IpRangeAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public IpRangeAggregationDescriptor Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -382,6 +477,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MissingAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MissingAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -102,6 +119,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal MissingAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Field? Field { get; set; }
 
@@ -117,9 +136,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public MissingAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public MissingAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public MissingAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public MissingAggregationDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -157,6 +206,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -168,9 +233,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private Dictionary<string, object>? MetaValue { get; set; }
+
+		public MissingAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public MissingAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public MissingAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public MissingAggregationDescriptor Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -212,6 +307,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregation.g.cs
@@ -151,6 +151,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -213,6 +224,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -224,6 +241,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal MultiTermsAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectMode { get; set; }
 
@@ -254,6 +273,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
 
 		private MultiTermLookupDescriptor<TDocument> TermsDescriptor { get; set; }
@@ -277,6 +302,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private bool? ShowTermDocCountErrorValue { get; set; }
 
 		private int? SizeValue { get; set; }
+
+		public MultiTermsAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public MultiTermsAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public MultiTermsAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public MultiTermsAggregationDescriptor<TDocument> Terms(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
 		{
@@ -447,6 +496,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -457,6 +522,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public MultiTermsAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
 
@@ -481,6 +552,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private bool? ShowTermDocCountErrorValue { get; set; }
 
 		private int? SizeValue { get; set; }
+
+		public MultiTermsAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public MultiTermsAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public MultiTermsAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public MultiTermsAggregationDescriptor Terms(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
 		{
@@ -649,6 +744,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/NestedAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/NestedAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -102,6 +119,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal NestedAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Dictionary<string, object>? Meta { get; set; }
 
@@ -117,9 +136,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? PathValue { get; set; }
+
+		public NestedAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public NestedAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public NestedAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public NestedAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -157,6 +206,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -168,9 +233,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? PathValue { get; set; }
+
+		public NestedAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public NestedAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public NestedAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public NestedAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -212,6 +307,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ParentAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ParentAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -103,11 +120,104 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Dictionary<string, object>? Meta { get; set; }
 
 		public override string? Name { get; internal set; }
 
 		public string? Type { get; set; }
+	}
+
+	public sealed partial class ParentAggregationDescriptor<TDocument> : SerializableDescriptorBase<ParentAggregationDescriptor<TDocument>>
+	{
+		internal ParentAggregationDescriptor(Action<ParentAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
+		public ParentAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		private string? TypeValue { get; set; }
+
+		public ParentAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ParentAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ParentAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public ParentAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		public ParentAggregationDescriptor<TDocument> Type(string? type)
+		{
+			TypeValue = type;
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("parent");
+			writer.WriteStartObject();
+			if (TypeValue is not null)
+			{
+				writer.WritePropertyName("type");
+				JsonSerializer.Serialize(writer, TypeValue, options);
+			}
+
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
 	}
 
 	public sealed partial class ParentAggregationDescriptor : SerializableDescriptorBase<ParentAggregationDescriptor>
@@ -117,9 +227,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private string? TypeValue { get; set; }
+
+		public ParentAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ParentAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ParentAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public ParentAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -149,6 +289,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregation.g.cs
@@ -115,6 +115,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -163,6 +174,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -174,6 +191,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal RangeAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Field? Field { get; set; }
 
@@ -197,6 +216,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
 		private string? FormatValue { get; set; }
@@ -214,6 +239,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<AggregationRangeDescriptor>[] RangesDescriptorActions { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
+
+		public RangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public RangeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public RangeAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public RangeAggregationDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -354,6 +403,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -364,6 +429,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public RangeAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
@@ -382,6 +453,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private Action<AggregationRangeDescriptor>[] RangesDescriptorActions { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
+
+		public RangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public RangeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public RangeAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public RangeAggregationDescriptor Field(Elastic.Clients.Elasticsearch.Field? field)
 		{
@@ -526,6 +621,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ReverseNestedAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/ReverseNestedAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -102,6 +119,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal ReverseNestedAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Dictionary<string, object>? Meta { get; set; }
 
@@ -117,9 +136,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? PathValue { get; set; }
+
+		public ReverseNestedAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ReverseNestedAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ReverseNestedAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public ReverseNestedAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -157,6 +206,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -168,9 +233,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Field? PathValue { get; set; }
+
+		public ReverseNestedAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public ReverseNestedAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public ReverseNestedAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public ReverseNestedAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -212,6 +307,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/SamplerAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/SamplerAggregation.g.cs
@@ -67,6 +67,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -91,6 +102,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -103,11 +120,104 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
+
 		public Dictionary<string, object>? Meta { get; set; }
 
 		public override string? Name { get; internal set; }
 
 		public int? ShardSize { get; set; }
+	}
+
+	public sealed partial class SamplerAggregationDescriptor<TDocument> : SerializableDescriptorBase<SamplerAggregationDescriptor<TDocument>>
+	{
+		internal SamplerAggregationDescriptor(Action<SamplerAggregationDescriptor<TDocument>> configure) => configure.Invoke(this);
+		public SamplerAggregationDescriptor() : base()
+		{
+		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
+		private Dictionary<string, object>? MetaValue { get; set; }
+
+		private int? ShardSizeValue { get; set; }
+
+		public SamplerAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor<TDocument> Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
+		{
+			MetaValue = selector?.Invoke(new FluentDictionary<string, object>());
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor<TDocument> ShardSize(int? shardSize)
+		{
+			ShardSizeValue = shardSize;
+			return Self;
+		}
+
+		protected override void Serialize(Utf8JsonWriter writer, JsonSerializerOptions options, IElasticsearchClientSettings settings)
+		{
+			writer.WriteStartObject();
+			writer.WritePropertyName("sampler");
+			writer.WriteStartObject();
+			if (ShardSizeValue.HasValue)
+			{
+				writer.WritePropertyName("shard_size");
+				writer.WriteNumberValue(ShardSizeValue.Value);
+			}
+
+			writer.WriteEndObject();
+			if (MetaValue is not null)
+			{
+				writer.WritePropertyName("meta");
+				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
+			writer.WriteEndObject();
+		}
 	}
 
 	public sealed partial class SamplerAggregationDescriptor : SerializableDescriptorBase<SamplerAggregationDescriptor>
@@ -117,9 +227,39 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
+
 		private Dictionary<string, object>? MetaValue { get; set; }
 
 		private int? ShardSizeValue { get; set; }
+
+		public SamplerAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public SamplerAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public SamplerAggregationDescriptor Meta(Func<FluentDictionary<string, object>, FluentDictionary<string, object>> selector)
 		{
@@ -149,6 +289,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TermsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TermsAggregation.g.cs
@@ -235,6 +235,17 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 						continue;
 					}
+
+					if (reader.ValueTextEquals("aggs") || reader.ValueTextEquals("aggregations"))
+					{
+						var value = JsonSerializer.Deserialize<AggregationDictionary>(ref reader, options);
+						if (value is not null)
+						{
+							agg.Aggregations = value;
+						}
+
+						continue;
+					}
 				}
 			}
 
@@ -343,6 +354,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, value.Meta, options);
 			}
 
+			if (value.Aggregations is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, value.Aggregations, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -354,6 +371,8 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		internal TermsAggregation()
 		{
 		}
+
+		public Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? Aggregations { get; set; }
 
 		public Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectMode { get; set; }
 
@@ -399,6 +418,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		{
 		}
 
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
+
 		private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectModeValue { get; set; }
 
 		private IEnumerable<string>? ExcludeValue { get; set; }
@@ -430,6 +455,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private int? SizeValue { get; set; }
 
 		private string? ValueTypeValue { get; set; }
+
+		public TermsAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public TermsAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument> descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public TermsAggregationDescriptor<TDocument> Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public TermsAggregationDescriptor<TDocument> CollectMode(Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? collectMode)
 		{
@@ -635,6 +684,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				JsonSerializer.Serialize(writer, MetaValue, options);
 			}
 
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor<TDocument>(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
+			}
+
 			writer.WriteEndObject();
 		}
 	}
@@ -645,6 +710,12 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		public TermsAggregationDescriptor() : base()
 		{
 		}
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? AggregationsValue { get; set; }
+
+		private Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor AggregationsDescriptor { get; set; }
+
+		private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
 		private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectModeValue { get; set; }
 
@@ -677,6 +748,30 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 		private int? SizeValue { get; set; }
 
 		private string? ValueTypeValue { get; set; }
+
+		public TermsAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
+		{
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = null;
+			AggregationsValue = aggregations;
+			return Self;
+		}
+
+		public TermsAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor descriptor)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptorAction = null;
+			AggregationsDescriptor = descriptor;
+			return Self;
+		}
+
+		public TermsAggregationDescriptor Aggregations(Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> configure)
+		{
+			AggregationsValue = null;
+			AggregationsDescriptor = null;
+			AggregationsDescriptorAction = configure;
+			return Self;
+		}
 
 		public TermsAggregationDescriptor CollectMode(Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? collectMode)
 		{
@@ -886,6 +981,22 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 			{
 				writer.WritePropertyName("meta");
 				JsonSerializer.Serialize(writer, MetaValue, options);
+			}
+
+			if (AggregationsDescriptor is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsDescriptor, options);
+			}
+			else if (AggregationsDescriptorAction is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, new AggregationContainerDescriptor(AggregationsDescriptorAction), options);
+			}
+			else if (AggregationsValue is not null)
+			{
+				writer.WritePropertyName("aggregations");
+				JsonSerializer.Serialize(writer, AggregationsValue, options);
 			}
 
 			writer.WriteEndObject();

--- a/tests/Tests/Aggregations/Bucket/DateHistogramAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/DateHistogramAggregationUsageTests.cs
@@ -2,120 +2,120 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-//using System;
-//using System.Linq;
-//using Elastic.Clients.Elasticsearch.Aggregations;
-//using Tests.Core.Extensions;
-//using Tests.Core.ManagedElasticsearch.Clusters;
-//using Tests.Domain;
-//using Tests.Framework.EndpointTests.TestState;
-//using static Elastic.Clients.Elasticsearch.Infer;
+using System;
+using System.Linq;
+using Elastic.Clients.Elasticsearch.Aggregations;
+using Tests.Core.Extensions;
+using Tests.Core.ManagedElasticsearch.Clusters;
+using Tests.Domain;
+using Tests.Framework.EndpointTests.TestState;
+using static Elastic.Clients.Elasticsearch.Infer;
 
-//namespace Tests.Aggregations.Bucket;
+namespace Tests.Aggregations.Bucket;
 
-//public class DateHistogramAggregationUsageTests : ProjectsOnlyAggregationUsageTestBase
-//{
-//	public DateHistogramAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
+public class DateHistogramAggregationUsageTests : ProjectsOnlyAggregationUsageTestBase
+{
+	public DateHistogramAggregationUsageTests(ReadOnlyCluster i, EndpointUsage usage) : base(i, usage) { }
 
-//	protected override object AggregationJson => new
-//	{
-//		projects_started_per_month = new
-//		{
-//			date_histogram = new
-//			{
-//				field = "startedOn",
-//				calendar_interval = "month",
-//				min_doc_count = 2,
-//				format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", // <1> Note the inclusion of `date_optional_time` to `format`
-//				order = new { _key = "asc" },
-//				//extended_bounds = new
-//				//{
-//				//	min = FixedDate.AddYears(-1),
-//				//	max = FixedDate.AddYears(1)
-//				//},
-//				missing = "2015-06-06T12:01:02.123+00:00"
-//			},
-//			aggregations = new
-//			{
-//				project_tags = new
-//				{
-//					nested = new
-//					{
-//						path = "tags"
-//					},
-//					aggregations = new
-//					{
-//						tags = new
-//						{
-//							terms = new { field = "tags.name" }
-//						}
-//					}
-//				}
-//			}
-//		}
-//	};
+	protected override object AggregationJson => new
+	{
+		projects_started_per_month = new
+		{
+			date_histogram = new
+			{
+				field = "startedOn",
+				calendar_interval = "month",
+				min_doc_count = 2,
+				format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time", // <1> Note the inclusion of `date_optional_time` to `format`
+				order = new { _key = "asc" },
+				//extended_bounds = new
+				//{
+				//	min = FixedDate.AddYears(-1),
+				//	max = FixedDate.AddYears(1)
+				//},
+				missing = "2015-06-06T12:01:02.123+00:00"
+			},
+			aggregations = new
+			{
+				project_tags = new
+				{
+					nested = new
+					{
+						path = "tags"
+					},
+					aggregations = new
+					{
+						tags = new
+						{
+							terms = new { field = "tags.name" }
+						}
+					}
+				}
+			}
+		}
+	};
 
-//	protected override Action<AggregationContainerDescriptor<Project>> FluentAggs => a => a
-//		.DateHistogram("projects_started_per_month", date => date
-//			.Field(p => p.StartedOn)
-//			.CalendarInterval(CalendarInterval.Month)
-//			.MinDocCount(2)
-//			.Format("yyyy-MM-dd'T'HH:mm:ss||date_optional_time")
-//			//.ExtendedBounds(FixedDate.AddYears(-1), FixedDate.AddYears(1))
-//			.Order(new[] { AggregateOrder.KeyAscending })
-//			.Missing(DateTimeOffset.Parse("2015-06-06T12:01:02.1230000", styles: System.Globalization.DateTimeStyles.AssumeUniversal))
-//			.Aggregations(childAggs => childAggs
-//				.Nested("project_tags", n => n
-//					.Path(p => p.Tags)
-//					.Aggregations(nestedAggs => nestedAggs
-//						.Terms("tags", avg => avg.Field(p => p.Tags.First().Name))
-//					)
-//				)
-//			)
-//		);
+	protected override Action<AggregationContainerDescriptor<Project>> FluentAggs => a => a
+		.DateHistogram("projects_started_per_month", date => date
+			.Field(p => p.StartedOn)
+			.CalendarInterval(CalendarInterval.Month)
+			.MinDocCount(2)
+			.Format("yyyy-MM-dd'T'HH:mm:ss||date_optional_time")
+			//.ExtendedBounds(FixedDate.AddYears(-1), FixedDate.AddYears(1))
+			.Order(new[] { AggregateOrder.KeyAscending })
+			.Missing(DateTimeOffset.Parse("2015-06-06T12:01:02.1230000", styles: System.Globalization.DateTimeStyles.AssumeUniversal))
+			.Aggregations(childAggs => childAggs
+				.Nested("project_tags", n => n
+					.Path(p => p.Tags)
+					.Aggregations(nestedAggs => nestedAggs
+						.Terms("tags", avg => avg.Field(p => p.Tags.First().Name))
+					)
+				)
+			)
+		);
 
-//	protected override AggregationDictionary InitializerAggs =>
-//		new DateHistogramAggregation("projects_started_per_month")
-//		{
-//			Field = Field<Project>(p => p.StartedOn),
-//			CalendarInterval = CalendarInterval.Month,
-//			MinDocCount = 2,
-//			Format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time",
-//			//ExtendedBounds = new ExtendedBounds<DateMath>
-//			//{
-//			//	Minimum = FixedDate.AddYears(-1),
-//			//	Maximum = FixedDate.AddYears(1),
-//			//},
-//			Order = new[] { AggregateOrder.KeyAscending },
-//			Missing = DateTimeOffset.Parse("2015-06-06T12:01:02.1230000", styles: System.Globalization.DateTimeStyles.AssumeUniversal),
-//			Aggregations = new NestedAggregation("project_tags")
-//			{
-//				Path = Field<Project>(p => p.Tags),
-//				Aggregations = new TermsAggregation("tags")
-//				{
-//					Field = Field<Project>(p => p.Tags.First().Name)
-//				}
-//			}
-//		};
+	protected override AggregationDictionary InitializerAggs =>
+		new DateHistogramAggregation("projects_started_per_month")
+		{
+			Field = Field<Project>(p => p.StartedOn),
+			CalendarInterval = CalendarInterval.Month,
+			MinDocCount = 2,
+			Format = "yyyy-MM-dd'T'HH:mm:ss||date_optional_time",
+			//ExtendedBounds = new ExtendedBounds<DateMath>
+			//{
+			//	Minimum = FixedDate.AddYears(-1),
+			//	Maximum = FixedDate.AddYears(1),
+			//},
+			Order = new[] { AggregateOrder.KeyAscending },
+			Missing = DateTimeOffset.Parse("2015-06-06T12:01:02.1230000", styles: System.Globalization.DateTimeStyles.AssumeUniversal),
+			Aggregations = new NestedAggregation("project_tags")
+			{
+				Path = Field<Project>(p => p.Tags),
+				Aggregations = new TermsAggregation("tags")
+				{
+					Field = Field<Project>(p => p.Tags.First().Name)
+				}
+			}
+		};
 
-//	protected override void ExpectResponse(SearchResponse<Project> response)
-//	{
-//		response.ShouldBeValid();
+	protected override void ExpectResponse(SearchResponse<Project> response)
+	{
+		response.ShouldBeValid();
 
-//		var dateHistogram = response.Aggregations.GetDateHistogram("projects_started_per_month");
-//		dateHistogram.Should().NotBeNull();
-//		//dateHistogram.Buckets.Should().NotBeNull();
-//		//dateHistogram.Buckets.Count.Should().BeGreaterThan(10);
-//		//foreach (var item in dateHistogram.Buckets)
-//		//{
-//		//	item.Date.Should().NotBe(default(DateTime));
-//		//	item.DocCount.Should().BeGreaterThan(0);
+		var dateHistogram = response.Aggregations.GetDateHistogram("projects_started_per_month");
+		dateHistogram.Should().NotBeNull();
+		//dateHistogram.Buckets.Should().NotBeNull();
+		//dateHistogram.Buckets.Count.Should().BeGreaterThan(10);
+		//foreach (var item in dateHistogram.Buckets)
+		//{
+		//	item.Date.Should().NotBe(default(DateTime));
+		//	item.DocCount.Should().BeGreaterThan(0);
 
-//		//	var nested = item.Nested("project_tags");
-//		//	nested.Should().NotBeNull();
+		//	var nested = item.Nested("project_tags");
+		//	nested.Should().NotBeNull();
 
-//		//	var nestedTerms = nested.Terms("tags");
-//		//	nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
-//		//}
-//	}
-//}
+		//	var nestedTerms = nested.Terms("tags");
+		//	nestedTerms.Buckets.Count.Should().BeGreaterThan(0);
+		//}
+	}
+}


### PR DESCRIPTION
After the inheritance work, sub-aggregations for bucket aggregations were missing. The code-generator has been updated to copy these up from inherited classes.