### PR TITLE
[8.4] [DOCS] Changes hero image to contain .NET logo

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -69,7 +69,7 @@
       </p>
     </div>
     <div class="col-md-6 col-12">
-      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/blt26ff619caf69bb16/6422f874200d46108081fcef/ES_.NET_landing_page.png" />
+      <img class="w-100" src="https://images.contentstack.io/v3/assets/bltefdd0b53724fa2ce/bltc51b0fd4ec244fb0/64256da1ef8a60117ad7468b/ES_.NET_landing_page.png" />
     </div>
   </div>
 


### PR DESCRIPTION
# Backport

This will backport the following commits from `main` to `8.4`:
 - [[DOCS] Changes hero image to contain .NET logo](https://github.com/elastic/elasticsearch-net/pull/7507)

<!--- Backport version: 8.9.7 -->

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sqren/backport)