### PR TITLE
Prefer IList for collection properties on request types

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Serialization/IEnumerableSingleOrManyConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/IEnumerableSingleOrManyConverter.cs
@@ -9,11 +9,11 @@ using System.Text.Json.Serialization;
 
 namespace Elastic.Clients.Elasticsearch.Serialization;
 
-internal abstract class IEnumerableSingleOrManyConverter<TItem> : JsonConverter<IEnumerable<TItem>>
+internal abstract class IEnumerableSingleOrManyConverter<TItem> : JsonConverter<IList<TItem>>
 {
-	public override IEnumerable<TItem>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+	public override IList<TItem>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
 		SingleOrManySerializationHelper.Deserialize<TItem>(ref reader, options);
 
-	public override void Write(Utf8JsonWriter writer, IEnumerable<TItem> value, JsonSerializerOptions options) => 
+	public override void Write(Utf8JsonWriter writer, IList<TItem> value, JsonSerializerOptions options) => 
 		SingleOrManySerializationHelper.Serialize<TItem>(value, writer, options);
 }

--- a/src/Elastic.Clients.Elasticsearch/Serialization/SingleOrManySerializationHelper.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/SingleOrManySerializationHelper.cs
@@ -5,13 +5,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
-using System;
 
 namespace Elastic.Clients.Elasticsearch.Serialization;
 
 internal static class SingleOrManySerializationHelper
 {
-	public static IEnumerable<TItem> Deserialize<TItem>(ref Utf8JsonReader reader, JsonSerializerOptions options)
+	public static IList<TItem> Deserialize<TItem>(ref Utf8JsonReader reader, JsonSerializerOptions options)
 	{
 		if (reader.TokenType == JsonTokenType.StartObject)
 		{
@@ -44,7 +43,7 @@ internal static class SingleOrManySerializationHelper
 		throw new JsonException("Unexpected token.");
 	}
 
-	public static void Serialize<TItem>(IEnumerable<TItem> value, Utf8JsonWriter writer, JsonSerializerOptions options)
+	public static void Serialize<TItem>(IList<TItem> value, Utf8JsonWriter writer, JsonSerializerOptions options)
 	{
 		if (value is not ICollection<TItem> collection)
 		{

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/AsyncSearchSubmitRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/AsyncSearchSubmitRequest.g.cs
@@ -63,7 +63,7 @@ public sealed class AsyncSearchSubmitRequestParameters : RequestParameters<Async
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -182,13 +182,13 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "indices_boost")
 				{
-					variant.IndicesBoost = JsonSerializer.Deserialize<IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
+					variant.IndicesBoost = JsonSerializer.Deserialize<IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
 					continue;
 				}
 
 				if (property == "docvalue_fields")
 				{
-					variant.DocvalueFields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.DocvalueFields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -224,7 +224,7 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "rescore")
 				{
-					variant.Rescore = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
+					variant.Rescore = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
 					continue;
 				}
 
@@ -236,7 +236,7 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "search_after")
 				{
-					variant.SearchAfter = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
+					variant.SearchAfter = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
 					continue;
 				}
 
@@ -254,7 +254,7 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "sort")
 				{
-					variant.Sort = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
+					variant.Sort = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
 					continue;
 				}
 
@@ -266,7 +266,7 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "fields")
 				{
-					variant.Fields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.Fields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -326,7 +326,7 @@ internal sealed class AsyncSearchSubmitRequestConverter : JsonConverter<AsyncSea
 
 				if (property == "stats")
 				{
-					variant.Stats = JsonSerializer.Deserialize<IEnumerable<string>?>(ref reader, options);
+					variant.Stats = JsonSerializer.Deserialize<IList<string>?>(ref reader, options);
 					continue;
 				}
 			}
@@ -582,7 +582,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -674,11 +674,11 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 
 	[JsonInclude]
 	[JsonPropertyName("indices_boost")]
-	public IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
+	public IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("docvalue_fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("knn")]
@@ -702,7 +702,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 
 	[JsonInclude]
 	[JsonPropertyName("rescore")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("script_fields")]
@@ -710,7 +710,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 
 	[JsonInclude]
 	[JsonPropertyName("search_after")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("size")]
@@ -723,7 +723,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 	[JsonInclude]
 	[JsonPropertyName("sort")]
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("_source")]
@@ -731,7 +731,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("suggest")]
@@ -771,7 +771,7 @@ public partial class AsyncSearchSubmitRequest : PlainRequest<AsyncSearchSubmitRe
 
 	[JsonInclude]
 	[JsonPropertyName("stats")]
-	public IEnumerable<string>? Stats { get; set; }
+	public IList<string>? Stats { get; set; }
 }
 
 public sealed partial class AsyncSearchSubmitRequest<TInferDocument> : AsyncSearchSubmitRequest
@@ -801,7 +801,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 	public AsyncSearchSubmitRequestDescriptor<TDocument> CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
 	public AsyncSearchSubmitRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public AsyncSearchSubmitRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public AsyncSearchSubmitRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public AsyncSearchSubmitRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public AsyncSearchSubmitRequestDescriptor<TDocument> IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public AsyncSearchSubmitRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public AsyncSearchSubmitRequestDescriptor<TDocument> KeepAlive(Elastic.Clients.Elasticsearch.Duration? keepAlive) => Qs("keep_alive", keepAlive);
@@ -841,7 +841,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 
 	private Action<Core.Search.FieldCollapseDescriptor<TDocument>> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> DocvalueFieldsDescriptor { get; set; }
 
@@ -849,7 +849,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 
 	private Action<QueryDsl.FieldAndFormatDescriptor<TDocument>>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> FieldsDescriptor { get; set; }
 
@@ -881,7 +881,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 
 	private Action<QueryDsl.QueryContainerDescriptor<TDocument>> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor<TDocument> RescoreDescriptor { get; set; }
 
@@ -903,7 +903,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -919,15 +919,15 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -995,7 +995,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -1031,7 +1031,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -1163,7 +1163,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -1247,7 +1247,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -1301,7 +1301,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -1319,13 +1319,13 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor<TDocument> : Requ
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor<TDocument> Stats(IEnumerable<string>? stats)
+	public AsyncSearchSubmitRequestDescriptor<TDocument> Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;
@@ -1775,7 +1775,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 	public AsyncSearchSubmitRequestDescriptor CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
 	public AsyncSearchSubmitRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public AsyncSearchSubmitRequestDescriptor Df(string? df) => Qs("df", df);
-	public AsyncSearchSubmitRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public AsyncSearchSubmitRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public AsyncSearchSubmitRequestDescriptor IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public AsyncSearchSubmitRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public AsyncSearchSubmitRequestDescriptor KeepAlive(Elastic.Clients.Elasticsearch.Duration? keepAlive) => Qs("keep_alive", keepAlive);
@@ -1815,7 +1815,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 
 	private Action<Core.Search.FieldCollapseDescriptor> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor DocvalueFieldsDescriptor { get; set; }
 
@@ -1823,7 +1823,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 
 	private Action<QueryDsl.FieldAndFormatDescriptor>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor FieldsDescriptor { get; set; }
 
@@ -1855,7 +1855,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 
 	private Action<QueryDsl.QueryContainerDescriptor> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor RescoreDescriptor { get; set; }
 
