### PR TITLE
Fix buckets type for multi-bucket aggregates

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Types/Aggregations/AggregateDictionary.cs
+++ b/src/Elastic.Clients.Elasticsearch/Types/Aggregations/AggregateDictionary.cs
@@ -49,35 +49,19 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 				return null;
 			}
 
-			Buckets<TermsBucket<TKey>> buckets = null;
-
 			switch (agg)
 			{
 				case EmptyTermsAggregate empty:
 					return new TermsAggregate<TKey>
 					{
-						Buckets = new Buckets<TermsBucket<TKey>>(Array.Empty<TermsBucket<TKey>>()),
+						Buckets = Array.Empty<TermsBucket<TKey>>().ToReadOnlyCollection(),
 						Meta = empty.Meta,
 						DocCountErrorUpperBound = empty.DocCountErrorUpperBound,
 						SumOtherDocCount = empty.SumOtherDocCount
 					};
 
 				case StringTermsAggregate stringTerms:
-					stringTerms.Buckets.Match(a =>
-					{
-						var dict = new Dictionary<string, TermsBucket<TKey>>();
-						foreach (var item in a)
-						{
-							var key = item.Key;
-							var value = item.Value;
-							dict.Add(key, new TermsBucket<TKey>(value.BackingDictionary) { DocCount = value.DocCount, DocCountError = value.DocCountError, Key = GetKeyFromBucketKey<TKey>(value.Key), KeyAsString = value.Key });
-						}
-						buckets = new(dict);
-					}, a =>
-					{
-						buckets = new(a.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.Key }).ToReadOnlyCollection());
-					});
-
+					var buckets = stringTerms.Buckets.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.Key }).ToReadOnlyCollection();
 					return new TermsAggregate<TKey>
 					{
 						Buckets = buckets,
@@ -87,48 +71,20 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 					};
 
 				case DoubleTermsAggregate doubleTerms:
-					doubleTerms.Buckets.Match(a =>
-					{
-						var dict = new Dictionary<string, TermsBucket<TKey>>();
-						foreach (var item in a)
-						{
-							var key = item.Key;
-							var value = item.Value;
-							dict.Add(key, new TermsBucket<TKey>(value.BackingDictionary) { DocCount = value.DocCount, DocCountError = value.DocCountError, Key = GetKeyFromBucketKey<TKey>(value.Key), KeyAsString = value.KeyAsString });
-						}
-						buckets = new(dict);
-					}, a =>
-					{
-						buckets = new(a.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.KeyAsString }).ToReadOnlyCollection());
-					});
-
+					var doubleTermsBuckets = doubleTerms.Buckets.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.KeyAsString }).ToReadOnlyCollection();
 					return new TermsAggregate<TKey>
 					{
-						Buckets = buckets,
+						Buckets = doubleTermsBuckets,
 						Meta = doubleTerms.Meta,
 						DocCountErrorUpperBound = doubleTerms.DocCountErrorUpperBound,
 						SumOtherDocCount = doubleTerms.SumOtherDocCount
 					};
 
 				case LongTermsAggregate longTerms:
