### PR TITLE
[Backport 8.2][DOCS] Removes outdated pages from docs

### DIFF
--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -71,12 +71,11 @@ disk which is used to sign the certificates for the HTTP layer of the {es}
 cluster.
 
 In order for the client to establish a connection with the cluster over HTTPS, 
-the CA certificate must be trusted by the client application. There are several 
-mechanisms for <<working-with-certificates, working with certificates>>, but the 
-simplest choice is to use the hex-encoded SHA-256 fingerprint of the CA 
-certificate. The CA fingerprint is output to the terminal when you start {es} 
-for the first time. You'll see a distinct block like the one 
-below in the output from {es} (you may have to scroll up if it's been a while):
+the CA certificate must be trusted by the client application. The simplest 
+choice is to use the hex-encoded SHA-256 fingerprint of the CA certificate. The 
+CA fingerprint is output to the terminal when you start {es} for the first time. 
+You'll see a distinct block like the one below in the output from {es} (you may 
+have to scroll up if it's been a while):
 
 ```sh
 ----------------------------------------------------------------
@@ -144,9 +143,7 @@ nodes for each request in a round robin fashion. The client also tracks
 unhealthy nodes and avoids sending requests to them until they become healthy.
 
 This configuration is best suited to connect to a known small sized cluster, 
-where you do not require sniffing to detect the cluster topology. Refer to the 
-<<connection-pooling,node pool documentation>> for more information about the 
-types of node pool available in the {es} .NET client.
+where you do not require sniffing to detect the cluster topology.
 
 The following snippet shows you how to connect to multiple nodes by using a 
 static node pool:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -18,17 +18,7 @@ include::configuration.asciidoc[]
 
 include::breaking-changes.asciidoc[]
 
-include::conventions.asciidoc[]
-
-include::high-level.asciidoc[]
-
 include::troubleshooting.asciidoc[]
-
-include::search.asciidoc[]
-
-include::query-dsl.asciidoc[]
-
-include::aggregations.asciidoc[]
 
 include::redirects.asciidoc[]
 

--- a/docs/redirects.asciidoc
+++ b/docs/redirects.asciidoc
@@ -7,3 +7,8 @@ The following pages have moved or been deleted.
 == Configuration options
 
 This page has moved. See <<configuration>>.
+
+[role="exclude",id="nest"]
+== NEST - High level client
+
+This page has been deleted.


### PR DESCRIPTION
## Overview

This PR backports the changes of https://github.com/elastic/elasticsearch-net/pull/6655 to the 8.2 branch.