### PR TITLE
[DOCS] Sets the shared attribute ref_current to ref

### DIFF
--- a/docs/aggregations/aggregation-meta-usage.asciidoc
+++ b/docs/aggregations/aggregation-meta-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/aggregation-meta-usage.asciidoc
+++ b/docs/aggregations/aggregation-meta-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
+++ b/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
+++ b/docs/aggregations/bucket/adjacency-matrix/adjacency-matrix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/auto-date-histogram/auto-date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/children/children-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/composite/composite-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-histogram/date-histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/date-range/date-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/diversified-sampler/diversified-sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/diversified-sampler/diversified-sampler-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/diversified-sampler/diversified-sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/diversified-sampler/diversified-sampler-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filter/filter-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/filters/filters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-distance/geo-distance-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-hash-grid/geo-hash-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/geo-tile-grid/geo-tile-grid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/global/global-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/histogram/histogram-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/ip-range/ip-range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/missing/missing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/multi-terms/multi-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/multi-terms/multi-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/multi-terms/multi-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/multi-terms/multi-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/nested/nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/parent/parent-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/range/range-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/rare-terms/rare-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/rare-terms/rare-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/rare-terms/rare-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/rare-terms/rare-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/reverse-nested/reverse-nested-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/sampler/sampler-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-terms/significant-terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/significant-text/significant-text-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
+++ b/docs/aggregations/bucket/terms/terms-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/matrix/matrix-stats/matrix-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/average/average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/boxplot/boxplot-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/cardinality/cardinality-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/extended-stats/extended-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-bounds/geo-bounds-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-centroid/geo-centroid-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-line/geo-line-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-line/geo-line-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/geo-line/geo-line-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/geo-line/geo-line-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/max/max-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/median-absolute-deviation/median-absolute-deviation-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/min/min-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentile-ranks/percentile-ranks-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/percentiles/percentiles-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/rate/rate-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/rate/rate-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/rate/rate-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/rate/rate-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/scripted-metric/scripted-metric-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/stats/stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/string-stats/string-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/string-stats/string-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/string-stats/string-stats-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/string-stats/string-stats-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/sum/sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/t-test/t-test-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/t-test/t-test-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/t-test/t-test-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/t-test/t-test-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-hits/top-hits-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/top-metrics/top-metrics-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/value-count/value-count-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
+++ b/docs/aggregations/metric/weighted-average/weighted-average-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/average-bucket/average-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-script/bucket-script-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-selector/bucket-selector-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/bucket-sort/bucket-sort-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/cumulative-cardinality/cumulative-cardinality-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/cumulative-cardinality/cumulative-cardinality-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/cumulative-cardinality/cumulative-cardinality-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/cumulative-cardinality/cumulative-cardinality-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/cumulative-sum/cumulative-sum-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/derivative/derivative-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/extended-stats-bucket/extended-stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/max-bucket/max-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/min-bucket/min-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-ewma-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-holt-winters-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-linear-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-average/moving-average-simple-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-function/moving-function-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-percentiles/moving-percentiles-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-percentiles/moving-percentiles-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/moving-percentiles/moving-percentiles-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/moving-percentiles/moving-percentiles-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/normalize/normalize-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/normalize/normalize-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/normalize/normalize-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/normalize/normalize-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/percentiles-bucket/percentiles-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/serial-differencing/serial-differencing-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/stats-bucket/stats-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
+++ b/docs/aggregations/pipeline/sum-bucket/sum-bucket-aggregation-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/reserved-aggregation-names.asciidoc
+++ b/docs/aggregations/reserved-aggregation-names.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/reserved-aggregation-names.asciidoc
+++ b/docs/aggregations/reserved-aggregation-names.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/writing-aggregations.asciidoc
+++ b/docs/aggregations/writing-aggregations.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/aggregations/writing-aggregations.asciidoc
+++ b/docs/aggregations/writing-aggregations.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/analysis/analysis-usage.asciidoc
+++ b/docs/analysis/analysis-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/analysis/analysis-usage.asciidoc
+++ b/docs/analysis/analysis-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/analysis/token-filters/token-filter-usage.asciidoc
+++ b/docs/analysis/token-filters/token-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/certificates/working-with-certificates.asciidoc
+++ b/docs/client-concepts/certificates/working-with-certificates.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/certificates/working-with-certificates.asciidoc
+++ b/docs/client-concepts/certificates/working-with-certificates.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/connection-pooling.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/date-time-providers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/keeping-track-of-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/request-pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
+++ b/docs/client-concepts/connection-pooling/building-blocks/transports.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unexpected-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
+++ b/docs/client-concepts/connection-pooling/exceptions/unrecoverable-exceptions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
+++ b/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
+++ b/docs/client-concepts/connection-pooling/failover/falling-over.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
+++ b/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
+++ b/docs/client-concepts/connection-pooling/max-retries/respects-max-retry.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/first-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
+++ b/docs/client-concepts/connection-pooling/pinging/revival.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/disable-sniff-ping-per-request.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/request-timeouts-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-allowed-status-code.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-force-node.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
+++ b/docs/client-concepts/connection-pooling/request-overrides/respects-max-retry-overrides.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}ranch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/round-robin.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}ranch}
+ranch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/round-robin/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/address-parsing.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-connection-failure.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-stale-cluster-state.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/on-startup.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
+++ b/docs/client-concepts/connection-pooling/sniffing/role-detection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/skip-dead-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky-sniffing-connection-pool.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
+++ b/docs/client-concepts/connection-pooling/sticky/sticky.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/configuration-options.asciidoc
+++ b/docs/client-concepts/connection/configuration-options.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/function-as-a-service-environments.asciidoc
+++ b/docs/client-concepts/connection/function-as-a-service-environments.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/function-as-a-service-environments.asciidoc
+++ b/docs/client-concepts/connection/function-as-a-service-environments.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/modifying-default-connection.asciidoc
+++ b/docs/client-concepts/connection/modifying-default-connection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/connection/modifying-default-connection.asciidoc
+++ b/docs/client-concepts/connection/modifying-default-connection.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/testing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
+++ b/docs/client-concepts/high-level/analysis/writing-analyzers.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
+++ b/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
+++ b/docs/client-concepts/high-level/covariant-hits/covariant-search-results.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/getting-started.asciidoc
+++ b/docs/client-concepts/high-level/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/getting-started.asciidoc
+++ b/docs/client-concepts/high-level/getting-started.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
+++ b/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
+++ b/docs/client-concepts/high-level/indexing/indexing-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
+++ b/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
+++ b/docs/client-concepts/high-level/indexing/ingest-nodes.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/pipelines.asciidoc
+++ b/docs/client-concepts/high-level/indexing/pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/pipelines.asciidoc
+++ b/docs/client-concepts/high-level/indexing/pipelines.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/reindexing-documents.asciidoc
+++ b/docs/client-concepts/high-level/indexing/reindexing-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/indexing/reindexing-documents.asciidoc
+++ b/docs/client-concepts/high-level/indexing/reindexing-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/document-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/document-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/document-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/document-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/field-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/field-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/ids-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/ids-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/ids-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/ids-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/index-name-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/indices-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/indices-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/indices-paths.asciidoc
+++ b/docs/client-concepts/high-level/inference/indices-paths.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/property-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/property-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/property-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/property-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/routing-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/routing-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/routing-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/routing-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
+++ b/docs/client-concepts/high-level/inference/types-and-relations-inference.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/attribute-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/auto-map.asciidoc
+++ b/docs/client-concepts/high-level/mapping/auto-map.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/auto-map.asciidoc
+++ b/docs/client-concepts/high-level/mapping/auto-map.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/fluent-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
+++ b/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
+++ b/docs/client-concepts/high-level/mapping/ignoring-properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
+++ b/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
+++ b/docs/client-concepts/high-level/mapping/multi-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
+++ b/docs/client-concepts/high-level/mapping/parent-child-relationships.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
+++ b/docs/client-concepts/high-level/mapping/visitor-pattern-mapping.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
+++ b/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
+++ b/docs/client-concepts/high-level/serialization/custom-serialization.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/extending-nest-types.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/modelling-documents-with-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/modelling-documents-with-types.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/high-level/serialization/modelling-documents-with-types.asciidoc
+++ b/docs/client-concepts/high-level/serialization/modelling-documents-with-types.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/audit-trail.asciidoc
+++ b/docs/client-concepts/troubleshooting/audit-trail.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/audit-trail.asciidoc
+++ b/docs/client-concepts/troubleshooting/audit-trail.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/debug-information.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-information.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/debug-information.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-information.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/debug-mode.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-mode.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/debug-mode.asciidoc
+++ b/docs/client-concepts/troubleshooting/debug-mode.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
+++ b/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
+++ b/docs/client-concepts/troubleshooting/deprecation-logging.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
+++ b/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
+++ b/docs/client-concepts/troubleshooting/diagnostic-source.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-fiddler.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
+++ b/docs/client-concepts/troubleshooting/logging-with-on-request-completed.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/descriptors.asciidoc
+++ b/docs/code-standards/descriptors.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/descriptors.asciidoc
+++ b/docs/code-standards/descriptors.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/elastic-client.asciidoc
+++ b/docs/code-standards/elastic-client.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/elastic-client.asciidoc
+++ b/docs/code-standards/elastic-client.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/naming-conventions.asciidoc
+++ b/docs/code-standards/naming-conventions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/naming-conventions.asciidoc
+++ b/docs/code-standards/naming-conventions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/queries.asciidoc
+++ b/docs/code-standards/queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/queries.asciidoc
+++ b/docs/code-standards/queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/requests.asciidoc
+++ b/docs/code-standards/requests.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/requests.asciidoc
+++ b/docs/code-standards/requests.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/responses.asciidoc
+++ b/docs/code-standards/responses.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/responses.asciidoc
+++ b/docs/code-standards/responses.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/serialization/formatters.asciidoc
+++ b/docs/code-standards/serialization/formatters.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/serialization/formatters.asciidoc
+++ b/docs/code-standards/serialization/formatters.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/serialization/properties.asciidoc
+++ b/docs/code-standards/serialization/properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/code-standards/serialization/properties.asciidoc
+++ b/docs/code-standards/serialization/properties.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/date-math/date-math-expressions.asciidoc
+++ b/docs/common-options/date-math/date-math-expressions.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/distance-unit/distance-units.asciidoc
+++ b/docs/common-options/distance-unit/distance-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/distance-unit/distance-units.asciidoc
+++ b/docs/common-options/distance-unit/distance-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/time-unit/time-units.asciidoc
+++ b/docs/common-options/time-unit/time-units.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/union/union.asciidoc
+++ b/docs/common-options/union/union.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/common-options/union/union.asciidoc
+++ b/docs/common-options/union/union.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -112,7 +112,7 @@ SHA256 Fingerprint=<FINGERPRINT>
 ----
 
 Visit the 