-					longTerms.Buckets.Match(a =>
-					{
-						var dict = new Dictionary<string, TermsBucket<TKey>>();
-						foreach (var item in a)
-						{
-							var key = item.Key;
-							var value = item.Value;
-							dict.Add(key, new TermsBucket<TKey>(value.BackingDictionary) { DocCount = value.DocCount, DocCountError = value.DocCountError, Key = GetKeyFromBucketKey<TKey>(value.Key), KeyAsString = value.KeyAsString });
-						}
-						buckets = new(dict);
-					}, a =>
-					{
-						buckets = new(a.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.KeyAsString }).ToReadOnlyCollection());
-					});
-
+					var longTermsBuckets = longTerms.Buckets.Select(b => new TermsBucket<TKey>(b.BackingDictionary) { DocCount = b.DocCount, DocCountError = b.DocCountError, Key = GetKeyFromBucketKey<TKey>(b.Key), KeyAsString = b.KeyAsString }).ToReadOnlyCollection();
 					return new TermsAggregate<TKey>
 					{
-						Buckets = buckets,
+						Buckets = longTermsBuckets,
 						Meta = longTerms.Meta,
 						DocCountErrorUpperBound = longTerms.DocCountErrorUpperBound,
 						SumOtherDocCount = longTerms.SumOtherDocCount

--- a/src/Elastic.Clients.Elasticsearch/Types/Aggregations/TermsAggregate.cs
+++ b/src/Elastic.Clients.Elasticsearch/Types/Aggregations/TermsAggregate.cs
@@ -19,7 +19,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Buckets<TermsBucket<TKey>> Buckets { get; init; }
+		public IReadOnlyCollection<TermsBucket<TKey>> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AdjacencyMatrixAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AdjacencyMatrixAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.AdjacencyMatrixBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.AdjacencyMatrixBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AutoDateHistogramAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/AutoDateHistogramAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.DateHistogramBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.DateHistogramBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("interval")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/CompositeAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/CompositeAggregate.g.cs
@@ -32,7 +32,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.CompositeBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.CompositeBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.DateHistogramBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.DateHistogramBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.RangeBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.RangeBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DoubleTermsAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DoubleTermsAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.DoubleTermsBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.DoubleTermsBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("doc_count_error_upper_bound")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/FiltersAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/FiltersAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.FiltersBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.FiltersBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.HistogramBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.HistogramBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.IpRangeBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.IpRangeBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/LongTermsAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/LongTermsAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.LongTermsBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.LongTermsBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("doc_count_error_upper_bound")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.MultiTermsBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.MultiTermsBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("doc_count_error_upper_bound")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.RangeBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.RangeBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/StringTermsAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/StringTermsAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.StringTermsBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.StringTermsBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("doc_count_error_upper_bound")]

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/VariableWidthHistogramAggregate.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/VariableWidthHistogramAggregate.g.cs
@@ -28,7 +28,7 @@ namespace Elastic.Clients.Elasticsearch.Aggregations
 	{
 		[JsonInclude]
 		[JsonPropertyName("buckets")]
-		public Elastic.Clients.Elasticsearch.Aggregations.Buckets<Elastic.Clients.Elasticsearch.Aggregations.VariableWidthHistogramBucket> Buckets { get; init; }
+		public IReadOnlyCollection<Elastic.Clients.Elasticsearch.Aggregations.VariableWidthHistogramBucket> Buckets { get; init; }
 
 		[JsonInclude]
 		[JsonPropertyName("meta")]

--- a/tests/Tests/Aggregations/Bucket/TermsAggregationUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/TermsAggregationUsageTests.cs
@@ -97,7 +97,7 @@ public class TermsAggregationUsageTests : AggregationUsageTestBase<ReadOnlyClust
 		states.SumOtherDocCount.Should().BeGreaterOrEqualTo(0);
 		states.Buckets.Should().NotBeNull();
 
-		var bucketsCollection = states.Buckets.Item2;
+		var bucketsCollection = states.Buckets;
 
 		bucketsCollection.Count.Should().BeGreaterThan(0);
 		foreach (var item in bucketsCollection)

--- a/tests/Tests/Serialization/Aggregations/BucketSubAggregationSerializationTests.cs
+++ b/tests/Tests/Serialization/Aggregations/BucketSubAggregationSerializationTests.cs
@@ -20,7 +20,7 @@ public class BucketSubAggregationSerializationTests : SerializerTestBase
 
 		dateHistogramAgg.Should().NotBeNull();
 
-		var bucketsCollection = dateHistogramAgg.Buckets.Item2;
+		var bucketsCollection = dateHistogramAgg.Buckets;
 		bucketsCollection.Should().HaveCount(1);
 
 		var dateBucket = bucketsCollection.First();

--- a/tests/Tests/Serialization/Aggregations/ChildrenAggregateSerializationTests.cs
+++ b/tests/Tests/Serialization/Aggregations/ChildrenAggregateSerializationTests.cs
@@ -16,10 +16,10 @@ public class ChildrenAggregateSerializationTests : SerializerTestBase
 		var searchResponse = DeserializeJsonString<SearchResponse<object>>(json);
 
 		var topTagsTermsAggregate = searchResponse.Aggregations.GetTerms("top-tags");
-		var firstTopTagsBucket = topTagsTermsAggregate.Buckets.Item2.Single();
+		var firstTopTagsBucket = topTagsTermsAggregate.Buckets.Single();
 		var childrenAggregate = firstTopTagsBucket.GetChildren("to-answers");
 		var topNamesAggregate = childrenAggregate.GetTerms("top-names");
-		var firstTopNameBucket = topNamesAggregate.Buckets.Item2.First();
+		var firstTopNameBucket = topNamesAggregate.Buckets.First();
 		firstTopNameBucket.Key.Should().Be("Sam");
 	}
 }

