### PR TITLE
Made ElasticsearchClient disposable, disposed of activity source

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
+++ b/src/Elastic.Clients.Elasticsearch/Client/ElasticsearchClient.cs
@@ -18,7 +18,7 @@ namespace Elastic.Clients.Elasticsearch;
 /// <summary>
 /// A strongly-typed client for communicating with Elasticsearch server endpoints.
 /// </summary>
-public partial class ElasticsearchClient
+public partial class ElasticsearchClient : IDisposable
 {
 	private readonly HttpTransport<IElasticsearchClientSettings> _transport;
 
@@ -563,5 +563,12 @@ public partial class ElasticsearchClient
 	{
 		requestConfiguration.Accept = RequestData.MimeTypeTextPlain;
 		requestConfiguration.ContentType = RequestData.MimeTypeTextPlain;
+	}
+
+	public void Dispose()
+	{
+		_activitySource.Dispose(); 
+		GC.SuppressFinalize(this);
+
 	}
 }


### PR DESCRIPTION
In high throughput applications the ActivitySource does not get disposed of properly. By adding IDisposable to the ElasticsearchClient, this can hopefully be remedied.