-{ref}/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
+{ref-current}/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
 
 The following snippet shows you how to create a client instance that connects to 
 your {es} cluster via a single node, using the CA fingerprint:

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -112,7 +112,7 @@ SHA256 Fingerprint=<FINGERPRINT>
 ----
 
 Visit the 
-https://www.elastic.co/guide/en/elasticsearch/reference/master/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
+https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
 
 The following snippet shows you how to create a client instance that connects to 
 your {es} cluster via a single node, using the CA fingerprint:

--- a/docs/connecting.asciidoc
+++ b/docs/connecting.asciidoc
@@ -112,7 +112,7 @@ SHA256 Fingerprint=<FINGERPRINT>
 ----
 
 Visit the 
-https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
+{ref}/configuring-stack-security.html[Connect clients to {es}] documentation for more information.
 
 The following snippet shows you how to create a client instance that connects to 
 your {es} cluster via a single node, using the CA fingerprint:

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 = Elasticsearch .NET Client
 
 :net-client: Elasticsearch .NET Client
-:ref-branch: main
+:ref-branch: {ref}
 
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,7 +4,7 @@
 = Elasticsearch .NET Client
 
 :net-client: Elasticsearch .NET Client
-:ref-branch: {ref}
+:ref-current: {ref}
 
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/docs/index.asciidoc
+++ b/docs/index.asciidoc
@@ -4,6 +4,7 @@
 = Elasticsearch .NET Client
 
 :net-client: Elasticsearch .NET Client