--- a/tests/Tests/Serialization/Aggregations/TermsAggregateDeserializationTests.cs
+++ b/tests/Tests/Serialization/Aggregations/TermsAggregateDeserializationTests.cs
@@ -24,7 +24,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		var termsAgg = search.Aggregations.GetStringTerms("my-agg-name");
 		termsAgg.DocCountErrorUpperBound.Should().Be(10);
 		termsAgg.SumOtherDocCount.Should().Be(200);
-		var bucketCollection = termsAgg.Buckets.Item2;
+		var bucketCollection = termsAgg.Buckets;
 		bucketCollection.Should().HaveCount(2);
 
 		var firstBucket = bucketCollection.First();
@@ -54,7 +54,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		termsAgg.DocCountErrorUpperBound.Should().Be(10);
 		termsAgg.SumOtherDocCount.Should().Be(200);
 
-		var bucketCollection = termsAgg.Buckets.Item2;
+		var bucketCollection = termsAgg.Buckets;
 		bucketCollection.Should().HaveCount(2);
 
 		var firstBucket = bucketCollection.First();
@@ -86,7 +86,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		termsAgg.DocCountErrorUpperBound.Should().Be(10);
 		termsAgg.SumOtherDocCount.Should().Be(200);
 
-		var bucketCollection = termsAgg.Buckets.Item2;
+		var bucketCollection = termsAgg.Buckets;
 		bucketCollection.Should().HaveCount(2);
 
 		var firstBucket = bucketCollection.First();
@@ -119,7 +119,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		termsAgg.DocCountErrorUpperBound.Should().Be(10);
 		termsAgg.SumOtherDocCount.Should().Be(200);
 
-		var bucketCollection = termsAgg.Buckets.Item2;
+		var bucketCollection = termsAgg.Buckets;
 
 		var firstBucket = bucketCollection.First();
 		firstBucket.Key.Should().HaveCount(2);
@@ -154,7 +154,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		termsAgg.DocCountErrorUpperBound.Should().Be(10);
 		termsAgg.SumOtherDocCount.Should().Be(200);
 
-		var bucketCollection = termsAgg.Buckets.Item2;
+		var bucketCollection = termsAgg.Buckets;
 
 		bucketCollection.Should().HaveCount(2);
 
@@ -201,7 +201,7 @@ public class TermsAggregateDeserializationTests : SerializerTestBase
 		var response = DeserializeJsonString<SearchResponse<object>>(json);
 
 		var termsAgg = response.Aggregations.GetTerms("my-agg-name");
-		var avgAgg = termsAgg.Buckets.Item2.Single().GetAverage("my-sub-agg-name");
+		var avgAgg = termsAgg.Buckets.Single().GetAverage("my-sub-agg-name");
 		avgAgg.Value.Should().Be(75.0);
 	}
 }


### PR DESCRIPTION
After flattening the inheritance hierarchy for types, multi-bucket aggregates lost their derived manual handling for the buckets property which opts to avoid the use of a union by preventing the use of keyed buckets. This PR reapplies the fixup for these types as part of code generation.