### PR TITLE
Make ElasticsearchClient more mockable

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -6,7 +6,8 @@
   </PropertyGroup>
   <PropertyGroup Condition="$(IsPackable) == True">
     <OutDir>bin/$(Configuration)/$(TargetFramework)/</OutDir>
-    <NoWarn>1591,1572,1571,1573,1587,1570,NU5048,</NoWarn>
+    <NoWarn>1591,1572,1571,1573,1587,1570,NU5048</NoWarn>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Prefer32Bit>false</Prefer32Bit>
     <DebugSymbols>true</DebugSymbols>
 

--- a/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient-BulkAll.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient-BulkAll.cs
@@ -10,13 +10,13 @@ namespace Elastic.Clients.Elasticsearch;
 
 public partial class ElasticsearchClient
 {
-	public BulkAllObservable<T> BulkAll<T>(IEnumerable<T> documents, Action<BulkAllRequestDescriptor<T>> configure, CancellationToken cancellationToken = default)
+	public virtual BulkAllObservable<T> BulkAll<T>(IEnumerable<T> documents, Action<BulkAllRequestDescriptor<T>> configure, CancellationToken cancellationToken = default)
     {
         var descriptor = new BulkAllRequestDescriptor<T>(documents);
         configure?.Invoke(descriptor);
         return BulkAll<T>(descriptor, cancellationToken);
     }
 
-    public BulkAllObservable<T> BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default) =>
+    public virtual BulkAllObservable<T> BulkAll<T>(IBulkAllRequest<T> request, CancellationToken cancellationToken = default) =>
         new(this, request, cancellationToken);
 }

--- a/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient-Manual.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient-Manual.cs
@@ -10,26 +10,26 @@ namespace Elastic.Clients.Elasticsearch;
 
 public partial class ElasticsearchClient
 {
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IndexName index, Id id, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IndexName index, Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(index, id);
-		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
+		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor, cancellationToken);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IndexName index, Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(IndexName index, Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
-		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
+		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor, cancellationToken);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IndexName index, Id id)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IndexName index, Id id)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(index, id);
 		return DoRequest<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IndexName index, Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(IndexName index, Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(index, id);
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
@@ -8,40 +8,39 @@ using System.Runtime.CompilerServices;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
-using Elastic.Clients.Elasticsearch.IndexManagement;
 using Elastic.Clients.Elasticsearch.Requests;
 using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Clients.Elasticsearch;
 
-/// <inheritdoc />
-public sealed partial class ElasticsearchClient
+/// <summary>
+/// A strongly-typed client for communicating with Elasticsearch server endpoints.
+/// </summary>
+public partial class ElasticsearchClient
 {
 	private readonly HttpTransport<IElasticsearchClientSettings> _transport;
 
 	internal static ConditionalWeakTable<JsonSerializerOptions, IElasticsearchClientSettings> SettingsTable { get; } = new();
 
 	/// <summary>
-	///     Creates a client configured to connect to localhost:9200.
+	/// Creates a client configured to connect to http://localhost:9200.
 	/// </summary>
 	public ElasticsearchClient() : this(new ElasticsearchClientSettings(new Uri("http://localhost:9200"))) { }
 
 	/// <summary>
-	///     Creates a client configured to connect to a node reachable at the provided <paramref name="uri" />.
+	/// Creates a client configured to connect to a node reachable at the provided <paramref name="uri" />.
 	/// </summary>
 	/// <param name="uri">The <see cref="Uri" /> to connect to.</param>
 	public ElasticsearchClient(Uri uri) : this(new ElasticsearchClientSettings(uri)) { }
 
 	/// <summary>
-	///     Creates a client configured to communicate with Elastic Cloud using the provided <paramref name="cloudId" />.
-	///     <para>See the <see cref="CloudNodePool" /> documentation for more information on how to obtain your Cloud Id.</para>
-	///     <para>
-	///         If you want more control, use the <see cref="ElasticsearchClient(IElasticsearchClientSettings)" /> constructor and
-	///         pass
-	///         an instance of
-	///         <see cref="ElasticsearchClientSettings" /> that takes a <paramref name="cloudId" /> in its constructor as well.
-	///     </para>
+	/// Creates a client configured to communicate with Elastic Cloud using the provided <paramref name="cloudId" />.
+	/// <para>See the <see cref="CloudNodePool" /> documentation for more information on how to obtain your Cloud Id.</para>
+	///   <para>
+	///     If you want more control, use the <see cref="ElasticsearchClient(IElasticsearchClientSettings)" /> constructor and
+	///     pass an instance of <see cref="ElasticsearchClientSettings" /> that takes a <paramref name="cloudId" /> in its constructor as well.
+	///   </para>
 	/// </summary>
 	/// <param name="cloudId">The Cloud ID of an Elastic Cloud deployment.</param>
 	/// <param name="credentials">The credentials to use for the connection.</param>
@@ -51,19 +50,15 @@ public sealed partial class ElasticsearchClient
 	}
 
 	/// <summary>
-	///     TODO
+	/// Creates a client using the provided configuration to initialise the client.
 	/// </summary>
-	/// <param name="elasticsearchClientSettings"></param>
+	/// <param name="elasticsearchClientSettings">The <see cref="IElasticsearchClientSettings"/> used to configure the client.</param>
 	public ElasticsearchClient(IElasticsearchClientSettings elasticsearchClientSettings)
 		: this(new DefaultHttpTransport<IElasticsearchClientSettings>(elasticsearchClientSettings))
 	{
 	}
 
-	/// <summary>
-	///     TODO
-	/// </summary>
-	/// <param name="transport"></param>
-	public ElasticsearchClient(HttpTransport<IElasticsearchClientSettings> transport)
+	internal ElasticsearchClient(HttpTransport<IElasticsearchClientSettings> transport)
 	{
 		transport.ThrowIfNull(nameof(transport));
 		transport.Settings.ThrowIfNull(nameof(transport.Settings));

--- a/src/Elastic.Clients.Elasticsearch/Client/IndicesNamespace.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/IndicesNamespace.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 namespace Elastic.Clients.Elasticsearch.IndexManagement;
 
-public partial class IndicesNamespace
+public partial class IndicesNamespacedClient
 {
 	/// <summary>
 	/// Refresh one or more indices. A refresh makes recent operations performed on one or more indices available for search. For data streams,

--- a/src/Elastic.Clients.Elasticsearch/Client/NamespacedClientProxy.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/NamespacedClientProxy.cs
@@ -11,14 +11,17 @@ using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Clients.Elasticsearch;
 
-/// <summary>
-/// </summary>
-/// <remarks>
-///     Not intended to be used directly.
-/// </remarks>
 public abstract class NamespacedClientProxy
 {
+	private const string InvalidOperation = "The client has not been initialised for proper usage as may have been partially mocked. Ensure you are using a " +
+		"new instance of ElasticsearchClient to perform requests over a network to Elasticsearch.";
+
 	private readonly ElasticsearchClient _client;
+	
+	/// <summary>
+	/// Initializes a new instance for mocking.
+	/// </summary>
+	protected NamespacedClientProxy() { }
 
 	internal NamespacedClientProxy(ElasticsearchClient client) => _client = client;
 
@@ -28,16 +31,39 @@ public abstract class NamespacedClientProxy
 		Action<IRequestConfiguration>? forceConfiguration = null)
 		where TRequest : Request<TRequestParameters>
 		where TResponse : ElasticsearchResponse, new()
-		where TRequestParameters : RequestParameters, new() =>
-			_client.DoRequest<TRequest, TResponse, TRequestParameters>(request, parameters, forceConfiguration);
+		where TRequestParameters : RequestParameters, new()
+	{
+		if (_client is null)
+			ThrowHelper.ThrowInvalidOperationException(InvalidOperation);
+
+		return _client.DoRequest<TRequest, TResponse, TRequestParameters>(request, parameters, forceConfiguration);
+	}
 
 	internal TResponse DoRequest<TRequest, TResponse, TRequestParameters>(
 		TRequest request,
 		Action<IRequestConfiguration>? forceConfiguration = null)
 		where TRequest : Request<TRequestParameters>
 		where TResponse : ElasticsearchResponse, new()
-		where TRequestParameters : RequestParameters, new() =>
-			_client.DoRequest<TRequest, TResponse, TRequestParameters>(request, forceConfiguration);
+		where TRequestParameters : RequestParameters, new()
+	{
+		if (_client is null)
+			ThrowHelper.ThrowInvalidOperationException(InvalidOperation);
+
+		return _client.DoRequest<TRequest, TResponse, TRequestParameters>(request, forceConfiguration);
+	}
+
+	internal Task<TResponse> DoRequestAsync<TRequest, TResponse, TRequestParameters>(
+		TRequest request,
+		CancellationToken cancellationToken = default)
+		where TRequest : Request<TRequestParameters>
+		where TResponse : ElasticsearchResponse, new()
+		where TRequestParameters : RequestParameters, new()
+	{
+		if (_client is null)
+			ThrowHelper.ThrowInvalidOperationException(InvalidOperation);
+
+		return _client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, cancellationToken: cancellationToken);
+	}
 
 	internal Task<TResponse> DoRequestAsync<TRequest, TResponse, TRequestParameters>(
 		TRequest request,
@@ -45,16 +71,13 @@ public abstract class NamespacedClientProxy
 		CancellationToken cancellationToken = default)
 		where TRequest : Request<TRequestParameters>
 		where TResponse : ElasticsearchResponse, new()
-		where TRequestParameters : RequestParameters, new() =>
-			_client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, parameters, cancellationToken: cancellationToken);
+		where TRequestParameters : RequestParameters, new()
+	{
+		if (_client is null)
+			ThrowHelper.ThrowInvalidOperationException(InvalidOperation);
 
-	internal Task<TResponse> DoRequestAsync<TRequest, TResponse, TRequestParameters>(
-		TRequest request,
-		CancellationToken cancellationToken = default)
-		where TRequest : Request<TRequestParameters>
-		where TResponse : ElasticsearchResponse, new()
-		where TRequestParameters : RequestParameters, new() =>
-			_client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, cancellationToken: cancellationToken);
+		return _client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, parameters, cancellationToken: cancellationToken);
+	}
 
 	internal Task<TResponse> DoRequestAsync<TRequest, TResponse, TRequestParameters>(
 		TRequest request,
@@ -63,6 +86,11 @@ public abstract class NamespacedClientProxy
 		CancellationToken cancellationToken = default)
 		where TRequest : Request<TRequestParameters>
 		where TResponse : ElasticsearchResponse, new()
-		where TRequestParameters : RequestParameters, new() =>
-			_client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, parameters, forceConfiguration, cancellationToken);
+		where TRequestParameters : RequestParameters, new()
+	{
+		if (_client is null)
+			ThrowHelper.ThrowInvalidOperationException(InvalidOperation);
+
+		return _client.DoRequestAsync<TRequest, TResponse, TRequestParameters>(request, parameters, forceConfiguration, cancellationToken);
+	}
 }

--- a/src/Elastic.Clients.Elasticsearch/Core/Exceptions/ThrowHelper.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Exceptions/ThrowHelper.cs
@@ -18,5 +18,11 @@ internal static class ThrowHelper
 		throw new JsonException($"Encounted an unsupported variant tag '{variantTag}' on '{SimplifiedFullName(interfaceType)}', which could not be deserialised.");
 
 	[MethodImpl(MethodImplOptions.NoInlining)]
+	internal static void ThrowInvalidOperationException(string message) =>
+		throw new InvalidOperationException(message);
+
+	[MethodImpl(MethodImplOptions.NoInlining)]
+#pragma warning disable IDE0057 // Use range operator
 	private static string SimplifiedFullName(Type type) => type.FullName.Substring(30);