+:ref-branch: main
 
 
 include::{asciidoc-dir}/../../shared/attributes.asciidoc[]

--- a/docs/mapping/local-metadata/local-metadata-usage.asciidoc
+++ b/docs/mapping/local-metadata/local-metadata-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/mapping/local-metadata/local-metadata-usage.asciidoc
+++ b/docs/mapping/local-metadata/local-metadata-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/mapping/scalar/scalar-usage.asciidoc
+++ b/docs/mapping/scalar/scalar-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/mapping/scalar/scalar-usage.asciidoc
+++ b/docs/mapping/scalar/scalar-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
+++ b/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
+++ b/docs/query-dsl/bool-dsl/bool-dsl.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-dsl-complex-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
+++ b/docs/query-dsl/compound/bool/bool-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
+++ b/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
+++ b/docs/query-dsl/compound/boosting/boosting-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/constant-score/constant-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
+++ b/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
+++ b/docs/query-dsl/compound/dismax/dismax-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
+++ b/docs/query-dsl/compound/function-score/function-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/combined-fields/combined-fields-usage.asciidoc
+++ b/docs/query-dsl/full-text/combined-fields/combined-fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/combined-fields/combined-fields-usage.asciidoc
+++ b/docs/query-dsl/full-text/combined-fields/combined-fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
+++ b/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
+++ b/docs/query-dsl/full-text/common-terms/common-terms-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
+++ b/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
+++ b/docs/query-dsl/full-text/intervals/intervals-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-bool-prefix/match-bool-prefix-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-bool-prefix/match-bool-prefix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-bool-prefix/match-bool-prefix-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-bool-prefix/match-bool-prefix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase-prefix/match-phrase-prefix-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
+++ b/docs/query-dsl/full-text/match-phrase/match-phrase-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match/match-usage.asciidoc
+++ b/docs/query-dsl/full-text/match/match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/match/match-usage.asciidoc
+++ b/docs/query-dsl/full-text/match/match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
+++ b/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
+++ b/docs/query-dsl/full-text/multi-match/multi-match-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/query-string/query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
+++ b/docs/query-dsl/full-text/simple-query-string/simple-query-string-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
+++ b/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
+++ b/docs/query-dsl/geo/bounding-box/geo-bounding-box-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
+++ b/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
+++ b/docs/query-dsl/geo/distance/geo-distance-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/geo-shape/geo-shape-query-usage.asciidoc
+++ b/docs/query-dsl/geo/geo-shape/geo-shape-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/geo-shape/geo-shape-query-usage.asciidoc
+++ b/docs/query-dsl/geo/geo-shape/geo-shape-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
+++ b/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
+++ b/docs/query-dsl/geo/polygon/geo-polygon-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-child/has-child-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
+++ b/docs/query-dsl/joining/has-parent/has-parent-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
+++ b/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
+++ b/docs/query-dsl/joining/nested/nested-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
+++ b/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
+++ b/docs/query-dsl/joining/parent-id/parent-id-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/match-none-query-usage.asciidoc
+++ b/docs/query-dsl/match-none-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/match-none-query-usage.asciidoc
+++ b/docs/query-dsl/match-none-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-combine-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
+++ b/docs/query-dsl/nest-specific/raw/raw-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
+++ b/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
+++ b/docs/query-dsl/span/containing/span-containing-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
+++ b/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
+++ b/docs/query-dsl/span/field-masking/span-field-masking-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/first/span-first-query-usage.asciidoc
+++ b/docs/query-dsl/span/first/span-first-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/first/span-first-query-usage.asciidoc
+++ b/docs/query-dsl/span/first/span-first-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/multi-term/span-multi-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/near/span-near-query-usage.asciidoc
+++ b/docs/query-dsl/span/near/span-near-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/near/span-near-query-usage.asciidoc
+++ b/docs/query-dsl/span/near/span-near-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/not/span-not-query-usage.asciidoc
+++ b/docs/query-dsl/span/not/span-not-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/not/span-not-query-usage.asciidoc
+++ b/docs/query-dsl/span/not/span-not-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/or/span-or-query-usage.asciidoc
+++ b/docs/query-dsl/span/or/span-or-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/or/span-or-query-usage.asciidoc
+++ b/docs/query-dsl/span/or/span-or-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/term/span-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/term/span-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/term/span-term-query-usage.asciidoc
+++ b/docs/query-dsl/span/term/span-term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/within/span-within-query-usage.asciidoc
+++ b/docs/query-dsl/span/within/span-within-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/span/within/span-within-query-usage.asciidoc
+++ b/docs/query-dsl/span/within/span-within-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/distance-feature/distance-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/distance-feature/distance-feature-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/distance-feature/distance-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/distance-feature/distance-feature-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-full-document-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/more-like-this/more-like-this-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/percolate/percolate-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/pinned/pinned-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/pinned/pinned-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/pinned/pinned-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/pinned/pinned-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/rank-feature/rank-feature-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script-score/script-score-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/script/script-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script/script-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/script/script-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/script/script-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/shape/shape-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/shape/shape-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/specialized/shape/shape-query-usage.asciidoc
+++ b/docs/query-dsl/specialized/shape/shape-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/exists/exists-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-date-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-numeric-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/fuzzy/fuzzy-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/ids/ids-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/prefix/prefix-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/date-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/long-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/numeric-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/range/term-range-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/regexp/regexp-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/term/term-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/term/term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/term/term-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/term/term-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms-set/terms-set-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-list-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-lookup-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/terms/terms-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
+++ b/docs/query-dsl/term-level/wildcard/wildcard-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
+++ b/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
+++ b/docs/query-dsl/verbatim/verbatim-and-strict-query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/explain-usage.asciidoc
+++ b/docs/search/request/explain-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/explain-usage.asciidoc
+++ b/docs/search/request/explain-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/fields-usage.asciidoc
+++ b/docs/search/request/fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/fields-usage.asciidoc
+++ b/docs/search/request/fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/from-and-size-usage.asciidoc
+++ b/docs/search/request/from-and-size-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/from-and-size-usage.asciidoc
+++ b/docs/search/request/from-and-size-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/highlighting-usage.asciidoc
+++ b/docs/search/request/highlighting-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/highlighting-usage.asciidoc
+++ b/docs/search/request/highlighting-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/indices-boost-usage.asciidoc
+++ b/docs/search/request/indices-boost-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/indices-boost-usage.asciidoc
+++ b/docs/search/request/indices-boost-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/inner-hits-usage.asciidoc
+++ b/docs/search/request/inner-hits-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/inner-hits-usage.asciidoc
+++ b/docs/search/request/inner-hits-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/min-score-usage.asciidoc
+++ b/docs/search/request/min-score-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/min-score-usage.asciidoc
+++ b/docs/search/request/min-score-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/point-in-time-usage.asciidoc
+++ b/docs/search/request/point-in-time-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/point-in-time-usage.asciidoc
+++ b/docs/search/request/point-in-time-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/post-filter-usage.asciidoc
+++ b/docs/search/request/post-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/post-filter-usage.asciidoc
+++ b/docs/search/request/post-filter-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/profile-usage.asciidoc
+++ b/docs/search/request/profile-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/profile-usage.asciidoc
+++ b/docs/search/request/profile-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/query-usage.asciidoc
+++ b/docs/search/request/query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/query-usage.asciidoc
+++ b/docs/search/request/query-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/script-fields-usage.asciidoc
+++ b/docs/search/request/script-fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/script-fields-usage.asciidoc
+++ b/docs/search/request/script-fields-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/search-after-usage.asciidoc
+++ b/docs/search/request/search-after-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/search-after-usage.asciidoc
+++ b/docs/search/request/search-after-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/sliced-scroll-search-usage.asciidoc
+++ b/docs/search/request/sliced-scroll-search-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/sliced-scroll-search-usage.asciidoc
+++ b/docs/search/request/sliced-scroll-search-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/sort-usage.asciidoc
+++ b/docs/search/request/sort-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/sort-usage.asciidoc
+++ b/docs/search/request/sort-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/source-filtering-usage.asciidoc
+++ b/docs/search/request/source-filtering-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/source-filtering-usage.asciidoc
+++ b/docs/search/request/source-filtering-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/suggest-usage.asciidoc
+++ b/docs/search/request/suggest-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/request/suggest-usage.asciidoc
+++ b/docs/search/request/suggest-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/returned-fields.asciidoc
+++ b/docs/search/returned-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/returned-fields.asciidoc
+++ b/docs/search/returned-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/scrolling-documents.asciidoc
+++ b/docs/search/scrolling-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/scrolling-documents.asciidoc
+++ b/docs/search/scrolling-documents.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/search/collapsing/field-collapse-usage.asciidoc
+++ b/docs/search/search/collapsing/field-collapse-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/search/collapsing/field-collapse-usage.asciidoc
+++ b/docs/search/search/collapsing/field-collapse-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/search/rescoring/rescore-usage.asciidoc
+++ b/docs/search/search/rescoring/rescore-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/search/rescoring/rescore-usage.asciidoc
+++ b/docs/search/search/rescoring/rescore-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/searching-runtime-fields.asciidoc
+++ b/docs/search/searching-runtime-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/searching-runtime-fields.asciidoc
+++ b/docs/search/searching-runtime-fields.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/writing-queries.asciidoc
+++ b/docs/search/writing-queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/search/writing-queries.asciidoc
+++ b/docs/search/writing-queries.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
+++ b/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
+++ b/docs/x-pack/security/api-key/security-api-key-usage.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
+++ b/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
+
 
 :github: https://github.com/elastic/elasticsearch-net
 

--- a/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
+++ b/docs/x-pack/security/role-mapping/role-mapping-rules.asciidoc
@@ -1,4 +1,4 @@
-:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/master
+:ref_current: https://www.elastic.co/guide/en/elasticsearch/reference/{ref-branch}
 
 :github: https://github.com/elastic/elasticsearch-net
 


### PR DESCRIPTION
## Overview

This PR sets the `ref_current` shared attribute to ref, so it will be used in the docs URLs.