@@ -1877,7 +1877,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -1893,15 +1893,15 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -1969,7 +1969,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public AsyncSearchSubmitRequestDescriptor DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -2005,7 +2005,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public AsyncSearchSubmitRequestDescriptor Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -2137,7 +2137,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public AsyncSearchSubmitRequestDescriptor Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -2221,7 +2221,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public AsyncSearchSubmitRequestDescriptor IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -2275,7 +2275,7 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public AsyncSearchSubmitRequestDescriptor SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -2293,13 +2293,13 @@ public sealed partial class AsyncSearchSubmitRequestDescriptor : RequestDescript
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public AsyncSearchSubmitRequestDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public AsyncSearchSubmitRequestDescriptor Stats(IEnumerable<string>? stats)
+	public AsyncSearchSubmitRequestDescriptor Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterHealthRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/ClusterHealthRequest.g.cs
@@ -30,7 +30,7 @@ namespace Elastic.Clients.Elasticsearch.Cluster;
 public sealed class ClusterHealthRequestParameters : RequestParameters<ClusterHealthRequestParameters>
 {
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Level? Level { get => Q<Elastic.Clients.Elasticsearch.Level?>("level"); set => Q("level", value); }
@@ -77,7 +77,7 @@ public sealed partial class ClusterHealthRequest : PlainRequest<ClusterHealthReq
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Level? Level { get => Q<Elastic.Clients.Elasticsearch.Level?>("level"); set => Q("level", value); }
@@ -120,7 +120,7 @@ public sealed partial class ClusterHealthRequestDescriptor<TDocument> : RequestD
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterHealth;
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
-	public ClusterHealthRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ClusterHealthRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ClusterHealthRequestDescriptor<TDocument> Level(Elastic.Clients.Elasticsearch.Level? level) => Qs("level", level);
 	public ClusterHealthRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	public ClusterHealthRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
@@ -152,7 +152,7 @@ public sealed partial class ClusterHealthRequestDescriptor : RequestDescriptor<C
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.ClusterHealth;
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
-	public ClusterHealthRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ClusterHealthRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ClusterHealthRequestDescriptor Level(Elastic.Clients.Elasticsearch.Level? level) => Qs("level", level);
 	public ClusterHealthRequestDescriptor Local(bool? local = true) => Qs("local", local);
 	public ClusterHealthRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountRequest.g.cs
@@ -45,7 +45,7 @@ public sealed class CountRequestParameters : RequestParameters<CountRequestParam
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -101,7 +101,7 @@ public partial class CountRequest : PlainRequest<CountRequestParameters>
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -151,7 +151,7 @@ public sealed partial class CountRequestDescriptor<TDocument> : RequestDescripto
 	public CountRequestDescriptor<TDocument> Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public CountRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public CountRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public CountRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public CountRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public CountRequestDescriptor<TDocument> IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public CountRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public CountRequestDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -238,7 +238,7 @@ public sealed partial class CountRequestDescriptor : RequestDescriptor<CountRequ
 	public CountRequestDescriptor Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public CountRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public CountRequestDescriptor Df(string? df) => Qs("df", df);
-	public CountRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public CountRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public CountRequestDescriptor IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public CountRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public CountRequestDescriptor Lenient(bool? lenient = true) => Qs("lenient", lenient);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/DeleteByQueryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/DeleteByQueryRequest.g.cs
@@ -48,7 +48,7 @@ public sealed class DeleteByQueryRequestParameters : RequestParameters<DeleteByQ
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public long? From { get => Q<long?>("from"); set => Q("from", value); }
@@ -93,10 +93,10 @@ public sealed class DeleteByQueryRequestParameters : RequestParameters<DeleteByQ
 	public Elastic.Clients.Elasticsearch.Slices? Slices { get => Q<Elastic.Clients.Elasticsearch.Slices?>("slices"); set => Q("slices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Sort { get => Q<IEnumerable<string>?>("sort"); set => Q("sort", value); }
+	public IList<string>? Sort { get => Q<IList<string>?>("sort"); set => Q("sort", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Stats { get => Q<IEnumerable<string>?>("stats"); set => Q("stats", value); }
+	public IList<string>? Stats { get => Q<IList<string>?>("stats"); set => Q("stats", value); }
 
 	[JsonIgnore]
 	public long? TerminateAfter { get => Q<long?>("terminate_after"); set => Q("terminate_after", value); }
@@ -142,7 +142,7 @@ public sealed partial class DeleteByQueryRequest : PlainRequest<DeleteByQueryReq
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public long? From { get => Q<long?>("from"); set => Q("from", value); }
@@ -187,10 +187,10 @@ public sealed partial class DeleteByQueryRequest : PlainRequest<DeleteByQueryReq
 	public Elastic.Clients.Elasticsearch.Slices? Slices { get => Q<Elastic.Clients.Elasticsearch.Slices?>("slices"); set => Q("slices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Sort { get => Q<IEnumerable<string>?>("sort"); set => Q("sort", value); }
+	public IList<string>? Sort { get => Q<IList<string>?>("sort"); set => Q("sort", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Stats { get => Q<IEnumerable<string>?>("stats"); set => Q("stats", value); }
+	public IList<string>? Stats { get => Q<IList<string>?>("stats"); set => Q("stats", value); }
 
 	[JsonIgnore]
 	public long? TerminateAfter { get => Q<long?>("terminate_after"); set => Q("terminate_after", value); }
@@ -240,7 +240,7 @@ public sealed partial class DeleteByQueryRequestDescriptor<TDocument> : RequestD
 	public DeleteByQueryRequestDescriptor<TDocument> Conflicts(Elastic.Clients.Elasticsearch.Conflicts? conflicts) => Qs("conflicts", conflicts);
 	public DeleteByQueryRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public DeleteByQueryRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public DeleteByQueryRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DeleteByQueryRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DeleteByQueryRequestDescriptor<TDocument> From(long? from) => Qs("from", from);
 	public DeleteByQueryRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public DeleteByQueryRequestDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -255,8 +255,8 @@ public sealed partial class DeleteByQueryRequestDescriptor<TDocument> : RequestD
 	public DeleteByQueryRequestDescriptor<TDocument> SearchTimeout(Elastic.Clients.Elasticsearch.Duration? searchTimeout) => Qs("search_timeout", searchTimeout);
 	public DeleteByQueryRequestDescriptor<TDocument> SearchType(Elastic.Clients.Elasticsearch.SearchType? searchType) => Qs("search_type", searchType);
 	public DeleteByQueryRequestDescriptor<TDocument> Slices(Elastic.Clients.Elasticsearch.Slices? slices) => Qs("slices", slices);
-	public DeleteByQueryRequestDescriptor<TDocument> Sort(IEnumerable<string>? sort) => Qs("sort", sort);
-	public DeleteByQueryRequestDescriptor<TDocument> Stats(IEnumerable<string>? stats) => Qs("stats", stats);
+	public DeleteByQueryRequestDescriptor<TDocument> Sort(IList<string>? sort) => Qs("sort", sort);
+	public DeleteByQueryRequestDescriptor<TDocument> Stats(IList<string>? stats) => Qs("stats", stats);
 	public DeleteByQueryRequestDescriptor<TDocument> TerminateAfter(long? terminateAfter) => Qs("terminate_after", terminateAfter);
 	public DeleteByQueryRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
 	public DeleteByQueryRequestDescriptor<TDocument> Version(bool? version = true) => Qs("version", version);
@@ -401,7 +401,7 @@ public sealed partial class DeleteByQueryRequestDescriptor : RequestDescriptor<D
 	public DeleteByQueryRequestDescriptor Conflicts(Elastic.Clients.Elasticsearch.Conflicts? conflicts) => Qs("conflicts", conflicts);
 	public DeleteByQueryRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public DeleteByQueryRequestDescriptor Df(string? df) => Qs("df", df);
-	public DeleteByQueryRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DeleteByQueryRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DeleteByQueryRequestDescriptor From(long? from) => Qs("from", from);
 	public DeleteByQueryRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public DeleteByQueryRequestDescriptor Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -416,8 +416,8 @@ public sealed partial class DeleteByQueryRequestDescriptor : RequestDescriptor<D
 	public DeleteByQueryRequestDescriptor SearchTimeout(Elastic.Clients.Elasticsearch.Duration? searchTimeout) => Qs("search_timeout", searchTimeout);
 	public DeleteByQueryRequestDescriptor SearchType(Elastic.Clients.Elasticsearch.SearchType? searchType) => Qs("search_type", searchType);
 	public DeleteByQueryRequestDescriptor Slices(Elastic.Clients.Elasticsearch.Slices? slices) => Qs("slices", slices);
-	public DeleteByQueryRequestDescriptor Sort(IEnumerable<string>? sort) => Qs("sort", sort);
-	public DeleteByQueryRequestDescriptor Stats(IEnumerable<string>? stats) => Qs("stats", stats);
+	public DeleteByQueryRequestDescriptor Sort(IList<string>? sort) => Qs("sort", sort);
+	public DeleteByQueryRequestDescriptor Stats(IList<string>? stats) => Qs("stats", stats);
 	public DeleteByQueryRequestDescriptor TerminateAfter(long? terminateAfter) => Qs("terminate_after", terminateAfter);
 	public DeleteByQueryRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
 	public DeleteByQueryRequestDescriptor Version(bool? version = true) => Qs("version", version);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/EqlSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Eql/EqlSearchRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class EqlSearchRequestParameters : RequestParameters<EqlSearchRequ
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -52,7 +52,7 @@ public sealed partial class EqlSearchRequest : PlainRequest<EqlSearchRequestPara
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -83,7 +83,7 @@ public sealed partial class EqlSearchRequest : PlainRequest<EqlSearchRequestPara
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("keep_alive")]
@@ -103,7 +103,7 @@ public sealed partial class EqlSearchRequest : PlainRequest<EqlSearchRequestPara
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("result_position")]
@@ -129,7 +129,7 @@ public sealed partial class EqlSearchRequestDescriptor<TDocument> : RequestDescr
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public EqlSearchRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public EqlSearchRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public EqlSearchRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public EqlSearchRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public EqlSearchRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices indices)
 	{
@@ -137,7 +137,7 @@ public sealed partial class EqlSearchRequestDescriptor<TDocument> : RequestDescr
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> FieldsDescriptor { get; set; }
 
@@ -145,7 +145,7 @@ public sealed partial class EqlSearchRequestDescriptor<TDocument> : RequestDescr
 
 	private Action<QueryDsl.FieldAndFormatDescriptor<TDocument>>[] FieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryDsl.QueryContainerDescriptor<TDocument> FilterDescriptor { get; set; }
 
@@ -177,7 +177,7 @@ public sealed partial class EqlSearchRequestDescriptor<TDocument> : RequestDescr
 
 	private Elastic.Clients.Elasticsearch.Duration? WaitForCompletionTimeoutValue { get; set; }
 
-	public EqlSearchRequestDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public EqlSearchRequestDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -213,7 +213,7 @@ public sealed partial class EqlSearchRequestDescriptor<TDocument> : RequestDescr
 		return Self;
 	}
 
-	public EqlSearchRequestDescriptor<TDocument> Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public EqlSearchRequestDescriptor<TDocument> Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;
@@ -491,7 +491,7 @@ public sealed partial class EqlSearchRequestDescriptor : RequestDescriptor<EqlSe
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public EqlSearchRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public EqlSearchRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public EqlSearchRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public EqlSearchRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public EqlSearchRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices indices)
 	{
@@ -499,7 +499,7 @@ public sealed partial class EqlSearchRequestDescriptor : RequestDescriptor<EqlSe
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor FieldsDescriptor { get; set; }
 
@@ -507,7 +507,7 @@ public sealed partial class EqlSearchRequestDescriptor : RequestDescriptor<EqlSe
 
 	private Action<QueryDsl.FieldAndFormatDescriptor>[] FieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryDsl.QueryContainerDescriptor FilterDescriptor { get; set; }
 
@@ -539,7 +539,7 @@ public sealed partial class EqlSearchRequestDescriptor : RequestDescriptor<EqlSe
 
 	private Elastic.Clients.Elasticsearch.Duration? WaitForCompletionTimeoutValue { get; set; }
 
-	public EqlSearchRequestDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public EqlSearchRequestDescriptor Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -575,7 +575,7 @@ public sealed partial class EqlSearchRequestDescriptor : RequestDescriptor<EqlSe
 		return Self;
 	}
 
-	public EqlSearchRequestDescriptor Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public EqlSearchRequestDescriptor Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/FieldCapsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/FieldCapsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class FieldCapsRequestParameters : RequestParameters<FieldCapsRequ
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Fields? Fields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("fields"); set => Q("fields", value); }
@@ -48,7 +48,7 @@ public sealed class FieldCapsRequestParameters : RequestParameters<FieldCapsRequ
 	public string? Filters { get => Q<string?>("filters"); set => Q("filters", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Types { get => Q<IEnumerable<string>?>("types"); set => Q("types", value); }
+	public IList<string>? Types { get => Q<IList<string>?>("types"); set => Q("types", value); }
 }
 
 public sealed partial class FieldCapsRequest : PlainRequest<FieldCapsRequestParameters>
@@ -68,7 +68,7 @@ public sealed partial class FieldCapsRequest : PlainRequest<FieldCapsRequestPara
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Fields? Fields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("fields"); set => Q("fields", value); }
@@ -83,7 +83,7 @@ public sealed partial class FieldCapsRequest : PlainRequest<FieldCapsRequestPara
 	public string? Filters { get => Q<string?>("filters"); set => Q("filters", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Types { get => Q<IEnumerable<string>?>("types"); set => Q("types", value); }
+	public IList<string>? Types { get => Q<IList<string>?>("types"); set => Q("types", value); }
 
 	[JsonInclude]
 	[JsonPropertyName("index_filter")]
@@ -105,12 +105,12 @@ public sealed partial class FieldCapsRequestDescriptor<TDocument> : RequestDescr
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public FieldCapsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FieldCapsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FieldCapsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FieldCapsRequestDescriptor<TDocument> Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public FieldCapsRequestDescriptor<TDocument> Filters(string? filters) => Qs("filters", filters);
 	public FieldCapsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FieldCapsRequestDescriptor<TDocument> IncludeUnmapped(bool? includeUnmapped = true) => Qs("include_unmapped", includeUnmapped);
-	public FieldCapsRequestDescriptor<TDocument> Types(IEnumerable<string>? types) => Qs("types", types);
+	public FieldCapsRequestDescriptor<TDocument> Types(IList<string>? types) => Qs("types", types);
 	public FieldCapsRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{
 		RouteValues.Optional("index", indices);
@@ -195,12 +195,12 @@ public sealed partial class FieldCapsRequestDescriptor : RequestDescriptor<Field
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public FieldCapsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FieldCapsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FieldCapsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FieldCapsRequestDescriptor Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public FieldCapsRequestDescriptor Filters(string? filters) => Qs("filters", filters);
 	public FieldCapsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FieldCapsRequestDescriptor IncludeUnmapped(bool? includeUnmapped = true) => Qs("include_unmapped", includeUnmapped);
-	public FieldCapsRequestDescriptor Types(IEnumerable<string>? types) => Qs("types", types);
+	public FieldCapsRequestDescriptor Types(IList<string>? types) => Qs("types", types);
 	public FieldCapsRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{
 		RouteValues.Optional("index", indices);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/AliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/AliasRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class AliasRequestParameters : RequestParameters<AliasRequestParam
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -67,7 +67,7 @@ public sealed partial class AliasRequest : PlainRequest<AliasRequestParameters>
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -95,7 +95,7 @@ public sealed partial class AliasRequestDescriptor<TDocument> : RequestDescripto
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public AliasRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public AliasRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public AliasRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public AliasRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public AliasRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	public AliasRequestDescriptor<TDocument> Name(Elastic.Clients.Elasticsearch.Names? name)
@@ -134,7 +134,7 @@ public sealed partial class AliasRequestDescriptor : RequestDescriptor<AliasRequ
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public AliasRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public AliasRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public AliasRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public AliasRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public AliasRequestDescriptor Local(bool? local = true) => Qs("local", local);
 	public AliasRequestDescriptor Name(Elastic.Clients.Elasticsearch.Names? name)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/AnalyzeRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/AnalyzeRequest.g.cs
@@ -50,11 +50,11 @@ public sealed partial class AnalyzeRequest : PlainRequest<AnalyzeRequestParamete
 
 	[JsonInclude]
 	[JsonPropertyName("attributes")]
-	public IEnumerable<string>? Attributes { get; set; }
+	public IList<string>? Attributes { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("char_filter")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("explain")]
@@ -66,7 +66,7 @@ public sealed partial class AnalyzeRequest : PlainRequest<AnalyzeRequestParamete
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? Filter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("normalizer")]
@@ -75,7 +75,7 @@ public sealed partial class AnalyzeRequest : PlainRequest<AnalyzeRequestParamete
 	[JsonInclude]
 	[JsonPropertyName("text")]
 	[JsonConverter(typeof(TextToAnalyzeConverter))]
-	public IEnumerable<string>? Text { get; set; }
+	public IList<string>? Text { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("tokenizer")]
@@ -100,19 +100,19 @@ public sealed partial class AnalyzeRequestDescriptor<TDocument> : RequestDescrip
 
 	private string? AnalyzerValue { get; set; }
 
-	private IEnumerable<string>? AttributesValue { get; set; }
+	private IList<string>? AttributesValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilterValue { get; set; }
 
 	private bool? ExplainValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? FilterValue { get; set; }
 
 	private string? NormalizerValue { get; set; }
 
-	private IEnumerable<string>? TextValue { get; set; }
+	private IList<string>? TextValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Analysis.Tokenizer? TokenizerValue { get; set; }
 
@@ -122,13 +122,13 @@ public sealed partial class AnalyzeRequestDescriptor<TDocument> : RequestDescrip
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor<TDocument> Attributes(IEnumerable<string>? attributes)
+	public AnalyzeRequestDescriptor<TDocument> Attributes(IList<string>? attributes)
 	{
 		AttributesValue = attributes;
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor<TDocument> CharFilter(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? charFilter)
+	public AnalyzeRequestDescriptor<TDocument> CharFilter(IList<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? charFilter)
 	{
 		CharFilterValue = charFilter;
 		return Self;
@@ -152,7 +152,7 @@ public sealed partial class AnalyzeRequestDescriptor<TDocument> : RequestDescrip
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor<TDocument> Filter(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? filter)
+	public AnalyzeRequestDescriptor<TDocument> Filter(IList<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? filter)
 	{
 		FilterValue = filter;
 		return Self;
@@ -164,7 +164,7 @@ public sealed partial class AnalyzeRequestDescriptor<TDocument> : RequestDescrip
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor<TDocument> Text(IEnumerable<string>? text)
+	public AnalyzeRequestDescriptor<TDocument> Text(IList<string>? text)
 	{
 		TextValue = text;
 		return Self;
@@ -255,19 +255,19 @@ public sealed partial class AnalyzeRequestDescriptor : RequestDescriptor<Analyze
 
 	private string? AnalyzerValue { get; set; }
 
-	private IEnumerable<string>? AttributesValue { get; set; }
+	private IList<string>? AttributesValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? CharFilterValue { get; set; }
 
 	private bool? ExplainValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field? FieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? FilterValue { get; set; }
 
 	private string? NormalizerValue { get; set; }
 
-	private IEnumerable<string>? TextValue { get; set; }
+	private IList<string>? TextValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Analysis.Tokenizer? TokenizerValue { get; set; }
 
@@ -277,13 +277,13 @@ public sealed partial class AnalyzeRequestDescriptor : RequestDescriptor<Analyze
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor Attributes(IEnumerable<string>? attributes)
+	public AnalyzeRequestDescriptor Attributes(IList<string>? attributes)
 	{
 		AttributesValue = attributes;
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor CharFilter(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? charFilter)
+	public AnalyzeRequestDescriptor CharFilter(IList<Elastic.Clients.Elasticsearch.Analysis.CharFilter>? charFilter)
 	{
 		CharFilterValue = charFilter;
 		return Self;
@@ -313,7 +313,7 @@ public sealed partial class AnalyzeRequestDescriptor : RequestDescriptor<Analyze
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor Filter(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? filter)
+	public AnalyzeRequestDescriptor Filter(IList<Elastic.Clients.Elasticsearch.Analysis.TokenFilter>? filter)
 	{
 		FilterValue = filter;
 		return Self;
@@ -325,7 +325,7 @@ public sealed partial class AnalyzeRequestDescriptor : RequestDescriptor<Analyze
 		return Self;
 	}
 
-	public AnalyzeRequestDescriptor Text(IEnumerable<string>? text)
+	public AnalyzeRequestDescriptor Text(IList<string>? text)
 	{
 		TextValue = text;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class ClearCacheRequestParameters : RequestParameters<ClearCacheRe
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Fielddata { get => Q<bool?>("fielddata"); set => Q("fielddata", value); }
@@ -68,7 +68,7 @@ public sealed partial class ClearCacheRequest : PlainRequest<ClearCacheRequestPa
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Fielddata { get => Q<bool?>("fielddata"); set => Q("fielddata", value); }
@@ -97,7 +97,7 @@ public sealed partial class ClearCacheRequestDescriptor<TDocument> : RequestDesc
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ClearCacheRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ClearCacheRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ClearCacheRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ClearCacheRequestDescriptor<TDocument> Fielddata(bool? fielddata = true) => Qs("fielddata", fielddata);
 	public ClearCacheRequestDescriptor<TDocument> Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public ClearCacheRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
@@ -125,7 +125,7 @@ public sealed partial class ClearCacheRequestDescriptor : RequestDescriptor<Clea
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ClearCacheRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ClearCacheRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ClearCacheRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ClearCacheRequestDescriptor Fielddata(bool? fielddata = true) => Qs("fielddata", fielddata);
 	public ClearCacheRequestDescriptor Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public ClearCacheRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/CloseRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/CloseRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class CloseRequestParameters : RequestParameters<CloseRequestParam
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -61,7 +61,7 @@ public sealed partial class CloseRequest : PlainRequest<CloseRequestParameters>
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -91,7 +91,7 @@ public sealed partial class CloseRequestDescriptor<TDocument> : RequestDescripto
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public CloseRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public CloseRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public CloseRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public CloseRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public CloseRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public CloseRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
@@ -122,7 +122,7 @@ public sealed partial class CloseRequestDescriptor : RequestDescriptor<CloseRequ
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public CloseRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public CloseRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public CloseRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public CloseRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public CloseRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public CloseRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DataStreamRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DataStreamRequest.g.cs
@@ -30,7 +30,7 @@ namespace Elastic.Clients.Elasticsearch.IndexManagement;
 public sealed class DataStreamRequestParameters : RequestParameters<DataStreamRequestParameters>
 {
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DataStreamRequest : PlainRequest<DataStreamRequestParameters>
@@ -47,7 +47,7 @@ public sealed partial class DataStreamRequest : PlainRequest<DataStreamRequestPa
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DataStreamRequestDescriptor : RequestDescriptor<DataStreamRequestDescriptor, DataStreamRequestParameters>
@@ -60,7 +60,7 @@ public sealed partial class DataStreamRequestDescriptor : RequestDescriptor<Data
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexManagementGetDataStream;
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
-	public DataStreamRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DataStreamRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DataStreamRequestDescriptor Name(Elastic.Clients.Elasticsearch.DataStreamNames? name)
 	{
 		RouteValues.Optional("name", name);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DataStreamsStatsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DataStreamsStatsRequest.g.cs
@@ -30,7 +30,7 @@ namespace Elastic.Clients.Elasticsearch.IndexManagement;
 public sealed class DataStreamsStatsRequestParameters : RequestParameters<DataStreamsStatsRequestParameters>
 {
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DataStreamsStatsRequest : PlainRequest<DataStreamsStatsRequestParameters>
@@ -47,7 +47,7 @@ public sealed partial class DataStreamsStatsRequest : PlainRequest<DataStreamsSt
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DataStreamsStatsRequestDescriptor : RequestDescriptor<DataStreamsStatsRequestDescriptor, DataStreamsStatsRequestParameters>
@@ -60,7 +60,7 @@ public sealed partial class DataStreamsStatsRequestDescriptor : RequestDescripto
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexManagementDataStreamsStats;
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
-	public DataStreamsStatsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DataStreamsStatsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DataStreamsStatsRequestDescriptor Name(Elastic.Clients.Elasticsearch.IndexName? name)
 	{
 		RouteValues.Optional("name", name);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteDataStreamRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteDataStreamRequest.g.cs
@@ -30,7 +30,7 @@ namespace Elastic.Clients.Elasticsearch.IndexManagement;
 public sealed class DeleteDataStreamRequestParameters : RequestParameters<DeleteDataStreamRequestParameters>
 {
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DeleteDataStreamRequest : PlainRequest<DeleteDataStreamRequestParameters>
@@ -43,7 +43,7 @@ public sealed partial class DeleteDataStreamRequest : PlainRequest<DeleteDataStr
 	protected override HttpMethod HttpMethod => HttpMethod.DELETE;
 	protected override bool SupportsBody => false;
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class DeleteDataStreamRequestDescriptor : RequestDescriptor<DeleteDataStreamRequestDescriptor, DeleteDataStreamRequestParameters>
@@ -60,7 +60,7 @@ public sealed partial class DeleteDataStreamRequestDescriptor : RequestDescripto
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexManagementDeleteDataStream;
 	protected override HttpMethod HttpMethod => HttpMethod.DELETE;
 	protected override bool SupportsBody => false;
-	public DeleteDataStreamRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DeleteDataStreamRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DeleteDataStreamRequestDescriptor Name(Elastic.Clients.Elasticsearch.DataStreamNames name)
 	{
 		RouteValues.Required("name", name);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/DeleteRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class DeleteRequestParameters : RequestParameters<DeleteRequestPar
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -58,7 +58,7 @@ public sealed partial class DeleteRequest : PlainRequest<DeleteRequestParameters
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -85,7 +85,7 @@ public sealed partial class DeleteRequestDescriptor<TDocument> : RequestDescript
 	protected override HttpMethod HttpMethod => HttpMethod.DELETE;
 	protected override bool SupportsBody => false;
 	public DeleteRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public DeleteRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DeleteRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DeleteRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public DeleteRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public DeleteRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
@@ -115,7 +115,7 @@ public sealed partial class DeleteRequestDescriptor : RequestDescriptor<DeleteRe
 	protected override HttpMethod HttpMethod => HttpMethod.DELETE;
 	protected override bool SupportsBody => false;
 	public DeleteRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public DeleteRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public DeleteRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public DeleteRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public DeleteRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public DeleteRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class ExistsAliasRequestParameters : RequestParameters<ExistsAlias
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -59,7 +59,7 @@ public sealed partial class ExistsAliasRequest : PlainRequest<ExistsAliasRequest
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -87,7 +87,7 @@ public sealed partial class ExistsAliasRequestDescriptor<TDocument> : RequestDes
 	protected override HttpMethod HttpMethod => HttpMethod.HEAD;
 	protected override bool SupportsBody => false;
 	public ExistsAliasRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ExistsAliasRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ExistsAliasRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ExistsAliasRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ExistsAliasRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	public ExistsAliasRequestDescriptor<TDocument> Name(Elastic.Clients.Elasticsearch.Names name)
@@ -126,7 +126,7 @@ public sealed partial class ExistsAliasRequestDescriptor : RequestDescriptor<Exi
 	protected override HttpMethod HttpMethod => HttpMethod.HEAD;
 	protected override bool SupportsBody => false;
 	public ExistsAliasRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ExistsAliasRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ExistsAliasRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ExistsAliasRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ExistsAliasRequestDescriptor Local(bool? local = true) => Qs("local", local);
 	public ExistsAliasRequestDescriptor Name(Elastic.Clients.Elasticsearch.Names name)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class ExistsRequestParameters : RequestParameters<ExistsRequestPar
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -61,7 +61,7 @@ public sealed partial class ExistsRequest : PlainRequest<ExistsRequestParameters
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -91,7 +91,7 @@ public sealed partial class ExistsRequestDescriptor<TDocument> : RequestDescript
 	protected override HttpMethod HttpMethod => HttpMethod.HEAD;
 	protected override bool SupportsBody => false;
 	public ExistsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ExistsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ExistsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ExistsRequestDescriptor<TDocument> FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public ExistsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ExistsRequestDescriptor<TDocument> IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);
@@ -122,7 +122,7 @@ public sealed partial class ExistsRequestDescriptor : RequestDescriptor<ExistsRe
 	protected override HttpMethod HttpMethod => HttpMethod.HEAD;
 	protected override bool SupportsBody => false;
 	public ExistsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ExistsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ExistsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ExistsRequestDescriptor FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public ExistsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ExistsRequestDescriptor IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FieldMappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FieldMappingRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class FieldMappingRequestParameters : RequestParameters<FieldMappi
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -62,7 +62,7 @@ public sealed partial class FieldMappingRequest : PlainRequest<FieldMappingReque
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -93,7 +93,7 @@ public sealed partial class FieldMappingRequestDescriptor<TDocument> : RequestDe
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public FieldMappingRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FieldMappingRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FieldMappingRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FieldMappingRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FieldMappingRequestDescriptor<TDocument> IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);
 	public FieldMappingRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
@@ -133,7 +133,7 @@ public sealed partial class FieldMappingRequestDescriptor : RequestDescriptor<Fi
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public FieldMappingRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FieldMappingRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FieldMappingRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FieldMappingRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FieldMappingRequestDescriptor IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);
 	public FieldMappingRequestDescriptor Local(bool? local = true) => Qs("local", local);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FlushRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FlushRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class FlushRequestParameters : RequestParameters<FlushRequestParam
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Force { get => Q<bool?>("force"); set => Q("force", value); }
@@ -62,7 +62,7 @@ public sealed partial class FlushRequest : PlainRequest<FlushRequestParameters>
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Force { get => Q<bool?>("force"); set => Q("force", value); }
@@ -85,7 +85,7 @@ public sealed partial class FlushRequestDescriptor<TDocument> : RequestDescripto
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public FlushRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FlushRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FlushRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FlushRequestDescriptor<TDocument> Force(bool? force = true) => Qs("force", force);
 	public FlushRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FlushRequestDescriptor<TDocument> WaitIfOngoing(bool? waitIfOngoing = true) => Qs("wait_if_ongoing", waitIfOngoing);
@@ -111,7 +111,7 @@ public sealed partial class FlushRequestDescriptor : RequestDescriptor<FlushRequ
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public FlushRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public FlushRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public FlushRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public FlushRequestDescriptor Force(bool? force = true) => Qs("force", force);
 	public FlushRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public FlushRequestDescriptor WaitIfOngoing(bool? waitIfOngoing = true) => Qs("wait_if_ongoing", waitIfOngoing);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class ForcemergeRequestParameters : RequestParameters<ForcemergeRe
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Flush { get => Q<bool?>("flush"); set => Q("flush", value); }
@@ -68,7 +68,7 @@ public sealed partial class ForcemergeRequest : PlainRequest<ForcemergeRequestPa
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Flush { get => Q<bool?>("flush"); set => Q("flush", value); }
@@ -97,7 +97,7 @@ public sealed partial class ForcemergeRequestDescriptor<TDocument> : RequestDesc
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ForcemergeRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ForcemergeRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ForcemergeRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ForcemergeRequestDescriptor<TDocument> Flush(bool? flush = true) => Qs("flush", flush);
 	public ForcemergeRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ForcemergeRequestDescriptor<TDocument> MaxNumSegments(long? maxNumSegments) => Qs("max_num_segments", maxNumSegments);
@@ -125,7 +125,7 @@ public sealed partial class ForcemergeRequestDescriptor : RequestDescriptor<Forc
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ForcemergeRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ForcemergeRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ForcemergeRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ForcemergeRequestDescriptor Flush(bool? flush = true) => Qs("flush", flush);
 	public ForcemergeRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ForcemergeRequestDescriptor MaxNumSegments(long? maxNumSegments) => Qs("max_num_segments", maxNumSegments);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class GetRequestParameters : RequestParameters<GetRequestParameter
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -51,7 +51,7 @@ public sealed class GetRequestParameters : RequestParameters<GetRequestParameter
 	public Elastic.Clients.Elasticsearch.Duration? MasterTimeout { get => Q<Elastic.Clients.Elasticsearch.Duration?>("master_timeout"); set => Q("master_timeout", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? Features { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>?>("features"); set => Q("features", value); }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? Features { get => Q<IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>?>("features"); set => Q("features", value); }
 }
 
 public sealed partial class GetRequest : PlainRequest<GetRequestParameters>
@@ -67,7 +67,7 @@ public sealed partial class GetRequest : PlainRequest<GetRequestParameters>
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -85,7 +85,7 @@ public sealed partial class GetRequest : PlainRequest<GetRequestParameters>
 	public Elastic.Clients.Elasticsearch.Duration? MasterTimeout { get => Q<Elastic.Clients.Elasticsearch.Duration?>("master_timeout"); set => Q("master_timeout", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? Features { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>?>("features"); set => Q("features", value); }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? Features { get => Q<IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>?>("features"); set => Q("features", value); }
 }
 
 public sealed partial class GetRequestDescriptor<TDocument> : RequestDescriptor<GetRequestDescriptor<TDocument>, GetRequestParameters>
@@ -103,8 +103,8 @@ public sealed partial class GetRequestDescriptor<TDocument> : RequestDescriptor<
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public GetRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public GetRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
-	public GetRequestDescriptor<TDocument> Features(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? features) => Qs("features", features);
+	public GetRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public GetRequestDescriptor<TDocument> Features(IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? features) => Qs("features", features);
 	public GetRequestDescriptor<TDocument> FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public GetRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public GetRequestDescriptor<TDocument> IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);
@@ -136,8 +136,8 @@ public sealed partial class GetRequestDescriptor : RequestDescriptor<GetRequestD
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public GetRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public GetRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
-	public GetRequestDescriptor Features(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? features) => Qs("features", features);
+	public GetRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public GetRequestDescriptor Features(IList<Elastic.Clients.Elasticsearch.IndexManagement.Feature>? features) => Qs("features", features);
 	public GetRequestDescriptor FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public GetRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public GetRequestDescriptor IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/MappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/MappingRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class MappingRequestParameters : RequestParameters<MappingRequestP
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -62,7 +62,7 @@ public sealed partial class MappingRequest : PlainRequest<MappingRequestParamete
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -85,7 +85,7 @@ public sealed partial class MappingRequestDescriptor<TDocument> : RequestDescrip
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public MappingRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public MappingRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public MappingRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public MappingRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public MappingRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	public MappingRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
@@ -111,7 +111,7 @@ public sealed partial class MappingRequestDescriptor : RequestDescriptor<Mapping
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public MappingRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public MappingRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public MappingRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public MappingRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public MappingRequestDescriptor Local(bool? local = true) => Qs("local", local);
 	public MappingRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/OpenRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/OpenRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class OpenRequestParameters : RequestParameters<OpenRequestParamet
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -61,7 +61,7 @@ public sealed partial class OpenRequest : PlainRequest<OpenRequestParameters>
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -91,7 +91,7 @@ public sealed partial class OpenRequestDescriptor<TDocument> : RequestDescriptor
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public OpenRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public OpenRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public OpenRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public OpenRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public OpenRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public OpenRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
@@ -122,7 +122,7 @@ public sealed partial class OpenRequestDescriptor : RequestDescriptor<OpenReques
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public OpenRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public OpenRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public OpenRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public OpenRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public OpenRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public OpenRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutIndexTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutIndexTemplateRequest.g.cs
@@ -51,7 +51,7 @@ public sealed partial class PutIndexTemplateRequest : PlainRequest<PutIndexTempl
 
 	[JsonInclude]
 	[JsonPropertyName("composed_of")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOf { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Name>? ComposedOf { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("template")]
@@ -103,7 +103,7 @@ public sealed partial class PutIndexTemplateRequestDescriptor<TDocument> : Reque
 
 	private Dictionary<string, object>? MetaValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.DataStreamVisibility? DataStreamValue { get; set; }
 
@@ -147,7 +147,7 @@ public sealed partial class PutIndexTemplateRequestDescriptor<TDocument> : Reque
 		return Self;
 	}
 
-	public PutIndexTemplateRequestDescriptor<TDocument> ComposedOf(IEnumerable<Elastic.Clients.Elasticsearch.Name>? composedOf)
+	public PutIndexTemplateRequestDescriptor<TDocument> ComposedOf(IList<Elastic.Clients.Elasticsearch.Name>? composedOf)
 	{
 		ComposedOfValue = composedOf;
 		return Self;
@@ -293,7 +293,7 @@ public sealed partial class PutIndexTemplateRequestDescriptor : RequestDescripto
 
 	private Dictionary<string, object>? MetaValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.DataStreamVisibility? DataStreamValue { get; set; }
 
@@ -337,7 +337,7 @@ public sealed partial class PutIndexTemplateRequestDescriptor : RequestDescripto
 		return Self;
 	}
 
-	public PutIndexTemplateRequestDescriptor ComposedOf(IEnumerable<Elastic.Clients.Elasticsearch.Name>? composedOf)
+	public PutIndexTemplateRequestDescriptor ComposedOf(IList<Elastic.Clients.Elasticsearch.Name>? composedOf)
 	{
 		ComposedOfValue = composedOf;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutMappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutMappingRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class PutMappingRequestParameters : RequestParameters<PutMappingRe
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -61,7 +61,7 @@ public sealed partial class PutMappingRequest : PlainRequest<PutMappingRequestPa
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -85,11 +85,11 @@ public sealed partial class PutMappingRequest : PlainRequest<PutMappingRequestPa
 
 	[JsonInclude]
 	[JsonPropertyName("dynamic_date_formats")]
-	public IEnumerable<string>? DynamicDateFormats { get; set; }
+	public IList<string>? DynamicDateFormats { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("dynamic_templates")]
-	public Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplates { get; set; }
+	public Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplates { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("_field_names")]
@@ -135,7 +135,7 @@ public sealed partial class PutMappingRequestDescriptor<TDocument> : RequestDesc
 	protected override HttpMethod HttpMethod => HttpMethod.PUT;
 	protected override bool SupportsBody => true;
 	public PutMappingRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public PutMappingRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public PutMappingRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public PutMappingRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public PutMappingRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public PutMappingRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
@@ -170,9 +170,9 @@ public sealed partial class PutMappingRequestDescriptor<TDocument> : RequestDesc
 
 	private Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? DynamicValue { get; set; }
 
-	private IEnumerable<string>? DynamicDateFormatsValue { get; set; }
+	private IList<string>? DynamicDateFormatsValue { get; set; }
 
-	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
+	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
 
 	private bool? NumericDetectionValue { get; set; }
 
@@ -270,13 +270,13 @@ public sealed partial class PutMappingRequestDescriptor<TDocument> : RequestDesc
 		return Self;
 	}
 
-	public PutMappingRequestDescriptor<TDocument> DynamicDateFormats(IEnumerable<string>? dynamicDateFormats)
+	public PutMappingRequestDescriptor<TDocument> DynamicDateFormats(IList<string>? dynamicDateFormats)
 	{
 		DynamicDateFormatsValue = dynamicDateFormats;
 		return Self;
 	}
 
-	public PutMappingRequestDescriptor<TDocument> DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
+	public PutMappingRequestDescriptor<TDocument> DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
 	{
 		DynamicTemplatesValue = dynamicTemplates;
 		return Self;
@@ -432,7 +432,7 @@ public sealed partial class PutMappingRequestDescriptor : RequestDescriptor<PutM
 	protected override HttpMethod HttpMethod => HttpMethod.PUT;
 	protected override bool SupportsBody => true;
 	public PutMappingRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public PutMappingRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public PutMappingRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public PutMappingRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public PutMappingRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
 	public PutMappingRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
@@ -467,9 +467,9 @@ public sealed partial class PutMappingRequestDescriptor : RequestDescriptor<PutM
 
 	private Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? DynamicValue { get; set; }
 
-	private IEnumerable<string>? DynamicDateFormatsValue { get; set; }
+	private IList<string>? DynamicDateFormatsValue { get; set; }
 
-	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
+	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
 
 	private bool? NumericDetectionValue { get; set; }
 
@@ -567,13 +567,13 @@ public sealed partial class PutMappingRequestDescriptor : RequestDescriptor<PutM
 		return Self;
 	}
 
-	public PutMappingRequestDescriptor DynamicDateFormats(IEnumerable<string>? dynamicDateFormats)
+	public PutMappingRequestDescriptor DynamicDateFormats(IList<string>? dynamicDateFormats)
 	{
 		DynamicDateFormatsValue = dynamicDateFormats;
 		return Self;
 	}
 
-	public PutMappingRequestDescriptor DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
+	public PutMappingRequestDescriptor DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
 	{
 		DynamicTemplatesValue = dynamicTemplates;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutSettingsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutSettingsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class PutSettingsRequestParameters : RequestParameters<PutSettings
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -68,7 +68,7 @@ public sealed partial class PutSettingsRequest : PlainRequest<PutSettingsRequest
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -97,7 +97,7 @@ public sealed partial class PutSettingsRequestDescriptor<TDocument> : RequestDes
 	protected override HttpMethod HttpMethod => HttpMethod.PUT;
 	protected override bool SupportsBody => false;
 	public PutSettingsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public PutSettingsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public PutSettingsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public PutSettingsRequestDescriptor<TDocument> FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public PutSettingsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public PutSettingsRequestDescriptor<TDocument> MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);
@@ -125,7 +125,7 @@ public sealed partial class PutSettingsRequestDescriptor : RequestDescriptor<Put
 	protected override HttpMethod HttpMethod => HttpMethod.PUT;
 	protected override bool SupportsBody => false;
 	public PutSettingsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public PutSettingsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public PutSettingsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public PutSettingsRequestDescriptor FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public PutSettingsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public PutSettingsRequestDescriptor MasterTimeout(Elastic.Clients.Elasticsearch.Duration? masterTimeout) => Qs("master_timeout", masterTimeout);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/PutTemplateRequest.g.cs
@@ -69,7 +69,7 @@ public sealed partial class PutTemplateRequest : PlainRequest<PutTemplateRequest
 
 	[JsonInclude]
 	[JsonPropertyName("index_patterns")]
-	public IEnumerable<string>? IndexPatterns { get; set; }
+	public IList<string>? IndexPatterns { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("mappings")]
@@ -114,7 +114,7 @@ public sealed partial class PutTemplateRequestDescriptor : RequestDescriptor<Put
 
 	private Dictionary<Elastic.Clients.Elasticsearch.IndexName, Elastic.Clients.Elasticsearch.IndexManagement.Alias>? AliasesValue { get; set; }
 
-	private IEnumerable<string>? IndexPatternsValue { get; set; }
+	private IList<string>? IndexPatternsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Mapping.TypeMapping? MappingsValue { get; set; }
 
@@ -134,7 +134,7 @@ public sealed partial class PutTemplateRequestDescriptor : RequestDescriptor<Put
 		return Self;
 	}
 
-	public PutTemplateRequestDescriptor IndexPatterns(IEnumerable<string>? indexPatterns)
+	public PutTemplateRequestDescriptor IndexPatterns(IList<string>? indexPatterns)
 	{
 		IndexPatternsValue = indexPatterns;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class RefreshRequestParameters : RequestParameters<RefreshRequestP
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -56,7 +56,7 @@ public sealed partial class RefreshRequest : PlainRequest<RefreshRequestParamete
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -73,7 +73,7 @@ public sealed partial class RefreshRequestDescriptor<TDocument> : RequestDescrip
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public RefreshRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public RefreshRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public RefreshRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public RefreshRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public RefreshRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{
@@ -97,7 +97,7 @@ public sealed partial class RefreshRequestDescriptor : RequestDescriptor<Refresh
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public RefreshRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public RefreshRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public RefreshRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public RefreshRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public RefreshRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ReloadSearchAnalyzersRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ReloadSearchAnalyzersRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class ReloadSearchAnalyzersRequestParameters : RequestParameters<R
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -52,7 +52,7 @@ public sealed partial class ReloadSearchAnalyzersRequest : PlainRequest<ReloadSe
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -73,7 +73,7 @@ public sealed partial class ReloadSearchAnalyzersRequestDescriptor<TDocument> : 
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ReloadSearchAnalyzersRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ReloadSearchAnalyzersRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ReloadSearchAnalyzersRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ReloadSearchAnalyzersRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ReloadSearchAnalyzersRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices indices)
 	{
@@ -101,7 +101,7 @@ public sealed partial class ReloadSearchAnalyzersRequestDescriptor : RequestDesc
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public ReloadSearchAnalyzersRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ReloadSearchAnalyzersRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ReloadSearchAnalyzersRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ReloadSearchAnalyzersRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ReloadSearchAnalyzersRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices indices)
 	{

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ResolveIndexRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ResolveIndexRequest.g.cs
@@ -30,7 +30,7 @@ namespace Elastic.Clients.Elasticsearch.IndexManagement;
 public sealed class ResolveIndexRequestParameters : RequestParameters<ResolveIndexRequestParameters>
 {
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class ResolveIndexRequest : PlainRequest<ResolveIndexRequestParameters>
@@ -43,7 +43,7 @@ public sealed partial class ResolveIndexRequest : PlainRequest<ResolveIndexReque
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 }
 
 public sealed partial class ResolveIndexRequestDescriptor : RequestDescriptor<ResolveIndexRequestDescriptor, ResolveIndexRequestParameters>
@@ -60,7 +60,7 @@ public sealed partial class ResolveIndexRequestDescriptor : RequestDescriptor<Re
 	internal override ApiUrls ApiUrls => ApiUrlsLookups.IndexManagementResolveIndex;
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
-	public ResolveIndexRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ResolveIndexRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ResolveIndexRequestDescriptor Name(Elastic.Clients.Elasticsearch.Names name)
 	{
 		RouteValues.Required("name", name);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class SegmentsRequestParameters : RequestParameters<SegmentsReques
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -59,7 +59,7 @@ public sealed partial class SegmentsRequest : PlainRequest<SegmentsRequestParame
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -79,7 +79,7 @@ public sealed partial class SegmentsRequestDescriptor<TDocument> : RequestDescri
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public SegmentsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SegmentsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SegmentsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SegmentsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SegmentsRequestDescriptor<TDocument> Verbose(bool? verbose = true) => Qs("verbose", verbose);
 	public SegmentsRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices? indices)
@@ -104,7 +104,7 @@ public sealed partial class SegmentsRequestDescriptor : RequestDescriptor<Segmen
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public SegmentsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SegmentsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SegmentsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SegmentsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SegmentsRequestDescriptor Verbose(bool? verbose = true) => Qs("verbose", verbose);
 	public SegmentsRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices? indices)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SettingsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SettingsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class SettingsRequestParameters : RequestParameters<SettingsReques
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -76,7 +76,7 @@ public sealed partial class SettingsRequest : PlainRequest<SettingsRequestParame
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? FlatSettings { get => Q<bool?>("flat_settings"); set => Q("flat_settings", value); }
@@ -113,7 +113,7 @@ public sealed partial class SettingsRequestDescriptor<TDocument> : RequestDescri
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public SettingsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SettingsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SettingsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SettingsRequestDescriptor<TDocument> FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public SettingsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SettingsRequestDescriptor<TDocument> IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);
@@ -155,7 +155,7 @@ public sealed partial class SettingsRequestDescriptor : RequestDescriptor<Settin
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public SettingsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SettingsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SettingsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SettingsRequestDescriptor FlatSettings(bool? flatSettings = true) => Qs("flat_settings", flatSettings);
 	public SettingsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SettingsRequestDescriptor IncludeDefaults(bool? includeDefaults = true) => Qs("include_defaults", includeDefaults);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ShardStoresRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ShardStoresRequest.g.cs
@@ -33,13 +33,13 @@ public sealed class ShardStoresRequestParameters : RequestParameters<ShardStores
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? Status { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>?>("status"); set => Q("status", value); }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? Status { get => Q<IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>?>("status"); set => Q("status", value); }
 }
 
 public sealed partial class ShardStoresRequest : PlainRequest<ShardStoresRequestParameters>
@@ -59,13 +59,13 @@ public sealed partial class ShardStoresRequest : PlainRequest<ShardStoresRequest
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? Status { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>?>("status"); set => Q("status", value); }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? Status { get => Q<IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>?>("status"); set => Q("status", value); }
 }
 
 public sealed partial class ShardStoresRequestDescriptor<TDocument> : RequestDescriptor<ShardStoresRequestDescriptor<TDocument>, ShardStoresRequestParameters>
@@ -79,9 +79,9 @@ public sealed partial class ShardStoresRequestDescriptor<TDocument> : RequestDes
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public ShardStoresRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ShardStoresRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ShardStoresRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ShardStoresRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
-	public ShardStoresRequestDescriptor<TDocument> Status(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? status) => Qs("status", status);
+	public ShardStoresRequestDescriptor<TDocument> Status(IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? status) => Qs("status", status);
 	public ShardStoresRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{
 		RouteValues.Optional("index", indices);
@@ -104,9 +104,9 @@ public sealed partial class ShardStoresRequestDescriptor : RequestDescriptor<Sha
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public ShardStoresRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public ShardStoresRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ShardStoresRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ShardStoresRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
-	public ShardStoresRequestDescriptor Status(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? status) => Qs("status", status);
+	public ShardStoresRequestDescriptor Status(IList<Elastic.Clients.Elasticsearch.IndexManagement.ShardStoreStatus>? status) => Qs("status", status);
 	public ShardStoresRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices? indices)
 	{
 		RouteValues.Optional("index", indices);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SimulateIndexTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SimulateIndexTemplateRequest.g.cs
@@ -61,7 +61,7 @@ public sealed partial class SimulateIndexTemplateRequest : PlainRequest<Simulate
 
 	[JsonInclude]
 	[JsonPropertyName("composed_of")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOf { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Name>? ComposedOf { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("template")]
@@ -116,7 +116,7 @@ public sealed partial class SimulateIndexTemplateRequestDescriptor<TDocument> : 
 
 	private bool? AllowAutoCreateValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.DataStreamVisibility? DataStreamValue { get; set; }
 
@@ -166,7 +166,7 @@ public sealed partial class SimulateIndexTemplateRequestDescriptor<TDocument> : 
 		return Self;
 	}
 
-	public SimulateIndexTemplateRequestDescriptor<TDocument> ComposedOf(IEnumerable<Elastic.Clients.Elasticsearch.Name>? composedOf)
+	public SimulateIndexTemplateRequestDescriptor<TDocument> ComposedOf(IList<Elastic.Clients.Elasticsearch.Name>? composedOf)
 	{
 		ComposedOfValue = composedOf;
 		return Self;
@@ -321,7 +321,7 @@ public sealed partial class SimulateIndexTemplateRequestDescriptor : RequestDesc
 
 	private bool? AllowAutoCreateValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Name>? ComposedOfValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.DataStreamVisibility? DataStreamValue { get; set; }
 
@@ -371,7 +371,7 @@ public sealed partial class SimulateIndexTemplateRequestDescriptor : RequestDesc
 		return Self;
 	}
 
-	public SimulateIndexTemplateRequestDescriptor ComposedOf(IEnumerable<Elastic.Clients.Elasticsearch.Name>? composedOf)
+	public SimulateIndexTemplateRequestDescriptor ComposedOf(IList<Elastic.Clients.Elasticsearch.Name>? composedOf)
 	{
 		ComposedOfValue = composedOf;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/StatsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/StatsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class StatsRequestParameters : RequestParameters<StatsRequestParam
 	public Elastic.Clients.Elasticsearch.Fields? CompletionFields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("completion_fields"); set => Q("completion_fields", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Fields? FielddataFields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("fielddata_fields"); set => Q("fielddata_fields", value); }
@@ -45,7 +45,7 @@ public sealed class StatsRequestParameters : RequestParameters<StatsRequestParam
 	public bool? ForbidClosedIndices { get => Q<bool?>("forbid_closed_indices"); set => Q("forbid_closed_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Groups { get => Q<IEnumerable<string>?>("groups"); set => Q("groups", value); }
+	public IList<string>? Groups { get => Q<IList<string>?>("groups"); set => Q("groups", value); }
 
 	[JsonIgnore]
 	public bool? IncludeSegmentFileSizes { get => Q<bool?>("include_segment_file_sizes"); set => Q("include_segment_file_sizes", value); }
@@ -82,7 +82,7 @@ public sealed partial class StatsRequest : PlainRequest<StatsRequestParameters>
 	public Elastic.Clients.Elasticsearch.Fields? CompletionFields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("completion_fields"); set => Q("completion_fields", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public Elastic.Clients.Elasticsearch.Fields? FielddataFields { get => Q<Elastic.Clients.Elasticsearch.Fields?>("fielddata_fields"); set => Q("fielddata_fields", value); }
@@ -94,7 +94,7 @@ public sealed partial class StatsRequest : PlainRequest<StatsRequestParameters>
 	public bool? ForbidClosedIndices { get => Q<bool?>("forbid_closed_indices"); set => Q("forbid_closed_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Groups { get => Q<IEnumerable<string>?>("groups"); set => Q("groups", value); }
+	public IList<string>? Groups { get => Q<IList<string>?>("groups"); set => Q("groups", value); }
 
 	[JsonIgnore]
 	public bool? IncludeSegmentFileSizes { get => Q<bool?>("include_segment_file_sizes"); set => Q("include_segment_file_sizes", value); }
@@ -125,11 +125,11 @@ public sealed partial class StatsRequestDescriptor<TDocument> : RequestDescripto
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public StatsRequestDescriptor<TDocument> CompletionFields(Elastic.Clients.Elasticsearch.Fields? completionFields) => Qs("completion_fields", completionFields);
-	public StatsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public StatsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public StatsRequestDescriptor<TDocument> FielddataFields(Elastic.Clients.Elasticsearch.Fields? fielddataFields) => Qs("fielddata_fields", fielddataFields);
 	public StatsRequestDescriptor<TDocument> Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public StatsRequestDescriptor<TDocument> ForbidClosedIndices(bool? forbidClosedIndices = true) => Qs("forbid_closed_indices", forbidClosedIndices);
-	public StatsRequestDescriptor<TDocument> Groups(IEnumerable<string>? groups) => Qs("groups", groups);
+	public StatsRequestDescriptor<TDocument> Groups(IList<string>? groups) => Qs("groups", groups);
 	public StatsRequestDescriptor<TDocument> IncludeSegmentFileSizes(bool? includeSegmentFileSizes = true) => Qs("include_segment_file_sizes", includeSegmentFileSizes);
 	public StatsRequestDescriptor<TDocument> IncludeUnloadedSegments(bool? includeUnloadedSegments = true) => Qs("include_unloaded_segments", includeUnloadedSegments);
 	public StatsRequestDescriptor<TDocument> Level(Elastic.Clients.Elasticsearch.Level? level) => Qs("level", level);
@@ -169,11 +169,11 @@ public sealed partial class StatsRequestDescriptor : RequestDescriptor<StatsRequ
 	protected override HttpMethod HttpMethod => HttpMethod.GET;
 	protected override bool SupportsBody => false;
 	public StatsRequestDescriptor CompletionFields(Elastic.Clients.Elasticsearch.Fields? completionFields) => Qs("completion_fields", completionFields);
-	public StatsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public StatsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public StatsRequestDescriptor FielddataFields(Elastic.Clients.Elasticsearch.Fields? fielddataFields) => Qs("fielddata_fields", fielddataFields);
 	public StatsRequestDescriptor Fields(Elastic.Clients.Elasticsearch.Fields? fields) => Qs("fields", fields);
 	public StatsRequestDescriptor ForbidClosedIndices(bool? forbidClosedIndices = true) => Qs("forbid_closed_indices", forbidClosedIndices);
-	public StatsRequestDescriptor Groups(IEnumerable<string>? groups) => Qs("groups", groups);
+	public StatsRequestDescriptor Groups(IList<string>? groups) => Qs("groups", groups);
 	public StatsRequestDescriptor IncludeSegmentFileSizes(bool? includeSegmentFileSizes = true) => Qs("include_segment_file_sizes", includeSegmentFileSizes);
 	public StatsRequestDescriptor IncludeUnloadedSegments(bool? includeUnloadedSegments = true) => Qs("include_unloaded_segments", includeUnloadedSegments);
 	public StatsRequestDescriptor Level(Elastic.Clients.Elasticsearch.Level? level) => Qs("level", level);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
@@ -48,7 +48,7 @@ public sealed class ValidateQueryRequestParameters : RequestParameters<ValidateQ
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Explain { get => Q<bool?>("explain"); set => Q("explain", value); }
@@ -98,7 +98,7 @@ public sealed partial class ValidateQueryRequest : PlainRequest<ValidateQueryReq
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? Explain { get => Q<bool?>("explain"); set => Q("explain", value); }
@@ -136,7 +136,7 @@ public sealed partial class ValidateQueryRequestDescriptor<TDocument> : RequestD
 	public ValidateQueryRequestDescriptor<TDocument> Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public ValidateQueryRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public ValidateQueryRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public ValidateQueryRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ValidateQueryRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ValidateQueryRequestDescriptor<TDocument> Explain(bool? explain = true) => Qs("explain", explain);
 	public ValidateQueryRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ValidateQueryRequestDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -217,7 +217,7 @@ public sealed partial class ValidateQueryRequestDescriptor : RequestDescriptor<V
 	public ValidateQueryRequestDescriptor Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public ValidateQueryRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public ValidateQueryRequestDescriptor Df(string? df) => Qs("df", df);
-	public ValidateQueryRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public ValidateQueryRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public ValidateQueryRequestDescriptor Explain(bool? explain = true) => Qs("explain", explain);
 	public ValidateQueryRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public ValidateQueryRequestDescriptor Lenient(bool? lenient = true) => Qs("lenient", lenient);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiGetRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiGetRequest.g.cs
@@ -93,7 +93,7 @@ public sealed partial class MultiGetRequest : PlainRequest<MultiGetRequestParame
 
 	[JsonInclude]
 	[JsonPropertyName("docs")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? Docs { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? Docs { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("ids")]
@@ -124,7 +124,7 @@ public sealed partial class MultiGetRequestDescriptor<TDocument> : RequestDescri
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? DocsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? DocsValue { get; set; }
 
 	private Core.MGet.OperationDescriptor DocsDescriptor { get; set; }
 
@@ -134,7 +134,7 @@ public sealed partial class MultiGetRequestDescriptor<TDocument> : RequestDescri
 
 	private Elastic.Clients.Elasticsearch.Ids? IdsValue { get; set; }
 
-	public MultiGetRequestDescriptor<TDocument> Docs(IEnumerable<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? docs)
+	public MultiGetRequestDescriptor<TDocument> Docs(IList<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? docs)
 	{
 		DocsDescriptor = null;
 		DocsDescriptorAction = null;
@@ -244,7 +244,7 @@ public sealed partial class MultiGetRequestDescriptor : RequestDescriptor<MultiG
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? DocsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? DocsValue { get; set; }
 
 	private Core.MGet.OperationDescriptor DocsDescriptor { get; set; }
 
@@ -254,7 +254,7 @@ public sealed partial class MultiGetRequestDescriptor : RequestDescriptor<MultiG
 
 	private Elastic.Clients.Elasticsearch.Ids? IdsValue { get; set; }
 
-	public MultiGetRequestDescriptor Docs(IEnumerable<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? docs)
+	public MultiGetRequestDescriptor Docs(IList<Elastic.Clients.Elasticsearch.Core.MGet.Operation>? docs)
 	{
 		DocsDescriptor = null;
 		DocsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchRequest.g.cs
@@ -38,7 +38,7 @@ public sealed class MultiSearchRequestParameters : RequestParameters<MultiSearch
 	public bool? CcsMinimizeRoundtrips { get => Q<bool?>("ccs_minimize_roundtrips"); set => Q("ccs_minimize_roundtrips", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -88,7 +88,7 @@ public sealed partial class MultiSearchRequest : PlainRequest<MultiSearchRequest
 	public bool? CcsMinimizeRoundtrips { get => Q<bool?>("ccs_minimize_roundtrips"); set => Q("ccs_minimize_roundtrips", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -154,7 +154,7 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 	protected override bool SupportsBody => true;
 	public MultiSearchRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
 	public MultiSearchRequestDescriptor<TDocument> CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
-	public MultiSearchRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public MultiSearchRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public MultiSearchRequestDescriptor<TDocument> IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public MultiSearchRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public MultiSearchRequestDescriptor<TDocument> MaxConcurrentSearches(long? maxConcurrentSearches) => Qs("max_concurrent_searches", maxConcurrentSearches);
@@ -216,7 +216,7 @@ public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<Mul
 	protected override bool SupportsBody => true;
 	public MultiSearchRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
 	public MultiSearchRequestDescriptor CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
-	public MultiSearchRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public MultiSearchRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public MultiSearchRequestDescriptor IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public MultiSearchRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public MultiSearchRequestDescriptor MaxConcurrentSearches(long? maxConcurrentSearches) => Qs("max_concurrent_searches", maxConcurrentSearches);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/RankEvalRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/RankEvalRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class RankEvalRequestParameters : RequestParameters<RankEvalReques
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -55,7 +55,7 @@ public sealed partial class RankEvalRequest : PlainRequest<RankEvalRequestParame
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -65,7 +65,7 @@ public sealed partial class RankEvalRequest : PlainRequest<RankEvalRequestParame
 
 	[JsonInclude]
 	[JsonPropertyName("requests")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> Requests { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> Requests { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("metric")]
@@ -87,7 +87,7 @@ public sealed partial class RankEvalRequestDescriptor<TDocument> : RequestDescri
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public RankEvalRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public RankEvalRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public RankEvalRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public RankEvalRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public RankEvalRequestDescriptor<TDocument> SearchType(string? searchType) => Qs("search_type", searchType);
 	public RankEvalRequestDescriptor<TDocument> Indices(Elastic.Clients.Elasticsearch.Indices indices)
@@ -96,7 +96,7 @@ public sealed partial class RankEvalRequestDescriptor<TDocument> : RequestDescri
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> RequestsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> RequestsValue { get; set; }
 
 	private Core.RankEval.RankEvalRequestItemDescriptor<TDocument> RequestsDescriptor { get; set; }
 
@@ -110,7 +110,7 @@ public sealed partial class RankEvalRequestDescriptor<TDocument> : RequestDescri
 
 	private Action<Core.RankEval.RankEvalMetricDescriptor> MetricDescriptorAction { get; set; }
 
-	public RankEvalRequestDescriptor<TDocument> Requests(IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> requests)
+	public RankEvalRequestDescriptor<TDocument> Requests(IList<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> requests)
 	{
 		RequestsDescriptor = null;
 		RequestsDescriptorAction = null;
@@ -239,7 +239,7 @@ public sealed partial class RankEvalRequestDescriptor : RequestDescriptor<RankEv
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => true;
 	public RankEvalRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public RankEvalRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public RankEvalRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public RankEvalRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public RankEvalRequestDescriptor SearchType(string? searchType) => Qs("search_type", searchType);
 	public RankEvalRequestDescriptor Indices(Elastic.Clients.Elasticsearch.Indices indices)
@@ -248,7 +248,7 @@ public sealed partial class RankEvalRequestDescriptor : RequestDescriptor<RankEv
 		return Self;
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> RequestsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> RequestsValue { get; set; }
 
 	private Core.RankEval.RankEvalRequestItemDescriptor RequestsDescriptor { get; set; }
 
@@ -262,7 +262,7 @@ public sealed partial class RankEvalRequestDescriptor : RequestDescriptor<RankEv
 
 	private Action<Core.RankEval.RankEvalMetricDescriptor> MetricDescriptorAction { get; set; }
 
-	public RankEvalRequestDescriptor Requests(IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> requests)
+	public RankEvalRequestDescriptor Requests(IList<Elastic.Clients.Elasticsearch.Core.RankEval.RankEvalRequestItem> requests)
 	{
 		RequestsDescriptor = null;
 		RequestsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
@@ -54,7 +54,7 @@ public sealed class SearchRequestParameters : RequestParameters<SearchRequestPar
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -173,13 +173,13 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "indices_boost")
 				{
-					variant.IndicesBoost = JsonSerializer.Deserialize<IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
+					variant.IndicesBoost = JsonSerializer.Deserialize<IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
 					continue;
 				}
 
 				if (property == "docvalue_fields")
 				{
-					variant.DocvalueFields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.DocvalueFields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -215,7 +215,7 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "rescore")
 				{
-					variant.Rescore = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
+					variant.Rescore = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
 					continue;
 				}
 
@@ -227,7 +227,7 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "search_after")
 				{
-					variant.SearchAfter = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
+					variant.SearchAfter = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
 					continue;
 				}
 
@@ -245,7 +245,7 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "sort")
 				{
-					variant.Sort = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
+					variant.Sort = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
 					continue;
 				}
 
@@ -257,7 +257,7 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "fields")
 				{
-					variant.Fields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.Fields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -317,7 +317,7 @@ internal sealed class SearchRequestConverter : JsonConverter<SearchRequest>
 
 				if (property == "stats")
 				{
-					variant.Stats = JsonSerializer.Deserialize<IEnumerable<string>?>(ref reader, options);
+					variant.Stats = JsonSerializer.Deserialize<IList<string>?>(ref reader, options);
 					continue;
 				}
 			}
@@ -564,7 +564,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreThrottled { get => Q<bool?>("ignore_throttled"); set => Q("ignore_throttled", value); }
@@ -656,11 +656,11 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 
 	[JsonInclude]
 	[JsonPropertyName("indices_boost")]
-	public IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
+	public IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("docvalue_fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("knn")]
@@ -684,7 +684,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 
 	[JsonInclude]
 	[JsonPropertyName("rescore")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("script_fields")]
@@ -692,7 +692,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 
 	[JsonInclude]
 	[JsonPropertyName("search_after")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("size")]
@@ -705,7 +705,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 	[JsonInclude]
 	[JsonPropertyName("sort")]
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("_source")]
@@ -713,7 +713,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("suggest")]
@@ -753,7 +753,7 @@ public partial class SearchRequest : PlainRequest<SearchRequestParameters>
 
 	[JsonInclude]
 	[JsonPropertyName("stats")]
-	public IEnumerable<string>? Stats { get; set; }
+	public IList<string>? Stats { get; set; }
 }
 
 public sealed partial class SearchRequest<TInferDocument> : SearchRequest
@@ -787,7 +787,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 	public SearchRequestDescriptor<TDocument> CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
 	public SearchRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public SearchRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public SearchRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SearchRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SearchRequestDescriptor<TDocument> IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public SearchRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SearchRequestDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -824,7 +824,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 
 	private Action<Core.Search.FieldCollapseDescriptor<TDocument>> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> DocvalueFieldsDescriptor { get; set; }
 
@@ -832,7 +832,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 
 	private Action<QueryDsl.FieldAndFormatDescriptor<TDocument>>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> FieldsDescriptor { get; set; }
 
@@ -864,7 +864,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 
 	private Action<QueryDsl.QueryContainerDescriptor<TDocument>> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor<TDocument> RescoreDescriptor { get; set; }
 
@@ -886,7 +886,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -902,15 +902,15 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -978,7 +978,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public SearchRequestDescriptor<TDocument> DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -1014,7 +1014,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public SearchRequestDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -1146,7 +1146,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public SearchRequestDescriptor<TDocument> Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -1230,7 +1230,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public SearchRequestDescriptor<TDocument> IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -1284,7 +1284,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public SearchRequestDescriptor<TDocument> SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -1302,13 +1302,13 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public SearchRequestDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public SearchRequestDescriptor<TDocument> Stats(IEnumerable<string>? stats)
+	public SearchRequestDescriptor<TDocument> Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;
@@ -1762,7 +1762,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 	public SearchRequestDescriptor CcsMinimizeRoundtrips(bool? ccsMinimizeRoundtrips = true) => Qs("ccs_minimize_roundtrips", ccsMinimizeRoundtrips);
 	public SearchRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public SearchRequestDescriptor Df(string? df) => Qs("df", df);
-	public SearchRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SearchRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SearchRequestDescriptor IgnoreThrottled(bool? ignoreThrottled = true) => Qs("ignore_throttled", ignoreThrottled);
 	public SearchRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SearchRequestDescriptor Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -1799,7 +1799,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 
 	private Action<Core.Search.FieldCollapseDescriptor> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor DocvalueFieldsDescriptor { get; set; }
 
@@ -1807,7 +1807,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 
 	private Action<QueryDsl.FieldAndFormatDescriptor>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor FieldsDescriptor { get; set; }
 
@@ -1839,7 +1839,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 
 	private Action<QueryDsl.QueryContainerDescriptor> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor RescoreDescriptor { get; set; }
 
@@ -1861,7 +1861,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -1877,15 +1877,15 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -1953,7 +1953,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public SearchRequestDescriptor DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -1989,7 +1989,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public SearchRequestDescriptor Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -2121,7 +2121,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public SearchRequestDescriptor Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -2205,7 +2205,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public SearchRequestDescriptor IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -2259,7 +2259,7 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public SearchRequestDescriptor SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -2277,13 +2277,13 @@ public sealed partial class SearchRequestDescriptor : RequestDescriptor<SearchRe
 		return Self;
 	}
 
-	public SearchRequestDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public SearchRequestDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public SearchRequestDescriptor Stats(IEnumerable<string>? stats)
+	public SearchRequestDescriptor Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchShardsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchShardsRequest.g.cs
@@ -33,7 +33,7 @@ public sealed class SearchShardsRequestParameters : RequestParameters<SearchShar
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -65,7 +65,7 @@ public sealed partial class SearchShardsRequest : PlainRequest<SearchShardsReque
 	public bool? AllowNoIndices { get => Q<bool?>("allow_no_indices"); set => Q("allow_no_indices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public bool? IgnoreUnavailable { get => Q<bool?>("ignore_unavailable"); set => Q("ignore_unavailable", value); }
@@ -91,7 +91,7 @@ public sealed partial class SearchShardsRequestDescriptor<TDocument> : RequestDe
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public SearchShardsRequestDescriptor<TDocument> AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SearchShardsRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SearchShardsRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SearchShardsRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SearchShardsRequestDescriptor<TDocument> Local(bool? local = true) => Qs("local", local);
 	public SearchShardsRequestDescriptor<TDocument> Preference(string? preference) => Qs("preference", preference);
@@ -118,7 +118,7 @@ public sealed partial class SearchShardsRequestDescriptor : RequestDescriptor<Se
 	protected override HttpMethod HttpMethod => HttpMethod.POST;
 	protected override bool SupportsBody => false;
 	public SearchShardsRequestDescriptor AllowNoIndices(bool? allowNoIndices = true) => Qs("allow_no_indices", allowNoIndices);
-	public SearchShardsRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public SearchShardsRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public SearchShardsRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public SearchShardsRequestDescriptor Local(bool? local = true) => Qs("local", local);
 	public SearchShardsRequestDescriptor Preference(string? preference) => Qs("preference", preference);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/UpdateByQueryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/UpdateByQueryRequest.g.cs
@@ -45,7 +45,7 @@ public sealed class UpdateByQueryRequestParameters : RequestParameters<UpdateByQ
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public long? From { get => Q<long?>("from"); set => Q("from", value); }
@@ -90,10 +90,10 @@ public sealed class UpdateByQueryRequestParameters : RequestParameters<UpdateByQ
 	public Elastic.Clients.Elasticsearch.Slices? Slices { get => Q<Elastic.Clients.Elasticsearch.Slices?>("slices"); set => Q("slices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Sort { get => Q<IEnumerable<string>?>("sort"); set => Q("sort", value); }
+	public IList<string>? Sort { get => Q<IList<string>?>("sort"); set => Q("sort", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Stats { get => Q<IEnumerable<string>?>("stats"); set => Q("stats", value); }
+	public IList<string>? Stats { get => Q<IList<string>?>("stats"); set => Q("stats", value); }
 
 	[JsonIgnore]
 	public long? TerminateAfter { get => Q<long?>("terminate_after"); set => Q("terminate_after", value); }
@@ -139,7 +139,7 @@ public sealed partial class UpdateByQueryRequest : PlainRequest<UpdateByQueryReq
 	public string? Df { get => Q<string?>("df"); set => Q("df", value); }
 
 	[JsonIgnore]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get => Q<IList<Elastic.Clients.Elasticsearch.ExpandWildcard>?>("expand_wildcards"); set => Q("expand_wildcards", value); }
 
 	[JsonIgnore]
 	public long? From { get => Q<long?>("from"); set => Q("from", value); }
@@ -184,10 +184,10 @@ public sealed partial class UpdateByQueryRequest : PlainRequest<UpdateByQueryReq
 	public Elastic.Clients.Elasticsearch.Slices? Slices { get => Q<Elastic.Clients.Elasticsearch.Slices?>("slices"); set => Q("slices", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Sort { get => Q<IEnumerable<string>?>("sort"); set => Q("sort", value); }
+	public IList<string>? Sort { get => Q<IList<string>?>("sort"); set => Q("sort", value); }
 
 	[JsonIgnore]
-	public IEnumerable<string>? Stats { get => Q<IEnumerable<string>?>("stats"); set => Q("stats", value); }
+	public IList<string>? Stats { get => Q<IList<string>?>("stats"); set => Q("stats", value); }
 
 	[JsonIgnore]
 	public long? TerminateAfter { get => Q<long?>("terminate_after"); set => Q("terminate_after", value); }
@@ -247,7 +247,7 @@ public sealed partial class UpdateByQueryRequestDescriptor<TDocument> : RequestD
 	public UpdateByQueryRequestDescriptor<TDocument> Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public UpdateByQueryRequestDescriptor<TDocument> DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public UpdateByQueryRequestDescriptor<TDocument> Df(string? df) => Qs("df", df);
-	public UpdateByQueryRequestDescriptor<TDocument> ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public UpdateByQueryRequestDescriptor<TDocument> ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public UpdateByQueryRequestDescriptor<TDocument> From(long? from) => Qs("from", from);
 	public UpdateByQueryRequestDescriptor<TDocument> IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public UpdateByQueryRequestDescriptor<TDocument> Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -262,8 +262,8 @@ public sealed partial class UpdateByQueryRequestDescriptor<TDocument> : RequestD
 	public UpdateByQueryRequestDescriptor<TDocument> SearchTimeout(Elastic.Clients.Elasticsearch.Duration? searchTimeout) => Qs("search_timeout", searchTimeout);
 	public UpdateByQueryRequestDescriptor<TDocument> SearchType(Elastic.Clients.Elasticsearch.SearchType? searchType) => Qs("search_type", searchType);
 	public UpdateByQueryRequestDescriptor<TDocument> Slices(Elastic.Clients.Elasticsearch.Slices? slices) => Qs("slices", slices);
-	public UpdateByQueryRequestDescriptor<TDocument> Sort(IEnumerable<string>? sort) => Qs("sort", sort);
-	public UpdateByQueryRequestDescriptor<TDocument> Stats(IEnumerable<string>? stats) => Qs("stats", stats);
+	public UpdateByQueryRequestDescriptor<TDocument> Sort(IList<string>? sort) => Qs("sort", sort);
+	public UpdateByQueryRequestDescriptor<TDocument> Stats(IList<string>? stats) => Qs("stats", stats);
 	public UpdateByQueryRequestDescriptor<TDocument> TerminateAfter(long? terminateAfter) => Qs("terminate_after", terminateAfter);
 	public UpdateByQueryRequestDescriptor<TDocument> Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
 	public UpdateByQueryRequestDescriptor<TDocument> Version(bool? version = true) => Qs("version", version);
@@ -436,7 +436,7 @@ public sealed partial class UpdateByQueryRequestDescriptor : RequestDescriptor<U
 	public UpdateByQueryRequestDescriptor Analyzer(string? analyzer) => Qs("analyzer", analyzer);
 	public UpdateByQueryRequestDescriptor DefaultOperator(Elastic.Clients.Elasticsearch.QueryDsl.Operator? defaultOperator) => Qs("default_operator", defaultOperator);
 	public UpdateByQueryRequestDescriptor Df(string? df) => Qs("df", df);
-	public UpdateByQueryRequestDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
+	public UpdateByQueryRequestDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards) => Qs("expand_wildcards", expandWildcards);
 	public UpdateByQueryRequestDescriptor From(long? from) => Qs("from", from);
 	public UpdateByQueryRequestDescriptor IgnoreUnavailable(bool? ignoreUnavailable = true) => Qs("ignore_unavailable", ignoreUnavailable);
 	public UpdateByQueryRequestDescriptor Lenient(bool? lenient = true) => Qs("lenient", lenient);
@@ -451,8 +451,8 @@ public sealed partial class UpdateByQueryRequestDescriptor : RequestDescriptor<U
 	public UpdateByQueryRequestDescriptor SearchTimeout(Elastic.Clients.Elasticsearch.Duration? searchTimeout) => Qs("search_timeout", searchTimeout);
 	public UpdateByQueryRequestDescriptor SearchType(Elastic.Clients.Elasticsearch.SearchType? searchType) => Qs("search_type", searchType);
 	public UpdateByQueryRequestDescriptor Slices(Elastic.Clients.Elasticsearch.Slices? slices) => Qs("slices", slices);
-	public UpdateByQueryRequestDescriptor Sort(IEnumerable<string>? sort) => Qs("sort", sort);
-	public UpdateByQueryRequestDescriptor Stats(IEnumerable<string>? stats) => Qs("stats", stats);
+	public UpdateByQueryRequestDescriptor Sort(IList<string>? sort) => Qs("sort", sort);
+	public UpdateByQueryRequestDescriptor Stats(IList<string>? stats) => Qs("stats", stats);
 	public UpdateByQueryRequestDescriptor TerminateAfter(long? terminateAfter) => Qs("terminate_after", terminateAfter);
 	public UpdateByQueryRequestDescriptor Timeout(Elastic.Clients.Elasticsearch.Duration? timeout) => Qs("timeout", timeout);
 	public UpdateByQueryRequestDescriptor Version(bool? version = true) => Qs("version", version);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/CompositeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/CompositeAggregation.g.cs
@@ -67,7 +67,7 @@ internal sealed class CompositeAggregationConverter : JsonConverter<CompositeAgg
 				if (reader.ValueTextEquals("sources"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Sources = value;
@@ -167,7 +167,7 @@ public sealed partial class CompositeAggregation : Aggregation
 
 	public int? Size { get; set; }
 
-	public IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? Sources { get; set; }
+	public IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? Sources { get; set; }
 }
 
 public sealed partial class CompositeAggregationDescriptor<TDocument> : SerializableDescriptor<CompositeAggregationDescriptor<TDocument>>
@@ -189,7 +189,7 @@ public sealed partial class CompositeAggregationDescriptor<TDocument> : Serializ
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? SourcesValue { get; set; }
+	private IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? SourcesValue { get; set; }
 
 	public CompositeAggregationDescriptor<TDocument> Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
 	{
@@ -233,7 +233,7 @@ public sealed partial class CompositeAggregationDescriptor<TDocument> : Serializ
 		return Self;
 	}
 
-	public CompositeAggregationDescriptor<TDocument> Sources(IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? sources)
+	public CompositeAggregationDescriptor<TDocument> Sources(IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? sources)
 	{
 		SourcesValue = sources;
 		return Self;
@@ -308,7 +308,7 @@ public sealed partial class CompositeAggregationDescriptor : SerializableDescrip
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? SourcesValue { get; set; }
+	private IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? SourcesValue { get; set; }
 
 	public CompositeAggregationDescriptor Aggregations(Elastic.Clients.Elasticsearch.Aggregations.AggregationDictionary? aggregations)
 	{
@@ -352,7 +352,7 @@ public sealed partial class CompositeAggregationDescriptor : SerializableDescrip
 		return Self;
 	}
 
-	public CompositeAggregationDescriptor Sources(IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? sources)
+	public CompositeAggregationDescriptor Sources(IList<Dictionary<string, Elastic.Clients.Elasticsearch.Aggregations.CompositeAggregationSource>>? sources)
 	{
 		SourcesValue = sources;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateHistogramAggregation.g.cs
@@ -322,7 +322,7 @@ public sealed partial class DateHistogramAggregation : Aggregation
 	public Elastic.Clients.Elasticsearch.Duration? Offset { get; set; }
 
 	[JsonConverter(typeof(AggregateOrderConverter))]
-	public IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
+	public IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
 
 	public Dictionary<string, object>? Params { get; set; }
 
@@ -360,7 +360,7 @@ public sealed partial class DateHistogramAggregationDescriptor<TDocument> : Seri
 
 	private Elastic.Clients.Elasticsearch.Duration? OffsetValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Dictionary<string, object>? ParamsValue { get; set; }
 
@@ -446,7 +446,7 @@ public sealed partial class DateHistogramAggregationDescriptor<TDocument> : Seri
 		return Self;
 	}
 
-	public DateHistogramAggregationDescriptor<TDocument> Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public DateHistogramAggregationDescriptor<TDocument> Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;
@@ -597,7 +597,7 @@ public sealed partial class DateHistogramAggregationDescriptor : SerializableDes
 
 	private Elastic.Clients.Elasticsearch.Duration? OffsetValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Dictionary<string, object>? ParamsValue { get; set; }
 
@@ -689,7 +689,7 @@ public sealed partial class DateHistogramAggregationDescriptor : SerializableDes
 		return Self;
 	}
 
-	public DateHistogramAggregationDescriptor Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public DateHistogramAggregationDescriptor Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/DateRangeAggregation.g.cs
@@ -79,7 +79,7 @@ internal sealed class DateRangeAggregationConverter : JsonConverter<DateRangeAgg
 				if (reader.ValueTextEquals("ranges"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Ranges = value;
@@ -205,7 +205,7 @@ public sealed partial class DateRangeAggregation : Aggregation
 
 	public override string? Name { get; internal set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? Ranges { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? Ranges { get; set; }
 
 	public string? TimeZone { get; set; }
 }
@@ -231,7 +231,7 @@ public sealed partial class DateRangeAggregationDescriptor<TDocument> : Serializ
 
 	private FieldValue? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? RangesValue { get; set; }
 
 	private DateRangeExpressionDescriptor RangesDescriptor { get; set; }
 
@@ -295,7 +295,7 @@ public sealed partial class DateRangeAggregationDescriptor<TDocument> : Serializ
 		return Self;
 	}
 
-	public DateRangeAggregationDescriptor<TDocument> Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? ranges)
+	public DateRangeAggregationDescriptor<TDocument> Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;
@@ -445,7 +445,7 @@ public sealed partial class DateRangeAggregationDescriptor : SerializableDescrip
 
 	private FieldValue? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? RangesValue { get; set; }
 
 	private DateRangeExpressionDescriptor RangesDescriptor { get; set; }
 
@@ -515,7 +515,7 @@ public sealed partial class DateRangeAggregationDescriptor : SerializableDescrip
 		return Self;
 	}
 
-	public DateRangeAggregationDescriptor Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? ranges)
+	public DateRangeAggregationDescriptor Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.DateRangeExpression>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/HistogramAggregation.g.cs
@@ -266,7 +266,7 @@ public sealed partial class HistogramAggregation : Aggregation
 	public double? Offset { get; set; }
 
 	[JsonConverter(typeof(AggregateOrderConverter))]
-	public IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
+	public IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Script? Script { get; set; }
 }
@@ -298,7 +298,7 @@ public sealed partial class HistogramAggregationDescriptor<TDocument> : Serializ
 
 	private double? OffsetValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
@@ -374,7 +374,7 @@ public sealed partial class HistogramAggregationDescriptor<TDocument> : Serializ
 		return Self;
 	}
 
-	public HistogramAggregationDescriptor<TDocument> Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public HistogramAggregationDescriptor<TDocument> Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;
@@ -493,7 +493,7 @@ public sealed partial class HistogramAggregationDescriptor : SerializableDescrip
 
 	private double? OffsetValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
@@ -575,7 +575,7 @@ public sealed partial class HistogramAggregationDescriptor : SerializableDescrip
 		return Self;
 	}
 
-	public HistogramAggregationDescriptor Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public HistogramAggregationDescriptor Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/IpRangeAggregation.g.cs
@@ -55,7 +55,7 @@ internal sealed class IpRangeAggregationConverter : JsonConverter<IpRangeAggrega
 				if (reader.ValueTextEquals("ranges"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Ranges = value;
@@ -147,7 +147,7 @@ public sealed partial class IpRangeAggregation : Aggregation
 
 	public override string? Name { get; internal set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? Ranges { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? Ranges { get; set; }
 }
 
 public sealed partial class IpRangeAggregationDescriptor<TDocument> : SerializableDescriptor<IpRangeAggregationDescriptor<TDocument>>
@@ -167,7 +167,7 @@ public sealed partial class IpRangeAggregationDescriptor<TDocument> : Serializab
 
 	private Dictionary<string, object>? MetaValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? RangesValue { get; set; }
 
 	private IpRangeAggregationRangeDescriptor RangesDescriptor { get; set; }
 
@@ -217,7 +217,7 @@ public sealed partial class IpRangeAggregationDescriptor<TDocument> : Serializab
 		return Self;
 	}
 
-	public IpRangeAggregationDescriptor<TDocument> Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? ranges)
+	public IpRangeAggregationDescriptor<TDocument> Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;
@@ -339,7 +339,7 @@ public sealed partial class IpRangeAggregationDescriptor : SerializableDescripto
 
 	private Dictionary<string, object>? MetaValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? RangesValue { get; set; }
 
 	private IpRangeAggregationRangeDescriptor RangesDescriptor { get; set; }
 
@@ -395,7 +395,7 @@ public sealed partial class IpRangeAggregationDescriptor : SerializableDescripto
 		return Self;
 	}
 
-	public IpRangeAggregationDescriptor Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? ranges)
+	public IpRangeAggregationDescriptor Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.IpRangeAggregationRange>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/MultiTermsAggregation.g.cs
@@ -127,7 +127,7 @@ internal sealed class MultiTermsAggregationConverter : JsonConverter<MultiTermsA
 				if (reader.ValueTextEquals("terms"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup>>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup>>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Terms = value;
@@ -254,7 +254,7 @@ public sealed partial class MultiTermsAggregation : Aggregation
 	public override string? Name { get; internal set; }
 
 	[JsonConverter(typeof(AggregateOrderConverter))]
-	public IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
+	public IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
 
 	public long? ShardMinDocCount { get; set; }
 
@@ -264,7 +264,7 @@ public sealed partial class MultiTermsAggregation : Aggregation
 
 	public int? Size { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> Terms { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> Terms { get; set; }
 }
 
 public sealed partial class MultiTermsAggregationDescriptor<TDocument> : SerializableDescriptor<MultiTermsAggregationDescriptor<TDocument>>
@@ -280,7 +280,7 @@ public sealed partial class MultiTermsAggregationDescriptor<TDocument> : Seriali
 
 	private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor<TDocument>> AggregationsDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
 
 	private MultiTermLookupDescriptor<TDocument> TermsDescriptor { get; set; }
 
@@ -294,7 +294,7 @@ public sealed partial class MultiTermsAggregationDescriptor<TDocument> : Seriali
 
 	private long? MinDocCountValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private long? ShardMinDocCountValue { get; set; }
 
@@ -328,7 +328,7 @@ public sealed partial class MultiTermsAggregationDescriptor<TDocument> : Seriali
 		return Self;
 	}
 
-	public MultiTermsAggregationDescriptor<TDocument> Terms(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
+	public MultiTermsAggregationDescriptor<TDocument> Terms(IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
 	{
 		TermsDescriptor = null;
 		TermsDescriptorAction = null;
@@ -382,7 +382,7 @@ public sealed partial class MultiTermsAggregationDescriptor<TDocument> : Seriali
 		return Self;
 	}
 
-	public MultiTermsAggregationDescriptor<TDocument> Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public MultiTermsAggregationDescriptor<TDocument> Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;
@@ -530,7 +530,7 @@ public sealed partial class MultiTermsAggregationDescriptor : SerializableDescri
 
 	private Action<Elastic.Clients.Elasticsearch.Aggregations.AggregationContainerDescriptor> AggregationsDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> TermsValue { get; set; }
 
 	private MultiTermLookupDescriptor TermsDescriptor { get; set; }
 
@@ -544,7 +544,7 @@ public sealed partial class MultiTermsAggregationDescriptor : SerializableDescri
 
 	private long? MinDocCountValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private long? ShardMinDocCountValue { get; set; }
 
@@ -578,7 +578,7 @@ public sealed partial class MultiTermsAggregationDescriptor : SerializableDescri
 		return Self;
 	}
 
-	public MultiTermsAggregationDescriptor Terms(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
+	public MultiTermsAggregationDescriptor Terms(IList<Elastic.Clients.Elasticsearch.Aggregations.MultiTermLookup> terms)
 	{
 		TermsDescriptor = null;
 		TermsDescriptorAction = null;
@@ -632,7 +632,7 @@ public sealed partial class MultiTermsAggregationDescriptor : SerializableDescri
 		return Self;
 	}
 
-	public MultiTermsAggregationDescriptor Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public MultiTermsAggregationDescriptor Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/PercentilesBucketAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/PercentilesBucketAggregation.g.cs
@@ -67,7 +67,7 @@ internal sealed class PercentilesBucketAggregationConverter : JsonConverter<Perc
 				if (reader.ValueTextEquals("percents"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<double>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<double>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Percents = value;
@@ -148,7 +148,7 @@ public sealed partial class PercentilesBucketAggregation : Aggregation
 
 	public override string? Name { get; internal set; }
 
-	public IEnumerable<double>? Percents { get; set; }
+	public IList<double>? Percents { get; set; }
 }
 
 public sealed partial class PercentilesBucketAggregationDescriptor : SerializableDescriptor<PercentilesBucketAggregationDescriptor>
@@ -164,7 +164,7 @@ public sealed partial class PercentilesBucketAggregationDescriptor : Serializabl
 
 	private Dictionary<string, object>? MetaValue { get; set; }
 
-	private IEnumerable<double>? PercentsValue { get; set; }
+	private IList<double>? PercentsValue { get; set; }
 
 	public PercentilesBucketAggregationDescriptor Format(string? format)
 	{
@@ -184,7 +184,7 @@ public sealed partial class PercentilesBucketAggregationDescriptor : Serializabl
 		return Self;
 	}
 
-	public PercentilesBucketAggregationDescriptor Percents(IEnumerable<double>? percents)
+	public PercentilesBucketAggregationDescriptor Percents(IList<double>? percents)
 	{
 		PercentsValue = percents;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/RangeAggregation.g.cs
@@ -79,7 +79,7 @@ internal sealed class RangeAggregationConverter : JsonConverter<RangeAggregation
 				if (reader.ValueTextEquals("ranges"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Ranges = value;
@@ -205,7 +205,7 @@ public sealed partial class RangeAggregation : Aggregation
 
 	public override string? Name { get; internal set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? Ranges { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? Ranges { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Script? Script { get; set; }
 }
@@ -231,7 +231,7 @@ public sealed partial class RangeAggregationDescriptor<TDocument> : Serializable
 
 	private int? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? RangesValue { get; set; }
 
 	private AggregationRangeDescriptor RangesDescriptor { get; set; }
 
@@ -295,7 +295,7 @@ public sealed partial class RangeAggregationDescriptor<TDocument> : Serializable
 		return Self;
 	}
 
-	public RangeAggregationDescriptor<TDocument> Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? ranges)
+	public RangeAggregationDescriptor<TDocument> Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;
@@ -445,7 +445,7 @@ public sealed partial class RangeAggregationDescriptor : SerializableDescriptor<
 
 	private int? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? RangesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? RangesValue { get; set; }
 
 	private AggregationRangeDescriptor RangesDescriptor { get; set; }
 
@@ -515,7 +515,7 @@ public sealed partial class RangeAggregationDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public RangeAggregationDescriptor Ranges(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? ranges)
+	public RangeAggregationDescriptor Ranges(IList<Elastic.Clients.Elasticsearch.Aggregations.AggregationRange>? ranges)
 	{
 		RangesDescriptor = null;
 		RangesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TermsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TermsAggregation.g.cs
@@ -378,7 +378,7 @@ public sealed partial class TermsAggregation : Aggregation
 	public Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectMode { get; set; }
 
 	[JsonConverter(typeof(TermsExcludeConverter))]
-	public IEnumerable<string>? Exclude { get; set; }
+	public IList<string>? Exclude { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationExecutionHint? ExecutionHint { get; set; }
 
@@ -399,7 +399,7 @@ public sealed partial class TermsAggregation : Aggregation
 	public override string? Name { get; internal set; }
 
 	[JsonConverter(typeof(AggregateOrderConverter))]
-	public IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
+	public IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? Order { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Script? Script { get; set; }
 
@@ -427,7 +427,7 @@ public sealed partial class TermsAggregationDescriptor<TDocument> : Serializable
 
 	private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectModeValue { get; set; }
 
-	private IEnumerable<string>? ExcludeValue { get; set; }
+	private IList<string>? ExcludeValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationExecutionHint? ExecutionHintValue { get; set; }
 
@@ -445,7 +445,7 @@ public sealed partial class TermsAggregationDescriptor<TDocument> : Serializable
 
 	private Elastic.Clients.Elasticsearch.Aggregations.MissingOrder? MissingOrderValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
@@ -487,7 +487,7 @@ public sealed partial class TermsAggregationDescriptor<TDocument> : Serializable
 		return Self;
 	}
 
-	public TermsAggregationDescriptor<TDocument> Exclude(IEnumerable<string>? exclude)
+	public TermsAggregationDescriptor<TDocument> Exclude(IList<string>? exclude)
 	{
 		ExcludeValue = exclude;
 		return Self;
@@ -547,7 +547,7 @@ public sealed partial class TermsAggregationDescriptor<TDocument> : Serializable
 		return Self;
 	}
 
-	public TermsAggregationDescriptor<TDocument> Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public TermsAggregationDescriptor<TDocument> Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;
@@ -720,7 +720,7 @@ public sealed partial class TermsAggregationDescriptor : SerializableDescriptor<
 
 	private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationCollectMode? CollectModeValue { get; set; }
 
-	private IEnumerable<string>? ExcludeValue { get; set; }
+	private IList<string>? ExcludeValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Aggregations.TermsAggregationExecutionHint? ExecutionHintValue { get; set; }
 
@@ -738,7 +738,7 @@ public sealed partial class TermsAggregationDescriptor : SerializableDescriptor<
 
 	private Elastic.Clients.Elasticsearch.Aggregations.MissingOrder? MissingOrderValue { get; set; }
 
-	private IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
+	private IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? OrderValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Script? ScriptValue { get; set; }
 
@@ -780,7 +780,7 @@ public sealed partial class TermsAggregationDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public TermsAggregationDescriptor Exclude(IEnumerable<string>? exclude)
+	public TermsAggregationDescriptor Exclude(IList<string>? exclude)
 	{
 		ExcludeValue = exclude;
 		return Self;
@@ -846,7 +846,7 @@ public sealed partial class TermsAggregationDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public TermsAggregationDescriptor Order(IEnumerable<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
+	public TermsAggregationDescriptor Order(IList<KeyValuePair<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.SortOrder>>? order)
 	{
 		OrderValue = order;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TopHitsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TopHitsAggregation.g.cs
@@ -384,7 +384,7 @@ public sealed partial class TopHitsAggregation : Aggregation
 	public int? Size { get; set; }
 
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Fields? StoredFields { get; set; }
 
@@ -428,7 +428,7 @@ public sealed partial class TopHitsAggregationDescriptor<TDocument> : Serializab
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -532,7 +532,7 @@ public sealed partial class TopHitsAggregationDescriptor<TDocument> : Serializab
 		return Self;
 	}
 
-	public TopHitsAggregationDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public TopHitsAggregationDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
@@ -707,7 +707,7 @@ public sealed partial class TopHitsAggregationDescriptor : SerializableDescripto
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -817,7 +817,7 @@ public sealed partial class TopHitsAggregationDescriptor : SerializableDescripto
 		return Self;
 	}
 
-	public TopHitsAggregationDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public TopHitsAggregationDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TopMetricsAggregation.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Aggregations/TopMetricsAggregation.g.cs
@@ -55,7 +55,7 @@ internal sealed class TopMetricsAggregationConverter : JsonConverter<TopMetricsA
 				if (reader.ValueTextEquals("metrics"))
 				{
 					reader.Read();
-					var value = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>?>(ref reader, options);
+					var value = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>?>(ref reader, options);
 					if (value is not null)
 					{
 						agg.Metrics = value;
@@ -199,7 +199,7 @@ public sealed partial class TopMetricsAggregation : Aggregation
 
 	public Dictionary<string, object>? Meta { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? Metrics { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? Metrics { get; set; }
 
 	public FieldValue? Missing { get; set; }
 
@@ -210,7 +210,7 @@ public sealed partial class TopMetricsAggregation : Aggregation
 	public int? Size { get; set; }
 
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 }
 
 public sealed partial class TopMetricsAggregationDescriptor<TDocument> : SerializableDescriptor<TopMetricsAggregationDescriptor<TDocument>>
@@ -220,7 +220,7 @@ public sealed partial class TopMetricsAggregationDescriptor<TDocument> : Seriali
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? MetricsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? MetricsValue { get; set; }
 
 	private TopMetricsValueDescriptor<TDocument> MetricsDescriptor { get; set; }
 
@@ -238,9 +238,9 @@ public sealed partial class TopMetricsAggregationDescriptor<TDocument> : Seriali
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	public TopMetricsAggregationDescriptor<TDocument> Metrics(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? metrics)
+	public TopMetricsAggregationDescriptor<TDocument> Metrics(IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? metrics)
 	{
 		MetricsDescriptor = null;
 		MetricsDescriptorAction = null;
@@ -312,7 +312,7 @@ public sealed partial class TopMetricsAggregationDescriptor<TDocument> : Seriali
 		return Self;
 	}
 
-	public TopMetricsAggregationDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public TopMetricsAggregationDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
@@ -402,7 +402,7 @@ public sealed partial class TopMetricsAggregationDescriptor : SerializableDescri
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? MetricsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? MetricsValue { get; set; }
 
 	private TopMetricsValueDescriptor MetricsDescriptor { get; set; }
 
@@ -420,9 +420,9 @@ public sealed partial class TopMetricsAggregationDescriptor : SerializableDescri
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	public TopMetricsAggregationDescriptor Metrics(IEnumerable<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? metrics)
+	public TopMetricsAggregationDescriptor Metrics(IList<Elastic.Clients.Elasticsearch.Aggregations.TopMetricsValue>? metrics)
 	{
 		MetricsDescriptor = null;
 		MetricsDescriptorAction = null;
@@ -500,7 +500,7 @@ public sealed partial class TopMetricsAggregationDescriptor : SerializableDescri
 		return Self;
 	}
 
-	public TopMetricsAggregationDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public TopMetricsAggregationDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CharGroupTokenizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CharGroupTokenizer.g.cs
@@ -33,7 +33,7 @@ public sealed partial class CharGroupTokenizer : ITokenizerDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("tokenize_on_chars")]
-	public IEnumerable<string> TokenizeOnChars { get; set; }
+	public IList<string> TokenizeOnChars { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -52,7 +52,7 @@ public sealed partial class CharGroupTokenizerDescriptor : SerializableDescripto
 
 	private int? MaxTokenLengthValue { get; set; }
 
-	private IEnumerable<string> TokenizeOnCharsValue { get; set; }
+	private IList<string> TokenizeOnCharsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -62,7 +62,7 @@ public sealed partial class CharGroupTokenizerDescriptor : SerializableDescripto
 		return Self;
 	}
 
-	public CharGroupTokenizerDescriptor TokenizeOnChars(IEnumerable<string> tokenizeOnChars)
+	public CharGroupTokenizerDescriptor TokenizeOnChars(IList<string> tokenizeOnChars)
 	{
 		TokenizeOnCharsValue = tokenizeOnChars;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CommonGramsTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CommonGramsTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class CommonGramsTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("common_words")]
-	public IEnumerable<string>? CommonWords { get; set; }
+	public IList<string>? CommonWords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("common_words_path")]
@@ -58,7 +58,7 @@ public sealed partial class CommonGramsTokenFilterDescriptor : SerializableDescr
 	{
 	}
 
-	private IEnumerable<string>? CommonWordsValue { get; set; }
+	private IList<string>? CommonWordsValue { get; set; }
 
 	private string? CommonWordsPathValue { get; set; }
 
@@ -68,7 +68,7 @@ public sealed partial class CommonGramsTokenFilterDescriptor : SerializableDescr
 
 	private string? VersionValue { get; set; }
 
-	public CommonGramsTokenFilterDescriptor CommonWords(IEnumerable<string>? commonWords)
+	public CommonGramsTokenFilterDescriptor CommonWords(IList<string>? commonWords)
 	{
 		CommonWordsValue = commonWords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/ConditionTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/ConditionTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class ConditionTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<string> Filter { get; set; }
+	public IList<string> Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("script")]
@@ -50,13 +50,13 @@ public sealed partial class ConditionTokenFilterDescriptor : SerializableDescrip
 	{
 	}
 
-	private IEnumerable<string> FilterValue { get; set; }
+	private IList<string> FilterValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Script ScriptValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public ConditionTokenFilterDescriptor Filter(IEnumerable<string> filter)
+	public ConditionTokenFilterDescriptor Filter(IList<string> filter)
 	{
 		FilterValue = filter;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CustomAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CustomAnalyzer.g.cs
@@ -29,11 +29,11 @@ public sealed partial class CustomAnalyzer : IAnalyzer
 {
 	[JsonInclude]
 	[JsonPropertyName("char_filter")]
-	public IEnumerable<string>? CharFilter { get; set; }
+	public IList<string>? CharFilter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<string>? Filter { get; set; }
+	public IList<string>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("position_increment_gap")]
@@ -59,9 +59,9 @@ public sealed partial class CustomAnalyzerDescriptor : SerializableDescriptor<Cu
 	{
 	}
 
-	private IEnumerable<string>? CharFilterValue { get; set; }
+	private IList<string>? CharFilterValue { get; set; }
 
-	private IEnumerable<string>? FilterValue { get; set; }
+	private IList<string>? FilterValue { get; set; }
 
 	private int? PositionIncrementGapValue { get; set; }
 
@@ -69,13 +69,13 @@ public sealed partial class CustomAnalyzerDescriptor : SerializableDescriptor<Cu
 
 	private string TokenizerValue { get; set; }
 
-	public CustomAnalyzerDescriptor CharFilter(IEnumerable<string>? charFilter)
+	public CustomAnalyzerDescriptor CharFilter(IList<string>? charFilter)
 	{
 		CharFilterValue = charFilter;
 		return Self;
 	}
 
-	public CustomAnalyzerDescriptor Filter(IEnumerable<string>? filter)
+	public CustomAnalyzerDescriptor Filter(IList<string>? filter)
 	{
 		FilterValue = filter;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CustomNormalizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/CustomNormalizer.g.cs
@@ -29,11 +29,11 @@ public sealed partial class CustomNormalizer : INormalizer
 {
 	[JsonInclude]
 	[JsonPropertyName("char_filter")]
-	public IEnumerable<string>? CharFilter { get; set; }
+	public IList<string>? CharFilter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<string>? Filter { get; set; }
+	public IList<string>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -47,17 +47,17 @@ public sealed partial class CustomNormalizerDescriptor : SerializableDescriptor<
 	{
 	}
 
-	private IEnumerable<string>? CharFilterValue { get; set; }
+	private IList<string>? CharFilterValue { get; set; }
 
-	private IEnumerable<string>? FilterValue { get; set; }
+	private IList<string>? FilterValue { get; set; }
 
-	public CustomNormalizerDescriptor CharFilter(IEnumerable<string>? charFilter)
+	public CustomNormalizerDescriptor CharFilter(IList<string>? charFilter)
 	{
 		CharFilterValue = charFilter;
 		return Self;
 	}
 
-	public CustomNormalizerDescriptor Filter(IEnumerable<string>? filter)
+	public CustomNormalizerDescriptor Filter(IList<string>? filter)
 	{
 		FilterValue = filter;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/DictionaryDecompounderTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/DictionaryDecompounderTokenFilter.g.cs
@@ -56,7 +56,7 @@ public sealed partial class DictionaryDecompounderTokenFilter : ITokenFilterDefi
 
 	[JsonInclude]
 	[JsonPropertyName("word_list")]
-	public IEnumerable<string>? WordList { get; set; }
+	public IList<string>? WordList { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("word_list_path")]
@@ -82,7 +82,7 @@ public sealed partial class DictionaryDecompounderTokenFilterDescriptor : Serial
 
 	private string? VersionValue { get; set; }
 
-	private IEnumerable<string>? WordListValue { get; set; }
+	private IList<string>? WordListValue { get; set; }
 
 	private string? WordListPathValue { get; set; }
 
@@ -122,7 +122,7 @@ public sealed partial class DictionaryDecompounderTokenFilterDescriptor : Serial
 		return Self;
 	}
 
-	public DictionaryDecompounderTokenFilterDescriptor WordList(IEnumerable<string>? wordList)
+	public DictionaryDecompounderTokenFilterDescriptor WordList(IList<string>? wordList)
 	{
 		WordListValue = wordList;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/DutchAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/DutchAnalyzer.g.cs
@@ -30,7 +30,7 @@ public sealed partial class DutchAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -44,9 +44,9 @@ public sealed partial class DutchAnalyzerDescriptor : SerializableDescriptor<Dut
 	{
 	}
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
-	public DutchAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public DutchAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/EdgeNGramTokenizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/EdgeNGramTokenizer.g.cs
@@ -41,7 +41,7 @@ public sealed partial class EdgeNGramTokenizer : ITokenizerDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("token_chars")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenChars { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenChars { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -64,7 +64,7 @@ public sealed partial class EdgeNGramTokenizerDescriptor : SerializableDescripto
 
 	private int MinGramValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenCharsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenCharsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -86,7 +86,7 @@ public sealed partial class EdgeNGramTokenizerDescriptor : SerializableDescripto
 		return Self;
 	}
 
-	public EdgeNGramTokenizerDescriptor TokenChars(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> tokenChars)
+	public EdgeNGramTokenizerDescriptor TokenChars(IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> tokenChars)
 	{
 		TokenCharsValue = tokenChars;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/ElisionTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/ElisionTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class ElisionTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("articles")]
-	public IEnumerable<string>? Articles { get; set; }
+	public IList<string>? Articles { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("articles_case")]
@@ -54,7 +54,7 @@ public sealed partial class ElisionTokenFilterDescriptor : SerializableDescripto
 	{
 	}
 
-	private IEnumerable<string>? ArticlesValue { get; set; }
+	private IList<string>? ArticlesValue { get; set; }
 
 	private bool? ArticlesCaseValue { get; set; }
 
@@ -62,7 +62,7 @@ public sealed partial class ElisionTokenFilterDescriptor : SerializableDescripto
 
 	private string? VersionValue { get; set; }
 
-	public ElisionTokenFilterDescriptor Articles(IEnumerable<string>? articles)
+	public ElisionTokenFilterDescriptor Articles(IList<string>? articles)
 	{
 		ArticlesValue = articles;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/FingerprintAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/FingerprintAnalyzer.g.cs
@@ -42,7 +42,7 @@ public sealed partial class FingerprintAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stopwords_path")]
@@ -69,7 +69,7 @@ public sealed partial class FingerprintAnalyzerDescriptor : SerializableDescript
 
 	private string SeparatorValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? StopwordsPathValue { get; set; }
 
@@ -93,7 +93,7 @@ public sealed partial class FingerprintAnalyzerDescriptor : SerializableDescript
 		return Self;
 	}
 
-	public FingerprintAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public FingerprintAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/HyphenationDecompounderTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/HyphenationDecompounderTokenFilter.g.cs
@@ -56,7 +56,7 @@ public sealed partial class HyphenationDecompounderTokenFilter : ITokenFilterDef
 
 	[JsonInclude]
 	[JsonPropertyName("word_list")]
-	public IEnumerable<string>? WordList { get; set; }
+	public IList<string>? WordList { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("word_list_path")]
@@ -82,7 +82,7 @@ public sealed partial class HyphenationDecompounderTokenFilterDescriptor : Seria
 
 	private string? VersionValue { get; set; }
 
-	private IEnumerable<string>? WordListValue { get; set; }
+	private IList<string>? WordListValue { get; set; }
 
 	private string? WordListPathValue { get; set; }
 
@@ -122,7 +122,7 @@ public sealed partial class HyphenationDecompounderTokenFilterDescriptor : Seria
 		return Self;
 	}
 
-	public HyphenationDecompounderTokenFilterDescriptor WordList(IEnumerable<string>? wordList)
+	public HyphenationDecompounderTokenFilterDescriptor WordList(IList<string>? wordList)
 	{
 		WordListValue = wordList;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeepTypesTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeepTypesTokenFilter.g.cs
@@ -36,7 +36,7 @@ public sealed partial class KeepTypesTokenFilter : ITokenFilterDefinition
 	public string Type => "keep_types";
 	[JsonInclude]
 	[JsonPropertyName("types")]
-	public IEnumerable<string>? Types { get; set; }
+	public IList<string>? Types { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("version")]
@@ -52,7 +52,7 @@ public sealed partial class KeepTypesTokenFilterDescriptor : SerializableDescrip
 
 	private Elastic.Clients.Elasticsearch.Analysis.KeepTypesMode? ModeValue { get; set; }
 
-	private IEnumerable<string>? TypesValue { get; set; }
+	private IList<string>? TypesValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -62,7 +62,7 @@ public sealed partial class KeepTypesTokenFilterDescriptor : SerializableDescrip
 		return Self;
 	}
 
-	public KeepTypesTokenFilterDescriptor Types(IEnumerable<string>? types)
+	public KeepTypesTokenFilterDescriptor Types(IList<string>? types)
 	{
 		TypesValue = types;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeepWordsTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeepWordsTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class KeepWordsTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("keep_words")]
-	public IEnumerable<string>? KeepWords { get; set; }
+	public IList<string>? KeepWords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("keep_words_case")]
@@ -54,7 +54,7 @@ public sealed partial class KeepWordsTokenFilterDescriptor : SerializableDescrip
 	{
 	}
 
-	private IEnumerable<string>? KeepWordsValue { get; set; }
+	private IList<string>? KeepWordsValue { get; set; }
 
 	private bool? KeepWordsCaseValue { get; set; }
 
@@ -62,7 +62,7 @@ public sealed partial class KeepWordsTokenFilterDescriptor : SerializableDescrip
 
 	private string? VersionValue { get; set; }
 
-	public KeepWordsTokenFilterDescriptor KeepWords(IEnumerable<string>? keepWords)
+	public KeepWordsTokenFilterDescriptor KeepWords(IList<string>? keepWords)
 	{
 		KeepWordsValue = keepWords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeywordMarkerTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KeywordMarkerTokenFilter.g.cs
@@ -33,7 +33,7 @@ public sealed partial class KeywordMarkerTokenFilter : ITokenFilterDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("keywords")]
-	public IEnumerable<string>? Keywords { get; set; }
+	public IList<string>? Keywords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("keywords_path")]
@@ -60,7 +60,7 @@ public sealed partial class KeywordMarkerTokenFilterDescriptor : SerializableDes
 
 	private bool? IgnoreCaseValue { get; set; }
 
-	private IEnumerable<string>? KeywordsValue { get; set; }
+	private IList<string>? KeywordsValue { get; set; }
 
 	private string? KeywordsPathValue { get; set; }
 
@@ -74,7 +74,7 @@ public sealed partial class KeywordMarkerTokenFilterDescriptor : SerializableDes
 		return Self;
 	}
 
-	public KeywordMarkerTokenFilterDescriptor Keywords(IEnumerable<string>? keywords)
+	public KeywordMarkerTokenFilterDescriptor Keywords(IList<string>? keywords)
 	{
 		KeywordsValue = keywords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KuromojiPartOfSpeechTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KuromojiPartOfSpeechTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class KuromojiPartOfSpeechTokenFilter : ITokenFilterDefini
 {
 	[JsonInclude]
 	[JsonPropertyName("stoptags")]
-	public IEnumerable<string> Stoptags { get; set; }
+	public IList<string> Stoptags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -46,11 +46,11 @@ public sealed partial class KuromojiPartOfSpeechTokenFilterDescriptor : Serializ
 	{
 	}
 
-	private IEnumerable<string> StoptagsValue { get; set; }
+	private IList<string> StoptagsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public KuromojiPartOfSpeechTokenFilterDescriptor Stoptags(IEnumerable<string> stoptags)
+	public KuromojiPartOfSpeechTokenFilterDescriptor Stoptags(IList<string> stoptags)
 	{
 		StoptagsValue = stoptags;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KuromojiTokenizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/KuromojiTokenizer.g.cs
@@ -56,7 +56,7 @@ public sealed partial class KuromojiTokenizer : ITokenizerDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("user_dictionary_rules")]
-	public IEnumerable<string>? UserDictionaryRules { get; set; }
+	public IList<string>? UserDictionaryRules { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("version")]
@@ -82,7 +82,7 @@ public sealed partial class KuromojiTokenizerDescriptor : SerializableDescriptor
 
 	private string? UserDictionaryValue { get; set; }
 
-	private IEnumerable<string>? UserDictionaryRulesValue { get; set; }
+	private IList<string>? UserDictionaryRulesValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -122,7 +122,7 @@ public sealed partial class KuromojiTokenizerDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public KuromojiTokenizerDescriptor UserDictionaryRules(IEnumerable<string>? userDictionaryRules)
+	public KuromojiTokenizerDescriptor UserDictionaryRules(IList<string>? userDictionaryRules)
 	{
 		UserDictionaryRulesValue = userDictionaryRules;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/LanguageAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/LanguageAnalyzer.g.cs
@@ -33,12 +33,12 @@ public sealed partial class LanguageAnalyzer : IAnalyzer
 
 	[JsonInclude]
 	[JsonPropertyName("stem_exclusion")]
-	public IEnumerable<string> StemExclusion { get; set; }
+	public IList<string> StemExclusion { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stopwords_path")]
@@ -61,9 +61,9 @@ public sealed partial class LanguageAnalyzerDescriptor : SerializableDescriptor<
 
 	private Elastic.Clients.Elasticsearch.Analysis.Language LanguageValue { get; set; }
 
-	private IEnumerable<string> StemExclusionValue { get; set; }
+	private IList<string> StemExclusionValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? StopwordsPathValue { get; set; }
 
@@ -75,13 +75,13 @@ public sealed partial class LanguageAnalyzerDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public LanguageAnalyzerDescriptor StemExclusion(IEnumerable<string> stemExclusion)
+	public LanguageAnalyzerDescriptor StemExclusion(IList<string> stemExclusion)
 	{
 		StemExclusionValue = stemExclusion;
 		return Self;
 	}
 
-	public LanguageAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public LanguageAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/MappingCharFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/MappingCharFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class MappingCharFilter : ICharFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("mappings")]
-	public IEnumerable<string>? Mappings { get; set; }
+	public IList<string>? Mappings { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("mappings_path")]
@@ -50,13 +50,13 @@ public sealed partial class MappingCharFilterDescriptor : SerializableDescriptor
 	{
 	}
 
-	private IEnumerable<string>? MappingsValue { get; set; }
+	private IList<string>? MappingsValue { get; set; }
 
 	private string? MappingsPathValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public MappingCharFilterDescriptor Mappings(IEnumerable<string>? mappings)
+	public MappingCharFilterDescriptor Mappings(IList<string>? mappings)
 	{
 		MappingsValue = mappings;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/MultiplexerTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/MultiplexerTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class MultiplexerTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("filters")]
-	public IEnumerable<string> Filters { get; set; }
+	public IList<string> Filters { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("preserve_original")]
@@ -50,13 +50,13 @@ public sealed partial class MultiplexerTokenFilterDescriptor : SerializableDescr
 	{
 	}
 
-	private IEnumerable<string> FiltersValue { get; set; }
+	private IList<string> FiltersValue { get; set; }
 
 	private bool? PreserveOriginalValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public MultiplexerTokenFilterDescriptor Filters(IEnumerable<string> filters)
+	public MultiplexerTokenFilterDescriptor Filters(IList<string> filters)
 	{
 		FiltersValue = filters;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NGramTokenizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NGramTokenizer.g.cs
@@ -41,7 +41,7 @@ public sealed partial class NGramTokenizer : ITokenizerDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("token_chars")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenChars { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenChars { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -64,7 +64,7 @@ public sealed partial class NGramTokenizerDescriptor : SerializableDescriptor<NG
 
 	private int MinGramValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenCharsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> TokenCharsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -86,7 +86,7 @@ public sealed partial class NGramTokenizerDescriptor : SerializableDescriptor<NG
 		return Self;
 	}
 
-	public NGramTokenizerDescriptor TokenChars(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.TokenChar> tokenChars)
+	public NGramTokenizerDescriptor TokenChars(IList<Elastic.Clients.Elasticsearch.Analysis.TokenChar> tokenChars)
 	{
 		TokenCharsValue = tokenChars;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriAnalyzer.g.cs
@@ -33,7 +33,7 @@ public sealed partial class NoriAnalyzer : IAnalyzer
 
 	[JsonInclude]
 	[JsonPropertyName("stoptags")]
-	public IEnumerable<string>? Stoptags { get; set; }
+	public IList<string>? Stoptags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -56,7 +56,7 @@ public sealed partial class NoriAnalyzerDescriptor : SerializableDescriptor<Nori
 
 	private Elastic.Clients.Elasticsearch.Analysis.NoriDecompoundMode? DecompoundModeValue { get; set; }
 
-	private IEnumerable<string>? StoptagsValue { get; set; }
+	private IList<string>? StoptagsValue { get; set; }
 
 	private string? UserDictionaryValue { get; set; }
 
@@ -68,7 +68,7 @@ public sealed partial class NoriAnalyzerDescriptor : SerializableDescriptor<Nori
 		return Self;
 	}
 
-	public NoriAnalyzerDescriptor Stoptags(IEnumerable<string>? stoptags)
+	public NoriAnalyzerDescriptor Stoptags(IList<string>? stoptags)
 	{
 		StoptagsValue = stoptags;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriPartOfSpeechTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriPartOfSpeechTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class NoriPartOfSpeechTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("stoptags")]
-	public IEnumerable<string>? Stoptags { get; set; }
+	public IList<string>? Stoptags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -46,11 +46,11 @@ public sealed partial class NoriPartOfSpeechTokenFilterDescriptor : Serializable
 	{
 	}
 
-	private IEnumerable<string>? StoptagsValue { get; set; }
+	private IList<string>? StoptagsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public NoriPartOfSpeechTokenFilterDescriptor Stoptags(IEnumerable<string>? stoptags)
+	public NoriPartOfSpeechTokenFilterDescriptor Stoptags(IList<string>? stoptags)
 	{
 		StoptagsValue = stoptags;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriTokenizer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/NoriTokenizer.g.cs
@@ -44,7 +44,7 @@ public sealed partial class NoriTokenizer : ITokenizerDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("user_dictionary_rules")]
-	public IEnumerable<string>? UserDictionaryRules { get; set; }
+	public IList<string>? UserDictionaryRules { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("version")]
@@ -64,7 +64,7 @@ public sealed partial class NoriTokenizerDescriptor : SerializableDescriptor<Nor
 
 	private string? UserDictionaryValue { get; set; }
 
-	private IEnumerable<string>? UserDictionaryRulesValue { get; set; }
+	private IList<string>? UserDictionaryRulesValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -86,7 +86,7 @@ public sealed partial class NoriTokenizerDescriptor : SerializableDescriptor<Nor
 		return Self;
 	}
 
-	public NoriTokenizerDescriptor UserDictionaryRules(IEnumerable<string>? userDictionaryRules)
+	public NoriTokenizerDescriptor UserDictionaryRules(IList<string>? userDictionaryRules)
 	{
 		UserDictionaryRulesValue = userDictionaryRules;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PatternAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PatternAnalyzer.g.cs
@@ -42,7 +42,7 @@ public sealed partial class PatternAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -65,7 +65,7 @@ public sealed partial class PatternAnalyzerDescriptor : SerializableDescriptor<P
 
 	private string PatternValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -87,7 +87,7 @@ public sealed partial class PatternAnalyzerDescriptor : SerializableDescriptor<P
 		return Self;
 	}
 
-	public PatternAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public PatternAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PatternCaptureTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PatternCaptureTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class PatternCaptureTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("patterns")]
-	public IEnumerable<string> Patterns { get; set; }
+	public IList<string> Patterns { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("preserve_original")]
@@ -50,13 +50,13 @@ public sealed partial class PatternCaptureTokenFilterDescriptor : SerializableDe
 	{
 	}
 
-	private IEnumerable<string> PatternsValue { get; set; }
+	private IList<string> PatternsValue { get; set; }
 
 	private bool? PreserveOriginalValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public PatternCaptureTokenFilterDescriptor Patterns(IEnumerable<string> patterns)
+	public PatternCaptureTokenFilterDescriptor Patterns(IList<string> patterns)
 	{
 		PatternsValue = patterns;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PhoneticTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/PhoneticTokenFilter.g.cs
@@ -33,7 +33,7 @@ public sealed partial class PhoneticTokenFilter : ITokenFilterDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("languageset")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> Languageset { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> Languageset { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("max_code_len")]
@@ -68,7 +68,7 @@ public sealed partial class PhoneticTokenFilterDescriptor : SerializableDescript
 
 	private Elastic.Clients.Elasticsearch.Analysis.PhoneticEncoder EncoderValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> LanguagesetValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> LanguagesetValue { get; set; }
 
 	private int? MaxCodeLenValue { get; set; }
 
@@ -86,7 +86,7 @@ public sealed partial class PhoneticTokenFilterDescriptor : SerializableDescript
 		return Self;
 	}
 
-	public PhoneticTokenFilterDescriptor Languageset(IEnumerable<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> languageset)
+	public PhoneticTokenFilterDescriptor Languageset(IList<Elastic.Clients.Elasticsearch.Analysis.PhoneticLanguage> languageset)
 	{
 		LanguagesetValue = languageset;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SnowballAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SnowballAnalyzer.g.cs
@@ -34,7 +34,7 @@ public sealed partial class SnowballAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -53,7 +53,7 @@ public sealed partial class SnowballAnalyzerDescriptor : SerializableDescriptor<
 
 	private Elastic.Clients.Elasticsearch.Analysis.SnowballLanguage LanguageValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
@@ -63,7 +63,7 @@ public sealed partial class SnowballAnalyzerDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public SnowballAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public SnowballAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StandardAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StandardAnalyzer.g.cs
@@ -34,7 +34,7 @@ public sealed partial class StandardAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -50,7 +50,7 @@ public sealed partial class StandardAnalyzerDescriptor : SerializableDescriptor<
 
 	private int? MaxTokenLengthValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	public StandardAnalyzerDescriptor MaxTokenLength(int? maxTokenLength)
 	{
@@ -58,7 +58,7 @@ public sealed partial class StandardAnalyzerDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public StandardAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public StandardAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StemmerOverrideTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StemmerOverrideTokenFilter.g.cs
@@ -29,7 +29,7 @@ public sealed partial class StemmerOverrideTokenFilter : ITokenFilterDefinition
 {
 	[JsonInclude]
 	[JsonPropertyName("rules")]
-	public IEnumerable<string>? Rules { get; set; }
+	public IList<string>? Rules { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("rules_path")]
@@ -50,13 +50,13 @@ public sealed partial class StemmerOverrideTokenFilterDescriptor : SerializableD
 	{
 	}
 
-	private IEnumerable<string>? RulesValue { get; set; }
+	private IList<string>? RulesValue { get; set; }
 
 	private string? RulesPathValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public StemmerOverrideTokenFilterDescriptor Rules(IEnumerable<string>? rules)
+	public StemmerOverrideTokenFilterDescriptor Rules(IList<string>? rules)
 	{
 		RulesValue = rules;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StopAnalyzer.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StopAnalyzer.g.cs
@@ -30,7 +30,7 @@ public sealed partial class StopAnalyzer : IAnalyzer
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stopwords_path")]
@@ -51,13 +51,13 @@ public sealed partial class StopAnalyzerDescriptor : SerializableDescriptor<Stop
 	{
 	}
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? StopwordsPathValue { get; set; }
 
 	private string? VersionValue { get; set; }
 
-	public StopAnalyzerDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public StopAnalyzerDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StopTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/StopTokenFilter.g.cs
@@ -38,7 +38,7 @@ public sealed partial class StopTokenFilter : ITokenFilterDefinition
 	[JsonInclude]
 	[JsonPropertyName("stopwords")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? Stopwords { get; set; }
+	public IList<string>? Stopwords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stopwords_path")]
@@ -63,7 +63,7 @@ public sealed partial class StopTokenFilterDescriptor : SerializableDescriptor<S
 
 	private bool? RemoveTrailingValue { get; set; }
 
-	private IEnumerable<string>? StopwordsValue { get; set; }
+	private IList<string>? StopwordsValue { get; set; }
 
 	private string? StopwordsPathValue { get; set; }
 
@@ -81,7 +81,7 @@ public sealed partial class StopTokenFilterDescriptor : SerializableDescriptor<S
 		return Self;
 	}
 
-	public StopTokenFilterDescriptor Stopwords(IEnumerable<string>? stopwords)
+	public StopTokenFilterDescriptor Stopwords(IList<string>? stopwords)
 	{
 		StopwordsValue = stopwords;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SynonymGraphTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SynonymGraphTokenFilter.g.cs
@@ -41,7 +41,7 @@ public sealed partial class SynonymGraphTokenFilter : ITokenFilterDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("synonyms")]
-	public IEnumerable<string>? Synonyms { get; set; }
+	public IList<string>? Synonyms { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("synonyms_path")]
@@ -76,7 +76,7 @@ public sealed partial class SynonymGraphTokenFilterDescriptor : SerializableDesc
 
 	private bool? LenientValue { get; set; }
 
-	private IEnumerable<string>? SynonymsValue { get; set; }
+	private IList<string>? SynonymsValue { get; set; }
 
 	private string? SynonymsPathValue { get; set; }
 
@@ -104,7 +104,7 @@ public sealed partial class SynonymGraphTokenFilterDescriptor : SerializableDesc
 		return Self;
 	}
 
-	public SynonymGraphTokenFilterDescriptor Synonyms(IEnumerable<string>? synonyms)
+	public SynonymGraphTokenFilterDescriptor Synonyms(IList<string>? synonyms)
 	{
 		SynonymsValue = synonyms;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SynonymTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/SynonymTokenFilter.g.cs
@@ -41,7 +41,7 @@ public sealed partial class SynonymTokenFilter : ITokenFilterDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("synonyms")]
-	public IEnumerable<string>? Synonyms { get; set; }
+	public IList<string>? Synonyms { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("synonyms_path")]
@@ -76,7 +76,7 @@ public sealed partial class SynonymTokenFilterDescriptor : SerializableDescripto
 
 	private bool? LenientValue { get; set; }
 
-	private IEnumerable<string>? SynonymsValue { get; set; }
+	private IList<string>? SynonymsValue { get; set; }
 
 	private string? SynonymsPathValue { get; set; }
 
@@ -104,7 +104,7 @@ public sealed partial class SynonymTokenFilterDescriptor : SerializableDescripto
 		return Self;
 	}
 
-	public SynonymTokenFilterDescriptor Synonyms(IEnumerable<string>? synonyms)
+	public SynonymTokenFilterDescriptor Synonyms(IList<string>? synonyms)
 	{
 		SynonymsValue = synonyms;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/WordDelimiterGraphTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/WordDelimiterGraphTokenFilter.g.cs
@@ -61,7 +61,7 @@ public sealed partial class WordDelimiterGraphTokenFilter : ITokenFilterDefiniti
 
 	[JsonInclude]
 	[JsonPropertyName("protected_words")]
-	public IEnumerable<string>? ProtectedWords { get; set; }
+	public IList<string>? ProtectedWords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("protected_words_path")]
@@ -84,7 +84,7 @@ public sealed partial class WordDelimiterGraphTokenFilter : ITokenFilterDefiniti
 	public string Type => "word_delimiter_graph";
 	[JsonInclude]
 	[JsonPropertyName("type_table")]
-	public IEnumerable<string>? TypeTable { get; set; }
+	public IList<string>? TypeTable { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type_table_path")]
@@ -118,7 +118,7 @@ public sealed partial class WordDelimiterGraphTokenFilterDescriptor : Serializab
 
 	private bool? PreserveOriginalValue { get; set; }
 
-	private IEnumerable<string>? ProtectedWordsValue { get; set; }
+	private IList<string>? ProtectedWordsValue { get; set; }
 
 	private string? ProtectedWordsPathValue { get; set; }
 
@@ -128,7 +128,7 @@ public sealed partial class WordDelimiterGraphTokenFilterDescriptor : Serializab
 
 	private bool? StemEnglishPossessiveValue { get; set; }
 
-	private IEnumerable<string>? TypeTableValue { get; set; }
+	private IList<string>? TypeTableValue { get; set; }
 
 	private string? TypeTablePathValue { get; set; }
 
@@ -182,7 +182,7 @@ public sealed partial class WordDelimiterGraphTokenFilterDescriptor : Serializab
 		return Self;
 	}
 
-	public WordDelimiterGraphTokenFilterDescriptor ProtectedWords(IEnumerable<string>? protectedWords)
+	public WordDelimiterGraphTokenFilterDescriptor ProtectedWords(IList<string>? protectedWords)
 	{
 		ProtectedWordsValue = protectedWords;
 		return Self;
@@ -212,7 +212,7 @@ public sealed partial class WordDelimiterGraphTokenFilterDescriptor : Serializab
 		return Self;
 	}
 
-	public WordDelimiterGraphTokenFilterDescriptor TypeTable(IEnumerable<string>? typeTable)
+	public WordDelimiterGraphTokenFilterDescriptor TypeTable(IList<string>? typeTable)
 	{
 		TypeTableValue = typeTable;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/WordDelimiterTokenFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Analysis/WordDelimiterTokenFilter.g.cs
@@ -53,7 +53,7 @@ public sealed partial class WordDelimiterTokenFilter : ITokenFilterDefinition
 
 	[JsonInclude]
 	[JsonPropertyName("protected_words")]
-	public IEnumerable<string>? ProtectedWords { get; set; }
+	public IList<string>? ProtectedWords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("protected_words_path")]
@@ -76,7 +76,7 @@ public sealed partial class WordDelimiterTokenFilter : ITokenFilterDefinition
 	public string Type => "word_delimiter";
 	[JsonInclude]
 	[JsonPropertyName("type_table")]
-	public IEnumerable<string>? TypeTable { get; set; }
+	public IList<string>? TypeTable { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type_table_path")]
@@ -106,7 +106,7 @@ public sealed partial class WordDelimiterTokenFilterDescriptor : SerializableDes
 
 	private bool? PreserveOriginalValue { get; set; }
 
-	private IEnumerable<string>? ProtectedWordsValue { get; set; }
+	private IList<string>? ProtectedWordsValue { get; set; }
 
 	private string? ProtectedWordsPathValue { get; set; }
 
@@ -116,7 +116,7 @@ public sealed partial class WordDelimiterTokenFilterDescriptor : SerializableDes
 
 	private bool? StemEnglishPossessiveValue { get; set; }
 
-	private IEnumerable<string>? TypeTableValue { get; set; }
+	private IList<string>? TypeTableValue { get; set; }
 
 	private string? TypeTablePathValue { get; set; }
 
@@ -158,7 +158,7 @@ public sealed partial class WordDelimiterTokenFilterDescriptor : SerializableDes
 		return Self;
 	}
 
-	public WordDelimiterTokenFilterDescriptor ProtectedWords(IEnumerable<string>? protectedWords)
+	public WordDelimiterTokenFilterDescriptor ProtectedWords(IList<string>? protectedWords)
 	{
 		ProtectedWordsValue = protectedWords;
 		return Self;
@@ -188,7 +188,7 @@ public sealed partial class WordDelimiterTokenFilterDescriptor : SerializableDes
 		return Self;
 	}
 
-	public WordDelimiterTokenFilterDescriptor TypeTable(IEnumerable<string>? typeTable)
+	public WordDelimiterTokenFilterDescriptor TypeTable(IList<string>? typeTable)
 	{
 		TypeTableValue = typeTable;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
@@ -57,7 +57,7 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "docvalue_fields")
 				{
-					variant.DocvalueFields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.DocvalueFields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -75,7 +75,7 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "fields")
 				{
-					variant.Fields = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
+					variant.Fields = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>?>(ref reader, options);
 					continue;
 				}
 
@@ -93,7 +93,7 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "indices_boost")
 				{
-					variant.IndicesBoost = JsonSerializer.Deserialize<IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
+					variant.IndicesBoost = JsonSerializer.Deserialize<IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>?>(ref reader, options);
 					continue;
 				}
 
@@ -135,7 +135,7 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "rescore")
 				{
-					variant.Rescore = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
+					variant.Rescore = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>?>(ref reader, options);
 					continue;
 				}
 
@@ -153,7 +153,7 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "search_after")
 				{
-					variant.SearchAfter = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
+					variant.SearchAfter = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.FieldValue>?>(ref reader, options);
 					continue;
 				}
 
@@ -171,13 +171,13 @@ internal sealed class MultisearchBodyConverter : JsonConverter<MultisearchBody>
 
 				if (property == "sort")
 				{
-					variant.Sort = JsonSerializer.Deserialize<IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
+					variant.Sort = JsonSerializer.Deserialize<IList<Elastic.Clients.Elasticsearch.SortOptions>?>(ref reader, options);
 					continue;
 				}
 
 				if (property == "stats")
 				{
-					variant.Stats = JsonSerializer.Deserialize<IEnumerable<string>?>(ref reader, options);
+					variant.Stats = JsonSerializer.Deserialize<IList<string>?>(ref reader, options);
 					continue;
 				}
 
@@ -430,19 +430,19 @@ public sealed partial class MultisearchBody
 
 	public Elastic.Clients.Elasticsearch.Core.Search.FieldCollapse? Collapse { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
 
 	public bool? Explain { get; set; }
 
 	public Dictionary<string, object>? Ext { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? Fields { get; set; }
 
 	public int? From { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Core.Search.Highlight? Highlight { get; set; }
 
-	public IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
+	public IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoost { get; set; }
 
 	public Elastic.Clients.Elasticsearch.KnnQuery? Knn { get; set; }
 
@@ -456,22 +456,22 @@ public sealed partial class MultisearchBody
 
 	public Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer? Query { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? Rescore { get; set; }
 
 	public Dictionary<Elastic.Clients.Elasticsearch.Field, Elastic.Clients.Elasticsearch.Mapping.RuntimeField>? RuntimeMappings { get; set; }
 
 	public Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFields { get; set; }
 
-	public IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfter { get; set; }
 
 	public bool? SeqNoPrimaryTerm { get; set; }
 
 	public int? Size { get; set; }
 
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 
-	public IEnumerable<string>? Stats { get; set; }
+	public IList<string>? Stats { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Fields? StoredFields { get; set; }
 
@@ -501,7 +501,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 
 	private Action<Core.Search.FieldCollapseDescriptor<TDocument>> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> DocvalueFieldsDescriptor { get; set; }
 
@@ -509,7 +509,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 
 	private Action<QueryDsl.FieldAndFormatDescriptor<TDocument>>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> FieldsDescriptor { get; set; }
 
@@ -541,7 +541,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 
 	private Action<QueryDsl.QueryContainerDescriptor<TDocument>> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor<TDocument> RescoreDescriptor { get; set; }
 
@@ -559,7 +559,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -575,15 +575,15 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -627,7 +627,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public MultisearchBodyDescriptor<TDocument> DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -663,7 +663,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public MultisearchBodyDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -795,7 +795,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public MultisearchBodyDescriptor<TDocument> Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -861,7 +861,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public MultisearchBodyDescriptor<TDocument> IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -915,7 +915,7 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public MultisearchBodyDescriptor<TDocument> SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -933,13 +933,13 @@ public sealed partial class MultisearchBodyDescriptor<TDocument> : SerializableD
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public MultisearchBodyDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor<TDocument> Stats(IEnumerable<string>? stats)
+	public MultisearchBodyDescriptor<TDocument> Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;
@@ -1356,7 +1356,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 
 	private Action<Core.Search.FieldCollapseDescriptor> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor DocvalueFieldsDescriptor { get; set; }
 
@@ -1364,7 +1364,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 
 	private Action<QueryDsl.FieldAndFormatDescriptor>[] DocvalueFieldsDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? FieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor FieldsDescriptor { get; set; }
 
@@ -1396,7 +1396,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 
 	private Action<QueryDsl.QueryContainerDescriptor> QueryDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? RescoreValue { get; set; }
 
 	private Core.Search.RescoreDescriptor RescoreDescriptor { get; set; }
 
@@ -1414,7 +1414,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 
 	private int? FromValue { get; set; }
 
-	private IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
+	private IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? IndicesBoostValue { get; set; }
 
 	private double? MinScoreValue { get; set; }
 
@@ -1430,15 +1430,15 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 
 	private Dictionary<string, Elastic.Clients.Elasticsearch.ScriptField>? ScriptFieldsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.FieldValue>? SearchAfterValue { get; set; }
 
 	private bool? SeqNoPrimaryTermValue { get; set; }
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
-	private IEnumerable<string>? StatsValue { get; set; }
+	private IList<string>? StatsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldsValue { get; set; }
 
@@ -1482,7 +1482,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public MultisearchBodyDescriptor DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -1518,7 +1518,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
+	public MultisearchBodyDescriptor Fields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? fields)
 	{
 		FieldsDescriptor = null;
 		FieldsDescriptorAction = null;
@@ -1650,7 +1650,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor Rescore(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
+	public MultisearchBodyDescriptor Rescore(IList<Elastic.Clients.Elasticsearch.Core.Search.Rescore>? rescore)
 	{
 		RescoreDescriptor = null;
 		RescoreDescriptorAction = null;
@@ -1716,7 +1716,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor IndicesBoost(IEnumerable<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
+	public MultisearchBodyDescriptor IndicesBoost(IList<Dictionary<Elastic.Clients.Elasticsearch.IndexName, double>>? indicesBoost)
 	{
 		IndicesBoostValue = indicesBoost;
 		return Self;
@@ -1770,7 +1770,7 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor SearchAfter(IEnumerable<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
+	public MultisearchBodyDescriptor SearchAfter(IList<Elastic.Clients.Elasticsearch.FieldValue>? searchAfter)
 	{
 		SearchAfterValue = searchAfter;
 		return Self;
@@ -1788,13 +1788,13 @@ public sealed partial class MultisearchBodyDescriptor : SerializableDescriptor<M
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public MultisearchBodyDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
 	}
 
-	public MultisearchBodyDescriptor Stats(IEnumerable<string>? stats)
+	public MultisearchBodyDescriptor Stats(IList<string>? stats)
 	{
 		StatsValue = stats;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchHeader.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchHeader.g.cs
@@ -42,7 +42,7 @@ public sealed partial class MultisearchHeader
 	[JsonInclude]
 	[JsonPropertyName("expand_wildcards")]
 	[JsonConverter(typeof(ExpandWildcardsConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcards { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("ignore_throttled")]
@@ -86,7 +86,7 @@ public sealed partial class MultisearchHeaderDescriptor : SerializableDescriptor
 
 	private bool? CcsMinimizeRoundtripsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcardsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? ExpandWildcardsValue { get; set; }
 
 	private bool? IgnoreThrottledValue { get; set; }
 
@@ -120,7 +120,7 @@ public sealed partial class MultisearchHeaderDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public MultisearchHeaderDescriptor ExpandWildcards(IEnumerable<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards)
+	public MultisearchHeaderDescriptor ExpandWildcards(IList<Elastic.Clients.Elasticsearch.ExpandWildcard>? expandWildcards)
 	{
 		ExpandWildcardsValue = expandWildcards;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/RankEval/RankEvalRequestItem.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/RankEval/RankEvalRequestItem.g.cs
@@ -37,7 +37,7 @@ public sealed partial class RankEvalRequestItem
 
 	[JsonInclude]
 	[JsonPropertyName("ratings")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> Ratings { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> Ratings { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("request")]
@@ -65,7 +65,7 @@ public sealed partial class RankEvalRequestItemDescriptor<TDocument> : Serializa
 
 	private Dictionary<string, object>? ParamsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> RatingsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> RatingsValue { get; set; }
 
 	private DocumentRatingDescriptor RatingsDescriptor { get; set; }
 
@@ -111,7 +111,7 @@ public sealed partial class RankEvalRequestItemDescriptor<TDocument> : Serializa
 		return Self;
 	}
 
-	public RankEvalRequestItemDescriptor<TDocument> Ratings(IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> ratings)
+	public RankEvalRequestItemDescriptor<TDocument> Ratings(IList<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> ratings)
 	{
 		RatingsDescriptor = null;
 		RatingsDescriptorAction = null;
@@ -238,7 +238,7 @@ public sealed partial class RankEvalRequestItemDescriptor : SerializableDescript
 
 	private Dictionary<string, object>? ParamsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> RatingsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> RatingsValue { get; set; }
 
 	private DocumentRatingDescriptor RatingsDescriptor { get; set; }
 
@@ -284,7 +284,7 @@ public sealed partial class RankEvalRequestItemDescriptor : SerializableDescript
 		return Self;
 	}
 
-	public RankEvalRequestItemDescriptor Ratings(IEnumerable<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> ratings)
+	public RankEvalRequestItemDescriptor Ratings(IList<Elastic.Clients.Elasticsearch.Core.RankEval.DocumentRating> ratings)
 	{
 		RatingsDescriptor = null;
 		RatingsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Reindex/Source.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Reindex/Source.g.cs
@@ -58,7 +58,7 @@ public sealed partial class Source
 	[JsonInclude]
 	[JsonPropertyName("sort")]
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 }
 
 public sealed partial class SourceDescriptor<TDocument> : SerializableDescriptor<SourceDescriptor<TDocument>>
@@ -94,7 +94,7 @@ public sealed partial class SourceDescriptor<TDocument> : SerializableDescriptor
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	public SourceDescriptor<TDocument> Query(Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer? query)
 	{
@@ -192,7 +192,7 @@ public sealed partial class SourceDescriptor<TDocument> : SerializableDescriptor
 		return Self;
 	}
 
-	public SourceDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public SourceDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
@@ -312,7 +312,7 @@ public sealed partial class SourceDescriptor : SerializableDescriptor<SourceDesc
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	public SourceDescriptor Query(Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer? query)
 	{
@@ -410,7 +410,7 @@ public sealed partial class SourceDescriptor : SerializableDescriptor<SourceDesc
 		return Self;
 	}
 
-	public SourceDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public SourceDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/CompletionContext.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/CompletionContext.g.cs
@@ -33,7 +33,7 @@ public sealed partial class CompletionContext
 
 	[JsonInclude]
 	[JsonPropertyName("neighbours")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.GeoHashPrecision>? Neighbours { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.GeoHashPrecision>? Neighbours { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("precision")]
@@ -53,7 +53,7 @@ public sealed partial class CompletionContextDescriptor : SerializableDescriptor
 
 	private double? BoostValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.GeoHashPrecision>? NeighboursValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.GeoHashPrecision>? NeighboursValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.GeoHashPrecision? PrecisionValue { get; set; }
 
@@ -65,7 +65,7 @@ public sealed partial class CompletionContextDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public CompletionContextDescriptor Neighbours(IEnumerable<Elastic.Clients.Elasticsearch.GeoHashPrecision>? neighbours)
+	public CompletionContextDescriptor Neighbours(IList<Elastic.Clients.Elasticsearch.GeoHashPrecision>? neighbours)
 	{
 		NeighboursValue = neighbours;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/CompletionSuggester.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/CompletionSuggester.g.cs
@@ -33,7 +33,7 @@ public sealed partial class CompletionSuggester
 
 	[JsonInclude]
 	[JsonPropertyName("contexts")]
-	public Dictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? Contexts { get; set; }
+	public Dictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? Contexts { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("field")]
@@ -69,7 +69,7 @@ public sealed partial class CompletionSuggesterDescriptor<TDocument> : Serializa
 
 	private string? AnalyzerValue { get; set; }
 
-	private Dictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? ContextsValue { get; set; }
+	private Dictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? ContextsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field FieldValue { get; set; }
 
@@ -93,9 +93,9 @@ public sealed partial class CompletionSuggesterDescriptor<TDocument> : Serializa
 		return Self;
 	}
 
-	public CompletionSuggesterDescriptor<TDocument> Contexts(Func<FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>, FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>> selector)
+	public CompletionSuggesterDescriptor<TDocument> Contexts(Func<FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>, FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>> selector)
 	{
-		ContextsValue = selector?.Invoke(new FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>());
+		ContextsValue = selector?.Invoke(new FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>());
 		return Self;
 	}
 
@@ -229,7 +229,7 @@ public sealed partial class CompletionSuggesterDescriptor : SerializableDescript
 
 	private string? AnalyzerValue { get; set; }
 
-	private Dictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? ContextsValue { get; set; }
+	private Dictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>? ContextsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field FieldValue { get; set; }
 
@@ -253,9 +253,9 @@ public sealed partial class CompletionSuggesterDescriptor : SerializableDescript
 		return Self;
 	}
 
-	public CompletionSuggesterDescriptor Contexts(Func<FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>, FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>> selector)
+	public CompletionSuggesterDescriptor Contexts(Func<FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>, FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>> selector)
 	{
-		ContextsValue = selector?.Invoke(new FluentDictionary<Elastic.Clients.Elasticsearch.Field, IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>());
+		ContextsValue = selector?.Invoke(new FluentDictionary<Elastic.Clients.Elasticsearch.Field, IList<Elastic.Clients.Elasticsearch.Core.Search.CompletionContext>>());
 		return Self;
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/FieldCollapse.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/FieldCollapse.g.cs
@@ -37,7 +37,7 @@ public sealed partial class FieldCollapse
 
 	[JsonInclude]
 	[JsonPropertyName("inner_hits")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHits { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHits { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("max_concurrent_group_searches")]
@@ -57,7 +57,7 @@ public sealed partial class FieldCollapseDescriptor<TDocument> : SerializableDes
 
 	private Action<FieldCollapseDescriptor<TDocument>> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHitsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHitsValue { get; set; }
 
 	private InnerHitsDescriptor<TDocument> InnerHitsDescriptor { get; set; }
 
@@ -93,7 +93,7 @@ public sealed partial class FieldCollapseDescriptor<TDocument> : SerializableDes
 		return Self;
 	}
 
-	public FieldCollapseDescriptor<TDocument> InnerHits(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? innerHits)
+	public FieldCollapseDescriptor<TDocument> InnerHits(IList<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? innerHits)
 	{
 		InnerHitsDescriptor = null;
 		InnerHitsDescriptorAction = null;
@@ -222,7 +222,7 @@ public sealed partial class FieldCollapseDescriptor : SerializableDescriptor<Fie
 
 	private Action<FieldCollapseDescriptor> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHitsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? InnerHitsValue { get; set; }
 
 	private InnerHitsDescriptor InnerHitsDescriptor { get; set; }
 
@@ -258,7 +258,7 @@ public sealed partial class FieldCollapseDescriptor : SerializableDescriptor<Fie
 		return Self;
 	}
 
-	public FieldCollapseDescriptor InnerHits(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? innerHits)
+	public FieldCollapseDescriptor InnerHits(IList<Elastic.Clients.Elasticsearch.Core.Search.InnerHits>? innerHits)
 	{
 		InnerHitsDescriptor = null;
 		InnerHitsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/Highlight.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/Highlight.g.cs
@@ -101,11 +101,11 @@ public sealed partial class Highlight
 
 	[JsonInclude]
 	[JsonPropertyName("post_tags")]
-	public IEnumerable<string>? PostTags { get; set; }
+	public IList<string>? PostTags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("pre_tags")]
-	public IEnumerable<string>? PreTags { get; set; }
+	public IList<string>? PreTags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("require_field_match")]
@@ -167,9 +167,9 @@ public sealed partial class HighlightDescriptor<TDocument> : SerializableDescrip
 
 	private int? PhraseLimitValue { get; set; }
 
-	private IEnumerable<string>? PostTagsValue { get; set; }
+	private IList<string>? PostTagsValue { get; set; }
 
-	private IEnumerable<string>? PreTagsValue { get; set; }
+	private IList<string>? PreTagsValue { get; set; }
 
 	private bool? RequireFieldMatchValue { get; set; }
 
@@ -303,13 +303,13 @@ public sealed partial class HighlightDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public HighlightDescriptor<TDocument> PostTags(IEnumerable<string>? postTags)
+	public HighlightDescriptor<TDocument> PostTags(IList<string>? postTags)
 	{
 		PostTagsValue = postTags;
 		return Self;
 	}
 
-	public HighlightDescriptor<TDocument> PreTags(IEnumerable<string>? preTags)
+	public HighlightDescriptor<TDocument> PreTags(IList<string>? preTags)
 	{
 		PreTagsValue = preTags;
 		return Self;
@@ -531,9 +531,9 @@ public sealed partial class HighlightDescriptor : SerializableDescriptor<Highlig
 
 	private int? PhraseLimitValue { get; set; }
 
-	private IEnumerable<string>? PostTagsValue { get; set; }
+	private IList<string>? PostTagsValue { get; set; }
 
-	private IEnumerable<string>? PreTagsValue { get; set; }
+	private IList<string>? PreTagsValue { get; set; }
 
 	private bool? RequireFieldMatchValue { get; set; }
 
@@ -667,13 +667,13 @@ public sealed partial class HighlightDescriptor : SerializableDescriptor<Highlig
 		return Self;
 	}
 
-	public HighlightDescriptor PostTags(IEnumerable<string>? postTags)
+	public HighlightDescriptor PostTags(IList<string>? postTags)
 	{
 		PostTagsValue = postTags;
 		return Self;
 	}
 
-	public HighlightDescriptor PreTags(IEnumerable<string>? preTags)
+	public HighlightDescriptor PreTags(IList<string>? preTags)
 	{
 		PreTagsValue = preTags;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/HighlightField.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/HighlightField.g.cs
@@ -105,11 +105,11 @@ public sealed partial class HighlightField
 
 	[JsonInclude]
 	[JsonPropertyName("post_tags")]
-	public IEnumerable<string>? PostTags { get; set; }
+	public IList<string>? PostTags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("pre_tags")]
-	public IEnumerable<string>? PreTags { get; set; }
+	public IList<string>? PreTags { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("require_field_match")]
@@ -173,9 +173,9 @@ public sealed partial class HighlightFieldDescriptor<TDocument> : SerializableDe
 
 	private int? PhraseLimitValue { get; set; }
 
-	private IEnumerable<string>? PostTagsValue { get; set; }
+	private IList<string>? PostTagsValue { get; set; }
 
-	private IEnumerable<string>? PreTagsValue { get; set; }
+	private IList<string>? PreTagsValue { get; set; }
 
 	private bool? RequireFieldMatchValue { get; set; }
 
@@ -315,13 +315,13 @@ public sealed partial class HighlightFieldDescriptor<TDocument> : SerializableDe
 		return Self;
 	}
 
-	public HighlightFieldDescriptor<TDocument> PostTags(IEnumerable<string>? postTags)
+	public HighlightFieldDescriptor<TDocument> PostTags(IList<string>? postTags)
 	{
 		PostTagsValue = postTags;
 		return Self;
 	}
 
-	public HighlightFieldDescriptor<TDocument> PreTags(IEnumerable<string>? preTags)
+	public HighlightFieldDescriptor<TDocument> PreTags(IList<string>? preTags)
 	{
 		PreTagsValue = preTags;
 		return Self;
@@ -555,9 +555,9 @@ public sealed partial class HighlightFieldDescriptor : SerializableDescriptor<Hi
 
 	private int? PhraseLimitValue { get; set; }
 
-	private IEnumerable<string>? PostTagsValue { get; set; }
+	private IList<string>? PostTagsValue { get; set; }
 
-	private IEnumerable<string>? PreTagsValue { get; set; }
+	private IList<string>? PreTagsValue { get; set; }
 
 	private bool? RequireFieldMatchValue { get; set; }
 
@@ -697,13 +697,13 @@ public sealed partial class HighlightFieldDescriptor : SerializableDescriptor<Hi
 		return Self;
 	}
 
-	public HighlightFieldDescriptor PostTags(IEnumerable<string>? postTags)
+	public HighlightFieldDescriptor PostTags(IList<string>? postTags)
 	{
 		PostTagsValue = postTags;
 		return Self;
 	}
 
-	public HighlightFieldDescriptor PreTags(IEnumerable<string>? preTags)
+	public HighlightFieldDescriptor PreTags(IList<string>? preTags)
 	{
 		PreTagsValue = preTags;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/InnerHits.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/InnerHits.g.cs
@@ -37,7 +37,7 @@ public sealed partial class InnerHits
 
 	[JsonInclude]
 	[JsonPropertyName("docvalue_fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("explain")]
@@ -78,7 +78,7 @@ public sealed partial class InnerHits
 	[JsonInclude]
 	[JsonPropertyName("sort")]
 	[JsonConverter(typeof(SortConverter))]
-	public IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.SortOptions>? Sort { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("stored_field")]
@@ -106,7 +106,7 @@ public sealed partial class InnerHitsDescriptor<TDocument> : SerializableDescrip
 
 	private Action<FieldCollapseDescriptor<TDocument>> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor<TDocument> DocvalueFieldsDescriptor { get; set; }
 
@@ -138,7 +138,7 @@ public sealed partial class InnerHitsDescriptor<TDocument> : SerializableDescrip
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldValue { get; set; }
 
@@ -170,7 +170,7 @@ public sealed partial class InnerHitsDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public InnerHitsDescriptor<TDocument> DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public InnerHitsDescriptor<TDocument> DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -284,7 +284,7 @@ public sealed partial class InnerHitsDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public InnerHitsDescriptor<TDocument> Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public InnerHitsDescriptor<TDocument> Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;
@@ -469,7 +469,7 @@ public sealed partial class InnerHitsDescriptor : SerializableDescriptor<InnerHi
 
 	private Action<FieldCollapseDescriptor> CollapseDescriptorAction { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? DocvalueFieldsValue { get; set; }
 
 	private QueryDsl.FieldAndFormatDescriptor DocvalueFieldsDescriptor { get; set; }
 
@@ -501,7 +501,7 @@ public sealed partial class InnerHitsDescriptor : SerializableDescriptor<InnerHi
 
 	private int? SizeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.SortOptions>? SortValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fields? StoredFieldValue { get; set; }
 
@@ -533,7 +533,7 @@ public sealed partial class InnerHitsDescriptor : SerializableDescriptor<InnerHi
 		return Self;
 	}
 
-	public InnerHitsDescriptor DocvalueFields(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
+	public InnerHitsDescriptor DocvalueFields(IList<Elastic.Clients.Elasticsearch.QueryDsl.FieldAndFormat>? docvalueFields)
 	{
 		DocvalueFieldsDescriptor = null;
 		DocvalueFieldsDescriptorAction = null;
@@ -647,7 +647,7 @@ public sealed partial class InnerHitsDescriptor : SerializableDescriptor<InnerHi
 		return Self;
 	}
 
-	public InnerHitsDescriptor Sort(IEnumerable<Elastic.Clients.Elasticsearch.SortOptions>? sort)
+	public InnerHitsDescriptor Sort(IList<Elastic.Clients.Elasticsearch.SortOptions>? sort)
 	{
 		SortValue = sort;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/PhraseSuggester.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/PhraseSuggester.g.cs
@@ -41,7 +41,7 @@ public sealed partial class PhraseSuggester
 
 	[JsonInclude]
 	[JsonPropertyName("direct_generator")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGenerator { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGenerator { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("field")]
@@ -99,7 +99,7 @@ public sealed partial class PhraseSuggesterDescriptor<TDocument> : SerializableD
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGeneratorValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGeneratorValue { get; set; }
 
 	private DirectGeneratorDescriptor<TDocument> DirectGeneratorDescriptor { get; set; }
 
@@ -149,7 +149,7 @@ public sealed partial class PhraseSuggesterDescriptor<TDocument> : SerializableD
 
 	private int? TokenLimitValue { get; set; }
 
-	public PhraseSuggesterDescriptor<TDocument> DirectGenerator(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? directGenerator)
+	public PhraseSuggesterDescriptor<TDocument> DirectGenerator(IList<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? directGenerator)
 	{
 		DirectGeneratorDescriptor = null;
 		DirectGeneratorDescriptorAction = null;
@@ -496,7 +496,7 @@ public sealed partial class PhraseSuggesterDescriptor : SerializableDescriptor<P
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGeneratorValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? DirectGeneratorValue { get; set; }
 
 	private DirectGeneratorDescriptor DirectGeneratorDescriptor { get; set; }
 
@@ -546,7 +546,7 @@ public sealed partial class PhraseSuggesterDescriptor : SerializableDescriptor<P
 
 	private int? TokenLimitValue { get; set; }
 
-	public PhraseSuggesterDescriptor DirectGenerator(IEnumerable<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? directGenerator)
+	public PhraseSuggesterDescriptor DirectGenerator(IList<Elastic.Clients.Elasticsearch.Core.Search.DirectGenerator>? directGenerator)
 	{
 		DirectGeneratorDescriptor = null;
 		DirectGeneratorDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/IndexManagement/IndexSegmentSort.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/IndexManagement/IndexSegmentSort.g.cs
@@ -33,15 +33,15 @@ public sealed partial class IndexSegmentSort
 
 	[JsonInclude]
 	[JsonPropertyName("missing")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? Missing { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? Missing { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("mode")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? Mode { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? Mode { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("order")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? Order { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? Order { get; set; }
 }
 
 public sealed partial class IndexSegmentSortDescriptor<TDocument> : SerializableDescriptor<IndexSegmentSortDescriptor<TDocument>>
@@ -53,11 +53,11 @@ public sealed partial class IndexSegmentSortDescriptor<TDocument> : Serializable
 
 	private Elastic.Clients.Elasticsearch.Fields? FieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? MissingValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? ModeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? ModeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? OrderValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? OrderValue { get; set; }
 
 	public IndexSegmentSortDescriptor<TDocument> Field(Elastic.Clients.Elasticsearch.Fields? field)
 	{
@@ -65,19 +65,19 @@ public sealed partial class IndexSegmentSortDescriptor<TDocument> : Serializable
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor<TDocument> Missing(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? missing)
+	public IndexSegmentSortDescriptor<TDocument> Missing(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? missing)
 	{
 		MissingValue = missing;
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor<TDocument> Mode(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? mode)
+	public IndexSegmentSortDescriptor<TDocument> Mode(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? mode)
 	{
 		ModeValue = mode;
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor<TDocument> Order(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? order)
+	public IndexSegmentSortDescriptor<TDocument> Order(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? order)
 	{
 		OrderValue = order;
 		return Self;
@@ -123,11 +123,11 @@ public sealed partial class IndexSegmentSortDescriptor : SerializableDescriptor<
 
 	private Elastic.Clients.Elasticsearch.Fields? FieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? MissingValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? MissingValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? ModeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? ModeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? OrderValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? OrderValue { get; set; }
 
 	public IndexSegmentSortDescriptor Field(Elastic.Clients.Elasticsearch.Fields? field)
 	{
@@ -135,19 +135,19 @@ public sealed partial class IndexSegmentSortDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor Missing(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? missing)
+	public IndexSegmentSortDescriptor Missing(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMissing>? missing)
 	{
 		MissingValue = missing;
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor Mode(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? mode)
+	public IndexSegmentSortDescriptor Mode(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortMode>? mode)
 	{
 		ModeValue = mode;
 		return Self;
 	}
 
-	public IndexSegmentSortDescriptor Order(IEnumerable<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? order)
+	public IndexSegmentSortDescriptor Order(IList<Elastic.Clients.Elasticsearch.IndexManagement.SegmentSortOrder>? order)
 	{
 		OrderValue = order;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/IndexManagement/IndexSettings.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/IndexManagement/IndexSettings.g.cs
@@ -298,7 +298,7 @@ internal sealed class IndexSettingsConverter : JsonConverter<IndexSettings>
 
 				if (property == "routing_path")
 				{
-					variant.RoutingPath = JsonSerializer.Deserialize<IEnumerable<string>?>(ref reader, options);
+					variant.RoutingPath = JsonSerializer.Deserialize<IList<string>?>(ref reader, options);
 					continue;
 				}
 
@@ -840,7 +840,7 @@ public sealed partial class IndexSettings
 
 	public int? RoutingPartitionSize { get; set; }
 
-	public IEnumerable<string>? RoutingPath { get; set; }
+	public IList<string>? RoutingPath { get; set; }
 
 	public Elastic.Clients.Elasticsearch.IndexManagement.SettingsSearch? Search { get; set; }
 
@@ -1028,7 +1028,7 @@ public sealed partial class IndexSettingsDescriptor<TDocument> : SerializableDes
 
 	private int? RoutingPartitionSizeValue { get; set; }
 
-	private IEnumerable<string>? RoutingPathValue { get; set; }
+	private IList<string>? RoutingPathValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.SettingsSearch? SearchValue { get; set; }
 
@@ -1626,7 +1626,7 @@ public sealed partial class IndexSettingsDescriptor<TDocument> : SerializableDes
 		return Self;
 	}
 
-	public IndexSettingsDescriptor<TDocument> RoutingPath(IEnumerable<string>? routingPath)
+	public IndexSettingsDescriptor<TDocument> RoutingPath(IList<string>? routingPath)
 	{
 		RoutingPathValue = routingPath;
 		return Self;
@@ -2561,7 +2561,7 @@ public sealed partial class IndexSettingsDescriptor : SerializableDescriptor<Ind
 
 	private int? RoutingPartitionSizeValue { get; set; }
 
-	private IEnumerable<string>? RoutingPathValue { get; set; }
+	private IList<string>? RoutingPathValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.IndexManagement.SettingsSearch? SearchValue { get; set; }
 
@@ -3159,7 +3159,7 @@ public sealed partial class IndexSettingsDescriptor : SerializableDescriptor<Ind
 		return Self;
 	}
 
-	public IndexSettingsDescriptor RoutingPath(IEnumerable<string>? routingPath)
+	public IndexSettingsDescriptor RoutingPath(IList<string>? routingPath)
 	{
 		RoutingPathValue = routingPath;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/KnnQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/KnnQuery.g.cs
@@ -37,7 +37,7 @@ public sealed partial class KnnQuery
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("k")]
@@ -49,7 +49,7 @@ public sealed partial class KnnQuery
 
 	[JsonInclude]
 	[JsonPropertyName("query_vector")]
-	public IEnumerable<double> QueryVector { get; set; }
+	public IList<double> QueryVector { get; set; }
 }
 
 public sealed partial class KnnQueryDescriptor<TDocument> : SerializableDescriptor<KnnQueryDescriptor<TDocument>>
@@ -59,7 +59,7 @@ public sealed partial class KnnQueryDescriptor<TDocument> : SerializableDescript
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryDsl.QueryContainerDescriptor<TDocument> FilterDescriptor { get; set; }
 
@@ -75,9 +75,9 @@ public sealed partial class KnnQueryDescriptor<TDocument> : SerializableDescript
 
 	private long NumCandidatesValue { get; set; }
 
-	private IEnumerable<double> QueryVectorValue { get; set; }
+	private IList<double> QueryVectorValue { get; set; }
 
-	public KnnQueryDescriptor<TDocument> Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public KnnQueryDescriptor<TDocument> Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;
@@ -143,7 +143,7 @@ public sealed partial class KnnQueryDescriptor<TDocument> : SerializableDescript
 		return Self;
 	}
 
-	public KnnQueryDescriptor<TDocument> QueryVector(IEnumerable<double> queryVector)
+	public KnnQueryDescriptor<TDocument> QueryVector(IList<double> queryVector)
 	{
 		QueryVectorValue = queryVector;
 		return Self;
@@ -208,7 +208,7 @@ public sealed partial class KnnQueryDescriptor : SerializableDescriptor<KnnQuery
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryDsl.QueryContainerDescriptor FilterDescriptor { get; set; }
 
@@ -224,9 +224,9 @@ public sealed partial class KnnQueryDescriptor : SerializableDescriptor<KnnQuery
 
 	private long NumCandidatesValue { get; set; }
 
-	private IEnumerable<double> QueryVectorValue { get; set; }
+	private IList<double> QueryVectorValue { get; set; }
 
-	public KnnQueryDescriptor Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public KnnQueryDescriptor Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;
@@ -298,7 +298,7 @@ public sealed partial class KnnQueryDescriptor : SerializableDescriptor<KnnQuery
 		return Self;
 	}
 
-	public KnnQueryDescriptor QueryVector(IEnumerable<double> queryVector)
+	public KnnQueryDescriptor QueryVector(IList<double> queryVector)
 	{
 		QueryVectorValue = queryVector;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/AggregateMetricDoubleProperty.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/AggregateMetricDoubleProperty.g.cs
@@ -53,7 +53,7 @@ public sealed partial class AggregateMetricDoubleProperty : IProperty
 
 	[JsonInclude]
 	[JsonPropertyName("metrics")]
-	public IEnumerable<string> Metrics { get; set; }
+	public IList<string> Metrics { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("properties")]
@@ -87,7 +87,7 @@ public sealed partial class AggregateMetricDoublePropertyDescriptor<TDocument> :
 
 	private Dictionary<string, string>? MetaValue { get; set; }
 
-	private IEnumerable<string> MetricsValue { get; set; }
+	private IList<string> MetricsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Mapping.Properties? PropertiesValue { get; set; }
 
@@ -143,7 +143,7 @@ public sealed partial class AggregateMetricDoublePropertyDescriptor<TDocument> :
 		return Self;
 	}
 
-	public AggregateMetricDoublePropertyDescriptor<TDocument> Metrics(IEnumerable<string> metrics)
+	public AggregateMetricDoublePropertyDescriptor<TDocument> Metrics(IList<string> metrics)
 	{
 		MetricsValue = metrics;
 		return Self;
@@ -252,7 +252,7 @@ public sealed partial class AggregateMetricDoublePropertyDescriptor : Serializab
 
 	private Dictionary<string, string>? MetaValue { get; set; }
 
-	private IEnumerable<string> MetricsValue { get; set; }
+	private IList<string> MetricsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Mapping.Properties? PropertiesValue { get; set; }
 
@@ -308,7 +308,7 @@ public sealed partial class AggregateMetricDoublePropertyDescriptor : Serializab
 		return Self;
 	}
 
-	public AggregateMetricDoublePropertyDescriptor Metrics(IEnumerable<string> metrics)
+	public AggregateMetricDoublePropertyDescriptor Metrics(IList<string> metrics)
 	{
 		MetricsValue = metrics;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/CompletionProperty.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/CompletionProperty.g.cs
@@ -33,7 +33,7 @@ public sealed partial class CompletionProperty : IProperty
 
 	[JsonInclude]
 	[JsonPropertyName("contexts")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? Contexts { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? Contexts { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("copy_to")]
@@ -103,7 +103,7 @@ public sealed partial class CompletionPropertyDescriptor<TDocument> : Serializab
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? ContextsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? ContextsValue { get; set; }
 
 	private SuggestContextDescriptor<TDocument> ContextsDescriptor { get; set; }
 
@@ -141,7 +141,7 @@ public sealed partial class CompletionPropertyDescriptor<TDocument> : Serializab
 
 	private bool? StoreValue { get; set; }
 
-	public CompletionPropertyDescriptor<TDocument> Contexts(IEnumerable<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? contexts)
+	public CompletionPropertyDescriptor<TDocument> Contexts(IList<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? contexts)
 	{
 		ContextsDescriptor = null;
 		ContextsDescriptorAction = null;
@@ -435,7 +435,7 @@ public sealed partial class CompletionPropertyDescriptor : SerializableDescripto
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? ContextsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? ContextsValue { get; set; }
 
 	private SuggestContextDescriptor ContextsDescriptor { get; set; }
 
@@ -473,7 +473,7 @@ public sealed partial class CompletionPropertyDescriptor : SerializableDescripto
 
 	private bool? StoreValue { get; set; }
 
-	public CompletionPropertyDescriptor Contexts(IEnumerable<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? contexts)
+	public CompletionPropertyDescriptor Contexts(IList<Elastic.Clients.Elasticsearch.Mapping.SuggestContext>? contexts)
 	{
 		ContextsDescriptor = null;
 		ContextsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/JoinProperty.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/JoinProperty.g.cs
@@ -57,7 +57,7 @@ public sealed partial class JoinProperty : IProperty
 
 	[JsonInclude]
 	[JsonPropertyName("relations")]
-	public Dictionary<string, IEnumerable<string>>? Relations { get; set; }
+	public Dictionary<string, IList<string>>? Relations { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("type")]
@@ -85,7 +85,7 @@ public sealed partial class JoinPropertyDescriptor<TDocument> : SerializableDesc
 
 	private Elastic.Clients.Elasticsearch.Mapping.Properties? PropertiesValue { get; set; }
 
-	private Dictionary<string, IEnumerable<string>>? RelationsValue { get; set; }
+	private Dictionary<string, IList<string>>? RelationsValue { get; set; }
 
 	public JoinPropertyDescriptor<TDocument> Dynamic(Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? dynamic)
 	{
@@ -157,9 +157,9 @@ public sealed partial class JoinPropertyDescriptor<TDocument> : SerializableDesc
 		return Self;
 	}
 
-	public JoinPropertyDescriptor<TDocument> Relations(Func<FluentDictionary<string, IEnumerable<string>>, FluentDictionary<string, IEnumerable<string>>> selector)
+	public JoinPropertyDescriptor<TDocument> Relations(Func<FluentDictionary<string, IList<string>>, FluentDictionary<string, IList<string>>> selector)
 	{
-		RelationsValue = selector?.Invoke(new FluentDictionary<string, IEnumerable<string>>());
+		RelationsValue = selector?.Invoke(new FluentDictionary<string, IList<string>>());
 		return Self;
 	}
 
@@ -244,7 +244,7 @@ public sealed partial class JoinPropertyDescriptor : SerializableDescriptor<Join
 
 	private Elastic.Clients.Elasticsearch.Mapping.Properties? PropertiesValue { get; set; }
 
-	private Dictionary<string, IEnumerable<string>>? RelationsValue { get; set; }
+	private Dictionary<string, IList<string>>? RelationsValue { get; set; }
 
 	public JoinPropertyDescriptor Dynamic(Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? dynamic)
 	{
@@ -316,9 +316,9 @@ public sealed partial class JoinPropertyDescriptor : SerializableDescriptor<Join
 		return Self;
 	}
 
-	public JoinPropertyDescriptor Relations(Func<FluentDictionary<string, IEnumerable<string>>, FluentDictionary<string, IEnumerable<string>>> selector)
+	public JoinPropertyDescriptor Relations(Func<FluentDictionary<string, IList<string>>, FluentDictionary<string, IList<string>>> selector)
 	{
-		RelationsValue = selector?.Invoke(new FluentDictionary<string, IEnumerable<string>>());
+		RelationsValue = selector?.Invoke(new FluentDictionary<string, IList<string>>());
 		return Self;
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/SourceField.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/SourceField.g.cs
@@ -41,11 +41,11 @@ public sealed partial class SourceField
 
 	[JsonInclude]
 	[JsonPropertyName("excludes")]
-	public IEnumerable<string>? Excludes { get; set; }
+	public IList<string>? Excludes { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("includes")]
-	public IEnumerable<string>? Includes { get; set; }
+	public IList<string>? Includes { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("mode")]
@@ -65,9 +65,9 @@ public sealed partial class SourceFieldDescriptor : SerializableDescriptor<Sourc
 
 	private bool? EnabledValue { get; set; }
 
-	private IEnumerable<string>? ExcludesValue { get; set; }
+	private IList<string>? ExcludesValue { get; set; }
 
-	private IEnumerable<string>? IncludesValue { get; set; }
+	private IList<string>? IncludesValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Mapping.SourceFieldMode? ModeValue { get; set; }
 
@@ -89,13 +89,13 @@ public sealed partial class SourceFieldDescriptor : SerializableDescriptor<Sourc
 		return Self;
 	}
 
-	public SourceFieldDescriptor Excludes(IEnumerable<string>? excludes)
+	public SourceFieldDescriptor Excludes(IList<string>? excludes)
 	{
 		ExcludesValue = excludes;
 		return Self;
 	}
 
-	public SourceFieldDescriptor Includes(IEnumerable<string>? includes)
+	public SourceFieldDescriptor Includes(IList<string>? includes)
 	{
 		IncludesValue = includes;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/TypeMapping.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Mapping/TypeMapping.g.cs
@@ -65,11 +65,11 @@ public sealed partial class TypeMapping
 
 	[JsonInclude]
 	[JsonPropertyName("dynamic_date_formats")]
-	public IEnumerable<string>? DynamicDateFormats { get; set; }
+	public IList<string>? DynamicDateFormats { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("dynamic_templates")]
-	public Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplates { get; set; }
+	public Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplates { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("enabled")]
@@ -141,9 +141,9 @@ public sealed partial class TypeMappingDescriptor<TDocument> : SerializableDescr
 
 	private Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? DynamicValue { get; set; }
 
-	private IEnumerable<string>? DynamicDateFormatsValue { get; set; }
+	private IList<string>? DynamicDateFormatsValue { get; set; }
 
-	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
+	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
 
 	private bool? EnabledValue { get; set; }
 
@@ -321,13 +321,13 @@ public sealed partial class TypeMappingDescriptor<TDocument> : SerializableDescr
 		return Self;
 	}
 
-	public TypeMappingDescriptor<TDocument> DynamicDateFormats(IEnumerable<string>? dynamicDateFormats)
+	public TypeMappingDescriptor<TDocument> DynamicDateFormats(IList<string>? dynamicDateFormats)
 	{
 		DynamicDateFormatsValue = dynamicDateFormats;
 		return Self;
 	}
 
-	public TypeMappingDescriptor<TDocument> DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
+	public TypeMappingDescriptor<TDocument> DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
 	{
 		DynamicTemplatesValue = dynamicTemplates;
 		return Self;
@@ -617,9 +617,9 @@ public sealed partial class TypeMappingDescriptor : SerializableDescriptor<TypeM
 
 	private Elastic.Clients.Elasticsearch.Mapping.DynamicMapping? DynamicValue { get; set; }
 
-	private IEnumerable<string>? DynamicDateFormatsValue { get; set; }
+	private IList<string>? DynamicDateFormatsValue { get; set; }
 
-	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
+	private Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? DynamicTemplatesValue { get; set; }
 
 	private bool? EnabledValue { get; set; }
 
@@ -797,13 +797,13 @@ public sealed partial class TypeMappingDescriptor : SerializableDescriptor<TypeM
 		return Self;
 	}
 
-	public TypeMappingDescriptor DynamicDateFormats(IEnumerable<string>? dynamicDateFormats)
+	public TypeMappingDescriptor DynamicDateFormats(IList<string>? dynamicDateFormats)
 	{
 		DynamicDateFormatsValue = dynamicDateFormats;
 		return Self;
 	}
 
-	public TypeMappingDescriptor DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IEnumerable<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
+	public TypeMappingDescriptor DynamicTemplates(Union<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>?, IList<Dictionary<string, Elastic.Clients.Elasticsearch.Mapping.DynamicTemplate>>?>? dynamicTemplates)
 	{
 		DynamicTemplatesValue = dynamicTemplates;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/NerInferenceOptions.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/NerInferenceOptions.g.cs
@@ -29,7 +29,7 @@ public sealed partial class NerInferenceOptions
 {
 	[JsonInclude]
 	[JsonPropertyName("classification_labels")]
-	public IEnumerable<string>? ClassificationLabels { get; set; }
+	public IList<string>? ClassificationLabels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("results_field")]
@@ -47,7 +47,7 @@ public sealed partial class NerInferenceOptionsDescriptor : SerializableDescript
 	{
 	}
 
-	private IEnumerable<string>? ClassificationLabelsValue { get; set; }
+	private IList<string>? ClassificationLabelsValue { get; set; }
 
 	private string? ResultsFieldValue { get; set; }
 
@@ -57,7 +57,7 @@ public sealed partial class NerInferenceOptionsDescriptor : SerializableDescript
 
 	private Action<TokenizationConfigContainerDescriptor> TokenizationDescriptorAction { get; set; }
 
-	public NerInferenceOptionsDescriptor ClassificationLabels(IEnumerable<string>? classificationLabels)
+	public NerInferenceOptionsDescriptor ClassificationLabels(IList<string>? classificationLabels)
 	{
 		ClassificationLabelsValue = classificationLabels;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/TextClassificationInferenceOptions.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/TextClassificationInferenceOptions.g.cs
@@ -29,7 +29,7 @@ public sealed partial class TextClassificationInferenceOptions
 {
 	[JsonInclude]
 	[JsonPropertyName("classification_labels")]
-	public IEnumerable<string>? ClassificationLabels { get; set; }
+	public IList<string>? ClassificationLabels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("num_top_classes")]
@@ -51,7 +51,7 @@ public sealed partial class TextClassificationInferenceOptionsDescriptor : Seria
 	{
 	}
 
-	private IEnumerable<string>? ClassificationLabelsValue { get; set; }
+	private IList<string>? ClassificationLabelsValue { get; set; }
 
 	private int? NumTopClassesValue { get; set; }
 
@@ -63,7 +63,7 @@ public sealed partial class TextClassificationInferenceOptionsDescriptor : Seria
 
 	private Action<TokenizationConfigContainerDescriptor> TokenizationDescriptorAction { get; set; }
 
-	public TextClassificationInferenceOptionsDescriptor ClassificationLabels(IEnumerable<string>? classificationLabels)
+	public TextClassificationInferenceOptionsDescriptor ClassificationLabels(IList<string>? classificationLabels)
 	{
 		ClassificationLabelsValue = classificationLabels;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/TextClassificationInferenceUpdateOptions.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/TextClassificationInferenceUpdateOptions.g.cs
@@ -29,7 +29,7 @@ public sealed partial class TextClassificationInferenceUpdateOptions
 {
 	[JsonInclude]
 	[JsonPropertyName("classification_labels")]
-	public IEnumerable<string>? ClassificationLabels { get; set; }
+	public IList<string>? ClassificationLabels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("num_top_classes")]
@@ -51,7 +51,7 @@ public sealed partial class TextClassificationInferenceUpdateOptionsDescriptor :
 	{
 	}
 
-	private IEnumerable<string>? ClassificationLabelsValue { get; set; }
+	private IList<string>? ClassificationLabelsValue { get; set; }
 
 	private int? NumTopClassesValue { get; set; }
 
@@ -63,7 +63,7 @@ public sealed partial class TextClassificationInferenceUpdateOptionsDescriptor :
 
 	private Action<NlpTokenizationUpdateOptionsDescriptor> TokenizationDescriptorAction { get; set; }
 
-	public TextClassificationInferenceUpdateOptionsDescriptor ClassificationLabels(IEnumerable<string>? classificationLabels)
+	public TextClassificationInferenceUpdateOptionsDescriptor ClassificationLabels(IList<string>? classificationLabels)
 	{
 		ClassificationLabelsValue = classificationLabels;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/ZeroShotClassificationInferenceOptions.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/ZeroShotClassificationInferenceOptions.g.cs
@@ -29,7 +29,7 @@ public sealed partial class ZeroShotClassificationInferenceOptions
 {
 	[JsonInclude]
 	[JsonPropertyName("classification_labels")]
-	public IEnumerable<string> ClassificationLabels { get; set; }
+	public IList<string> ClassificationLabels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("hypothesis_template")]
@@ -37,7 +37,7 @@ public sealed partial class ZeroShotClassificationInferenceOptions
 
 	[JsonInclude]
 	[JsonPropertyName("labels")]
-	public IEnumerable<string>? Labels { get; set; }
+	public IList<string>? Labels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("multi_label")]
@@ -59,11 +59,11 @@ public sealed partial class ZeroShotClassificationInferenceOptionsDescriptor : S
 	{
 	}
 
-	private IEnumerable<string> ClassificationLabelsValue { get; set; }
+	private IList<string> ClassificationLabelsValue { get; set; }
 
 	private string? HypothesisTemplateValue { get; set; }
 
-	private IEnumerable<string>? LabelsValue { get; set; }
+	private IList<string>? LabelsValue { get; set; }
 
 	private bool? MultiLabelValue { get; set; }
 
@@ -75,7 +75,7 @@ public sealed partial class ZeroShotClassificationInferenceOptionsDescriptor : S
 
 	private Action<TokenizationConfigContainerDescriptor> TokenizationDescriptorAction { get; set; }
 
-	public ZeroShotClassificationInferenceOptionsDescriptor ClassificationLabels(IEnumerable<string> classificationLabels)
+	public ZeroShotClassificationInferenceOptionsDescriptor ClassificationLabels(IList<string> classificationLabels)
 	{
 		ClassificationLabelsValue = classificationLabels;
 		return Self;
@@ -87,7 +87,7 @@ public sealed partial class ZeroShotClassificationInferenceOptionsDescriptor : S
 		return Self;
 	}
 
-	public ZeroShotClassificationInferenceOptionsDescriptor Labels(IEnumerable<string>? labels)
+	public ZeroShotClassificationInferenceOptionsDescriptor Labels(IList<string>? labels)
 	{
 		LabelsValue = labels;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/ZeroShotClassificationInferenceUpdateOptions.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Ml/ZeroShotClassificationInferenceUpdateOptions.g.cs
@@ -29,7 +29,7 @@ public sealed partial class ZeroShotClassificationInferenceUpdateOptions
 {
 	[JsonInclude]
 	[JsonPropertyName("labels")]
-	public IEnumerable<string> Labels { get; set; }
+	public IList<string> Labels { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("multi_label")]
@@ -51,7 +51,7 @@ public sealed partial class ZeroShotClassificationInferenceUpdateOptionsDescript
 	{
 	}
 
-	private IEnumerable<string> LabelsValue { get; set; }
+	private IList<string> LabelsValue { get; set; }
 
 	private bool? MultiLabelValue { get; set; }
 
@@ -63,7 +63,7 @@ public sealed partial class ZeroShotClassificationInferenceUpdateOptionsDescript
 
 	private Action<NlpTokenizationUpdateOptionsDescriptor> TokenizationDescriptorAction { get; set; }
 
-	public ZeroShotClassificationInferenceUpdateOptionsDescriptor Labels(IEnumerable<string> labels)
+	public ZeroShotClassificationInferenceUpdateOptionsDescriptor Labels(IList<string> labels)
 	{
 		LabelsValue = labels;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/BoolQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/BoolQuery.g.cs
@@ -37,7 +37,7 @@ public sealed partial class BoolQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("filter")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Filter { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("minimum_should_match")]
@@ -45,15 +45,15 @@ public sealed partial class BoolQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("must")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Must { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Must { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("must_not")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNot { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNot { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("should")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Should { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? Should { get; set; }
 }
 
 public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescriptor<BoolQueryDescriptor<TDocument>>
@@ -63,7 +63,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryContainerDescriptor<TDocument> FilterDescriptor { get; set; }
 
@@ -71,7 +71,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 
 	private Action<QueryContainerDescriptor<TDocument>>[] FilterDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustValue { get; set; }
 
 	private QueryContainerDescriptor<TDocument> MustDescriptor { get; set; }
 
@@ -79,7 +79,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 
 	private Action<QueryContainerDescriptor<TDocument>>[] MustDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNotValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNotValue { get; set; }
 
 	private QueryContainerDescriptor<TDocument> MustNotDescriptor { get; set; }
 
@@ -87,7 +87,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 
 	private Action<QueryContainerDescriptor<TDocument>>[] MustNotDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? ShouldValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? ShouldValue { get; set; }
 
 	private QueryContainerDescriptor<TDocument> ShouldDescriptor { get; set; }
 
@@ -101,7 +101,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 
 	private Elastic.Clients.Elasticsearch.MinimumShouldMatch? MinimumShouldMatchValue { get; set; }
 
-	public BoolQueryDescriptor<TDocument> Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public BoolQueryDescriptor<TDocument> Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;
@@ -137,7 +137,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public BoolQueryDescriptor<TDocument> Must(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? must)
+	public BoolQueryDescriptor<TDocument> Must(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? must)
 	{
 		MustDescriptor = null;
 		MustDescriptorAction = null;
@@ -173,7 +173,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public BoolQueryDescriptor<TDocument> MustNot(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? mustNot)
+	public BoolQueryDescriptor<TDocument> MustNot(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? mustNot)
 	{
 		MustNotDescriptor = null;
 		MustNotDescriptorAction = null;
@@ -209,7 +209,7 @@ public sealed partial class BoolQueryDescriptor<TDocument> : SerializableDescrip
 		return Self;
 	}
 
-	public BoolQueryDescriptor<TDocument> Should(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? should)
+	public BoolQueryDescriptor<TDocument> Should(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? should)
 	{
 		ShouldDescriptor = null;
 		ShouldDescriptorAction = null;
@@ -419,7 +419,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? FilterValue { get; set; }
 
 	private QueryContainerDescriptor FilterDescriptor { get; set; }
 
@@ -427,7 +427,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 
 	private Action<QueryContainerDescriptor>[] FilterDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustValue { get; set; }
 
 	private QueryContainerDescriptor MustDescriptor { get; set; }
 
@@ -435,7 +435,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 
 	private Action<QueryContainerDescriptor>[] MustDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNotValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? MustNotValue { get; set; }
 
 	private QueryContainerDescriptor MustNotDescriptor { get; set; }
 
@@ -443,7 +443,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 
 	private Action<QueryContainerDescriptor>[] MustNotDescriptorActions { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? ShouldValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? ShouldValue { get; set; }
 
 	private QueryContainerDescriptor ShouldDescriptor { get; set; }
 
@@ -457,7 +457,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 
 	private Elastic.Clients.Elasticsearch.MinimumShouldMatch? MinimumShouldMatchValue { get; set; }
 
-	public BoolQueryDescriptor Filter(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
+	public BoolQueryDescriptor Filter(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? filter)
 	{
 		FilterDescriptor = null;
 		FilterDescriptorAction = null;
@@ -493,7 +493,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 		return Self;
 	}
 
-	public BoolQueryDescriptor Must(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? must)
+	public BoolQueryDescriptor Must(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? must)
 	{
 		MustDescriptor = null;
 		MustDescriptorAction = null;
@@ -529,7 +529,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 		return Self;
 	}
 
-	public BoolQueryDescriptor MustNot(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? mustNot)
+	public BoolQueryDescriptor MustNot(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? mustNot)
 	{
 		MustNotDescriptor = null;
 		MustNotDescriptorAction = null;
@@ -565,7 +565,7 @@ public sealed partial class BoolQueryDescriptor : SerializableDescriptor<BoolQue
 		return Self;
 	}
 
-	public BoolQueryDescriptor Should(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? should)
+	public BoolQueryDescriptor Should(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer>? should)
 	{
 		ShouldDescriptor = null;
 		ShouldDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/CombinedFieldsQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/CombinedFieldsQuery.g.cs
@@ -41,7 +41,7 @@ public sealed partial class CombinedFieldsQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Field> Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Field> Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("minimum_should_match")]
@@ -73,7 +73,7 @@ public sealed partial class CombinedFieldsQueryDescriptor<TDocument> : Serializa
 
 	private float? BoostValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field> FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field> FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.MinimumShouldMatch? MinimumShouldMatchValue { get; set; }
 
@@ -101,7 +101,7 @@ public sealed partial class CombinedFieldsQueryDescriptor<TDocument> : Serializa
 		return Self;
 	}
 
-	public CombinedFieldsQueryDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field> fields)
+	public CombinedFieldsQueryDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.Field> fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -191,7 +191,7 @@ public sealed partial class CombinedFieldsQueryDescriptor : SerializableDescript
 
 	private float? BoostValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field> FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field> FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.MinimumShouldMatch? MinimumShouldMatchValue { get; set; }
 
@@ -219,7 +219,7 @@ public sealed partial class CombinedFieldsQueryDescriptor : SerializableDescript
 		return Self;
 	}
 
-	public CombinedFieldsQueryDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field> fields)
+	public CombinedFieldsQueryDescriptor Fields(IList<Elastic.Clients.Elasticsearch.Field> fields)
 	{
 		FieldsValue = fields;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/DisMaxQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/DisMaxQuery.g.cs
@@ -37,7 +37,7 @@ public sealed partial class DisMaxQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("queries")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> Queries { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> Queries { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("tie_breaker")]
@@ -51,7 +51,7 @@ public sealed partial class DisMaxQueryDescriptor<TDocument> : SerializableDescr
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> QueriesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> QueriesValue { get; set; }
 
 	private QueryContainerDescriptor<TDocument> QueriesDescriptor { get; set; }
 
@@ -65,7 +65,7 @@ public sealed partial class DisMaxQueryDescriptor<TDocument> : SerializableDescr
 
 	private double? TieBreakerValue { get; set; }
 
-	public DisMaxQueryDescriptor<TDocument> Queries(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> queries)
+	public DisMaxQueryDescriptor<TDocument> Queries(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> queries)
 	{
 		QueriesDescriptor = null;
 		QueriesDescriptorAction = null;
@@ -182,7 +182,7 @@ public sealed partial class DisMaxQueryDescriptor : SerializableDescriptor<DisMa
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> QueriesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> QueriesValue { get; set; }
 
 	private QueryContainerDescriptor QueriesDescriptor { get; set; }
 
@@ -196,7 +196,7 @@ public sealed partial class DisMaxQueryDescriptor : SerializableDescriptor<DisMa
 
 	private double? TieBreakerValue { get; set; }
 
-	public DisMaxQueryDescriptor Queries(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> queries)
+	public DisMaxQueryDescriptor Queries(IList<Elastic.Clients.Elasticsearch.QueryDsl.QueryContainer> queries)
 	{
 		QueriesDescriptor = null;
 		QueriesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/FunctionScoreQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/FunctionScoreQuery.g.cs
@@ -41,7 +41,7 @@ public sealed partial class FunctionScoreQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("functions")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? Functions { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? Functions { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("max_boost")]
@@ -67,7 +67,7 @@ public sealed partial class FunctionScoreQueryDescriptor<TDocument> : Serializab
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? FunctionsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? FunctionsValue { get; set; }
 
 	private FunctionScoreContainerDescriptor<TDocument> FunctionsDescriptor { get; set; }
 
@@ -93,7 +93,7 @@ public sealed partial class FunctionScoreQueryDescriptor<TDocument> : Serializab
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreMode? ScoreModeValue { get; set; }
 
-	public FunctionScoreQueryDescriptor<TDocument> Functions(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? functions)
+	public FunctionScoreQueryDescriptor<TDocument> Functions(IList<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? functions)
 	{
 		FunctionsDescriptor = null;
 		FunctionsDescriptorAction = null;
@@ -286,7 +286,7 @@ public sealed partial class FunctionScoreQueryDescriptor : SerializableDescripto
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? FunctionsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? FunctionsValue { get; set; }
 
 	private FunctionScoreContainerDescriptor FunctionsDescriptor { get; set; }
 
@@ -312,7 +312,7 @@ public sealed partial class FunctionScoreQueryDescriptor : SerializableDescripto
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreMode? ScoreModeValue { get; set; }
 
-	public FunctionScoreQueryDescriptor Functions(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? functions)
+	public FunctionScoreQueryDescriptor Functions(IList<Elastic.Clients.Elasticsearch.QueryDsl.FunctionScoreContainer>? functions)
 	{
 		FunctionsDescriptor = null;
 		FunctionsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/IntervalsAllOf.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/IntervalsAllOf.g.cs
@@ -33,7 +33,7 @@ public sealed partial class IntervalsAllOf
 
 	[JsonInclude]
 	[JsonPropertyName("intervals")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> Intervals { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> Intervals { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("max_gaps")]
@@ -51,7 +51,7 @@ public sealed partial class IntervalsAllOfDescriptor<TDocument> : SerializableDe
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
 
 	private IntervalsContainerDescriptor<TDocument> IntervalsDescriptor { get; set; }
 
@@ -69,7 +69,7 @@ public sealed partial class IntervalsAllOfDescriptor<TDocument> : SerializableDe
 
 	private bool? OrderedValue { get; set; }
 
-	public IntervalsAllOfDescriptor<TDocument> Intervals(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
+	public IntervalsAllOfDescriptor<TDocument> Intervals(IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
 	{
 		IntervalsDescriptor = null;
 		IntervalsDescriptorAction = null;
@@ -214,7 +214,7 @@ public sealed partial class IntervalsAllOfDescriptor : SerializableDescriptor<In
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
 
 	private IntervalsContainerDescriptor IntervalsDescriptor { get; set; }
 
@@ -232,7 +232,7 @@ public sealed partial class IntervalsAllOfDescriptor : SerializableDescriptor<In
 
 	private bool? OrderedValue { get; set; }
 
-	public IntervalsAllOfDescriptor Intervals(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
+	public IntervalsAllOfDescriptor Intervals(IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
 	{
 		IntervalsDescriptor = null;
 		IntervalsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/IntervalsAnyOf.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/IntervalsAnyOf.g.cs
@@ -33,7 +33,7 @@ public sealed partial class IntervalsAnyOf
 
 	[JsonInclude]
 	[JsonPropertyName("intervals")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> Intervals { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> Intervals { get; set; }
 }
 
 public sealed partial class IntervalsAnyOfDescriptor<TDocument> : SerializableDescriptor<IntervalsAnyOfDescriptor<TDocument>>
@@ -43,7 +43,7 @@ public sealed partial class IntervalsAnyOfDescriptor<TDocument> : SerializableDe
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
 
 	private IntervalsContainerDescriptor<TDocument> IntervalsDescriptor { get; set; }
 
@@ -57,7 +57,7 @@ public sealed partial class IntervalsAnyOfDescriptor<TDocument> : SerializableDe
 
 	private Action<IntervalsFilterDescriptor> FilterDescriptorAction { get; set; }
 
-	public IntervalsAnyOfDescriptor<TDocument> Intervals(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
+	public IntervalsAnyOfDescriptor<TDocument> Intervals(IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
 	{
 		IntervalsDescriptor = null;
 		IntervalsDescriptorAction = null;
@@ -178,7 +178,7 @@ public sealed partial class IntervalsAnyOfDescriptor : SerializableDescriptor<In
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> IntervalsValue { get; set; }
 
 	private IntervalsContainerDescriptor IntervalsDescriptor { get; set; }
 
@@ -192,7 +192,7 @@ public sealed partial class IntervalsAnyOfDescriptor : SerializableDescriptor<In
 
 	private Action<IntervalsFilterDescriptor> FilterDescriptorAction { get; set; }
 
-	public IntervalsAnyOfDescriptor Intervals(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
+	public IntervalsAnyOfDescriptor Intervals(IList<Elastic.Clients.Elasticsearch.QueryDsl.IntervalsContainer> intervals)
 	{
 		IntervalsDescriptor = null;
 		IntervalsDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/LikeDocument.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/LikeDocument.g.cs
@@ -41,7 +41,7 @@ public sealed partial class LikeDocument
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("per_field_analyzer")]
@@ -73,7 +73,7 @@ public sealed partial class LikeDocumentDescriptor<TDocument> : SerializableDesc
 
 	private object? DocValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Dictionary<Elastic.Clients.Elasticsearch.Field, string>? PerFieldAnalyzerValue { get; set; }
 
@@ -101,7 +101,7 @@ public sealed partial class LikeDocumentDescriptor<TDocument> : SerializableDesc
 		return Self;
 	}
 
-	public LikeDocumentDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public LikeDocumentDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -193,7 +193,7 @@ public sealed partial class LikeDocumentDescriptor : SerializableDescriptor<Like
 
 	private object? DocValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Dictionary<Elastic.Clients.Elasticsearch.Field, string>? PerFieldAnalyzerValue { get; set; }
 
@@ -221,7 +221,7 @@ public sealed partial class LikeDocumentDescriptor : SerializableDescriptor<Like
 		return Self;
 	}
 
-	public LikeDocumentDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public LikeDocumentDescriptor Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/MoreLikeThisQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/MoreLikeThisQuery.g.cs
@@ -49,7 +49,7 @@ public sealed partial class MoreLikeThisQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("include")]
@@ -57,7 +57,7 @@ public sealed partial class MoreLikeThisQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("like")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like> Like { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.Like> Like { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("max_doc_freq")]
@@ -98,11 +98,11 @@ public sealed partial class MoreLikeThisQuery : Query
 	[JsonInclude]
 	[JsonPropertyName("stop_words")]
 	[JsonConverter(typeof(StopWordsConverter))]
-	public IEnumerable<string>? StopWords { get; set; }
+	public IList<string>? StopWords { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("unlike")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like>? Unlike { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.Like>? Unlike { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("version")]
@@ -130,11 +130,11 @@ public sealed partial class MoreLikeThisQueryDescriptor<TDocument> : Serializabl
 
 	private bool? FailOnUnsupportedFieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private bool? IncludeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like> LikeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.Like> LikeValue { get; set; }
 
 	private int? MaxDocFreqValue { get; set; }
 
@@ -154,9 +154,9 @@ public sealed partial class MoreLikeThisQueryDescriptor<TDocument> : Serializabl
 
 	private Elastic.Clients.Elasticsearch.Routing? RoutingValue { get; set; }
 
-	private IEnumerable<string>? StopWordsValue { get; set; }
+	private IList<string>? StopWordsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like>? UnlikeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.Like>? UnlikeValue { get; set; }
 
 	private long? VersionValue { get; set; }
 
@@ -192,7 +192,7 @@ public sealed partial class MoreLikeThisQueryDescriptor<TDocument> : Serializabl
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public MoreLikeThisQueryDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -204,7 +204,7 @@ public sealed partial class MoreLikeThisQueryDescriptor<TDocument> : Serializabl
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor<TDocument> Like(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like> like)
+	public MoreLikeThisQueryDescriptor<TDocument> Like(IList<Elastic.Clients.Elasticsearch.QueryDsl.Like> like)
 	{
 		LikeValue = like;
 		return Self;
@@ -264,13 +264,13 @@ public sealed partial class MoreLikeThisQueryDescriptor<TDocument> : Serializabl
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor<TDocument> StopWords(IEnumerable<string>? stopWords)
+	public MoreLikeThisQueryDescriptor<TDocument> StopWords(IList<string>? stopWords)
 	{
 		StopWordsValue = stopWords;
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor<TDocument> Unlike(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like>? unlike)
+	public MoreLikeThisQueryDescriptor<TDocument> Unlike(IList<Elastic.Clients.Elasticsearch.QueryDsl.Like>? unlike)
 	{
 		UnlikeValue = unlike;
 		return Self;
@@ -434,11 +434,11 @@ public sealed partial class MoreLikeThisQueryDescriptor : SerializableDescriptor
 
 	private bool? FailOnUnsupportedFieldValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private bool? IncludeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like> LikeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.Like> LikeValue { get; set; }
 
 	private int? MaxDocFreqValue { get; set; }
 
@@ -458,9 +458,9 @@ public sealed partial class MoreLikeThisQueryDescriptor : SerializableDescriptor
 
 	private Elastic.Clients.Elasticsearch.Routing? RoutingValue { get; set; }
 
-	private IEnumerable<string>? StopWordsValue { get; set; }
+	private IList<string>? StopWordsValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like>? UnlikeValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.Like>? UnlikeValue { get; set; }
 
 	private long? VersionValue { get; set; }
 
@@ -496,7 +496,7 @@ public sealed partial class MoreLikeThisQueryDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public MoreLikeThisQueryDescriptor Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -508,7 +508,7 @@ public sealed partial class MoreLikeThisQueryDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor Like(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like> like)
+	public MoreLikeThisQueryDescriptor Like(IList<Elastic.Clients.Elasticsearch.QueryDsl.Like> like)
 	{
 		LikeValue = like;
 		return Self;
@@ -568,13 +568,13 @@ public sealed partial class MoreLikeThisQueryDescriptor : SerializableDescriptor
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor StopWords(IEnumerable<string>? stopWords)
+	public MoreLikeThisQueryDescriptor StopWords(IList<string>? stopWords)
 	{
 		StopWordsValue = stopWords;
 		return Self;
 	}
 
-	public MoreLikeThisQueryDescriptor Unlike(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.Like>? unlike)
+	public MoreLikeThisQueryDescriptor Unlike(IList<Elastic.Clients.Elasticsearch.QueryDsl.Like>? unlike)
 	{
 		UnlikeValue = unlike;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/PercolateQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/PercolateQuery.g.cs
@@ -41,7 +41,7 @@ public sealed partial class PercolateQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("documents")]
-	public IEnumerable<object>? Documents { get; set; }
+	public IList<object>? Documents { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("field")]
@@ -85,7 +85,7 @@ public sealed partial class PercolateQueryDescriptor<TDocument> : SerializableDe
 
 	private object? DocumentValue { get; set; }
 
-	private IEnumerable<object>? DocumentsValue { get; set; }
+	private IList<object>? DocumentsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field FieldValue { get; set; }
 
@@ -119,7 +119,7 @@ public sealed partial class PercolateQueryDescriptor<TDocument> : SerializableDe
 		return Self;
 	}
 
-	public PercolateQueryDescriptor<TDocument> Documents(IEnumerable<object>? documents)
+	public PercolateQueryDescriptor<TDocument> Documents(IList<object>? documents)
 	{
 		DocumentsValue = documents;
 		return Self;
@@ -249,7 +249,7 @@ public sealed partial class PercolateQueryDescriptor : SerializableDescriptor<Pe
 
 	private object? DocumentValue { get; set; }
 
-	private IEnumerable<object>? DocumentsValue { get; set; }
+	private IList<object>? DocumentsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Field FieldValue { get; set; }
 
@@ -283,7 +283,7 @@ public sealed partial class PercolateQueryDescriptor : SerializableDescriptor<Pe
 		return Self;
 	}
 
-	public PercolateQueryDescriptor Documents(IEnumerable<object>? documents)
+	public PercolateQueryDescriptor Documents(IList<object>? documents)
 	{
 		DocumentsValue = documents;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/QueryStringQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/QueryStringQuery.g.cs
@@ -69,7 +69,7 @@ public sealed partial class QueryStringQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("fuzziness")]
@@ -163,7 +163,7 @@ public sealed partial class QueryStringQueryDescriptor<TDocument> : Serializable
 
 	private bool? EscapeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fuzziness? FuzzinessValue { get; set; }
 
@@ -263,7 +263,7 @@ public sealed partial class QueryStringQueryDescriptor<TDocument> : Serializable
 		return Self;
 	}
 
-	public QueryStringQueryDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public QueryStringQueryDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -557,7 +557,7 @@ public sealed partial class QueryStringQueryDescriptor : SerializableDescriptor<
 
 	private bool? EscapeValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.Fuzziness? FuzzinessValue { get; set; }
 
@@ -663,7 +663,7 @@ public sealed partial class QueryStringQueryDescriptor : SerializableDescriptor<
 		return Self;
 	}
 
-	public QueryStringQueryDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public QueryStringQueryDescriptor Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SimpleQueryStringQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SimpleQueryStringQuery.g.cs
@@ -53,7 +53,7 @@ public sealed partial class SimpleQueryStringQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("fields")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.Field>? Fields { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("flags")]
@@ -107,7 +107,7 @@ public sealed partial class SimpleQueryStringQueryDescriptor<TDocument> : Serial
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.Operator? DefaultOperatorValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.SimpleQueryStringFlags? FlagsValue { get; set; }
 
@@ -161,7 +161,7 @@ public sealed partial class SimpleQueryStringQueryDescriptor<TDocument> : Serial
 		return Self;
 	}
 
-	public SimpleQueryStringQueryDescriptor<TDocument> Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public SimpleQueryStringQueryDescriptor<TDocument> Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;
@@ -327,7 +327,7 @@ public sealed partial class SimpleQueryStringQueryDescriptor : SerializableDescr
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.Operator? DefaultOperatorValue { get; set; }
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.Field>? FieldsValue { get; set; }
 
 	private Elastic.Clients.Elasticsearch.QueryDsl.SimpleQueryStringFlags? FlagsValue { get; set; }
 
@@ -381,7 +381,7 @@ public sealed partial class SimpleQueryStringQueryDescriptor : SerializableDescr
 		return Self;
 	}
 
-	public SimpleQueryStringQueryDescriptor Fields(IEnumerable<Elastic.Clients.Elasticsearch.Field>? fields)
+	public SimpleQueryStringQueryDescriptor Fields(IList<Elastic.Clients.Elasticsearch.Field>? fields)
 	{
 		FieldsValue = fields;
 		return Self;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SpanNearQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SpanNearQuery.g.cs
@@ -37,7 +37,7 @@ public sealed partial class SpanNearQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("clauses")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> Clauses { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> Clauses { get; set; }
 
 	[JsonInclude]
 	[JsonPropertyName("in_order")]
@@ -55,7 +55,7 @@ public sealed partial class SpanNearQueryDescriptor<TDocument> : SerializableDes
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
 
 	private SpanQueryDescriptor<TDocument> ClausesDescriptor { get; set; }
 
@@ -71,7 +71,7 @@ public sealed partial class SpanNearQueryDescriptor<TDocument> : SerializableDes
 
 	private int? SlopValue { get; set; }
 
-	public SpanNearQueryDescriptor<TDocument> Clauses(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
+	public SpanNearQueryDescriptor<TDocument> Clauses(IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
 	{
 		ClausesDescriptor = null;
 		ClausesDescriptorAction = null;
@@ -200,7 +200,7 @@ public sealed partial class SpanNearQueryDescriptor : SerializableDescriptor<Spa
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
 
 	private SpanQueryDescriptor ClausesDescriptor { get; set; }
 
@@ -216,7 +216,7 @@ public sealed partial class SpanNearQueryDescriptor : SerializableDescriptor<Spa
 
 	private int? SlopValue { get; set; }
 
-	public SpanNearQueryDescriptor Clauses(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
+	public SpanNearQueryDescriptor Clauses(IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
 	{
 		ClausesDescriptor = null;
 		ClausesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SpanOrQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/SpanOrQuery.g.cs
@@ -37,7 +37,7 @@ public sealed partial class SpanOrQuery : Query
 
 	[JsonInclude]
 	[JsonPropertyName("clauses")]
-	public IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> Clauses { get; set; }
+	public IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> Clauses { get; set; }
 }
 
 public sealed partial class SpanOrQueryDescriptor<TDocument> : SerializableDescriptor<SpanOrQueryDescriptor<TDocument>>
@@ -47,7 +47,7 @@ public sealed partial class SpanOrQueryDescriptor<TDocument> : SerializableDescr
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
 
 	private SpanQueryDescriptor<TDocument> ClausesDescriptor { get; set; }
 
@@ -59,7 +59,7 @@ public sealed partial class SpanOrQueryDescriptor<TDocument> : SerializableDescr
 
 	private float? BoostValue { get; set; }
 
-	public SpanOrQueryDescriptor<TDocument> Clauses(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
+	public SpanOrQueryDescriptor<TDocument> Clauses(IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
 	{
 		ClausesDescriptor = null;
 		ClausesDescriptorAction = null;
@@ -164,7 +164,7 @@ public sealed partial class SpanOrQueryDescriptor : SerializableDescriptor<SpanO
 	{
 	}
 
-	private IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
+	private IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> ClausesValue { get; set; }
 
 	private SpanQueryDescriptor ClausesDescriptor { get; set; }
 
@@ -176,7 +176,7 @@ public sealed partial class SpanOrQueryDescriptor : SerializableDescriptor<SpanO
 
 	private float? BoostValue { get; set; }
 
-	public SpanOrQueryDescriptor Clauses(IEnumerable<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
+	public SpanOrQueryDescriptor Clauses(IList<Elastic.Clients.Elasticsearch.QueryDsl.SpanQuery> clauses)
 	{
 		ClausesDescriptor = null;
 		ClausesDescriptorAction = null;

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/TermsSetQuery.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/QueryDsl/TermsSetQuery.g.cs
@@ -66,7 +66,7 @@ internal sealed class TermsSetQueryConverter : JsonConverter<TermsSetQuery>
 
 				if (property == "terms")
 				{
-					variant.Terms = JsonSerializer.Deserialize<IEnumerable<string>>(ref reader, options);
+					variant.Terms = JsonSerializer.Deserialize<IList<string>>(ref reader, options);
 					continue;
 				}
 			}
@@ -138,7 +138,7 @@ public sealed partial class TermsSetQuery : Query
 
 	public Elastic.Clients.Elasticsearch.Script? MinimumShouldMatchScript { get; set; }
 
-	public IEnumerable<string> Terms { get; set; }
+	public IList<string> Terms { get; set; }
 
 	public Elastic.Clients.Elasticsearch.Field Field { get; set; }
 }
@@ -174,7 +174,7 @@ public sealed partial class TermsSetQueryDescriptor<TDocument> : SerializableDes
 
 	private Elastic.Clients.Elasticsearch.Script? MinimumShouldMatchScriptValue { get; set; }
 
-	private IEnumerable<string> TermsValue { get; set; }
+	private IList<string> TermsValue { get; set; }
 
 	public TermsSetQueryDescriptor<TDocument> QueryName(string? queryName)
 	{
@@ -218,7 +218,7 @@ public sealed partial class TermsSetQueryDescriptor<TDocument> : SerializableDes
 		return Self;
 	}
 
-	public TermsSetQueryDescriptor<TDocument> Terms(IEnumerable<string> terms)
+	public TermsSetQueryDescriptor<TDocument> Terms(IList<string> terms)
 	{
 		TermsValue = terms;
 		return Self;
@@ -286,7 +286,7 @@ public sealed partial class TermsSetQueryDescriptor : SerializableDescriptor<Ter
 
 	private Elastic.Clients.Elasticsearch.Script? MinimumShouldMatchScriptValue { get; set; }
 
-	private IEnumerable<string> TermsValue { get; set; }
+	private IList<string> TermsValue { get; set; }
 
 	public TermsSetQueryDescriptor QueryName(string? queryName)
 	{
@@ -342,7 +342,7 @@ public sealed partial class TermsSetQueryDescriptor : SerializableDescriptor<Ter
 		return Self;
 	}
 
-	public TermsSetQueryDescriptor Terms(IEnumerable<string> terms)
+	public TermsSetQueryDescriptor Terms(IList<string> terms)
 	{
 		TermsValue = terms;
 		return Self;

--- a/tests/Tests/IndexManagement/IndexSettingsSerializationTests.cs
+++ b/tests/Tests/IndexManagement/IndexSettingsSerializationTests.cs
@@ -30,7 +30,7 @@ public class IndexSettingsSerializationTests : SerializerTestBase
 				.Analyzer(a => a
 					.Custom("whitespace_lowercase", wl => wl
 						.Tokenizer("whitespace")
-						.Filter(Enumerable.Repeat("lowercase", 1))
+						.Filter(new[] { "lowercase" })
 					)
 				)
 		 );


### PR DESCRIPTION
Improve usability by prefering the IList interface to support easy additional/removal of items.