+#pragma warning restore IDE0057 // Use range operator
 }

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.AsyncSearch.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.AsyncSearch.g.cs
@@ -21,32 +21,39 @@ using System.Threading.Tasks;
 
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.AsyncSearch;
-public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
+public partial class AsyncSearchNamespacedClient : NamespacedClientProxy
 {
-	internal AsyncSearchNamespace(ElasticsearchClient client) : base(client)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="AsyncSearchNamespacedClient"/> class for mocking.
+	/// </summary>			
+	protected AsyncSearchNamespacedClient() : base()
 	{
 	}
 
-	public AsyncSearchStatusResponse Status(AsyncSearchStatusRequest request)
+	internal AsyncSearchNamespacedClient(ElasticsearchClient client) : base(client)
+	{
+	}
+
+	public virtual AsyncSearchStatusResponse Status(AsyncSearchStatusRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<AsyncSearchStatusRequest, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(request);
 	}
 
-	public Task<AsyncSearchStatusResponse> StatusAsync(AsyncSearchStatusRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchStatusResponse> StatusAsync(AsyncSearchStatusRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<AsyncSearchStatusRequest, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(request, cancellationToken);
 	}
 
-	public AsyncSearchStatusResponse Status(Elastic.Clients.Elasticsearch.Id id)
+	public virtual AsyncSearchStatusResponse Status(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<AsyncSearchStatusRequestDescriptor, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public AsyncSearchStatusResponse Status(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor> configureRequest)
+	public virtual AsyncSearchStatusResponse Status(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor> configureRequest)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -54,7 +61,7 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<AsyncSearchStatusRequestDescriptor, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public AsyncSearchStatusResponse Status<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor<TDocument>> configureRequest)
+	public virtual AsyncSearchStatusResponse Status<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -62,14 +69,14 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<AsyncSearchStatusRequestDescriptor<TDocument>, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public Task<AsyncSearchStatusResponse> StatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchStatusResponse> StatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<AsyncSearchStatusRequestDescriptor, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public Task<AsyncSearchStatusResponse> StatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchStatusResponse> StatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -77,7 +84,7 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequestAsync<AsyncSearchStatusRequestDescriptor, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public Task<AsyncSearchStatusResponse> StatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchStatusResponse> StatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<AsyncSearchStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AsyncSearchStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -85,26 +92,26 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequestAsync<AsyncSearchStatusRequestDescriptor<TDocument>, AsyncSearchStatusResponse, AsyncSearchStatusRequestParameters>(descriptor);
 	}
 
-	public AsyncSearchSubmitResponse<TDocument> Submit<TDocument>(AsyncSearchSubmitRequest request)
+	public virtual AsyncSearchSubmitResponse<TDocument> Submit<TDocument>(AsyncSearchSubmitRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<AsyncSearchSubmitRequest, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(request);
 	}
 
-	public Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(AsyncSearchSubmitRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(AsyncSearchSubmitRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<AsyncSearchSubmitRequest, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(request, cancellationToken);
 	}
 
-	public AsyncSearchSubmitResponse<TDocument> Submit<TDocument>()
+	public virtual AsyncSearchSubmitResponse<TDocument> Submit<TDocument>()
 	{
 		var descriptor = new AsyncSearchSubmitRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequest<AsyncSearchSubmitRequestDescriptor<TDocument>, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(descriptor);
 	}
 
-	public AsyncSearchSubmitResponse<TDocument> Submit<TDocument>(Action<AsyncSearchSubmitRequestDescriptor<TDocument>> configureRequest)
+	public virtual AsyncSearchSubmitResponse<TDocument> Submit<TDocument>(Action<AsyncSearchSubmitRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new AsyncSearchSubmitRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -112,14 +119,14 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<AsyncSearchSubmitRequestDescriptor<TDocument>, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(descriptor);
 	}
 
-	public Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AsyncSearchSubmitRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<AsyncSearchSubmitRequestDescriptor<TDocument>, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(descriptor);
 	}
 
-	public Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(Action<AsyncSearchSubmitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<AsyncSearchSubmitResponse<TDocument>> SubmitAsync<TDocument>(Action<AsyncSearchSubmitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AsyncSearchSubmitRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -127,26 +134,26 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequestAsync<AsyncSearchSubmitRequestDescriptor<TDocument>, AsyncSearchSubmitResponse<TDocument>, AsyncSearchSubmitRequestParameters>(descriptor);
 	}
 
-	public DeleteAsyncSearchResponse Delete(DeleteAsyncSearchRequest request)
+	public virtual DeleteAsyncSearchResponse Delete(DeleteAsyncSearchRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteAsyncSearchRequest, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(request);
 	}
 
-	public Task<DeleteAsyncSearchResponse> DeleteAsync(DeleteAsyncSearchRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAsyncSearchResponse> DeleteAsync(DeleteAsyncSearchRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteAsyncSearchRequest, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteAsyncSearchResponse Delete(Elastic.Clients.Elasticsearch.Id id)
+	public virtual DeleteAsyncSearchResponse Delete(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteAsyncSearchRequestDescriptor, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public DeleteAsyncSearchResponse Delete(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor> configureRequest)
+	public virtual DeleteAsyncSearchResponse Delete(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -154,7 +161,7 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<DeleteAsyncSearchRequestDescriptor, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public DeleteAsyncSearchResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteAsyncSearchResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -162,14 +169,14 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<DeleteAsyncSearchRequestDescriptor<TDocument>, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAsyncSearchResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAsyncSearchResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteAsyncSearchRequestDescriptor, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAsyncSearchResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAsyncSearchResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -177,7 +184,7 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteAsyncSearchRequestDescriptor, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAsyncSearchResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAsyncSearchResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteAsyncSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAsyncSearchRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -185,26 +192,26 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteAsyncSearchRequestDescriptor<TDocument>, DeleteAsyncSearchResponse, DeleteAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public GetAsyncSearchResponse<TDocument> Get<TDocument>(GetAsyncSearchRequest request)
+	public virtual GetAsyncSearchResponse<TDocument> Get<TDocument>(GetAsyncSearchRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<GetAsyncSearchRequest, GetAsyncSearchResponse<TDocument>, GetAsyncSearchRequestParameters>(request);
 	}
 
-	public Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(GetAsyncSearchRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(GetAsyncSearchRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<GetAsyncSearchRequest, GetAsyncSearchResponse<TDocument>, GetAsyncSearchRequestParameters>(request, cancellationToken);
 	}
 
-	public GetAsyncSearchResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual GetAsyncSearchResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new GetAsyncSearchRequestDescriptor<TDocument>(id);
 		descriptor.BeforeRequest();
 		return DoRequest<GetAsyncSearchRequestDescriptor<TDocument>, GetAsyncSearchResponse<TDocument>, GetAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public GetAsyncSearchResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetAsyncSearchRequestDescriptor<TDocument>> configureRequest)
+	public virtual GetAsyncSearchResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetAsyncSearchRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new GetAsyncSearchRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -212,14 +219,14 @@ public sealed partial class AsyncSearchNamespace : NamespacedClientProxy
 		return DoRequest<GetAsyncSearchRequestDescriptor<TDocument>, GetAsyncSearchResponse<TDocument>, GetAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetAsyncSearchRequestDescriptor<TDocument>(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetAsyncSearchRequestDescriptor<TDocument>, GetAsyncSearchResponse<TDocument>, GetAsyncSearchRequestParameters>(descriptor);
 	}
 
-	public Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetAsyncSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetAsyncSearchResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetAsyncSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetAsyncSearchRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Cluster.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Cluster.g.cs
@@ -21,32 +21,39 @@ using System.Threading.Tasks;
 
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Cluster;
-public sealed partial class ClusterNamespace : NamespacedClientProxy
+public partial class ClusterNamespacedClient : NamespacedClientProxy
 {
-	internal ClusterNamespace(ElasticsearchClient client) : base(client)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="ClusterNamespacedClient"/> class for mocking.
+	/// </summary>			
+	protected ClusterNamespacedClient() : base()
 	{
 	}
 
-	public ClusterHealthResponse Health(ClusterHealthRequest request)
+	internal ClusterNamespacedClient(ElasticsearchClient client) : base(client)
+	{
+	}
+
+	public virtual ClusterHealthResponse Health(ClusterHealthRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ClusterHealthRequest, ClusterHealthResponse, ClusterHealthRequestParameters>(request);
 	}
 
-	public Task<ClusterHealthResponse> HealthAsync(ClusterHealthRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ClusterHealthResponse> HealthAsync(ClusterHealthRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ClusterHealthRequest, ClusterHealthResponse, ClusterHealthRequestParameters>(request, cancellationToken);
 	}
 
-	public ClusterHealthResponse Health()
+	public virtual ClusterHealthResponse Health()
 	{
 		var descriptor = new ClusterHealthRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ClusterHealthRequestDescriptor, ClusterHealthResponse, ClusterHealthRequestParameters>(descriptor);
 	}
 
-	public ClusterHealthResponse Health(Action<ClusterHealthRequestDescriptor> configureRequest)
+	public virtual ClusterHealthResponse Health(Action<ClusterHealthRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ClusterHealthRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -54,7 +61,7 @@ public sealed partial class ClusterNamespace : NamespacedClientProxy
 		return DoRequest<ClusterHealthRequestDescriptor, ClusterHealthResponse, ClusterHealthRequestParameters>(descriptor);
 	}
 
-	public ClusterHealthResponse Health<TDocument>(Action<ClusterHealthRequestDescriptor<TDocument>> configureRequest)
+	public virtual ClusterHealthResponse Health<TDocument>(Action<ClusterHealthRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ClusterHealthRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -62,14 +69,14 @@ public sealed partial class ClusterNamespace : NamespacedClientProxy
 		return DoRequest<ClusterHealthRequestDescriptor<TDocument>, ClusterHealthResponse, ClusterHealthRequestParameters>(descriptor);
 	}
 
-	public Task<ClusterHealthResponse> HealthAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ClusterHealthResponse> HealthAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClusterHealthRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ClusterHealthRequestDescriptor, ClusterHealthResponse, ClusterHealthRequestParameters>(descriptor);
 	}
 
-	public Task<ClusterHealthResponse> HealthAsync(Action<ClusterHealthRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ClusterHealthResponse> HealthAsync(Action<ClusterHealthRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClusterHealthRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -77,7 +84,7 @@ public sealed partial class ClusterNamespace : NamespacedClientProxy
 		return DoRequestAsync<ClusterHealthRequestDescriptor, ClusterHealthResponse, ClusterHealthRequestParameters>(descriptor);
 	}
 
-	public Task<ClusterHealthResponse> HealthAsync<TDocument>(Action<ClusterHealthRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ClusterHealthResponse> HealthAsync<TDocument>(Action<ClusterHealthRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClusterHealthRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Eql.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Eql.g.cs
@@ -21,32 +21,39 @@ using System.Threading.Tasks;
 
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Eql;
-public sealed partial class EqlNamespace : NamespacedClientProxy
+public partial class EqlNamespacedClient : NamespacedClientProxy
 {
-	internal EqlNamespace(ElasticsearchClient client) : base(client)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="EqlNamespacedClient"/> class for mocking.
+	/// </summary>			
+	protected EqlNamespacedClient() : base()
 	{
 	}
 
-	public DeleteEqlResponse Delete(DeleteEqlRequest request)
+	internal EqlNamespacedClient(ElasticsearchClient client) : base(client)
+	{
+	}
+
+	public virtual DeleteEqlResponse Delete(DeleteEqlRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteEqlRequest, DeleteEqlResponse, DeleteEqlRequestParameters>(request);
 	}
 
-	public Task<DeleteEqlResponse> DeleteAsync(DeleteEqlRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteEqlResponse> DeleteAsync(DeleteEqlRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteEqlRequest, DeleteEqlResponse, DeleteEqlRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteEqlResponse Delete(Elastic.Clients.Elasticsearch.Id id)
+	public virtual DeleteEqlResponse Delete(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteEqlRequestDescriptor, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public DeleteEqlResponse Delete(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor> configureRequest)
+	public virtual DeleteEqlResponse Delete(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -54,7 +61,7 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<DeleteEqlRequestDescriptor, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public DeleteEqlResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteEqlResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -62,14 +69,14 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<DeleteEqlRequestDescriptor<TDocument>, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteEqlResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteEqlResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteEqlRequestDescriptor, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteEqlResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteEqlResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -77,7 +84,7 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteEqlRequestDescriptor, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteEqlResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteEqlResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteEqlRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteEqlRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -85,26 +92,26 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteEqlRequestDescriptor<TDocument>, DeleteEqlResponse, DeleteEqlRequestParameters>(descriptor);
 	}
 
-	public EqlGetStatusResponse GetStatus(EqlGetStatusRequest request)
+	public virtual EqlGetStatusResponse GetStatus(EqlGetStatusRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<EqlGetStatusRequest, EqlGetStatusResponse, EqlGetStatusRequestParameters>(request);
 	}
 
-	public Task<EqlGetStatusResponse> GetStatusAsync(EqlGetStatusRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<EqlGetStatusResponse> GetStatusAsync(EqlGetStatusRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<EqlGetStatusRequest, EqlGetStatusResponse, EqlGetStatusRequestParameters>(request, cancellationToken);
 	}
 
-	public EqlGetStatusResponse GetStatus(Elastic.Clients.Elasticsearch.Id id)
+	public virtual EqlGetStatusResponse GetStatus(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<EqlGetStatusRequestDescriptor, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public EqlGetStatusResponse GetStatus(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor> configureRequest)
+	public virtual EqlGetStatusResponse GetStatus(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor> configureRequest)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -112,7 +119,7 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<EqlGetStatusRequestDescriptor, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public EqlGetStatusResponse GetStatus<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor<TDocument>> configureRequest)
+	public virtual EqlGetStatusResponse GetStatus<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -120,14 +127,14 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<EqlGetStatusRequestDescriptor<TDocument>, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public Task<EqlGetStatusResponse> GetStatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<EqlGetStatusResponse> GetStatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<EqlGetStatusRequestDescriptor, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public Task<EqlGetStatusResponse> GetStatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<EqlGetStatusResponse> GetStatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -135,7 +142,7 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<EqlGetStatusRequestDescriptor, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public Task<EqlGetStatusResponse> GetStatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<EqlGetStatusResponse> GetStatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<EqlGetStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new EqlGetStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -143,26 +150,26 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<EqlGetStatusRequestDescriptor<TDocument>, EqlGetStatusResponse, EqlGetStatusRequestParameters>(descriptor);
 	}
 
-	public EqlSearchResponse<TEvent> Search<TEvent>(EqlSearchRequest request)
+	public virtual EqlSearchResponse<TEvent> Search<TEvent>(EqlSearchRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<EqlSearchRequest, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(request);
 	}
 
-	public Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(EqlSearchRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(EqlSearchRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<EqlSearchRequest, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(request, cancellationToken);
 	}
 
-	public EqlSearchResponse<TEvent> Search<TEvent>(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual EqlSearchResponse<TEvent> Search<TEvent>(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new EqlSearchRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<EqlSearchRequestDescriptor, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(descriptor);
 	}
 
-	public EqlSearchResponse<TEvent> Search<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, Action<EqlSearchRequestDescriptor> configureRequest)
+	public virtual EqlSearchResponse<TEvent> Search<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, Action<EqlSearchRequestDescriptor> configureRequest)
 	{
 		var descriptor = new EqlSearchRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -170,14 +177,14 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<EqlSearchRequestDescriptor, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(descriptor);
 	}
 
-	public Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new EqlSearchRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<EqlSearchRequestDescriptor, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(descriptor);
 	}
 
-	public Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, Action<EqlSearchRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<EqlSearchResponse<TEvent>> SearchAsync<TEvent>(Elastic.Clients.Elasticsearch.Indices indices, Action<EqlSearchRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new EqlSearchRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -185,26 +192,26 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<EqlSearchRequestDescriptor, EqlSearchResponse<TEvent>, EqlSearchRequestParameters>(descriptor);
 	}
 
-	public GetEqlResponse<TEvent> Get<TEvent>(GetEqlRequest request)
+	public virtual GetEqlResponse<TEvent> Get<TEvent>(GetEqlRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<GetEqlRequest, GetEqlResponse<TEvent>, GetEqlRequestParameters>(request);
 	}
 
-	public Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(GetEqlRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(GetEqlRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<GetEqlRequest, GetEqlResponse<TEvent>, GetEqlRequestParameters>(request, cancellationToken);
 	}
 
-	public GetEqlResponse<TEvent> Get<TEvent>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual GetEqlResponse<TEvent> Get<TEvent>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new GetEqlRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<GetEqlRequestDescriptor, GetEqlResponse<TEvent>, GetEqlRequestParameters>(descriptor);
 	}
 
-	public GetEqlResponse<TEvent> Get<TEvent>(Elastic.Clients.Elasticsearch.Id id, Action<GetEqlRequestDescriptor> configureRequest)
+	public virtual GetEqlResponse<TEvent> Get<TEvent>(Elastic.Clients.Elasticsearch.Id id, Action<GetEqlRequestDescriptor> configureRequest)
 	{
 		var descriptor = new GetEqlRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -212,14 +219,14 @@ public sealed partial class EqlNamespace : NamespacedClientProxy
 		return DoRequest<GetEqlRequestDescriptor, GetEqlResponse<TEvent>, GetEqlRequestParameters>(descriptor);
 	}
 
-	public Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetEqlRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetEqlRequestDescriptor, GetEqlResponse<TEvent>, GetEqlRequestParameters>(descriptor);
 	}
 
-	public Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(Elastic.Clients.Elasticsearch.Id id, Action<GetEqlRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetEqlResponse<TEvent>> GetAsync<TEvent>(Elastic.Clients.Elasticsearch.Id id, Action<GetEqlRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetEqlRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
@@ -21,32 +21,39 @@ using System.Threading.Tasks;
 
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.IndexManagement;
-public sealed partial class IndicesNamespace : NamespacedClientProxy
+public partial class IndicesNamespacedClient : NamespacedClientProxy
 {
-	internal IndicesNamespace(ElasticsearchClient client) : base(client)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="IndicesNamespacedClient"/> class for mocking.
+	/// </summary>			
+	protected IndicesNamespacedClient() : base()
 	{
 	}
 
-	public AliasResponse GetAlias(AliasRequest request)
+	internal IndicesNamespacedClient(ElasticsearchClient client) : base(client)
+	{
+	}
+
+	public virtual AliasResponse GetAlias(AliasRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<AliasRequest, AliasResponse, AliasRequestParameters>(request);
 	}
 
-	public Task<AliasResponse> GetAliasAsync(AliasRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<AliasResponse> GetAliasAsync(AliasRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<AliasRequest, AliasResponse, AliasRequestParameters>(request, cancellationToken);
 	}
 
-	public AliasResponse GetAlias()
+	public virtual AliasResponse GetAlias()
 	{
 		var descriptor = new AliasRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<AliasRequestDescriptor, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public AliasResponse GetAlias(Action<AliasRequestDescriptor> configureRequest)
+	public virtual AliasResponse GetAlias(Action<AliasRequestDescriptor> configureRequest)
 	{
 		var descriptor = new AliasRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -54,7 +61,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<AliasRequestDescriptor, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public AliasResponse GetAlias<TDocument>(Action<AliasRequestDescriptor<TDocument>> configureRequest)
+	public virtual AliasResponse GetAlias<TDocument>(Action<AliasRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new AliasRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -62,14 +69,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<AliasRequestDescriptor<TDocument>, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public Task<AliasResponse> GetAliasAsync(CancellationToken cancellationToken = default)
+	public virtual Task<AliasResponse> GetAliasAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AliasRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<AliasRequestDescriptor, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public Task<AliasResponse> GetAliasAsync(Action<AliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<AliasResponse> GetAliasAsync(Action<AliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AliasRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -77,7 +84,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<AliasRequestDescriptor, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public Task<AliasResponse> GetAliasAsync<TDocument>(Action<AliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<AliasResponse> GetAliasAsync<TDocument>(Action<AliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new AliasRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -85,26 +92,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<AliasRequestDescriptor<TDocument>, AliasResponse, AliasRequestParameters>(descriptor);
 	}
 
-	public CloneResponse Clone(CloneRequest request)
+	public virtual CloneResponse Clone(CloneRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CloneRequest, CloneResponse, CloneRequestParameters>(request);
 	}
 
-	public Task<CloneResponse> CloneAsync(CloneRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync(CloneRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CloneRequest, CloneResponse, CloneRequestParameters>(request, cancellationToken);
 	}
 
-	public CloneResponse Clone(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target)
+	public virtual CloneResponse Clone(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target)
 	{
 		var descriptor = new CloneRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequest<CloneRequestDescriptor, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public CloneResponse Clone(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor> configureRequest)
+	public virtual CloneResponse Clone(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor> configureRequest)
 	{
 		var descriptor = new CloneRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -112,14 +119,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CloneRequestDescriptor, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.Name target)
+	public virtual CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.Name target)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequest<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest)
+	public virtual CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -127,7 +134,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest)
+	public virtual CloneResponse Clone<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -135,14 +142,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public Task<CloneResponse> CloneAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloneRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CloneRequestDescriptor, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public Task<CloneResponse> CloneAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloneRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -150,14 +157,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CloneRequestDescriptor, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.Name target, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.Name target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -165,7 +172,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CloneResponse> CloneAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Name target, Action<CloneRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloneRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -173,26 +180,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CloneRequestDescriptor<TDocument>, CloneResponse, CloneRequestParameters>(descriptor);
 	}
 
-	public CloseResponse Close(CloseRequest request)
+	public virtual CloseResponse Close(CloseRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CloseRequest, CloseResponse, CloseRequestParameters>(request);
 	}
 
-	public Task<CloseResponse> CloseAsync(CloseRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<CloseResponse> CloseAsync(CloseRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CloseRequest, CloseResponse, CloseRequestParameters>(request, cancellationToken);
 	}
 
-	public CloseResponse Close(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual CloseResponse Close(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new CloseRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<CloseRequestDescriptor, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public CloseResponse Close(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor> configureRequest)
+	public virtual CloseResponse Close(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor> configureRequest)
 	{
 		var descriptor = new CloseRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -200,7 +207,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CloseRequestDescriptor, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public CloseResponse Close<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor<TDocument>> configureRequest)
+	public virtual CloseResponse Close<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CloseRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -208,14 +215,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CloseRequestDescriptor<TDocument>, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public Task<CloseResponse> CloseAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<CloseResponse> CloseAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloseRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CloseRequestDescriptor, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public Task<CloseResponse> CloseAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CloseResponse> CloseAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloseRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -223,7 +230,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CloseRequestDescriptor, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public Task<CloseResponse> CloseAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CloseResponse> CloseAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<CloseRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CloseRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -231,26 +238,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CloseRequestDescriptor<TDocument>, CloseResponse, CloseRequestParameters>(descriptor);
 	}
 
-	public CreateDataStreamResponse CreateDataStream(CreateDataStreamRequest request)
+	public virtual CreateDataStreamResponse CreateDataStream(CreateDataStreamRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CreateDataStreamRequest, CreateDataStreamResponse, CreateDataStreamRequestParameters>(request);
 	}
 
-	public Task<CreateDataStreamResponse> CreateDataStreamAsync(CreateDataStreamRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<CreateDataStreamResponse> CreateDataStreamAsync(CreateDataStreamRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CreateDataStreamRequest, CreateDataStreamResponse, CreateDataStreamRequestParameters>(request, cancellationToken);
 	}
 
-	public CreateDataStreamResponse CreateDataStream(Elastic.Clients.Elasticsearch.DataStreamName name)
+	public virtual CreateDataStreamResponse CreateDataStream(Elastic.Clients.Elasticsearch.DataStreamName name)
 	{
 		var descriptor = new CreateDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<CreateDataStreamRequestDescriptor, CreateDataStreamResponse, CreateDataStreamRequestParameters>(descriptor);
 	}
 
-	public CreateDataStreamResponse CreateDataStream(Elastic.Clients.Elasticsearch.DataStreamName name, Action<CreateDataStreamRequestDescriptor> configureRequest)
+	public virtual CreateDataStreamResponse CreateDataStream(Elastic.Clients.Elasticsearch.DataStreamName name, Action<CreateDataStreamRequestDescriptor> configureRequest)
 	{
 		var descriptor = new CreateDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -258,14 +265,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CreateDataStreamRequestDescriptor, CreateDataStreamResponse, CreateDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<CreateDataStreamResponse> CreateDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamName name, CancellationToken cancellationToken = default)
+	public virtual Task<CreateDataStreamResponse> CreateDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamName name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CreateDataStreamRequestDescriptor, CreateDataStreamResponse, CreateDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<CreateDataStreamResponse> CreateDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamName name, Action<CreateDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateDataStreamResponse> CreateDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamName name, Action<CreateDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -273,26 +280,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CreateDataStreamRequestDescriptor, CreateDataStreamResponse, CreateDataStreamRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create(CreateRequest request)
+	public virtual CreateResponse Create(CreateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CreateRequest, CreateResponse, CreateRequestParameters>(request);
 	}
 
-	public Task<CreateResponse> CreateAsync(CreateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync(CreateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CreateRequest, CreateResponse, CreateRequestParameters>(request, cancellationToken);
 	}
 
-	public CreateResponse Create(Elastic.Clients.Elasticsearch.IndexName index)
+	public virtual CreateResponse Create(Elastic.Clients.Elasticsearch.IndexName index)
 	{
 		var descriptor = new CreateRequestDescriptor(index);
 		descriptor.BeforeRequest();
 		return DoRequest<CreateRequestDescriptor, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor> configureRequest)
+	public virtual CreateResponse Create(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new CreateRequestDescriptor(index);
 		configureRequest?.Invoke(descriptor);
@@ -300,14 +307,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CreateRequestDescriptor, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>()
+	public virtual CreateResponse Create<TDocument>()
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(typeof(TDocument));
 		descriptor.BeforeRequest();
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(Action<CreateRequestDescriptor<TDocument>> configureRequest)
+	public virtual CreateResponse Create<TDocument>(Action<CreateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(typeof(TDocument));
 		configureRequest?.Invoke(descriptor);
@@ -315,7 +322,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor<TDocument>> configureRequest)
+	public virtual CreateResponse Create<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(index);
 		configureRequest?.Invoke(descriptor);
@@ -323,14 +330,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync(Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync(Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor(index);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CreateRequestDescriptor, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor(index);
 		configureRequest?.Invoke(descriptor);
@@ -338,14 +345,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CreateRequestDescriptor, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(typeof(TDocument));
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(typeof(TDocument));
 		configureRequest?.Invoke(descriptor);
@@ -353,7 +360,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(index);
 		configureRequest?.Invoke(descriptor);
@@ -361,26 +368,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public DataStreamResponse GetDataStream(DataStreamRequest request)
+	public virtual DataStreamResponse GetDataStream(DataStreamRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DataStreamRequest, DataStreamResponse, DataStreamRequestParameters>(request);
 	}
 
-	public Task<DataStreamResponse> GetDataStreamAsync(DataStreamRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DataStreamResponse> GetDataStreamAsync(DataStreamRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DataStreamRequest, DataStreamResponse, DataStreamRequestParameters>(request, cancellationToken);
 	}
 
-	public DataStreamResponse GetDataStream()
+	public virtual DataStreamResponse GetDataStream()
 	{
 		var descriptor = new DataStreamRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<DataStreamRequestDescriptor, DataStreamResponse, DataStreamRequestParameters>(descriptor);
 	}
 
-	public DataStreamResponse GetDataStream(Action<DataStreamRequestDescriptor> configureRequest)
+	public virtual DataStreamResponse GetDataStream(Action<DataStreamRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DataStreamRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -388,14 +395,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DataStreamRequestDescriptor, DataStreamResponse, DataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<DataStreamResponse> GetDataStreamAsync(CancellationToken cancellationToken = default)
+	public virtual Task<DataStreamResponse> GetDataStreamAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DataStreamRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DataStreamRequestDescriptor, DataStreamResponse, DataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<DataStreamResponse> GetDataStreamAsync(Action<DataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DataStreamResponse> GetDataStreamAsync(Action<DataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DataStreamRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -403,26 +410,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DataStreamRequestDescriptor, DataStreamResponse, DataStreamRequestParameters>(descriptor);
 	}
 
-	public DeleteAliasResponse DeleteAlias(DeleteAliasRequest request)
+	public virtual DeleteAliasResponse DeleteAlias(DeleteAliasRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteAliasRequest, DeleteAliasResponse, DeleteAliasRequestParameters>(request);
 	}
 
-	public Task<DeleteAliasResponse> DeleteAliasAsync(DeleteAliasRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAliasResponse> DeleteAliasAsync(DeleteAliasRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteAliasRequest, DeleteAliasResponse, DeleteAliasRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteAliasResponse DeleteAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name)
+	public virtual DeleteAliasResponse DeleteAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor(indices, name);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteAliasRequestDescriptor, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public DeleteAliasResponse DeleteAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor> configureRequest)
+	public virtual DeleteAliasResponse DeleteAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -430,7 +437,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteAliasRequestDescriptor, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public DeleteAliasResponse DeleteAlias<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteAliasResponse DeleteAlias<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor<TDocument>(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -438,14 +445,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteAliasRequestDescriptor<TDocument>, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAliasResponse> DeleteAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAliasResponse> DeleteAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor(indices, name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteAliasRequestDescriptor, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAliasResponse> DeleteAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAliasResponse> DeleteAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -453,7 +460,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteAliasRequestDescriptor, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteAliasResponse> DeleteAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteAliasResponse> DeleteAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Names name, Action<DeleteAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteAliasRequestDescriptor<TDocument>(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -461,26 +468,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteAliasRequestDescriptor<TDocument>, DeleteAliasResponse, DeleteAliasRequestParameters>(descriptor);
 	}
 
-	public DeleteDataStreamResponse DeleteDataStream(DeleteDataStreamRequest request)
+	public virtual DeleteDataStreamResponse DeleteDataStream(DeleteDataStreamRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteDataStreamRequest, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(request);
 	}
 
-	public Task<DeleteDataStreamResponse> DeleteDataStreamAsync(DeleteDataStreamRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteDataStreamResponse> DeleteDataStreamAsync(DeleteDataStreamRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteDataStreamRequest, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteDataStreamResponse DeleteDataStream(Elastic.Clients.Elasticsearch.DataStreamNames name)
+	public virtual DeleteDataStreamResponse DeleteDataStream(Elastic.Clients.Elasticsearch.DataStreamNames name)
 	{
 		var descriptor = new DeleteDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteDataStreamRequestDescriptor, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(descriptor);
 	}
 
-	public DeleteDataStreamResponse DeleteDataStream(Elastic.Clients.Elasticsearch.DataStreamNames name, Action<DeleteDataStreamRequestDescriptor> configureRequest)
+	public virtual DeleteDataStreamResponse DeleteDataStream(Elastic.Clients.Elasticsearch.DataStreamNames name, Action<DeleteDataStreamRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -488,14 +495,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteDataStreamRequestDescriptor, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteDataStreamResponse> DeleteDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamNames name, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteDataStreamResponse> DeleteDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamNames name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteDataStreamRequestDescriptor, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteDataStreamResponse> DeleteDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamNames name, Action<DeleteDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteDataStreamResponse> DeleteDataStreamAsync(Elastic.Clients.Elasticsearch.DataStreamNames name, Action<DeleteDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -503,26 +510,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteDataStreamRequestDescriptor, DeleteDataStreamResponse, DeleteDataStreamRequestParameters>(descriptor);
 	}
 
-	public DeleteIndexTemplateResponse DeleteIndexTemplate(DeleteIndexTemplateRequest request)
+	public virtual DeleteIndexTemplateResponse DeleteIndexTemplate(DeleteIndexTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteIndexTemplateRequest, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(request);
 	}
 
-	public Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(DeleteIndexTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(DeleteIndexTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteIndexTemplateRequest, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteIndexTemplateResponse DeleteIndexTemplate(Elastic.Clients.Elasticsearch.Names name)
+	public virtual DeleteIndexTemplateResponse DeleteIndexTemplate(Elastic.Clients.Elasticsearch.Names name)
 	{
 		var descriptor = new DeleteIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteIndexTemplateRequestDescriptor, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public DeleteIndexTemplateResponse DeleteIndexTemplate(Elastic.Clients.Elasticsearch.Names name, Action<DeleteIndexTemplateRequestDescriptor> configureRequest)
+	public virtual DeleteIndexTemplateResponse DeleteIndexTemplate(Elastic.Clients.Elasticsearch.Names name, Action<DeleteIndexTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -530,14 +537,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteIndexTemplateRequestDescriptor, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteIndexTemplateRequestDescriptor, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(Elastic.Clients.Elasticsearch.Names name, Action<DeleteIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteIndexTemplateResponse> DeleteIndexTemplateAsync(Elastic.Clients.Elasticsearch.Names name, Action<DeleteIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -545,26 +552,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteIndexTemplateRequestDescriptor, DeleteIndexTemplateResponse, DeleteIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete(DeleteRequest request)
+	public virtual DeleteResponse Delete(DeleteRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteRequest, DeleteResponse, DeleteRequestParameters>(request);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(DeleteRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(DeleteRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteRequest, DeleteResponse, DeleteRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteResponse Delete(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual DeleteResponse Delete(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new DeleteRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor> configureRequest)
+	public virtual DeleteResponse Delete(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -572,7 +579,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -580,14 +587,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -595,7 +602,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -603,26 +610,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteTemplateResponse DeleteTemplate(DeleteTemplateRequest request)
+	public virtual DeleteTemplateResponse DeleteTemplate(DeleteTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteTemplateRequest, DeleteTemplateResponse, DeleteTemplateRequestParameters>(request);
 	}
 
-	public Task<DeleteTemplateResponse> DeleteTemplateAsync(DeleteTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteTemplateResponse> DeleteTemplateAsync(DeleteTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteTemplateRequest, DeleteTemplateResponse, DeleteTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteTemplateResponse DeleteTemplate(Elastic.Clients.Elasticsearch.Name name)
+	public virtual DeleteTemplateResponse DeleteTemplate(Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new DeleteTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteTemplateRequestDescriptor, DeleteTemplateResponse, DeleteTemplateRequestParameters>(descriptor);
 	}
 
-	public DeleteTemplateResponse DeleteTemplate(Elastic.Clients.Elasticsearch.Name name, Action<DeleteTemplateRequestDescriptor> configureRequest)
+	public virtual DeleteTemplateResponse DeleteTemplate(Elastic.Clients.Elasticsearch.Name name, Action<DeleteTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -630,14 +637,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<DeleteTemplateRequestDescriptor, DeleteTemplateResponse, DeleteTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteTemplateResponse> DeleteTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteTemplateResponse> DeleteTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteTemplateRequestDescriptor, DeleteTemplateResponse, DeleteTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteTemplateResponse> DeleteTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<DeleteTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteTemplateResponse> DeleteTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<DeleteTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -645,26 +652,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<DeleteTemplateRequestDescriptor, DeleteTemplateResponse, DeleteTemplateRequestParameters>(descriptor);
 	}
 
-	public ExistsAliasResponse ExistsAlias(ExistsAliasRequest request)
+	public virtual ExistsAliasResponse ExistsAlias(ExistsAliasRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsAliasRequest, ExistsAliasResponse, ExistsAliasRequestParameters>(request);
 	}
 
-	public Task<ExistsAliasResponse> ExistsAliasAsync(ExistsAliasRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsAliasResponse> ExistsAliasAsync(ExistsAliasRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsAliasRequest, ExistsAliasResponse, ExistsAliasRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsAliasResponse ExistsAlias(Elastic.Clients.Elasticsearch.Names name)
+	public virtual ExistsAliasResponse ExistsAlias(Elastic.Clients.Elasticsearch.Names name)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsAliasRequestDescriptor, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public ExistsAliasResponse ExistsAlias(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor> configureRequest)
+	public virtual ExistsAliasResponse ExistsAlias(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -672,7 +679,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsAliasRequestDescriptor, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public ExistsAliasResponse ExistsAlias<TDocument>(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsAliasResponse ExistsAlias<TDocument>(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -680,14 +687,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsAliasRequestDescriptor<TDocument>, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsAliasResponse> ExistsAliasAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsAliasResponse> ExistsAliasAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsAliasRequestDescriptor, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsAliasResponse> ExistsAliasAsync(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsAliasResponse> ExistsAliasAsync(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -695,7 +702,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsAliasRequestDescriptor, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsAliasResponse> ExistsAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsAliasResponse> ExistsAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Names name, Action<ExistsAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsAliasRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -703,26 +710,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsAliasRequestDescriptor<TDocument>, ExistsAliasResponse, ExistsAliasRequestParameters>(descriptor);
 	}
 
-	public ExistsIndexTemplateResponse ExistsIndexTemplate(ExistsIndexTemplateRequest request)
+	public virtual ExistsIndexTemplateResponse ExistsIndexTemplate(ExistsIndexTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsIndexTemplateRequest, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(request);
 	}
 
-	public Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(ExistsIndexTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(ExistsIndexTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsIndexTemplateRequest, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsIndexTemplateResponse ExistsIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
+	public virtual ExistsIndexTemplateResponse ExistsIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new ExistsIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsIndexTemplateRequestDescriptor, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public ExistsIndexTemplateResponse ExistsIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<ExistsIndexTemplateRequestDescriptor> configureRequest)
+	public virtual ExistsIndexTemplateResponse ExistsIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<ExistsIndexTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -730,14 +737,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsIndexTemplateRequestDescriptor, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsIndexTemplateRequestDescriptor, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<ExistsIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsIndexTemplateResponse> ExistsIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<ExistsIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -745,26 +752,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsIndexTemplateRequestDescriptor, ExistsIndexTemplateResponse, ExistsIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists(ExistsRequest request)
+	public virtual ExistsResponse Exists(ExistsRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsRequest, ExistsResponse, ExistsRequestParameters>(request);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(ExistsRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(ExistsRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsRequest, ExistsResponse, ExistsRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsResponse Exists(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual ExistsResponse Exists(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new ExistsRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor> configureRequest)
+	public virtual ExistsResponse Exists(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -772,7 +779,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -780,14 +787,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -795,7 +802,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -803,26 +810,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsTemplateResponse ExistsTemplate(ExistsTemplateRequest request)
+	public virtual ExistsTemplateResponse ExistsTemplate(ExistsTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsTemplateRequest, ExistsTemplateResponse, ExistsTemplateRequestParameters>(request);
 	}
 
-	public Task<ExistsTemplateResponse> ExistsTemplateAsync(ExistsTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsTemplateResponse> ExistsTemplateAsync(ExistsTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsTemplateRequest, ExistsTemplateResponse, ExistsTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsTemplateResponse ExistsTemplate(Elastic.Clients.Elasticsearch.Names name)
+	public virtual ExistsTemplateResponse ExistsTemplate(Elastic.Clients.Elasticsearch.Names name)
 	{
 		var descriptor = new ExistsTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsTemplateRequestDescriptor, ExistsTemplateResponse, ExistsTemplateRequestParameters>(descriptor);
 	}
 
-	public ExistsTemplateResponse ExistsTemplate(Elastic.Clients.Elasticsearch.Names name, Action<ExistsTemplateRequestDescriptor> configureRequest)
+	public virtual ExistsTemplateResponse ExistsTemplate(Elastic.Clients.Elasticsearch.Names name, Action<ExistsTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -830,14 +837,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ExistsTemplateRequestDescriptor, ExistsTemplateResponse, ExistsTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsTemplateResponse> ExistsTemplateAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsTemplateResponse> ExistsTemplateAsync(Elastic.Clients.Elasticsearch.Names name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsTemplateRequestDescriptor, ExistsTemplateResponse, ExistsTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsTemplateResponse> ExistsTemplateAsync(Elastic.Clients.Elasticsearch.Names name, Action<ExistsTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsTemplateResponse> ExistsTemplateAsync(Elastic.Clients.Elasticsearch.Names name, Action<ExistsTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -845,26 +852,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ExistsTemplateRequestDescriptor, ExistsTemplateResponse, ExistsTemplateRequestParameters>(descriptor);
 	}
 
-	public FieldMappingResponse GetFieldMapping(FieldMappingRequest request)
+	public virtual FieldMappingResponse GetFieldMapping(FieldMappingRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<FieldMappingRequest, FieldMappingResponse, FieldMappingRequestParameters>(request);
 	}
 
-	public Task<FieldMappingResponse> GetFieldMappingAsync(FieldMappingRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<FieldMappingResponse> GetFieldMappingAsync(FieldMappingRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<FieldMappingRequest, FieldMappingResponse, FieldMappingRequestParameters>(request, cancellationToken);
 	}
 
-	public FieldMappingResponse GetFieldMapping(Elastic.Clients.Elasticsearch.Fields fields)
+	public virtual FieldMappingResponse GetFieldMapping(Elastic.Clients.Elasticsearch.Fields fields)
 	{
 		var descriptor = new FieldMappingRequestDescriptor(fields);
 		descriptor.BeforeRequest();
 		return DoRequest<FieldMappingRequestDescriptor, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public FieldMappingResponse GetFieldMapping(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor> configureRequest)
+	public virtual FieldMappingResponse GetFieldMapping(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor> configureRequest)
 	{
 		var descriptor = new FieldMappingRequestDescriptor(fields);
 		configureRequest?.Invoke(descriptor);
@@ -872,7 +879,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<FieldMappingRequestDescriptor, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public FieldMappingResponse GetFieldMapping<TDocument>(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor<TDocument>> configureRequest)
+	public virtual FieldMappingResponse GetFieldMapping<TDocument>(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new FieldMappingRequestDescriptor<TDocument>(fields);
 		configureRequest?.Invoke(descriptor);
@@ -880,14 +887,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<FieldMappingRequestDescriptor<TDocument>, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public Task<FieldMappingResponse> GetFieldMappingAsync(Elastic.Clients.Elasticsearch.Fields fields, CancellationToken cancellationToken = default)
+	public virtual Task<FieldMappingResponse> GetFieldMappingAsync(Elastic.Clients.Elasticsearch.Fields fields, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldMappingRequestDescriptor(fields);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<FieldMappingRequestDescriptor, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public Task<FieldMappingResponse> GetFieldMappingAsync(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FieldMappingResponse> GetFieldMappingAsync(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldMappingRequestDescriptor(fields);
 		configureRequest?.Invoke(descriptor);
@@ -895,7 +902,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<FieldMappingRequestDescriptor, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public Task<FieldMappingResponse> GetFieldMappingAsync<TDocument>(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FieldMappingResponse> GetFieldMappingAsync<TDocument>(Elastic.Clients.Elasticsearch.Fields fields, Action<FieldMappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldMappingRequestDescriptor<TDocument>(fields);
 		configureRequest?.Invoke(descriptor);
@@ -903,26 +910,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<FieldMappingRequestDescriptor<TDocument>, FieldMappingResponse, FieldMappingRequestParameters>(descriptor);
 	}
 
-	public FlushResponse Flush(FlushRequest request)
+	public virtual FlushResponse Flush(FlushRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<FlushRequest, FlushResponse, FlushRequestParameters>(request);
 	}
 
-	public Task<FlushResponse> FlushAsync(FlushRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<FlushResponse> FlushAsync(FlushRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<FlushRequest, FlushResponse, FlushRequestParameters>(request, cancellationToken);
 	}
 
-	public FlushResponse Flush()
+	public virtual FlushResponse Flush()
 	{
 		var descriptor = new FlushRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<FlushRequestDescriptor, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public FlushResponse Flush(Action<FlushRequestDescriptor> configureRequest)
+	public virtual FlushResponse Flush(Action<FlushRequestDescriptor> configureRequest)
 	{
 		var descriptor = new FlushRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -930,7 +937,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<FlushRequestDescriptor, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public FlushResponse Flush<TDocument>(Action<FlushRequestDescriptor<TDocument>> configureRequest)
+	public virtual FlushResponse Flush<TDocument>(Action<FlushRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new FlushRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -938,14 +945,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<FlushRequestDescriptor<TDocument>, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public Task<FlushResponse> FlushAsync(CancellationToken cancellationToken = default)
+	public virtual Task<FlushResponse> FlushAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FlushRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<FlushRequestDescriptor, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public Task<FlushResponse> FlushAsync(Action<FlushRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FlushResponse> FlushAsync(Action<FlushRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FlushRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -953,7 +960,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<FlushRequestDescriptor, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public Task<FlushResponse> FlushAsync<TDocument>(Action<FlushRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FlushResponse> FlushAsync<TDocument>(Action<FlushRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FlushRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -961,26 +968,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<FlushRequestDescriptor<TDocument>, FlushResponse, FlushRequestParameters>(descriptor);
 	}
 
-	public ForcemergeResponse Forcemerge(ForcemergeRequest request)
+	public virtual ForcemergeResponse Forcemerge(ForcemergeRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ForcemergeRequest, ForcemergeResponse, ForcemergeRequestParameters>(request);
 	}
 
-	public Task<ForcemergeResponse> ForcemergeAsync(ForcemergeRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ForcemergeResponse> ForcemergeAsync(ForcemergeRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ForcemergeRequest, ForcemergeResponse, ForcemergeRequestParameters>(request, cancellationToken);
 	}
 
-	public ForcemergeResponse Forcemerge()
+	public virtual ForcemergeResponse Forcemerge()
 	{
 		var descriptor = new ForcemergeRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ForcemergeRequestDescriptor, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public ForcemergeResponse Forcemerge(Action<ForcemergeRequestDescriptor> configureRequest)
+	public virtual ForcemergeResponse Forcemerge(Action<ForcemergeRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ForcemergeRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -988,7 +995,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ForcemergeRequestDescriptor, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public ForcemergeResponse Forcemerge<TDocument>(Action<ForcemergeRequestDescriptor<TDocument>> configureRequest)
+	public virtual ForcemergeResponse Forcemerge<TDocument>(Action<ForcemergeRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ForcemergeRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -996,14 +1003,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ForcemergeRequestDescriptor<TDocument>, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public Task<ForcemergeResponse> ForcemergeAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ForcemergeResponse> ForcemergeAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ForcemergeRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ForcemergeRequestDescriptor, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public Task<ForcemergeResponse> ForcemergeAsync(Action<ForcemergeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ForcemergeResponse> ForcemergeAsync(Action<ForcemergeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ForcemergeRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1011,7 +1018,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ForcemergeRequestDescriptor, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public Task<ForcemergeResponse> ForcemergeAsync<TDocument>(Action<ForcemergeRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ForcemergeResponse> ForcemergeAsync<TDocument>(Action<ForcemergeRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ForcemergeRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1019,26 +1026,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ForcemergeRequestDescriptor<TDocument>, ForcemergeResponse, ForcemergeRequestParameters>(descriptor);
 	}
 
-	public GetResponse Get(GetRequest request)
+	public virtual GetResponse Get(GetRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<GetRequest, GetResponse, GetRequestParameters>(request);
 	}
 
-	public Task<GetResponse> GetAsync(GetRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse> GetAsync(GetRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<GetRequest, GetResponse, GetRequestParameters>(request, cancellationToken);
 	}
 
-	public GetResponse Get(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual GetResponse Get(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new GetRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<GetRequestDescriptor, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public GetResponse Get(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor> configureRequest)
+	public virtual GetResponse Get(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor> configureRequest)
 	{
 		var descriptor = new GetRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1046,7 +1053,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<GetRequestDescriptor, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public GetResponse Get<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor<TDocument>> configureRequest)
+	public virtual GetResponse Get<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1054,14 +1061,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<GetRequestDescriptor<TDocument>, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse> GetAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse> GetAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetRequestDescriptor, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse> GetAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse> GetAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1069,7 +1076,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<GetRequestDescriptor, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1077,26 +1084,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<GetRequestDescriptor<TDocument>, GetResponse, GetRequestParameters>(descriptor);
 	}
 
-	public IndexTemplateResponse GetIndexTemplate(IndexTemplateRequest request)
+	public virtual IndexTemplateResponse GetIndexTemplate(IndexTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<IndexTemplateRequest, IndexTemplateResponse, IndexTemplateRequestParameters>(request);
 	}
 
-	public Task<IndexTemplateResponse> GetIndexTemplateAsync(IndexTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<IndexTemplateResponse> GetIndexTemplateAsync(IndexTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<IndexTemplateRequest, IndexTemplateResponse, IndexTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public IndexTemplateResponse GetIndexTemplate()
+	public virtual IndexTemplateResponse GetIndexTemplate()
 	{
 		var descriptor = new IndexTemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<IndexTemplateRequestDescriptor, IndexTemplateResponse, IndexTemplateRequestParameters>(descriptor);
 	}
 
-	public IndexTemplateResponse GetIndexTemplate(Action<IndexTemplateRequestDescriptor> configureRequest)
+	public virtual IndexTemplateResponse GetIndexTemplate(Action<IndexTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new IndexTemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1104,14 +1111,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<IndexTemplateRequestDescriptor, IndexTemplateResponse, IndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<IndexTemplateResponse> GetIndexTemplateAsync(CancellationToken cancellationToken = default)
+	public virtual Task<IndexTemplateResponse> GetIndexTemplateAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexTemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<IndexTemplateRequestDescriptor, IndexTemplateResponse, IndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<IndexTemplateResponse> GetIndexTemplateAsync(Action<IndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<IndexTemplateResponse> GetIndexTemplateAsync(Action<IndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexTemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1119,26 +1126,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<IndexTemplateRequestDescriptor, IndexTemplateResponse, IndexTemplateRequestParameters>(descriptor);
 	}
 
-	public MappingResponse GetMapping(MappingRequest request)
+	public virtual MappingResponse GetMapping(MappingRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<MappingRequest, MappingResponse, MappingRequestParameters>(request);
 	}
 
-	public Task<MappingResponse> GetMappingAsync(MappingRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<MappingResponse> GetMappingAsync(MappingRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<MappingRequest, MappingResponse, MappingRequestParameters>(request, cancellationToken);
 	}
 
-	public MappingResponse GetMapping()
+	public virtual MappingResponse GetMapping()
 	{
 		var descriptor = new MappingRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<MappingRequestDescriptor, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public MappingResponse GetMapping(Action<MappingRequestDescriptor> configureRequest)
+	public virtual MappingResponse GetMapping(Action<MappingRequestDescriptor> configureRequest)
 	{
 		var descriptor = new MappingRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1146,7 +1153,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<MappingRequestDescriptor, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public MappingResponse GetMapping<TDocument>(Action<MappingRequestDescriptor<TDocument>> configureRequest)
+	public virtual MappingResponse GetMapping<TDocument>(Action<MappingRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new MappingRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1154,14 +1161,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<MappingRequestDescriptor<TDocument>, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public Task<MappingResponse> GetMappingAsync(CancellationToken cancellationToken = default)
+	public virtual Task<MappingResponse> GetMappingAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MappingRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<MappingRequestDescriptor, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public Task<MappingResponse> GetMappingAsync(Action<MappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MappingResponse> GetMappingAsync(Action<MappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MappingRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1169,7 +1176,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<MappingRequestDescriptor, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public Task<MappingResponse> GetMappingAsync<TDocument>(Action<MappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MappingResponse> GetMappingAsync<TDocument>(Action<MappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MappingRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1177,26 +1184,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<MappingRequestDescriptor<TDocument>, MappingResponse, MappingRequestParameters>(descriptor);
 	}
 
-	public MigrateToDataStreamResponse MigrateToDataStream(MigrateToDataStreamRequest request)
+	public virtual MigrateToDataStreamResponse MigrateToDataStream(MigrateToDataStreamRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<MigrateToDataStreamRequest, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(request);
 	}
 
-	public Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(MigrateToDataStreamRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(MigrateToDataStreamRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<MigrateToDataStreamRequest, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(request, cancellationToken);
 	}
 
-	public MigrateToDataStreamResponse MigrateToDataStream(Elastic.Clients.Elasticsearch.IndexName name)
+	public virtual MigrateToDataStreamResponse MigrateToDataStream(Elastic.Clients.Elasticsearch.IndexName name)
 	{
 		var descriptor = new MigrateToDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<MigrateToDataStreamRequestDescriptor, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(descriptor);
 	}
 
-	public MigrateToDataStreamResponse MigrateToDataStream(Elastic.Clients.Elasticsearch.IndexName name, Action<MigrateToDataStreamRequestDescriptor> configureRequest)
+	public virtual MigrateToDataStreamResponse MigrateToDataStream(Elastic.Clients.Elasticsearch.IndexName name, Action<MigrateToDataStreamRequestDescriptor> configureRequest)
 	{
 		var descriptor = new MigrateToDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1204,14 +1211,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<MigrateToDataStreamRequestDescriptor, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(Elastic.Clients.Elasticsearch.IndexName name, CancellationToken cancellationToken = default)
+	public virtual Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(Elastic.Clients.Elasticsearch.IndexName name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MigrateToDataStreamRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<MigrateToDataStreamRequestDescriptor, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(descriptor);
 	}
 
-	public Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(Elastic.Clients.Elasticsearch.IndexName name, Action<MigrateToDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MigrateToDataStreamResponse> MigrateToDataStreamAsync(Elastic.Clients.Elasticsearch.IndexName name, Action<MigrateToDataStreamRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MigrateToDataStreamRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1219,26 +1226,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<MigrateToDataStreamRequestDescriptor, MigrateToDataStreamResponse, MigrateToDataStreamRequestParameters>(descriptor);
 	}
 
-	public OpenResponse Open(OpenRequest request)
+	public virtual OpenResponse Open(OpenRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<OpenRequest, OpenResponse, OpenRequestParameters>(request);
 	}
 
-	public Task<OpenResponse> OpenAsync(OpenRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<OpenResponse> OpenAsync(OpenRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<OpenRequest, OpenResponse, OpenRequestParameters>(request, cancellationToken);
 	}
 
-	public OpenResponse Open(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual OpenResponse Open(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new OpenRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<OpenRequestDescriptor, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public OpenResponse Open(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor> configureRequest)
+	public virtual OpenResponse Open(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor> configureRequest)
 	{
 		var descriptor = new OpenRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1246,7 +1253,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<OpenRequestDescriptor, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public OpenResponse Open<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor<TDocument>> configureRequest)
+	public virtual OpenResponse Open<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new OpenRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1254,14 +1261,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<OpenRequestDescriptor<TDocument>, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public Task<OpenResponse> OpenAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<OpenResponse> OpenAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<OpenRequestDescriptor, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public Task<OpenResponse> OpenAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<OpenResponse> OpenAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1269,7 +1276,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<OpenRequestDescriptor, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public Task<OpenResponse> OpenAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<OpenResponse> OpenAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1277,26 +1284,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<OpenRequestDescriptor<TDocument>, OpenResponse, OpenRequestParameters>(descriptor);
 	}
 
-	public PutAliasResponse PutAlias(PutAliasRequest request)
+	public virtual PutAliasResponse PutAlias(PutAliasRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PutAliasRequest, PutAliasResponse, PutAliasRequestParameters>(request);
 	}
 
-	public Task<PutAliasResponse> PutAliasAsync(PutAliasRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PutAliasResponse> PutAliasAsync(PutAliasRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PutAliasRequest, PutAliasResponse, PutAliasRequestParameters>(request, cancellationToken);
 	}
 
-	public PutAliasResponse PutAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name)
+	public virtual PutAliasResponse PutAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new PutAliasRequestDescriptor(indices, name);
 		descriptor.BeforeRequest();
 		return DoRequest<PutAliasRequestDescriptor, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public PutAliasResponse PutAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor> configureRequest)
+	public virtual PutAliasResponse PutAlias(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PutAliasRequestDescriptor(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -1304,7 +1311,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutAliasRequestDescriptor, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public PutAliasResponse PutAlias<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor<TDocument>> configureRequest)
+	public virtual PutAliasResponse PutAlias<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new PutAliasRequestDescriptor<TDocument>(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -1312,14 +1319,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutAliasRequestDescriptor<TDocument>, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public Task<PutAliasResponse> PutAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<PutAliasResponse> PutAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutAliasRequestDescriptor(indices, name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PutAliasRequestDescriptor, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public Task<PutAliasResponse> PutAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutAliasResponse> PutAliasAsync(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutAliasRequestDescriptor(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -1327,7 +1334,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutAliasRequestDescriptor, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public Task<PutAliasResponse> PutAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutAliasResponse> PutAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Elastic.Clients.Elasticsearch.Name name, Action<PutAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutAliasRequestDescriptor<TDocument>(indices, name);
 		configureRequest?.Invoke(descriptor);
@@ -1335,26 +1342,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutAliasRequestDescriptor<TDocument>, PutAliasResponse, PutAliasRequestParameters>(descriptor);
 	}
 
-	public PutIndexTemplateResponse PutIndexTemplate(PutIndexTemplateRequest request)
+	public virtual PutIndexTemplateResponse PutIndexTemplate(PutIndexTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PutIndexTemplateRequest, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(request);
 	}
 
-	public Task<PutIndexTemplateResponse> PutIndexTemplateAsync(PutIndexTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PutIndexTemplateResponse> PutIndexTemplateAsync(PutIndexTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PutIndexTemplateRequest, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public PutIndexTemplateResponse PutIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
+	public virtual PutIndexTemplateResponse PutIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<PutIndexTemplateRequestDescriptor, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public PutIndexTemplateResponse PutIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor> configureRequest)
+	public virtual PutIndexTemplateResponse PutIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1362,7 +1369,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutIndexTemplateRequestDescriptor, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public PutIndexTemplateResponse PutIndexTemplate<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor<TDocument>> configureRequest)
+	public virtual PutIndexTemplateResponse PutIndexTemplate<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -1370,14 +1377,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutIndexTemplateRequestDescriptor<TDocument>, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<PutIndexTemplateResponse> PutIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<PutIndexTemplateResponse> PutIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PutIndexTemplateRequestDescriptor, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<PutIndexTemplateResponse> PutIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutIndexTemplateResponse> PutIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1385,7 +1392,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutIndexTemplateRequestDescriptor, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<PutIndexTemplateResponse> PutIndexTemplateAsync<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutIndexTemplateResponse> PutIndexTemplateAsync<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<PutIndexTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutIndexTemplateRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -1393,26 +1400,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutIndexTemplateRequestDescriptor<TDocument>, PutIndexTemplateResponse, PutIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public PutMappingResponse PutMapping(PutMappingRequest request)
+	public virtual PutMappingResponse PutMapping(PutMappingRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PutMappingRequest, PutMappingResponse, PutMappingRequestParameters>(request);
 	}
 
-	public Task<PutMappingResponse> PutMappingAsync(PutMappingRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PutMappingResponse> PutMappingAsync(PutMappingRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PutMappingRequest, PutMappingResponse, PutMappingRequestParameters>(request, cancellationToken);
 	}
 
-	public PutMappingResponse PutMapping(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual PutMappingResponse PutMapping(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new PutMappingRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<PutMappingRequestDescriptor, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public PutMappingResponse PutMapping(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor> configureRequest)
+	public virtual PutMappingResponse PutMapping(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PutMappingRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1420,7 +1427,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutMappingRequestDescriptor, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public PutMappingResponse PutMapping<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor<TDocument>> configureRequest)
+	public virtual PutMappingResponse PutMapping<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new PutMappingRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1428,14 +1435,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutMappingRequestDescriptor<TDocument>, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public Task<PutMappingResponse> PutMappingAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<PutMappingResponse> PutMappingAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutMappingRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PutMappingRequestDescriptor, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public Task<PutMappingResponse> PutMappingAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutMappingResponse> PutMappingAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutMappingRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1443,7 +1450,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutMappingRequestDescriptor, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public Task<PutMappingResponse> PutMappingAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutMappingResponse> PutMappingAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<PutMappingRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutMappingRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1451,26 +1458,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutMappingRequestDescriptor<TDocument>, PutMappingResponse, PutMappingRequestParameters>(descriptor);
 	}
 
-	public PutTemplateResponse PutTemplate(PutTemplateRequest request)
+	public virtual PutTemplateResponse PutTemplate(PutTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PutTemplateRequest, PutTemplateResponse, PutTemplateRequestParameters>(request);
 	}
 
-	public Task<PutTemplateResponse> PutTemplateAsync(PutTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PutTemplateResponse> PutTemplateAsync(PutTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PutTemplateRequest, PutTemplateResponse, PutTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public PutTemplateResponse PutTemplate(Elastic.Clients.Elasticsearch.Name name)
+	public virtual PutTemplateResponse PutTemplate(Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new PutTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<PutTemplateRequestDescriptor, PutTemplateResponse, PutTemplateRequestParameters>(descriptor);
 	}
 
-	public PutTemplateResponse PutTemplate(Elastic.Clients.Elasticsearch.Name name, Action<PutTemplateRequestDescriptor> configureRequest)
+	public virtual PutTemplateResponse PutTemplate(Elastic.Clients.Elasticsearch.Name name, Action<PutTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PutTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1478,14 +1485,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<PutTemplateRequestDescriptor, PutTemplateResponse, PutTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<PutTemplateResponse> PutTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<PutTemplateResponse> PutTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PutTemplateRequestDescriptor, PutTemplateResponse, PutTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<PutTemplateResponse> PutTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<PutTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutTemplateResponse> PutTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<PutTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1493,26 +1500,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<PutTemplateRequestDescriptor, PutTemplateResponse, PutTemplateRequestParameters>(descriptor);
 	}
 
-	public RefreshResponse Refresh(RefreshRequest request)
+	public virtual RefreshResponse Refresh(RefreshRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<RefreshRequest, RefreshResponse, RefreshRequestParameters>(request);
 	}
 
-	public Task<RefreshResponse> RefreshAsync(RefreshRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<RefreshResponse> RefreshAsync(RefreshRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<RefreshRequest, RefreshResponse, RefreshRequestParameters>(request, cancellationToken);
 	}
 
-	public RefreshResponse Refresh()
+	public virtual RefreshResponse Refresh()
 	{
 		var descriptor = new RefreshRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<RefreshRequestDescriptor, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public RefreshResponse Refresh(Action<RefreshRequestDescriptor> configureRequest)
+	public virtual RefreshResponse Refresh(Action<RefreshRequestDescriptor> configureRequest)
 	{
 		var descriptor = new RefreshRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1520,7 +1527,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<RefreshRequestDescriptor, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public RefreshResponse Refresh<TDocument>(Action<RefreshRequestDescriptor<TDocument>> configureRequest)
+	public virtual RefreshResponse Refresh<TDocument>(Action<RefreshRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new RefreshRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1528,14 +1535,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<RefreshRequestDescriptor<TDocument>, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public Task<RefreshResponse> RefreshAsync(CancellationToken cancellationToken = default)
+	public virtual Task<RefreshResponse> RefreshAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RefreshRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<RefreshRequestDescriptor, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public Task<RefreshResponse> RefreshAsync(Action<RefreshRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<RefreshResponse> RefreshAsync(Action<RefreshRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RefreshRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1543,7 +1550,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<RefreshRequestDescriptor, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public Task<RefreshResponse> RefreshAsync<TDocument>(Action<RefreshRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<RefreshResponse> RefreshAsync<TDocument>(Action<RefreshRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RefreshRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1551,26 +1558,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<RefreshRequestDescriptor<TDocument>, RefreshResponse, RefreshRequestParameters>(descriptor);
 	}
 
-	public RolloverResponse Rollover(RolloverRequest request)
+	public virtual RolloverResponse Rollover(RolloverRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<RolloverRequest, RolloverResponse, RolloverRequestParameters>(request);
 	}
 
-	public Task<RolloverResponse> RolloverAsync(RolloverRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<RolloverResponse> RolloverAsync(RolloverRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<RolloverRequest, RolloverResponse, RolloverRequestParameters>(request, cancellationToken);
 	}
 
-	public RolloverResponse Rollover(Elastic.Clients.Elasticsearch.IndexAlias alias)
+	public virtual RolloverResponse Rollover(Elastic.Clients.Elasticsearch.IndexAlias alias)
 	{
 		var descriptor = new RolloverRequestDescriptor(alias);
 		descriptor.BeforeRequest();
 		return DoRequest<RolloverRequestDescriptor, RolloverResponse, RolloverRequestParameters>(descriptor);
 	}
 
-	public RolloverResponse Rollover(Elastic.Clients.Elasticsearch.IndexAlias alias, Action<RolloverRequestDescriptor> configureRequest)
+	public virtual RolloverResponse Rollover(Elastic.Clients.Elasticsearch.IndexAlias alias, Action<RolloverRequestDescriptor> configureRequest)
 	{
 		var descriptor = new RolloverRequestDescriptor(alias);
 		configureRequest?.Invoke(descriptor);
@@ -1578,14 +1585,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<RolloverRequestDescriptor, RolloverResponse, RolloverRequestParameters>(descriptor);
 	}
 
-	public Task<RolloverResponse> RolloverAsync(Elastic.Clients.Elasticsearch.IndexAlias alias, CancellationToken cancellationToken = default)
+	public virtual Task<RolloverResponse> RolloverAsync(Elastic.Clients.Elasticsearch.IndexAlias alias, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RolloverRequestDescriptor(alias);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<RolloverRequestDescriptor, RolloverResponse, RolloverRequestParameters>(descriptor);
 	}
 
-	public Task<RolloverResponse> RolloverAsync(Elastic.Clients.Elasticsearch.IndexAlias alias, Action<RolloverRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<RolloverResponse> RolloverAsync(Elastic.Clients.Elasticsearch.IndexAlias alias, Action<RolloverRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RolloverRequestDescriptor(alias);
 		configureRequest?.Invoke(descriptor);
@@ -1593,26 +1600,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<RolloverRequestDescriptor, RolloverResponse, RolloverRequestParameters>(descriptor);
 	}
 
-	public ShrinkResponse Shrink(ShrinkRequest request)
+	public virtual ShrinkResponse Shrink(ShrinkRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ShrinkRequest, ShrinkResponse, ShrinkRequestParameters>(request);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync(ShrinkRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync(ShrinkRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ShrinkRequest, ShrinkResponse, ShrinkRequestParameters>(request, cancellationToken);
 	}
 
-	public ShrinkResponse Shrink(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target)
+	public virtual ShrinkResponse Shrink(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target)
 	{
 		var descriptor = new ShrinkRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequest<ShrinkRequestDescriptor, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public ShrinkResponse Shrink(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor> configureRequest)
+	public virtual ShrinkResponse Shrink(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ShrinkRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1620,14 +1627,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ShrinkRequestDescriptor, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName target)
+	public virtual ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName target)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequest<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest)
+	public virtual ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -1635,7 +1642,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest)
+	public virtual ShrinkResponse Shrink<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1643,14 +1650,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ShrinkRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ShrinkRequestDescriptor, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ShrinkRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1658,14 +1665,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ShrinkRequestDescriptor, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -1673,7 +1680,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ShrinkResponse> ShrinkAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<ShrinkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ShrinkRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1681,26 +1688,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<ShrinkRequestDescriptor<TDocument>, ShrinkResponse, ShrinkRequestParameters>(descriptor);
 	}
 
-	public SimulateIndexTemplateResponse SimulateIndexTemplate(SimulateIndexTemplateRequest request)
+	public virtual SimulateIndexTemplateResponse SimulateIndexTemplate(SimulateIndexTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SimulateIndexTemplateRequest, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(request);
 	}
 
-	public Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(SimulateIndexTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(SimulateIndexTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SimulateIndexTemplateRequest, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public SimulateIndexTemplateResponse SimulateIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
+	public virtual SimulateIndexTemplateResponse SimulateIndexTemplate(Elastic.Clients.Elasticsearch.Name name)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequest<SimulateIndexTemplateRequestDescriptor, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public SimulateIndexTemplateResponse SimulateIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor> configureRequest)
+	public virtual SimulateIndexTemplateResponse SimulateIndexTemplate(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1708,7 +1715,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SimulateIndexTemplateRequestDescriptor, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public SimulateIndexTemplateResponse SimulateIndexTemplate<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor<TDocument>> configureRequest)
+	public virtual SimulateIndexTemplateResponse SimulateIndexTemplate<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -1716,14 +1723,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SimulateIndexTemplateRequestDescriptor<TDocument>, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor(name);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SimulateIndexTemplateRequestDescriptor, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor(name);
 		configureRequest?.Invoke(descriptor);
@@ -1731,7 +1738,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SimulateIndexTemplateRequestDescriptor, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateIndexTemplateResponse> SimulateIndexTemplateAsync<TDocument>(Elastic.Clients.Elasticsearch.Name name, Action<SimulateIndexTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SimulateIndexTemplateRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
@@ -1739,26 +1746,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SimulateIndexTemplateRequestDescriptor<TDocument>, SimulateIndexTemplateResponse, SimulateIndexTemplateRequestParameters>(descriptor);
 	}
 
-	public SimulateTemplateResponse SimulateTemplate(SimulateTemplateRequest request)
+	public virtual SimulateTemplateResponse SimulateTemplate(SimulateTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SimulateTemplateRequest, SimulateTemplateResponse, SimulateTemplateRequestParameters>(request);
 	}
 
-	public Task<SimulateTemplateResponse> SimulateTemplateAsync(SimulateTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateTemplateResponse> SimulateTemplateAsync(SimulateTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SimulateTemplateRequest, SimulateTemplateResponse, SimulateTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public SimulateTemplateResponse SimulateTemplate()
+	public virtual SimulateTemplateResponse SimulateTemplate()
 	{
 		var descriptor = new SimulateTemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<SimulateTemplateRequestDescriptor, SimulateTemplateResponse, SimulateTemplateRequestParameters>(descriptor);
 	}
 
-	public SimulateTemplateResponse SimulateTemplate(Action<SimulateTemplateRequestDescriptor> configureRequest)
+	public virtual SimulateTemplateResponse SimulateTemplate(Action<SimulateTemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SimulateTemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1766,14 +1773,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SimulateTemplateRequestDescriptor, SimulateTemplateResponse, SimulateTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<SimulateTemplateResponse> SimulateTemplateAsync(CancellationToken cancellationToken = default)
+	public virtual Task<SimulateTemplateResponse> SimulateTemplateAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SimulateTemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SimulateTemplateRequestDescriptor, SimulateTemplateResponse, SimulateTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<SimulateTemplateResponse> SimulateTemplateAsync(Action<SimulateTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SimulateTemplateResponse> SimulateTemplateAsync(Action<SimulateTemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SimulateTemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1781,26 +1788,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SimulateTemplateRequestDescriptor, SimulateTemplateResponse, SimulateTemplateRequestParameters>(descriptor);
 	}
 
-	public SplitResponse Split(SplitRequest request)
+	public virtual SplitResponse Split(SplitRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SplitRequest, SplitResponse, SplitRequestParameters>(request);
 	}
 
-	public Task<SplitResponse> SplitAsync(SplitRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync(SplitRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SplitRequest, SplitResponse, SplitRequestParameters>(request, cancellationToken);
 	}
 
-	public SplitResponse Split(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target)
+	public virtual SplitResponse Split(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target)
 	{
 		var descriptor = new SplitRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequest<SplitRequestDescriptor, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public SplitResponse Split(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor> configureRequest)
+	public virtual SplitResponse Split(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SplitRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1808,14 +1815,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SplitRequestDescriptor, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName target)
+	public virtual SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName target)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequest<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest)
+	public virtual SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -1823,7 +1830,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest)
+	public virtual SplitResponse Split<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1831,14 +1838,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public Task<SplitResponse> SplitAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SplitRequestDescriptor(index, target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SplitRequestDescriptor, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public Task<SplitResponse> SplitAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SplitRequestDescriptor(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1846,14 +1853,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SplitRequestDescriptor, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(typeof(TDocument), target);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(typeof(TDocument), target);
 		configureRequest?.Invoke(descriptor);
@@ -1861,7 +1868,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SplitResponse> SplitAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.IndexName target, Action<SplitRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SplitRequestDescriptor<TDocument>(index, target);
 		configureRequest?.Invoke(descriptor);
@@ -1869,26 +1876,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<SplitRequestDescriptor<TDocument>, SplitResponse, SplitRequestParameters>(descriptor);
 	}
 
-	public StatsResponse Stats(StatsRequest request)
+	public virtual StatsResponse Stats(StatsRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<StatsRequest, StatsResponse, StatsRequestParameters>(request);
 	}
 
-	public Task<StatsResponse> StatsAsync(StatsRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<StatsResponse> StatsAsync(StatsRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<StatsRequest, StatsResponse, StatsRequestParameters>(request, cancellationToken);
 	}
 
-	public StatsResponse Stats()
+	public virtual StatsResponse Stats()
 	{
 		var descriptor = new StatsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<StatsRequestDescriptor, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public StatsResponse Stats(Action<StatsRequestDescriptor> configureRequest)
+	public virtual StatsResponse Stats(Action<StatsRequestDescriptor> configureRequest)
 	{
 		var descriptor = new StatsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1896,7 +1903,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<StatsRequestDescriptor, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public StatsResponse Stats<TDocument>(Action<StatsRequestDescriptor<TDocument>> configureRequest)
+	public virtual StatsResponse Stats<TDocument>(Action<StatsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new StatsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1904,14 +1911,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<StatsRequestDescriptor<TDocument>, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public Task<StatsResponse> StatsAsync(CancellationToken cancellationToken = default)
+	public virtual Task<StatsResponse> StatsAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new StatsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<StatsRequestDescriptor, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public Task<StatsResponse> StatsAsync(Action<StatsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<StatsResponse> StatsAsync(Action<StatsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new StatsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1919,7 +1926,7 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<StatsRequestDescriptor, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public Task<StatsResponse> StatsAsync<TDocument>(Action<StatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<StatsResponse> StatsAsync<TDocument>(Action<StatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new StatsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1927,26 +1934,26 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequestAsync<StatsRequestDescriptor<TDocument>, StatsResponse, StatsRequestParameters>(descriptor);
 	}
 
-	public TemplateResponse GetTemplate(TemplateRequest request)
+	public virtual TemplateResponse GetTemplate(TemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<TemplateRequest, TemplateResponse, TemplateRequestParameters>(request);
 	}
 
-	public Task<TemplateResponse> GetTemplateAsync(TemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<TemplateResponse> GetTemplateAsync(TemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<TemplateRequest, TemplateResponse, TemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public TemplateResponse GetTemplate()
+	public virtual TemplateResponse GetTemplate()
 	{
 		var descriptor = new TemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<TemplateRequestDescriptor, TemplateResponse, TemplateRequestParameters>(descriptor);
 	}
 
-	public TemplateResponse GetTemplate(Action<TemplateRequestDescriptor> configureRequest)
+	public virtual TemplateResponse GetTemplate(Action<TemplateRequestDescriptor> configureRequest)
 	{
 		var descriptor = new TemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1954,14 +1961,14 @@ public sealed partial class IndicesNamespace : NamespacedClientProxy
 		return DoRequest<TemplateRequestDescriptor, TemplateResponse, TemplateRequestParameters>(descriptor);
 	}
 
-	public Task<TemplateResponse> GetTemplateAsync(CancellationToken cancellationToken = default)
+	public virtual Task<TemplateResponse> GetTemplateAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TemplateRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<TemplateRequestDescriptor, TemplateResponse, TemplateRequestParameters>(descriptor);
 	}
 
-	public Task<TemplateResponse> GetTemplateAsync(Action<TemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<TemplateResponse> GetTemplateAsync(Action<TemplateRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TemplateRequestDescriptor();
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Sql.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Sql.g.cs
@@ -21,32 +21,39 @@ using System.Threading.Tasks;
 
 #nullable restore
 namespace Elastic.Clients.Elasticsearch.Sql;
-public sealed partial class SqlNamespace : NamespacedClientProxy
+public partial class SqlNamespacedClient : NamespacedClientProxy
 {
-	internal SqlNamespace(ElasticsearchClient client) : base(client)
+	/// <summary>
+	/// Initializes a new instance of the <see cref="SqlNamespacedClient"/> class for mocking.
+	/// </summary>			
+	protected SqlNamespacedClient() : base()
 	{
 	}
 
-	public SqlClearCursorResponse ClearCursor(SqlClearCursorRequest request)
+	internal SqlNamespacedClient(ElasticsearchClient client) : base(client)
+	{
+	}
+
+	public virtual SqlClearCursorResponse ClearCursor(SqlClearCursorRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SqlClearCursorRequest, SqlClearCursorResponse, SqlClearCursorRequestParameters>(request);
 	}
 
-	public Task<SqlClearCursorResponse> ClearCursorAsync(SqlClearCursorRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SqlClearCursorResponse> ClearCursorAsync(SqlClearCursorRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SqlClearCursorRequest, SqlClearCursorResponse, SqlClearCursorRequestParameters>(request, cancellationToken);
 	}
 
-	public SqlClearCursorResponse ClearCursor()
+	public virtual SqlClearCursorResponse ClearCursor()
 	{
 		var descriptor = new SqlClearCursorRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<SqlClearCursorRequestDescriptor, SqlClearCursorResponse, SqlClearCursorRequestParameters>(descriptor);
 	}
 
-	public SqlClearCursorResponse ClearCursor(Action<SqlClearCursorRequestDescriptor> configureRequest)
+	public virtual SqlClearCursorResponse ClearCursor(Action<SqlClearCursorRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SqlClearCursorRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -54,14 +61,14 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlClearCursorRequestDescriptor, SqlClearCursorResponse, SqlClearCursorRequestParameters>(descriptor);
 	}
 
-	public Task<SqlClearCursorResponse> ClearCursorAsync(CancellationToken cancellationToken = default)
+	public virtual Task<SqlClearCursorResponse> ClearCursorAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlClearCursorRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SqlClearCursorRequestDescriptor, SqlClearCursorResponse, SqlClearCursorRequestParameters>(descriptor);
 	}
 
-	public Task<SqlClearCursorResponse> ClearCursorAsync(Action<SqlClearCursorRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlClearCursorResponse> ClearCursorAsync(Action<SqlClearCursorRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlClearCursorRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -69,26 +76,26 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlClearCursorRequestDescriptor, SqlClearCursorResponse, SqlClearCursorRequestParameters>(descriptor);
 	}
 
-	public SqlDeleteAsyncResponse DeleteAsyncSearch(SqlDeleteAsyncRequest request)
+	public virtual SqlDeleteAsyncResponse DeleteAsyncSearch(SqlDeleteAsyncRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SqlDeleteAsyncRequest, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(request);
 	}
 
-	public Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(SqlDeleteAsyncRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(SqlDeleteAsyncRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SqlDeleteAsyncRequest, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(request, cancellationToken);
 	}
 
-	public SqlDeleteAsyncResponse DeleteAsyncSearch(Elastic.Clients.Elasticsearch.Id id)
+	public virtual SqlDeleteAsyncResponse DeleteAsyncSearch(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<SqlDeleteAsyncRequestDescriptor, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlDeleteAsyncResponse DeleteAsyncSearch(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor> configureRequest)
+	public virtual SqlDeleteAsyncResponse DeleteAsyncSearch(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -96,7 +103,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlDeleteAsyncRequestDescriptor, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlDeleteAsyncResponse DeleteAsyncSearch<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor<TDocument>> configureRequest)
+	public virtual SqlDeleteAsyncResponse DeleteAsyncSearch<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -104,14 +111,14 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlDeleteAsyncRequestDescriptor<TDocument>, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SqlDeleteAsyncRequestDescriptor, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -119,7 +126,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlDeleteAsyncRequestDescriptor, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlDeleteAsyncResponse> DeleteAsyncSearchAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlDeleteAsyncRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlDeleteAsyncRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -127,26 +134,26 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlDeleteAsyncRequestDescriptor<TDocument>, SqlDeleteAsyncResponse, SqlDeleteAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncResponse GetAsyncSearch(SqlGetAsyncRequest request)
+	public virtual SqlGetAsyncResponse GetAsyncSearch(SqlGetAsyncRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SqlGetAsyncRequest, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(request);
 	}
 
-	public Task<SqlGetAsyncResponse> GetAsyncSearchAsync(SqlGetAsyncRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncResponse> GetAsyncSearchAsync(SqlGetAsyncRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SqlGetAsyncRequest, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(request, cancellationToken);
 	}
 
-	public SqlGetAsyncResponse GetAsyncSearch(Elastic.Clients.Elasticsearch.Id id)
+	public virtual SqlGetAsyncResponse GetAsyncSearch(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<SqlGetAsyncRequestDescriptor, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncResponse GetAsyncSearch(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor> configureRequest)
+	public virtual SqlGetAsyncResponse GetAsyncSearch(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -154,7 +161,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlGetAsyncRequestDescriptor, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncResponse GetAsyncSearch<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor<TDocument>> configureRequest)
+	public virtual SqlGetAsyncResponse GetAsyncSearch<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -162,14 +169,14 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlGetAsyncRequestDescriptor<TDocument>, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncResponse> GetAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncResponse> GetAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SqlGetAsyncRequestDescriptor, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncResponse> GetAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncResponse> GetAsyncSearchAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -177,7 +184,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlGetAsyncRequestDescriptor, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncResponse> GetAsyncSearchAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncResponse> GetAsyncSearchAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -185,26 +192,26 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlGetAsyncRequestDescriptor<TDocument>, SqlGetAsyncResponse, SqlGetAsyncRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncStatusResponse GetAsyncSearchStatus(SqlGetAsyncStatusRequest request)
+	public virtual SqlGetAsyncStatusResponse GetAsyncSearchStatus(SqlGetAsyncStatusRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SqlGetAsyncStatusRequest, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(request);
 	}
 
-	public Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(SqlGetAsyncStatusRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(SqlGetAsyncStatusRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SqlGetAsyncStatusRequest, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(request, cancellationToken);
 	}
 
-	public SqlGetAsyncStatusResponse GetAsyncSearchStatus(Elastic.Clients.Elasticsearch.Id id)
+	public virtual SqlGetAsyncStatusResponse GetAsyncSearchStatus(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<SqlGetAsyncStatusRequestDescriptor, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncStatusResponse GetAsyncSearchStatus(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor> configureRequest)
+	public virtual SqlGetAsyncStatusResponse GetAsyncSearchStatus(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -212,7 +219,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlGetAsyncStatusRequestDescriptor, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public SqlGetAsyncStatusResponse GetAsyncSearchStatus<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor<TDocument>> configureRequest)
+	public virtual SqlGetAsyncStatusResponse GetAsyncSearchStatus<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -220,14 +227,14 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlGetAsyncStatusRequestDescriptor<TDocument>, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SqlGetAsyncStatusRequestDescriptor, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -235,7 +242,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlGetAsyncStatusRequestDescriptor, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlGetAsyncStatusResponse> GetAsyncSearchStatusAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SqlGetAsyncStatusRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlGetAsyncStatusRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -243,26 +250,26 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlGetAsyncStatusRequestDescriptor<TDocument>, SqlGetAsyncStatusResponse, SqlGetAsyncStatusRequestParameters>(descriptor);
 	}
 
-	public SqlQueryResponse Query(SqlQueryRequest request)
+	public virtual SqlQueryResponse Query(SqlQueryRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SqlQueryRequest, SqlQueryResponse, SqlQueryRequestParameters>(request);
 	}
 
-	public Task<SqlQueryResponse> QueryAsync(SqlQueryRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SqlQueryResponse> QueryAsync(SqlQueryRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SqlQueryRequest, SqlQueryResponse, SqlQueryRequestParameters>(request, cancellationToken);
 	}
 
-	public SqlQueryResponse Query()
+	public virtual SqlQueryResponse Query()
 	{
 		var descriptor = new SqlQueryRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<SqlQueryRequestDescriptor, SqlQueryResponse, SqlQueryRequestParameters>(descriptor);
 	}
 
-	public SqlQueryResponse Query(Action<SqlQueryRequestDescriptor> configureRequest)
+	public virtual SqlQueryResponse Query(Action<SqlQueryRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SqlQueryRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -270,7 +277,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlQueryRequestDescriptor, SqlQueryResponse, SqlQueryRequestParameters>(descriptor);
 	}
 
-	public SqlQueryResponse Query<TDocument>(Action<SqlQueryRequestDescriptor<TDocument>> configureRequest)
+	public virtual SqlQueryResponse Query<TDocument>(Action<SqlQueryRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SqlQueryRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -278,14 +285,14 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequest<SqlQueryRequestDescriptor<TDocument>, SqlQueryResponse, SqlQueryRequestParameters>(descriptor);
 	}
 
-	public Task<SqlQueryResponse> QueryAsync(CancellationToken cancellationToken = default)
+	public virtual Task<SqlQueryResponse> QueryAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlQueryRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SqlQueryRequestDescriptor, SqlQueryResponse, SqlQueryRequestParameters>(descriptor);
 	}
 
-	public Task<SqlQueryResponse> QueryAsync(Action<SqlQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlQueryResponse> QueryAsync(Action<SqlQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlQueryRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -293,7 +300,7 @@ public sealed partial class SqlNamespace : NamespacedClientProxy
 		return DoRequestAsync<SqlQueryRequestDescriptor, SqlQueryResponse, SqlQueryRequestParameters>(descriptor);
 	}
 
-	public Task<SqlQueryResponse> QueryAsync<TDocument>(Action<SqlQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SqlQueryResponse> QueryAsync<TDocument>(Action<SqlQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SqlQueryRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.g.cs
@@ -28,45 +28,45 @@ using System.Threading.Tasks;
 namespace Elastic.Clients.Elasticsearch;
 public partial class ElasticsearchClient
 {
-	public AsyncSearchNamespace AsyncSearch { get; private set; }
+	public virtual AsyncSearchNamespacedClient AsyncSearch { get; private set; }
 
-	public ClusterNamespace Cluster { get; private set; }
+	public virtual ClusterNamespacedClient Cluster { get; private set; }
 
-	public EqlNamespace Eql { get; private set; }
+	public virtual EqlNamespacedClient Eql { get; private set; }
 
-	public IndicesNamespace Indices { get; private set; }
+	public virtual IndicesNamespacedClient Indices { get; private set; }
 
-	public SqlNamespace Sql { get; private set; }
+	public virtual SqlNamespacedClient Sql { get; private set; }
 
 	private partial void SetupNamespaces()
 	{
-		AsyncSearch = new AsyncSearchNamespace(this);
-		Cluster = new ClusterNamespace(this);
-		Eql = new EqlNamespace(this);
-		Indices = new IndicesNamespace(this);
-		Sql = new SqlNamespace(this);
+		AsyncSearch = new AsyncSearchNamespacedClient(this);
+		Cluster = new ClusterNamespacedClient(this);
+		Eql = new EqlNamespacedClient(this);
+		Indices = new IndicesNamespacedClient(this);
+		Sql = new SqlNamespacedClient(this);
 	}
 
-	public BulkResponse Bulk(BulkRequest request)
+	public virtual BulkResponse Bulk(BulkRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<BulkRequest, BulkResponse, BulkRequestParameters>(request);
 	}
 
-	public Task<BulkResponse> BulkAsync(BulkRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<BulkResponse> BulkAsync(BulkRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<BulkRequest, BulkResponse, BulkRequestParameters>(request, cancellationToken);
 	}
 
-	public BulkResponse Bulk()
+	public virtual BulkResponse Bulk()
 	{
 		var descriptor = new BulkRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<BulkRequestDescriptor, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public BulkResponse Bulk(Action<BulkRequestDescriptor> configureRequest)
+	public virtual BulkResponse Bulk(Action<BulkRequestDescriptor> configureRequest)
 	{
 		var descriptor = new BulkRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -74,7 +74,7 @@ public partial class ElasticsearchClient
 		return DoRequest<BulkRequestDescriptor, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public BulkResponse Bulk<TDocument>(Action<BulkRequestDescriptor<TDocument>> configureRequest)
+	public virtual BulkResponse Bulk<TDocument>(Action<BulkRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new BulkRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -82,14 +82,14 @@ public partial class ElasticsearchClient
 		return DoRequest<BulkRequestDescriptor<TDocument>, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public Task<BulkResponse> BulkAsync(CancellationToken cancellationToken = default)
+	public virtual Task<BulkResponse> BulkAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new BulkRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<BulkRequestDescriptor, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public Task<BulkResponse> BulkAsync(Action<BulkRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<BulkResponse> BulkAsync(Action<BulkRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new BulkRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -97,7 +97,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<BulkRequestDescriptor, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public Task<BulkResponse> BulkAsync<TDocument>(Action<BulkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<BulkResponse> BulkAsync<TDocument>(Action<BulkRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new BulkRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -105,26 +105,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<BulkRequestDescriptor<TDocument>, BulkResponse, BulkRequestParameters>(descriptor);
 	}
 
-	public ClearScrollResponse ClearScroll(ClearScrollRequest request)
+	public virtual ClearScrollResponse ClearScroll(ClearScrollRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ClearScrollRequest, ClearScrollResponse, ClearScrollRequestParameters>(request);
 	}
 
-	public Task<ClearScrollResponse> ClearScrollAsync(ClearScrollRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ClearScrollResponse> ClearScrollAsync(ClearScrollRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ClearScrollRequest, ClearScrollResponse, ClearScrollRequestParameters>(request, cancellationToken);
 	}
 
-	public ClearScrollResponse ClearScroll()
+	public virtual ClearScrollResponse ClearScroll()
 	{
 		var descriptor = new ClearScrollRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ClearScrollRequestDescriptor, ClearScrollResponse, ClearScrollRequestParameters>(descriptor);
 	}
 
-	public ClearScrollResponse ClearScroll(Action<ClearScrollRequestDescriptor> configureRequest)
+	public virtual ClearScrollResponse ClearScroll(Action<ClearScrollRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ClearScrollRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -132,14 +132,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ClearScrollRequestDescriptor, ClearScrollResponse, ClearScrollRequestParameters>(descriptor);
 	}
 
-	public Task<ClearScrollResponse> ClearScrollAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ClearScrollResponse> ClearScrollAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClearScrollRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ClearScrollRequestDescriptor, ClearScrollResponse, ClearScrollRequestParameters>(descriptor);
 	}
 
-	public Task<ClearScrollResponse> ClearScrollAsync(Action<ClearScrollRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ClearScrollResponse> ClearScrollAsync(Action<ClearScrollRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClearScrollRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -147,26 +147,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ClearScrollRequestDescriptor, ClearScrollResponse, ClearScrollRequestParameters>(descriptor);
 	}
 
-	public ClosePointInTimeResponse ClosePointInTime(ClosePointInTimeRequest request)
+	public virtual ClosePointInTimeResponse ClosePointInTime(ClosePointInTimeRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ClosePointInTimeRequest, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(request);
 	}
 
-	public Task<ClosePointInTimeResponse> ClosePointInTimeAsync(ClosePointInTimeRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ClosePointInTimeResponse> ClosePointInTimeAsync(ClosePointInTimeRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ClosePointInTimeRequest, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(request, cancellationToken);
 	}
 
-	public ClosePointInTimeResponse ClosePointInTime()
+	public virtual ClosePointInTimeResponse ClosePointInTime()
 	{
 		var descriptor = new ClosePointInTimeRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ClosePointInTimeRequestDescriptor, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(descriptor);
 	}
 
-	public ClosePointInTimeResponse ClosePointInTime(Action<ClosePointInTimeRequestDescriptor> configureRequest)
+	public virtual ClosePointInTimeResponse ClosePointInTime(Action<ClosePointInTimeRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ClosePointInTimeRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -174,14 +174,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ClosePointInTimeRequestDescriptor, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(descriptor);
 	}
 
-	public Task<ClosePointInTimeResponse> ClosePointInTimeAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ClosePointInTimeResponse> ClosePointInTimeAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClosePointInTimeRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ClosePointInTimeRequestDescriptor, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(descriptor);
 	}
 
-	public Task<ClosePointInTimeResponse> ClosePointInTimeAsync(Action<ClosePointInTimeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ClosePointInTimeResponse> ClosePointInTimeAsync(Action<ClosePointInTimeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ClosePointInTimeRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -189,26 +189,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ClosePointInTimeRequestDescriptor, ClosePointInTimeResponse, ClosePointInTimeRequestParameters>(descriptor);
 	}
 
-	public CountResponse Count(CountRequest request)
+	public virtual CountResponse Count(CountRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CountRequest, CountResponse, CountRequestParameters>(request);
 	}
 
-	public Task<CountResponse> CountAsync(CountRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<CountResponse> CountAsync(CountRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CountRequest, CountResponse, CountRequestParameters>(request, cancellationToken);
 	}
 
-	public CountResponse Count()
+	public virtual CountResponse Count()
 	{
 		var descriptor = new CountRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<CountRequestDescriptor, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public CountResponse Count(Action<CountRequestDescriptor> configureRequest)
+	public virtual CountResponse Count(Action<CountRequestDescriptor> configureRequest)
 	{
 		var descriptor = new CountRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -216,7 +216,7 @@ public partial class ElasticsearchClient
 		return DoRequest<CountRequestDescriptor, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public CountResponse Count<TDocument>(Action<CountRequestDescriptor<TDocument>> configureRequest)
+	public virtual CountResponse Count<TDocument>(Action<CountRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CountRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -224,14 +224,14 @@ public partial class ElasticsearchClient
 		return DoRequest<CountRequestDescriptor<TDocument>, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public Task<CountResponse> CountAsync(CancellationToken cancellationToken = default)
+	public virtual Task<CountResponse> CountAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CountRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CountRequestDescriptor, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public Task<CountResponse> CountAsync(Action<CountRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CountResponse> CountAsync(Action<CountRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CountRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -239,7 +239,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<CountRequestDescriptor, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public Task<CountResponse> CountAsync<TDocument>(Action<CountRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CountResponse> CountAsync<TDocument>(Action<CountRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CountRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -247,26 +247,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<CountRequestDescriptor<TDocument>, CountResponse, CountRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(CreateRequest<TDocument> request)
+	public virtual CreateResponse Create<TDocument>(CreateRequest<TDocument> request)
 	{
 		request.BeforeRequest();
 		return DoRequest<CreateRequest<TDocument>, CreateResponse, CreateRequestParameters>(request);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(CreateRequest<TDocument> request, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(CreateRequest<TDocument> request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<CreateRequest<TDocument>, CreateResponse, CreateRequestParameters>(request, cancellationToken);
 	}
 
-	public CreateResponse Create<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual CreateResponse Create<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document, index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<CreateRequestDescriptor<TDocument>> configureRequest)
+	public virtual CreateResponse Create<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<CreateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document, index, id);
 		configureRequest?.Invoke(descriptor);
@@ -274,14 +274,14 @@ public partial class ElasticsearchClient
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(TDocument document)
+	public virtual CreateResponse Create<TDocument>(TDocument document)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public CreateResponse Create<TDocument>(TDocument document, Action<CreateRequestDescriptor<TDocument>> configureRequest)
+	public virtual CreateResponse Create<TDocument>(TDocument document, Action<CreateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document);
 		configureRequest?.Invoke(descriptor);
@@ -289,14 +289,14 @@ public partial class ElasticsearchClient
 		return DoRequest<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document, index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document, index, id);
 		configureRequest?.Invoke(descriptor);
@@ -304,14 +304,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<CreateResponse> CreateAsync<TDocument>(TDocument document, Action<CreateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new CreateRequestDescriptor<TDocument>(document);
 		configureRequest?.Invoke(descriptor);
@@ -319,26 +319,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<CreateRequestDescriptor<TDocument>, CreateResponse, CreateRequestParameters>(descriptor);
 	}
 
-	public DeleteByQueryResponse DeleteByQuery(DeleteByQueryRequest request)
+	public virtual DeleteByQueryResponse DeleteByQuery(DeleteByQueryRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestParameters>(request);
 	}
 
-	public Task<DeleteByQueryResponse> DeleteByQueryAsync(DeleteByQueryRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryResponse> DeleteByQueryAsync(DeleteByQueryRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteByQueryRequest, DeleteByQueryResponse, DeleteByQueryRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteByQueryResponse DeleteByQuery(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual DeleteByQueryResponse DeleteByQuery(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteByQueryRequestDescriptor, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public DeleteByQueryResponse DeleteByQuery(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor> configureRequest)
+	public virtual DeleteByQueryResponse DeleteByQuery(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -346,7 +346,7 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteByQueryRequestDescriptor, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public DeleteByQueryResponse DeleteByQuery<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteByQueryResponse DeleteByQuery<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -354,14 +354,14 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteByQueryRequestDescriptor<TDocument>, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteByQueryResponse> DeleteByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryResponse> DeleteByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteByQueryRequestDescriptor, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteByQueryResponse> DeleteByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryResponse> DeleteByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -369,7 +369,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteByQueryRequestDescriptor, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteByQueryResponse> DeleteByQueryAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryResponse> DeleteByQueryAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<DeleteByQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteByQueryRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -377,26 +377,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteByQueryRequestDescriptor<TDocument>, DeleteByQueryResponse, DeleteByQueryRequestParameters>(descriptor);
 	}
 
-	public DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(DeleteByQueryRethrottleRequest request)
+	public virtual DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(DeleteByQueryRethrottleRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteByQueryRethrottleRequest, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(request);
 	}
 
-	public Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(DeleteByQueryRethrottleRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(DeleteByQueryRethrottleRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteByQueryRethrottleRequest, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(Elastic.Clients.Elasticsearch.TaskId task_id)
+	public virtual DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(Elastic.Clients.Elasticsearch.TaskId task_id)
 	{
 		var descriptor = new DeleteByQueryRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteByQueryRethrottleRequestDescriptor, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(Elastic.Clients.Elasticsearch.TaskId task_id, Action<DeleteByQueryRethrottleRequestDescriptor> configureRequest)
+	public virtual DeleteByQueryRethrottleResponse DeleteByQueryRethrottle(Elastic.Clients.Elasticsearch.TaskId task_id, Action<DeleteByQueryRethrottleRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteByQueryRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -404,14 +404,14 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteByQueryRethrottleRequestDescriptor, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.TaskId task_id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.TaskId task_id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteByQueryRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteByQueryRethrottleRequestDescriptor, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.TaskId task_id, Action<DeleteByQueryRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteByQueryRethrottleResponse> DeleteByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.TaskId task_id, Action<DeleteByQueryRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteByQueryRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -419,26 +419,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteByQueryRethrottleRequestDescriptor, DeleteByQueryRethrottleResponse, DeleteByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete(DeleteRequest request)
+	public virtual DeleteResponse Delete(DeleteRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteRequest, DeleteResponse, DeleteRequestParameters>(request);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(DeleteRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(DeleteRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteRequest, DeleteResponse, DeleteRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteResponse Delete(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual DeleteResponse Delete(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new DeleteRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor> configureRequest)
+	public virtual DeleteResponse Delete(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -446,14 +446,14 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -461,7 +461,7 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteResponse Delete<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -469,14 +469,14 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -484,14 +484,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteRequestDescriptor, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -499,7 +499,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteResponse> DeleteAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<DeleteRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -507,26 +507,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteRequestDescriptor<TDocument>, DeleteResponse, DeleteRequestParameters>(descriptor);
 	}
 
-	public DeleteScriptResponse DeleteScript(DeleteScriptRequest request)
+	public virtual DeleteScriptResponse DeleteScript(DeleteScriptRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<DeleteScriptRequest, DeleteScriptResponse, DeleteScriptRequestParameters>(request);
 	}
 
-	public Task<DeleteScriptResponse> DeleteScriptAsync(DeleteScriptRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteScriptResponse> DeleteScriptAsync(DeleteScriptRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<DeleteScriptRequest, DeleteScriptResponse, DeleteScriptRequestParameters>(request, cancellationToken);
 	}
 
-	public DeleteScriptResponse DeleteScript(Elastic.Clients.Elasticsearch.Id id)
+	public virtual DeleteScriptResponse DeleteScript(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<DeleteScriptRequestDescriptor, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public DeleteScriptResponse DeleteScript(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor> configureRequest)
+	public virtual DeleteScriptResponse DeleteScript(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor> configureRequest)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -534,7 +534,7 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteScriptRequestDescriptor, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public DeleteScriptResponse DeleteScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor<TDocument>> configureRequest)
+	public virtual DeleteScriptResponse DeleteScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -542,14 +542,14 @@ public partial class ElasticsearchClient
 		return DoRequest<DeleteScriptRequestDescriptor<TDocument>, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteScriptResponse> DeleteScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteScriptResponse> DeleteScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<DeleteScriptRequestDescriptor, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteScriptResponse> DeleteScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteScriptResponse> DeleteScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -557,7 +557,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteScriptRequestDescriptor, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public Task<DeleteScriptResponse> DeleteScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<DeleteScriptResponse> DeleteScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<DeleteScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new DeleteScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -565,26 +565,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<DeleteScriptRequestDescriptor<TDocument>, DeleteScriptResponse, DeleteScriptRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists(ExistsRequest request)
+	public virtual ExistsResponse Exists(ExistsRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsRequest, ExistsResponse, ExistsRequestParameters>(request);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(ExistsRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(ExistsRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsRequest, ExistsResponse, ExistsRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsResponse Exists(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExistsResponse Exists(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExistsRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor> configureRequest)
+	public virtual ExistsResponse Exists(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -592,14 +592,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -607,7 +607,7 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsResponse Exists<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -615,14 +615,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -630,14 +630,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsRequestDescriptor, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -645,7 +645,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsResponse> ExistsAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -653,26 +653,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsRequestDescriptor<TDocument>, ExistsResponse, ExistsRequestParameters>(descriptor);
 	}
 
-	public ExistsSourceResponse ExistsSource(ExistsSourceRequest request)
+	public virtual ExistsSourceResponse ExistsSource(ExistsSourceRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExistsSourceRequest, ExistsSourceResponse, ExistsSourceRequestParameters>(request);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync(ExistsSourceRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync(ExistsSourceRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExistsSourceRequest, ExistsSourceResponse, ExistsSourceRequestParameters>(request, cancellationToken);
 	}
 
-	public ExistsSourceResponse ExistsSource(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExistsSourceResponse ExistsSource(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsSourceRequestDescriptor, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public ExistsSourceResponse ExistsSource(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor> configureRequest)
+	public virtual ExistsSourceResponse ExistsSource(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -680,14 +680,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsSourceRequestDescriptor, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -695,7 +695,7 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExistsSourceResponse ExistsSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -703,14 +703,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsSourceRequestDescriptor, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -718,14 +718,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsSourceRequestDescriptor, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -733,7 +733,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExistsSourceResponse> ExistsSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExistsSourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExistsSourceRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -741,26 +741,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExistsSourceRequestDescriptor<TDocument>, ExistsSourceResponse, ExistsSourceRequestParameters>(descriptor);
 	}
 
-	public ExplainResponse<TDocument> Explain<TDocument>(ExplainRequest request)
+	public virtual ExplainResponse<TDocument> Explain<TDocument>(ExplainRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ExplainRequest, ExplainResponse<TDocument>, ExplainRequestParameters>(request);
 	}
 
-	public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(ExplainRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(ExplainRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ExplainRequest, ExplainResponse<TDocument>, ExplainRequestParameters>(request, cancellationToken);
 	}
 
-	public ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -768,14 +768,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest)
+	public virtual ExplainResponse<TDocument> Explain<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -783,14 +783,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -798,14 +798,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ExplainResponse<TDocument>> ExplainAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ExplainRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ExplainRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -813,26 +813,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ExplainRequestDescriptor<TDocument>, ExplainResponse<TDocument>, ExplainRequestParameters>(descriptor);
 	}
 
-	public FieldCapsResponse FieldCaps(FieldCapsRequest request)
+	public virtual FieldCapsResponse FieldCaps(FieldCapsRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<FieldCapsRequest, FieldCapsResponse, FieldCapsRequestParameters>(request);
 	}
 
-	public Task<FieldCapsResponse> FieldCapsAsync(FieldCapsRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<FieldCapsResponse> FieldCapsAsync(FieldCapsRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<FieldCapsRequest, FieldCapsResponse, FieldCapsRequestParameters>(request, cancellationToken);
 	}
 
-	public FieldCapsResponse FieldCaps()
+	public virtual FieldCapsResponse FieldCaps()
 	{
 		var descriptor = new FieldCapsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<FieldCapsRequestDescriptor, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public FieldCapsResponse FieldCaps(Action<FieldCapsRequestDescriptor> configureRequest)
+	public virtual FieldCapsResponse FieldCaps(Action<FieldCapsRequestDescriptor> configureRequest)
 	{
 		var descriptor = new FieldCapsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -840,7 +840,7 @@ public partial class ElasticsearchClient
 		return DoRequest<FieldCapsRequestDescriptor, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public FieldCapsResponse FieldCaps<TDocument>(Action<FieldCapsRequestDescriptor<TDocument>> configureRequest)
+	public virtual FieldCapsResponse FieldCaps<TDocument>(Action<FieldCapsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new FieldCapsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -848,14 +848,14 @@ public partial class ElasticsearchClient
 		return DoRequest<FieldCapsRequestDescriptor<TDocument>, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public Task<FieldCapsResponse> FieldCapsAsync(CancellationToken cancellationToken = default)
+	public virtual Task<FieldCapsResponse> FieldCapsAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldCapsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<FieldCapsRequestDescriptor, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public Task<FieldCapsResponse> FieldCapsAsync(Action<FieldCapsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FieldCapsResponse> FieldCapsAsync(Action<FieldCapsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldCapsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -863,7 +863,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<FieldCapsRequestDescriptor, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public Task<FieldCapsResponse> FieldCapsAsync<TDocument>(Action<FieldCapsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<FieldCapsResponse> FieldCapsAsync<TDocument>(Action<FieldCapsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new FieldCapsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -871,26 +871,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<FieldCapsRequestDescriptor<TDocument>, FieldCapsResponse, FieldCapsRequestParameters>(descriptor);
 	}
 
-	public GetResponse<TDocument> Get<TDocument>(GetRequest request)
+	public virtual GetResponse<TDocument> Get<TDocument>(GetRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<GetRequest, GetResponse<TDocument>, GetRequestParameters>(request);
 	}
 
-	public Task<GetResponse<TDocument>> GetAsync<TDocument>(GetRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse<TDocument>> GetAsync<TDocument>(GetRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<GetRequest, GetResponse<TDocument>, GetRequestParameters>(request, cancellationToken);
 	}
 
-	public GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest)
+	public virtual GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -898,14 +898,14 @@ public partial class ElasticsearchClient
 		return DoRequest<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest)
+	public virtual GetResponse<TDocument> Get<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -913,14 +913,14 @@ public partial class ElasticsearchClient
 		return DoRequest<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -928,14 +928,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<GetResponse<TDocument>> GetAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<GetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -943,26 +943,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<GetRequestDescriptor<TDocument>, GetResponse<TDocument>, GetRequestParameters>(descriptor);
 	}
 
-	public IndexResponse Index<TDocument>(IndexRequest<TDocument> request)
+	public virtual IndexResponse Index<TDocument>(IndexRequest<TDocument> request)
 	{
 		request.BeforeRequest();
 		return DoRequest<IndexRequest<TDocument>, IndexResponse, IndexRequestParameters>(request);
 	}
 
-	public Task<IndexResponse> IndexAsync<TDocument>(IndexRequest<TDocument> request, CancellationToken cancellationToken = default)
+	public virtual Task<IndexResponse> IndexAsync<TDocument>(IndexRequest<TDocument> request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<IndexRequest<TDocument>, IndexResponse, IndexRequestParameters>(request, cancellationToken);
 	}
 
-	public IndexResponse Index<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index)
+	public virtual IndexResponse Index<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document, index);
 		descriptor.BeforeRequest();
 		return DoRequest<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public IndexResponse Index<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Action<IndexRequestDescriptor<TDocument>> configureRequest)
+	public virtual IndexResponse Index<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Action<IndexRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document, index);
 		configureRequest?.Invoke(descriptor);
@@ -970,14 +970,14 @@ public partial class ElasticsearchClient
 		return DoRequest<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public IndexResponse Index<TDocument>(TDocument document)
+	public virtual IndexResponse Index<TDocument>(TDocument document)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequest<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public IndexResponse Index<TDocument>(TDocument document, Action<IndexRequestDescriptor<TDocument>> configureRequest)
+	public virtual IndexResponse Index<TDocument>(TDocument document, Action<IndexRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document);
 		configureRequest?.Invoke(descriptor);
@@ -985,14 +985,14 @@ public partial class ElasticsearchClient
 		return DoRequest<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
+	public virtual Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document, index);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Action<IndexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Elastic.Clients.Elasticsearch.IndexName index, Action<IndexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document, index);
 		configureRequest?.Invoke(descriptor);
@@ -1000,14 +1000,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public Task<IndexResponse> IndexAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default)
+	public virtual Task<IndexResponse> IndexAsync<TDocument>(TDocument document, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Action<IndexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<IndexResponse> IndexAsync<TDocument>(TDocument document, Action<IndexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndexRequestDescriptor<TDocument>(document);
 		configureRequest?.Invoke(descriptor);
@@ -1015,26 +1015,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<IndexRequestDescriptor<TDocument>, IndexResponse, IndexRequestParameters>(descriptor);
 	}
 
-	public InfoResponse Info(InfoRequest request)
+	public virtual InfoResponse Info(InfoRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<InfoRequest, InfoResponse, InfoRequestParameters>(request);
 	}
 
-	public Task<InfoResponse> InfoAsync(InfoRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<InfoResponse> InfoAsync(InfoRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<InfoRequest, InfoResponse, InfoRequestParameters>(request, cancellationToken);
 	}
 
-	public InfoResponse Info()
+	public virtual InfoResponse Info()
 	{
 		var descriptor = new InfoRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<InfoRequestDescriptor, InfoResponse, InfoRequestParameters>(descriptor);
 	}
 
-	public InfoResponse Info(Action<InfoRequestDescriptor> configureRequest)
+	public virtual InfoResponse Info(Action<InfoRequestDescriptor> configureRequest)
 	{
 		var descriptor = new InfoRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1042,14 +1042,14 @@ public partial class ElasticsearchClient
 		return DoRequest<InfoRequestDescriptor, InfoResponse, InfoRequestParameters>(descriptor);
 	}
 
-	public Task<InfoResponse> InfoAsync(CancellationToken cancellationToken = default)
+	public virtual Task<InfoResponse> InfoAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new InfoRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<InfoRequestDescriptor, InfoResponse, InfoRequestParameters>(descriptor);
 	}
 
-	public Task<InfoResponse> InfoAsync(Action<InfoRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<InfoResponse> InfoAsync(Action<InfoRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new InfoRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1057,26 +1057,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<InfoRequestDescriptor, InfoResponse, InfoRequestParameters>(descriptor);
 	}
 
-	public MultiGetResponse<TDocument> MultiGet<TDocument>(MultiGetRequest request)
+	public virtual MultiGetResponse<TDocument> MultiGet<TDocument>(MultiGetRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<MultiGetRequest, MultiGetResponse<TDocument>, MultiGetRequestParameters>(request);
 	}
 
-	public Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(MultiGetRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(MultiGetRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<MultiGetRequest, MultiGetResponse<TDocument>, MultiGetRequestParameters>(request, cancellationToken);
 	}
 
-	public MultiGetResponse<TDocument> MultiGet<TDocument>()
+	public virtual MultiGetResponse<TDocument> MultiGet<TDocument>()
 	{
 		var descriptor = new MultiGetRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequest<MultiGetRequestDescriptor<TDocument>, MultiGetResponse<TDocument>, MultiGetRequestParameters>(descriptor);
 	}
 
-	public MultiGetResponse<TDocument> MultiGet<TDocument>(Action<MultiGetRequestDescriptor<TDocument>> configureRequest)
+	public virtual MultiGetResponse<TDocument> MultiGet<TDocument>(Action<MultiGetRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new MultiGetRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1084,14 +1084,14 @@ public partial class ElasticsearchClient
 		return DoRequest<MultiGetRequestDescriptor<TDocument>, MultiGetResponse<TDocument>, MultiGetRequestParameters>(descriptor);
 	}
 
-	public Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiGetRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<MultiGetRequestDescriptor<TDocument>, MultiGetResponse<TDocument>, MultiGetRequestParameters>(descriptor);
 	}
 
-	public Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(Action<MultiGetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MultiGetResponse<TDocument>> MultiGetAsync<TDocument>(Action<MultiGetRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiGetRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1099,26 +1099,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<MultiGetRequestDescriptor<TDocument>, MultiGetResponse<TDocument>, MultiGetRequestParameters>(descriptor);
 	}
 
-	public MultiSearchResponse<TDocument> MultiSearch<TDocument>(MultiSearchRequest request)
+	public virtual MultiSearchResponse<TDocument> MultiSearch<TDocument>(MultiSearchRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<MultiSearchRequest, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(request);
 	}
 
-	public Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(MultiSearchRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(MultiSearchRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<MultiSearchRequest, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(request, cancellationToken);
 	}
 
-	public MultiSearchResponse<TDocument> MultiSearch<TDocument>()
+	public virtual MultiSearchResponse<TDocument> MultiSearch<TDocument>()
 	{
 		var descriptor = new MultiSearchRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequest<MultiSearchRequestDescriptor<TDocument>, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(descriptor);
 	}
 
-	public MultiSearchResponse<TDocument> MultiSearch<TDocument>(Action<MultiSearchRequestDescriptor<TDocument>> configureRequest)
+	public virtual MultiSearchResponse<TDocument> MultiSearch<TDocument>(Action<MultiSearchRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new MultiSearchRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1126,14 +1126,14 @@ public partial class ElasticsearchClient
 		return DoRequest<MultiSearchRequestDescriptor<TDocument>, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(descriptor);
 	}
 
-	public Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiSearchRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<MultiSearchRequestDescriptor<TDocument>, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(descriptor);
 	}
 
-	public Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(Action<MultiSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchResponse<TDocument>> MultiSearchAsync<TDocument>(Action<MultiSearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiSearchRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1141,26 +1141,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<MultiSearchRequestDescriptor<TDocument>, MultiSearchResponse<TDocument>, MultiSearchRequestParameters>(descriptor);
 	}
 
-	public MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>(MultiSearchTemplateRequest request)
+	public virtual MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>(MultiSearchTemplateRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<MultiSearchTemplateRequest, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(request);
 	}
 
-	public Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(MultiSearchTemplateRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(MultiSearchTemplateRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<MultiSearchTemplateRequest, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(request, cancellationToken);
 	}
 
-	public MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>()
+	public virtual MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>()
 	{
 		var descriptor = new MultiSearchTemplateRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequest<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(descriptor);
 	}
 
-	public MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configureRequest)
+	public virtual MultiSearchTemplateResponse<TDocument> MultiSearchTemplate<TDocument>(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new MultiSearchTemplateRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1168,14 +1168,14 @@ public partial class ElasticsearchClient
 		return DoRequest<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiSearchTemplateRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(descriptor);
 	}
 
-	public Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<MultiSearchTemplateResponse<TDocument>> MultiSearchTemplateAsync<TDocument>(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new MultiSearchTemplateRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1183,26 +1183,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateResponse<TDocument>, MultiSearchTemplateRequestParameters>(descriptor);
 	}
 
-	public OpenPointInTimeResponse OpenPointInTime(OpenPointInTimeRequest request)
+	public virtual OpenPointInTimeResponse OpenPointInTime(OpenPointInTimeRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<OpenPointInTimeRequest, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(request);
 	}
 
-	public Task<OpenPointInTimeResponse> OpenPointInTimeAsync(OpenPointInTimeRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<OpenPointInTimeResponse> OpenPointInTimeAsync(OpenPointInTimeRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<OpenPointInTimeRequest, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(request, cancellationToken);
 	}
 
-	public OpenPointInTimeResponse OpenPointInTime(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual OpenPointInTimeResponse OpenPointInTime(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<OpenPointInTimeRequestDescriptor, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public OpenPointInTimeResponse OpenPointInTime(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor> configureRequest)
+	public virtual OpenPointInTimeResponse OpenPointInTime(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor> configureRequest)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1210,7 +1210,7 @@ public partial class ElasticsearchClient
 		return DoRequest<OpenPointInTimeRequestDescriptor, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public OpenPointInTimeResponse OpenPointInTime<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor<TDocument>> configureRequest)
+	public virtual OpenPointInTimeResponse OpenPointInTime<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1218,14 +1218,14 @@ public partial class ElasticsearchClient
 		return DoRequest<OpenPointInTimeRequestDescriptor<TDocument>, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public Task<OpenPointInTimeResponse> OpenPointInTimeAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<OpenPointInTimeResponse> OpenPointInTimeAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<OpenPointInTimeRequestDescriptor, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public Task<OpenPointInTimeResponse> OpenPointInTimeAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<OpenPointInTimeResponse> OpenPointInTimeAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1233,7 +1233,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<OpenPointInTimeRequestDescriptor, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public Task<OpenPointInTimeResponse> OpenPointInTimeAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<OpenPointInTimeResponse> OpenPointInTimeAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<OpenPointInTimeRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new OpenPointInTimeRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1241,26 +1241,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<OpenPointInTimeRequestDescriptor<TDocument>, OpenPointInTimeResponse, OpenPointInTimeRequestParameters>(descriptor);
 	}
 
-	public PingResponse Ping(PingRequest request)
+	public virtual PingResponse Ping(PingRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PingRequest, PingResponse, PingRequestParameters>(request);
 	}
 
-	public Task<PingResponse> PingAsync(PingRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PingResponse> PingAsync(PingRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PingRequest, PingResponse, PingRequestParameters>(request, cancellationToken);
 	}
 
-	public PingResponse Ping()
+	public virtual PingResponse Ping()
 	{
 		var descriptor = new PingRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<PingRequestDescriptor, PingResponse, PingRequestParameters>(descriptor);
 	}
 
-	public PingResponse Ping(Action<PingRequestDescriptor> configureRequest)
+	public virtual PingResponse Ping(Action<PingRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PingRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1268,14 +1268,14 @@ public partial class ElasticsearchClient
 		return DoRequest<PingRequestDescriptor, PingResponse, PingRequestParameters>(descriptor);
 	}
 
-	public Task<PingResponse> PingAsync(CancellationToken cancellationToken = default)
+	public virtual Task<PingResponse> PingAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PingRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PingRequestDescriptor, PingResponse, PingRequestParameters>(descriptor);
 	}
 
-	public Task<PingResponse> PingAsync(Action<PingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PingResponse> PingAsync(Action<PingRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PingRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1283,26 +1283,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<PingRequestDescriptor, PingResponse, PingRequestParameters>(descriptor);
 	}
 
-	public PutScriptResponse PutScript(PutScriptRequest request)
+	public virtual PutScriptResponse PutScript(PutScriptRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<PutScriptRequest, PutScriptResponse, PutScriptRequestParameters>(request);
 	}
 
-	public Task<PutScriptResponse> PutScriptAsync(PutScriptRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<PutScriptResponse> PutScriptAsync(PutScriptRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<PutScriptRequest, PutScriptResponse, PutScriptRequestParameters>(request, cancellationToken);
 	}
 
-	public PutScriptResponse PutScript(Elastic.Clients.Elasticsearch.Id id)
+	public virtual PutScriptResponse PutScript(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new PutScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<PutScriptRequestDescriptor, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public PutScriptResponse PutScript(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor> configureRequest)
+	public virtual PutScriptResponse PutScript(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor> configureRequest)
 	{
 		var descriptor = new PutScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -1310,7 +1310,7 @@ public partial class ElasticsearchClient
 		return DoRequest<PutScriptRequestDescriptor, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public PutScriptResponse PutScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor<TDocument>> configureRequest)
+	public virtual PutScriptResponse PutScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new PutScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -1318,14 +1318,14 @@ public partial class ElasticsearchClient
 		return DoRequest<PutScriptRequestDescriptor<TDocument>, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public Task<PutScriptResponse> PutScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<PutScriptResponse> PutScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<PutScriptRequestDescriptor, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public Task<PutScriptResponse> PutScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutScriptResponse> PutScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -1333,7 +1333,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<PutScriptRequestDescriptor, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public Task<PutScriptResponse> PutScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<PutScriptResponse> PutScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<PutScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new PutScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -1341,26 +1341,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<PutScriptRequestDescriptor<TDocument>, PutScriptResponse, PutScriptRequestParameters>(descriptor);
 	}
 
-	public RankEvalResponse RankEval(RankEvalRequest request)
+	public virtual RankEvalResponse RankEval(RankEvalRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<RankEvalRequest, RankEvalResponse, RankEvalRequestParameters>(request);
 	}
 
-	public Task<RankEvalResponse> RankEvalAsync(RankEvalRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<RankEvalResponse> RankEvalAsync(RankEvalRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<RankEvalRequest, RankEvalResponse, RankEvalRequestParameters>(request, cancellationToken);
 	}
 
-	public RankEvalResponse RankEval()
+	public virtual RankEvalResponse RankEval()
 	{
 		var descriptor = new RankEvalRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<RankEvalRequestDescriptor, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public RankEvalResponse RankEval(Action<RankEvalRequestDescriptor> configureRequest)
+	public virtual RankEvalResponse RankEval(Action<RankEvalRequestDescriptor> configureRequest)
 	{
 		var descriptor = new RankEvalRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1368,7 +1368,7 @@ public partial class ElasticsearchClient
 		return DoRequest<RankEvalRequestDescriptor, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public RankEvalResponse RankEval<TDocument>(Action<RankEvalRequestDescriptor<TDocument>> configureRequest)
+	public virtual RankEvalResponse RankEval<TDocument>(Action<RankEvalRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new RankEvalRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1376,14 +1376,14 @@ public partial class ElasticsearchClient
 		return DoRequest<RankEvalRequestDescriptor<TDocument>, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public Task<RankEvalResponse> RankEvalAsync(CancellationToken cancellationToken = default)
+	public virtual Task<RankEvalResponse> RankEvalAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RankEvalRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<RankEvalRequestDescriptor, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public Task<RankEvalResponse> RankEvalAsync(Action<RankEvalRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<RankEvalResponse> RankEvalAsync(Action<RankEvalRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RankEvalRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1391,7 +1391,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<RankEvalRequestDescriptor, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public Task<RankEvalResponse> RankEvalAsync<TDocument>(Action<RankEvalRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<RankEvalResponse> RankEvalAsync<TDocument>(Action<RankEvalRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new RankEvalRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1399,26 +1399,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<RankEvalRequestDescriptor<TDocument>, RankEvalResponse, RankEvalRequestParameters>(descriptor);
 	}
 
-	public ReindexResponse Reindex(ReindexRequest request)
+	public virtual ReindexResponse Reindex(ReindexRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ReindexRequest, ReindexResponse, ReindexRequestParameters>(request);
 	}
 
-	public Task<ReindexResponse> ReindexAsync(ReindexRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexResponse> ReindexAsync(ReindexRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ReindexRequest, ReindexResponse, ReindexRequestParameters>(request, cancellationToken);
 	}
 
-	public ReindexResponse Reindex()
+	public virtual ReindexResponse Reindex()
 	{
 		var descriptor = new ReindexRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ReindexRequestDescriptor, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public ReindexResponse Reindex(Action<ReindexRequestDescriptor> configureRequest)
+	public virtual ReindexResponse Reindex(Action<ReindexRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ReindexRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1426,7 +1426,7 @@ public partial class ElasticsearchClient
 		return DoRequest<ReindexRequestDescriptor, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public ReindexResponse Reindex<TDocument>(Action<ReindexRequestDescriptor<TDocument>> configureRequest)
+	public virtual ReindexResponse Reindex<TDocument>(Action<ReindexRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ReindexRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1434,14 +1434,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ReindexRequestDescriptor<TDocument>, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public Task<ReindexResponse> ReindexAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ReindexResponse> ReindexAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ReindexRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ReindexRequestDescriptor, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public Task<ReindexResponse> ReindexAsync(Action<ReindexRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexResponse> ReindexAsync(Action<ReindexRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ReindexRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1449,7 +1449,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ReindexRequestDescriptor, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public Task<ReindexResponse> ReindexAsync<TDocument>(Action<ReindexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexResponse> ReindexAsync<TDocument>(Action<ReindexRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ReindexRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1457,26 +1457,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ReindexRequestDescriptor<TDocument>, ReindexResponse, ReindexRequestParameters>(descriptor);
 	}
 
-	public ReindexRethrottleResponse ReindexRethrottle(ReindexRethrottleRequest request)
+	public virtual ReindexRethrottleResponse ReindexRethrottle(ReindexRethrottleRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ReindexRethrottleRequest, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(request);
 	}
 
-	public Task<ReindexRethrottleResponse> ReindexRethrottleAsync(ReindexRethrottleRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexRethrottleResponse> ReindexRethrottleAsync(ReindexRethrottleRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ReindexRethrottleRequest, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(request, cancellationToken);
 	}
 
-	public ReindexRethrottleResponse ReindexRethrottle(Elastic.Clients.Elasticsearch.Id task_id)
+	public virtual ReindexRethrottleResponse ReindexRethrottle(Elastic.Clients.Elasticsearch.Id task_id)
 	{
 		var descriptor = new ReindexRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequest<ReindexRethrottleRequestDescriptor, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(descriptor);
 	}
 
-	public ReindexRethrottleResponse ReindexRethrottle(Elastic.Clients.Elasticsearch.Id task_id, Action<ReindexRethrottleRequestDescriptor> configureRequest)
+	public virtual ReindexRethrottleResponse ReindexRethrottle(Elastic.Clients.Elasticsearch.Id task_id, Action<ReindexRethrottleRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ReindexRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -1484,14 +1484,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ReindexRethrottleRequestDescriptor, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<ReindexRethrottleResponse> ReindexRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexRethrottleResponse> ReindexRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ReindexRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ReindexRethrottleRequestDescriptor, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<ReindexRethrottleResponse> ReindexRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, Action<ReindexRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ReindexRethrottleResponse> ReindexRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, Action<ReindexRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ReindexRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -1499,26 +1499,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ReindexRethrottleRequestDescriptor, ReindexRethrottleResponse, ReindexRethrottleRequestParameters>(descriptor);
 	}
 
-	public ScriptContextResponse GetScriptContext(ScriptContextRequest request)
+	public virtual ScriptContextResponse GetScriptContext(ScriptContextRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ScriptContextRequest, ScriptContextResponse, ScriptContextRequestParameters>(request);
 	}
 
-	public Task<ScriptContextResponse> GetScriptContextAsync(ScriptContextRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptContextResponse> GetScriptContextAsync(ScriptContextRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ScriptContextRequest, ScriptContextResponse, ScriptContextRequestParameters>(request, cancellationToken);
 	}
 
-	public ScriptContextResponse GetScriptContext()
+	public virtual ScriptContextResponse GetScriptContext()
 	{
 		var descriptor = new ScriptContextRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ScriptContextRequestDescriptor, ScriptContextResponse, ScriptContextRequestParameters>(descriptor);
 	}
 
-	public ScriptContextResponse GetScriptContext(Action<ScriptContextRequestDescriptor> configureRequest)
+	public virtual ScriptContextResponse GetScriptContext(Action<ScriptContextRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ScriptContextRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1526,14 +1526,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ScriptContextRequestDescriptor, ScriptContextResponse, ScriptContextRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptContextResponse> GetScriptContextAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ScriptContextResponse> GetScriptContextAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptContextRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ScriptContextRequestDescriptor, ScriptContextResponse, ScriptContextRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptContextResponse> GetScriptContextAsync(Action<ScriptContextRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptContextResponse> GetScriptContextAsync(Action<ScriptContextRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptContextRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1541,26 +1541,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ScriptContextRequestDescriptor, ScriptContextResponse, ScriptContextRequestParameters>(descriptor);
 	}
 
-	public ScriptLanguagesResponse GetScriptLanguages(ScriptLanguagesRequest request)
+	public virtual ScriptLanguagesResponse GetScriptLanguages(ScriptLanguagesRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ScriptLanguagesRequest, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(request);
 	}
 
-	public Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(ScriptLanguagesRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(ScriptLanguagesRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ScriptLanguagesRequest, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(request, cancellationToken);
 	}
 
-	public ScriptLanguagesResponse GetScriptLanguages()
+	public virtual ScriptLanguagesResponse GetScriptLanguages()
 	{
 		var descriptor = new ScriptLanguagesRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ScriptLanguagesRequestDescriptor, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(descriptor);
 	}
 
-	public ScriptLanguagesResponse GetScriptLanguages(Action<ScriptLanguagesRequestDescriptor> configureRequest)
+	public virtual ScriptLanguagesResponse GetScriptLanguages(Action<ScriptLanguagesRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ScriptLanguagesRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1568,14 +1568,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ScriptLanguagesRequestDescriptor, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(CancellationToken cancellationToken = default)
+	public virtual Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptLanguagesRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ScriptLanguagesRequestDescriptor, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(Action<ScriptLanguagesRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptLanguagesResponse> GetScriptLanguagesAsync(Action<ScriptLanguagesRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptLanguagesRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1583,26 +1583,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ScriptLanguagesRequestDescriptor, ScriptLanguagesResponse, ScriptLanguagesRequestParameters>(descriptor);
 	}
 
-	public ScriptResponse GetScript(ScriptRequest request)
+	public virtual ScriptResponse GetScript(ScriptRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ScriptRequest, ScriptResponse, ScriptRequestParameters>(request);
 	}
 
-	public Task<ScriptResponse> GetScriptAsync(ScriptRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptResponse> GetScriptAsync(ScriptRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ScriptRequest, ScriptResponse, ScriptRequestParameters>(request, cancellationToken);
 	}
 
-	public ScriptResponse GetScript(Elastic.Clients.Elasticsearch.Id id)
+	public virtual ScriptResponse GetScript(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new ScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequest<ScriptRequestDescriptor, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public ScriptResponse GetScript(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor> configureRequest)
+	public virtual ScriptResponse GetScript(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -1610,7 +1610,7 @@ public partial class ElasticsearchClient
 		return DoRequest<ScriptRequestDescriptor, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public ScriptResponse GetScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor<TDocument>> configureRequest)
+	public virtual ScriptResponse GetScript<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new ScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -1618,14 +1618,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ScriptRequestDescriptor<TDocument>, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptResponse> GetScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptResponse> GetScriptAsync(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptRequestDescriptor(id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ScriptRequestDescriptor, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptResponse> GetScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptResponse> GetScriptAsync(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptRequestDescriptor(id);
 		configureRequest?.Invoke(descriptor);
@@ -1633,7 +1633,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ScriptRequestDescriptor, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public Task<ScriptResponse> GetScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ScriptResponse> GetScriptAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<ScriptRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScriptRequestDescriptor<TDocument>(id);
 		configureRequest?.Invoke(descriptor);
@@ -1641,26 +1641,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ScriptRequestDescriptor<TDocument>, ScriptResponse, ScriptRequestParameters>(descriptor);
 	}
 
-	public ScrollResponse<TDocument> Scroll<TDocument>(ScrollRequest request)
+	public virtual ScrollResponse<TDocument> Scroll<TDocument>(ScrollRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<ScrollRequest, ScrollResponse<TDocument>, ScrollRequestParameters>(request);
 	}
 
-	public Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(ScrollRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(ScrollRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<ScrollRequest, ScrollResponse<TDocument>, ScrollRequestParameters>(request, cancellationToken);
 	}
 
-	public ScrollResponse<TDocument> Scroll<TDocument>()
+	public virtual ScrollResponse<TDocument> Scroll<TDocument>()
 	{
 		var descriptor = new ScrollRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<ScrollRequestDescriptor, ScrollResponse<TDocument>, ScrollRequestParameters>(descriptor);
 	}
 
-	public ScrollResponse<TDocument> Scroll<TDocument>(Action<ScrollRequestDescriptor> configureRequest)
+	public virtual ScrollResponse<TDocument> Scroll<TDocument>(Action<ScrollRequestDescriptor> configureRequest)
 	{
 		var descriptor = new ScrollRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1668,14 +1668,14 @@ public partial class ElasticsearchClient
 		return DoRequest<ScrollRequestDescriptor, ScrollResponse<TDocument>, ScrollRequestParameters>(descriptor);
 	}
 
-	public Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScrollRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<ScrollRequestDescriptor, ScrollResponse<TDocument>, ScrollRequestParameters>(descriptor);
 	}
 
-	public Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(Action<ScrollRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<ScrollResponse<TDocument>> ScrollAsync<TDocument>(Action<ScrollRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new ScrollRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1683,26 +1683,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<ScrollRequestDescriptor, ScrollResponse<TDocument>, ScrollRequestParameters>(descriptor);
 	}
 
-	public SearchResponse<TDocument> Search<TDocument>(SearchRequest request)
+	public virtual SearchResponse<TDocument> Search<TDocument>(SearchRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SearchRequest, SearchResponse<TDocument>, SearchRequestParameters>(request);
 	}
 
-	public Task<SearchResponse<TDocument>> SearchAsync<TDocument>(SearchRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SearchResponse<TDocument>> SearchAsync<TDocument>(SearchRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SearchRequest, SearchResponse<TDocument>, SearchRequestParameters>(request, cancellationToken);
 	}
 
-	public SearchResponse<TDocument> Search<TDocument>()
+	public virtual SearchResponse<TDocument> Search<TDocument>()
 	{
 		var descriptor = new SearchRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequest<SearchRequestDescriptor<TDocument>, SearchResponse<TDocument>, SearchRequestParameters>(descriptor);
 	}
 
-	public SearchResponse<TDocument> Search<TDocument>(Action<SearchRequestDescriptor<TDocument>> configureRequest)
+	public virtual SearchResponse<TDocument> Search<TDocument>(Action<SearchRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SearchRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1710,14 +1710,14 @@ public partial class ElasticsearchClient
 		return DoRequest<SearchRequestDescriptor<TDocument>, SearchResponse<TDocument>, SearchRequestParameters>(descriptor);
 	}
 
-	public Task<SearchResponse<TDocument>> SearchAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<SearchResponse<TDocument>> SearchAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SearchRequestDescriptor<TDocument>();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SearchRequestDescriptor<TDocument>, SearchResponse<TDocument>, SearchRequestParameters>(descriptor);
 	}
 
-	public Task<SearchResponse<TDocument>> SearchAsync<TDocument>(Action<SearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SearchResponse<TDocument>> SearchAsync<TDocument>(Action<SearchRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SearchRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1725,26 +1725,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<SearchRequestDescriptor<TDocument>, SearchResponse<TDocument>, SearchRequestParameters>(descriptor);
 	}
 
-	public SearchShardsResponse SearchShards(SearchShardsRequest request)
+	public virtual SearchShardsResponse SearchShards(SearchShardsRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SearchShardsRequest, SearchShardsResponse, SearchShardsRequestParameters>(request);
 	}
 
-	public Task<SearchShardsResponse> SearchShardsAsync(SearchShardsRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SearchShardsResponse> SearchShardsAsync(SearchShardsRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SearchShardsRequest, SearchShardsResponse, SearchShardsRequestParameters>(request, cancellationToken);
 	}
 
-	public SearchShardsResponse SearchShards()
+	public virtual SearchShardsResponse SearchShards()
 	{
 		var descriptor = new SearchShardsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequest<SearchShardsRequestDescriptor, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public SearchShardsResponse SearchShards(Action<SearchShardsRequestDescriptor> configureRequest)
+	public virtual SearchShardsResponse SearchShards(Action<SearchShardsRequestDescriptor> configureRequest)
 	{
 		var descriptor = new SearchShardsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1752,7 +1752,7 @@ public partial class ElasticsearchClient
 		return DoRequest<SearchShardsRequestDescriptor, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public SearchShardsResponse SearchShards<TDocument>(Action<SearchShardsRequestDescriptor<TDocument>> configureRequest)
+	public virtual SearchShardsResponse SearchShards<TDocument>(Action<SearchShardsRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SearchShardsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1760,14 +1760,14 @@ public partial class ElasticsearchClient
 		return DoRequest<SearchShardsRequestDescriptor<TDocument>, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public Task<SearchShardsResponse> SearchShardsAsync(CancellationToken cancellationToken = default)
+	public virtual Task<SearchShardsResponse> SearchShardsAsync(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SearchShardsRequestDescriptor();
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SearchShardsRequestDescriptor, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public Task<SearchShardsResponse> SearchShardsAsync(Action<SearchShardsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SearchShardsResponse> SearchShardsAsync(Action<SearchShardsRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SearchShardsRequestDescriptor();
 		configureRequest?.Invoke(descriptor);
@@ -1775,7 +1775,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<SearchShardsRequestDescriptor, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public Task<SearchShardsResponse> SearchShardsAsync<TDocument>(Action<SearchShardsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SearchShardsResponse> SearchShardsAsync<TDocument>(Action<SearchShardsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SearchShardsRequestDescriptor<TDocument>();
 		configureRequest?.Invoke(descriptor);
@@ -1783,26 +1783,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<SearchShardsRequestDescriptor<TDocument>, SearchShardsResponse, SearchShardsRequestParameters>(descriptor);
 	}
 
-	public SourceResponse<TDocument> GetSource<TDocument>(SourceRequest request)
+	public virtual SourceResponse<TDocument> GetSource<TDocument>(SourceRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<SourceRequest, SourceResponse<TDocument>, SourceRequestParameters>(request);
 	}
 
-	public Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(SourceRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(SourceRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<SourceRequest, SourceResponse<TDocument>, SourceRequestParameters>(request, cancellationToken);
 	}
 
-	public SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest)
+	public virtual SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -1810,14 +1810,14 @@ public partial class ElasticsearchClient
 		return DoRequest<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.Id id)
+	public virtual SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequest<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest)
+	public virtual SourceResponse<TDocument> GetSource<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -1825,14 +1825,14 @@ public partial class ElasticsearchClient
 		return DoRequest<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(index, id);
 		configureRequest?.Invoke(descriptor);
@@ -1840,14 +1840,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<SourceResponse<TDocument>> GetSourceAsync<TDocument>(Elastic.Clients.Elasticsearch.Id id, Action<SourceRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new SourceRequestDescriptor<TDocument>(typeof(TDocument), id);
 		configureRequest?.Invoke(descriptor);
@@ -1855,26 +1855,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<SourceRequestDescriptor<TDocument>, SourceResponse<TDocument>, SourceRequestParameters>(descriptor);
 	}
 
-	public TermsEnumResponse TermsEnum(TermsEnumRequest request)
+	public virtual TermsEnumResponse TermsEnum(TermsEnumRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<TermsEnumRequest, TermsEnumResponse, TermsEnumRequestParameters>(request);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync(TermsEnumRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync(TermsEnumRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<TermsEnumRequest, TermsEnumResponse, TermsEnumRequestParameters>(request, cancellationToken);
 	}
 
-	public TermsEnumResponse TermsEnum(Elastic.Clients.Elasticsearch.IndexName index)
+	public virtual TermsEnumResponse TermsEnum(Elastic.Clients.Elasticsearch.IndexName index)
 	{
 		var descriptor = new TermsEnumRequestDescriptor(index);
 		descriptor.BeforeRequest();
 		return DoRequest<TermsEnumRequestDescriptor, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public TermsEnumResponse TermsEnum(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor> configureRequest)
+	public virtual TermsEnumResponse TermsEnum(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor> configureRequest)
 	{
 		var descriptor = new TermsEnumRequestDescriptor(index);
 		configureRequest?.Invoke(descriptor);
@@ -1882,14 +1882,14 @@ public partial class ElasticsearchClient
 		return DoRequest<TermsEnumRequestDescriptor, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public TermsEnumResponse TermsEnum<TDocument>()
+	public virtual TermsEnumResponse TermsEnum<TDocument>()
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(typeof(TDocument));
 		descriptor.BeforeRequest();
 		return DoRequest<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public TermsEnumResponse TermsEnum<TDocument>(Action<TermsEnumRequestDescriptor<TDocument>> configureRequest)
+	public virtual TermsEnumResponse TermsEnum<TDocument>(Action<TermsEnumRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(typeof(TDocument));
 		configureRequest?.Invoke(descriptor);
@@ -1897,7 +1897,7 @@ public partial class ElasticsearchClient
 		return DoRequest<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public TermsEnumResponse TermsEnum<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor<TDocument>> configureRequest)
+	public virtual TermsEnumResponse TermsEnum<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(index);
 		configureRequest?.Invoke(descriptor);
@@ -1905,14 +1905,14 @@ public partial class ElasticsearchClient
 		return DoRequest<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync(Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync(Elastic.Clients.Elasticsearch.IndexName index, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TermsEnumRequestDescriptor(index);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<TermsEnumRequestDescriptor, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TermsEnumRequestDescriptor(index);
 		configureRequest?.Invoke(descriptor);
@@ -1920,14 +1920,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<TermsEnumRequestDescriptor, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync<TDocument>(CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(typeof(TDocument));
 		descriptor.BeforeRequest();
 		return DoRequestAsync<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync<TDocument>(Action<TermsEnumRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync<TDocument>(Action<TermsEnumRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(typeof(TDocument));
 		configureRequest?.Invoke(descriptor);
@@ -1935,7 +1935,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public Task<TermsEnumResponse> TermsEnumAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<TermsEnumResponse> TermsEnumAsync<TDocument>(Elastic.Clients.Elasticsearch.IndexName index, Action<TermsEnumRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new TermsEnumRequestDescriptor<TDocument>(index);
 		configureRequest?.Invoke(descriptor);
@@ -1943,26 +1943,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<TermsEnumRequestDescriptor<TDocument>, TermsEnumResponse, TermsEnumRequestParameters>(descriptor);
 	}
 
-	public UpdateByQueryResponse UpdateByQuery(UpdateByQueryRequest request)
+	public virtual UpdateByQueryResponse UpdateByQuery(UpdateByQueryRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<UpdateByQueryRequest, UpdateByQueryResponse, UpdateByQueryRequestParameters>(request);
 	}
 
-	public Task<UpdateByQueryResponse> UpdateByQueryAsync(UpdateByQueryRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryResponse> UpdateByQueryAsync(UpdateByQueryRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<UpdateByQueryRequest, UpdateByQueryResponse, UpdateByQueryRequestParameters>(request, cancellationToken);
 	}
 
-	public UpdateByQueryResponse UpdateByQuery(Elastic.Clients.Elasticsearch.Indices indices)
+	public virtual UpdateByQueryResponse UpdateByQuery(Elastic.Clients.Elasticsearch.Indices indices)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequest<UpdateByQueryRequestDescriptor, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public UpdateByQueryResponse UpdateByQuery(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor> configureRequest)
+	public virtual UpdateByQueryResponse UpdateByQuery(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor> configureRequest)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1970,7 +1970,7 @@ public partial class ElasticsearchClient
 		return DoRequest<UpdateByQueryRequestDescriptor, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public UpdateByQueryResponse UpdateByQuery<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor<TDocument>> configureRequest)
+	public virtual UpdateByQueryResponse UpdateByQuery<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor<TDocument>> configureRequest)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1978,14 +1978,14 @@ public partial class ElasticsearchClient
 		return DoRequest<UpdateByQueryRequestDescriptor<TDocument>, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateByQueryResponse> UpdateByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryResponse> UpdateByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor(indices);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<UpdateByQueryRequestDescriptor, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateByQueryResponse> UpdateByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryResponse> UpdateByQueryAsync(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor(indices);
 		configureRequest?.Invoke(descriptor);
@@ -1993,7 +1993,7 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<UpdateByQueryRequestDescriptor, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateByQueryResponse> UpdateByQueryAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryResponse> UpdateByQueryAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices indices, Action<UpdateByQueryRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateByQueryRequestDescriptor<TDocument>(indices);
 		configureRequest?.Invoke(descriptor);
@@ -2001,26 +2001,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<UpdateByQueryRequestDescriptor<TDocument>, UpdateByQueryResponse, UpdateByQueryRequestParameters>(descriptor);
 	}
 
-	public UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(UpdateByQueryRethrottleRequest request)
+	public virtual UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(UpdateByQueryRethrottleRequest request)
 	{
 		request.BeforeRequest();
 		return DoRequest<UpdateByQueryRethrottleRequest, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(request);
 	}
 
-	public Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(UpdateByQueryRethrottleRequest request, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(UpdateByQueryRethrottleRequest request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<UpdateByQueryRethrottleRequest, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(request, cancellationToken);
 	}
 
-	public UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(Elastic.Clients.Elasticsearch.Id task_id)
+	public virtual UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(Elastic.Clients.Elasticsearch.Id task_id)
 	{
 		var descriptor = new UpdateByQueryRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequest<UpdateByQueryRethrottleRequestDescriptor, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(Elastic.Clients.Elasticsearch.Id task_id, Action<UpdateByQueryRethrottleRequestDescriptor> configureRequest)
+	public virtual UpdateByQueryRethrottleResponse UpdateByQueryRethrottle(Elastic.Clients.Elasticsearch.Id task_id, Action<UpdateByQueryRethrottleRequestDescriptor> configureRequest)
 	{
 		var descriptor = new UpdateByQueryRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -2028,14 +2028,14 @@ public partial class ElasticsearchClient
 		return DoRequest<UpdateByQueryRethrottleRequestDescriptor, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateByQueryRethrottleRequestDescriptor(task_id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<UpdateByQueryRethrottleRequestDescriptor, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, Action<UpdateByQueryRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateByQueryRethrottleResponse> UpdateByQueryRethrottleAsync(Elastic.Clients.Elasticsearch.Id task_id, Action<UpdateByQueryRethrottleRequestDescriptor> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateByQueryRethrottleRequestDescriptor(task_id);
 		configureRequest?.Invoke(descriptor);
@@ -2043,26 +2043,26 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<UpdateByQueryRethrottleRequestDescriptor, UpdateByQueryRethrottleResponse, UpdateByQueryRethrottleRequestParameters>(descriptor);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(UpdateRequest<TDocument, TPartialDocument> request)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(UpdateRequest<TDocument, TPartialDocument> request)
 	{
 		request.BeforeRequest();
 		return DoRequest<UpdateRequest<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(request);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(UpdateRequest<TDocument, TPartialDocument> request, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(UpdateRequest<TDocument, TPartialDocument> request, CancellationToken cancellationToken = default)
 	{
 		request.BeforeRequest();
 		return DoRequestAsync<UpdateRequest<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(request, cancellationToken);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document, index, id);
 		descriptor.BeforeRequest();
 		return DoRequest<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document, index, id);
 		configureRequest?.Invoke(descriptor);
@@ -2070,14 +2070,14 @@ public partial class ElasticsearchClient
 		return DoRequest<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequest<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
+	public virtual UpdateResponse<TDocument> Update<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document);
 		configureRequest?.Invoke(descriptor);
@@ -2085,14 +2085,14 @@ public partial class ElasticsearchClient
 		return DoRequest<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document, index, id);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Elastic.Clients.Elasticsearch.IndexName index, Elastic.Clients.Elasticsearch.Id id, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document, index, id);
 		configureRequest?.Invoke(descriptor);
@@ -2100,14 +2100,14 @@ public partial class ElasticsearchClient
 		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<UpdateRequestDescriptor<TDocument, TPartialDocument>, UpdateResponse<TDocument>, UpdateRequestParameters>(descriptor);
 	}
 
-	public Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
+	public virtual Task<UpdateResponse<TDocument>> UpdateAsync<TDocument, TPartialDocument>(TDocument document, TPartialDocument partialDocument, Action<UpdateRequestDescriptor<TDocument, TPartialDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new UpdateRequestDescriptor<TDocument, TPartialDocument>(document);
 		configureRequest?.Invoke(descriptor);

--- a/src/Playground/Playground.csproj
+++ b/src/Playground/Playground.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/src/Playground/packages.lock.json
+++ b/src/Playground/packages.lock.json
@@ -23,11 +23,28 @@
           "Microsoft.NETFramework.ReferenceAssemblies.net461": "1.0.3"
         }
       },
+      "Moq": {
+        "type": "Direct",
+        "requested": "[4.18.2, )",
+        "resolved": "4.18.2",
+        "contentHash": "SjxKYS5nX6prcaT8ZjbkONh3vnh0Rxru09+gQ1a07v4TM530Oe/jq3Q4dOZPfo1wq0LYmTgLOZKrqRfEx4auPw==",
+        "dependencies": {
+          "Castle.Core": "5.1.0"
+        }
+      },
       "Newtonsoft.Json": {
         "type": "Direct",
         "requested": "[13.0.1, )",
         "resolved": "13.0.1",
         "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "Castle.Core": {
+        "type": "Transitive",
+        "resolved": "5.1.0",
+        "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
+        "dependencies": {
+          "System.Diagnostics.EventLog": "6.0.0"
+        }
       },
       "Elastic.Transport": {
         "type": "Transitive",
@@ -105,6 +122,11 @@
         "type": "Transitive",
         "resolved": "5.0.1",
         "contentHash": "uXQEYqav2V3zP6OwkOKtLv+qIi6z3m1hsGyKwXX7ZA7htT4shoVccGxnJ9kVRFPNAsi1ArZTq2oh7WOto6GbkQ=="
+      },
+      "System.Diagnostics.EventLog": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "lcyUiXTsETK2ALsZrX+nWuHSIQeazhqPphLfaRxzdGaG93+0kELqpgEHtwWOlQe7+jSFnKwaCAgL4kjeZCQJnw=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",

--- a/src/PlaygroundV7x/PlaygroundV7x.csproj
+++ b/src/PlaygroundV7x/PlaygroundV7x.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NEST" Version="7.17.4" />
+    <PackageReference Include="NEST" Version="7.17.5" />
   </ItemGroup>
 
 </Project>

--- a/src/PlaygroundV7x/packages.lock.json
+++ b/src/PlaygroundV7x/packages.lock.json
@@ -25,17 +25,17 @@
       },
       "NEST": {
         "type": "Direct",
-        "requested": "[7.17.4, )",
-        "resolved": "7.17.4",
-        "contentHash": "FFz357NTG4P+4cnclVZ4I7bpZp0oNYZ3Dk88IzZ2NEttaxzFSI7+C7yF93y9Jg5myNwiStI+/tppwNut8M85Lw==",
+        "requested": "[7.17.5, )",
+        "resolved": "7.17.5",
+        "contentHash": "bo9UyuIoVRx4IUQiuC8ZrlZuvAXKIccernC7UUKukQCEmRq2eVIk+gubHlnMQljrP51q0mN4cjgy9vv5uZPkoA==",
         "dependencies": {
-          "Elasticsearch.Net": "7.17.4"
+          "Elasticsearch.Net": "7.17.5"
         }
       },
       "Elasticsearch.Net": {
         "type": "Transitive",
-        "resolved": "7.17.4",
-        "contentHash": "5SIkngYAzsHhLLaj9fSmoTAZXARkKLUbvSzSdtZiNRdDxVPQjJgCT2q1FaSyTqRsWhh5zS5yhUUTL/CIKv2irA==",
+        "resolved": "7.17.5",
+        "contentHash": "orChsQi1Ceho/NyIylNOn6y4vuGcsbCfMZnCueNN0fzqYEGQmQdPfcVmsR5+3fwpXTgxCdjTUVmqOwvHpCSB+Q==",
         "dependencies": {
           "Microsoft.CSharp": "4.6.0",
           "System.Buffers": "4.5.1",

--- a/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
+++ b/tests/Tests.ClusterLauncher/Tests.ClusterLauncher.csproj
@@ -2,6 +2,7 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <CheckEolTargetFramework>false</CheckEolTargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Tests.Core\Tests.Core.csproj" />


### PR DESCRIPTION
Improves user testing in scenarios where no consumer abstraction exists.