### PR TITLE
Add script property to variable width histogram

### DIFF
--- a/src/Nest/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
@@ -24,9 +24,12 @@ namespace Nest
 
 		[DataMember(Name = "initial_buffer")]
 		int? InitialBuffer { get; set; }
-		
+
 		[DataMember(Name = "shard_size")]
 		int? ShardSize { get; set; }
+
+		[DataMember(Name = "script")]
+		string Script { get; set; }
 	}
 
 	public class VariableWidthHistogramAggregation : BucketAggregationBase, IVariableWidthHistogramAggregation
@@ -42,6 +45,8 @@ namespace Nest
 		/// <inheritdoc />
 		public int? ShardSize { get; set; }
 
+		public string Script { get; set; }
+
 		internal override void WrapInContainer(AggregationContainer c) => c.VariableWidthHistogram = this;
 	}
 
@@ -53,6 +58,7 @@ namespace Nest
 		int? IVariableWidthHistogramAggregation.Buckets { get; set; }
 		int? IVariableWidthHistogramAggregation.InitialBuffer { get; set; }
 		int? IVariableWidthHistogramAggregation.ShardSize { get; set; }
+		string IVariableWidthHistogramAggregation.Script { get; set; }
 
 		/// <inheritdoc cref="IVariableWidthHistogramAggregation.Field" />
 		public VariableWidthHistogramAggregationDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
@@ -68,5 +74,8 @@ namespace Nest
 
 		/// <inheritdoc cref="IVariableWidthHistogramAggregation.ShardSize" />
 		public VariableWidthHistogramAggregationDescriptor<T> ShardSize(int? shardSize) => Assign(shardSize, (a, v) => a.ShardSize = v);
+
+		/// <inheritdoc cref="IVariableWidthHistogramAggregation.Script" />
+		public VariableWidthHistogramAggregationDescriptor<T> Script(string script) => Assign(script, (a, v) => a.Script = v);
 	}
 }

--- a/src/Nest/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
+++ b/src/Nest/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramAggregation.cs
@@ -29,7 +29,7 @@ namespace Nest
 		int? ShardSize { get; set; }
 
 		[DataMember(Name = "script")]
-		string Script { get; set; }
+		IScript Script { get; set; }
 	}
 
 	public class VariableWidthHistogramAggregation : BucketAggregationBase, IVariableWidthHistogramAggregation
@@ -45,7 +45,7 @@ namespace Nest
 		/// <inheritdoc />
 		public int? ShardSize { get; set; }
 
-		public string Script { get; set; }
+		public IScript Script { get; set; }
 
 		internal override void WrapInContainer(AggregationContainer c) => c.VariableWidthHistogram = this;
 	}
@@ -58,7 +58,7 @@ namespace Nest
 		int? IVariableWidthHistogramAggregation.Buckets { get; set; }
 		int? IVariableWidthHistogramAggregation.InitialBuffer { get; set; }
 		int? IVariableWidthHistogramAggregation.ShardSize { get; set; }
-		string IVariableWidthHistogramAggregation.Script { get; set; }
+		IScript IVariableWidthHistogramAggregation.Script { get; set; }
 
 		/// <inheritdoc cref="IVariableWidthHistogramAggregation.Field" />
 		public VariableWidthHistogramAggregationDescriptor<T> Field(Field field) => Assign(field, (a, v) => a.Field = v);
@@ -76,6 +76,10 @@ namespace Nest
 		public VariableWidthHistogramAggregationDescriptor<T> ShardSize(int? shardSize) => Assign(shardSize, (a, v) => a.ShardSize = v);
 
 		/// <inheritdoc cref="IVariableWidthHistogramAggregation.Script" />
-		public VariableWidthHistogramAggregationDescriptor<T> Script(string script) => Assign(script, (a, v) => a.Script = v);
+		public VariableWidthHistogramAggregationDescriptor<T> Script(string script) => Assign((InlineScript)script, (a, v) => a.Script = v);
+
+		/// <inheritdoc cref="IVariableWidthHistogramAggregation.Script" />
+		public VariableWidthHistogramAggregationDescriptor<T> Script(Func<ScriptDescriptor, IScript> scriptSelector) =>
+			Assign(scriptSelector, (a, v) => a.Script = v?.Invoke(new ScriptDescriptor()));
 	}
 }

--- a/tests/Tests/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramUsageTests.cs
+++ b/tests/Tests/Aggregations/Bucket/VariableWidthHistogram/VariableWidthHistogramUsageTests.cs
@@ -106,7 +106,9 @@ namespace Tests.Aggregations.Bucket.VariableWidthHistogram
 					buckets = 2,
 					initial_buffer = 2,
 					shard_size = 100,
-					script = Script
+					script = new {
+						source = Script
+					}
 				}
 			}
 		};
@@ -129,7 +131,7 @@ namespace Tests.Aggregations.Bucket.VariableWidthHistogram
 				Buckets = 2,
 				InitialBuffer = 2,
 				ShardSize = 100,
-				Script = Script,
+				Script = new InlineScript(Script),
 				Meta = new Dictionary<string, object>
 				{
 					{ "foo", "bar" }


### PR DESCRIPTION
A very minor feature enhancement. ElasticSearch supports an inline script property on the VariableWidthHistogram. This PR makes this supported by the high level NEST client.

This is already supported by the `MultiTermsAggregation` https://github.com/elastic/elasticsearch-net/blob/96f36d0bbd47aefd781502cf0373df81ad686602/src/Nest/Aggregations/Bucket/MultiTerms/MultiTermsAggregation.cs#L54

--
There is a useful use-case for this enhancement which is to bucket ranges on the log scale on the VariableWidthHistogram. This results in a more even distribution.

Example of use case

```
GET arc-37-5/_search
{
	"aggs": {
		"prices": {
			"variable_width_histogram": {
				"field": "lot.sold_prices_usd",
				"script": {
				  "source": "Math.log10(_value)"
				},
				"buckets": 300
			}
		}
	},
	"size": 0
}
```

```
{
  "took" : 0,
  "timed_out" : false,
  "_shards" : {
    "total" : 1,
    "successful" : 1,
    "skipped" : 0,
    "failed" : 0
  },
  "hits" : {
    "total" : {
      "value" : 10000,
      "relation" : "gte"
    },
    "max_score" : null,
    "hits" : [ ]
  },
  "aggregations" : {
    "prices" : {
      "buckets" : [
        {
          "min" : 0.0,
          "key" : 0.20126268733718639,
          "max" : 0.6989700043360189,
          "doc_count" : 585
        },
        {
          "min" : 0.7781512503836436,
          "key" : 2.036468418035862,
          "max" : 2.294415862797104,
          "doc_count" : 11561
        },
        {
          "min" : 2.294415862797104,
          "key" : 3.4601699053739163,
          "max" : 4.910529536362189,
          "doc_count" : 2103060
        },
        {
          "min" : 4.910529536362189,
          "key" : 5.365584337340739,
          "max" : 7.101131689337512,
          "doc_count" : 82957
        },
        {
          "min" : 7.101131689337512,
          "key" : 7.3633284959971546,
          "max" : 8.04433197055116,
          "doc_count" : 360
        }
      ]
    }
  }
}

```

The log values can then be converted back to the original values afterwards.
