### PR TITLE
No allocations in `ResponseItem.IsValid` property

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Api/ResponseItem.cs
+++ b/src/Elastic.Clients.Elasticsearch/Api/ResponseItem.cs
@@ -2,6 +2,8 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System;
+
 namespace Elastic.Clients.Elasticsearch.Core.Bulk;
 
 public abstract partial class ResponseItem
@@ -15,12 +17,19 @@ public abstract partial class ResponseItem
 			if (Error is not null)
 				return false;
 
-			return Operation.ToLowerInvariant() switch
+			var operation = Operation;
+
+			if (operation.Equals("delete", StringComparison.OrdinalIgnoreCase))
+				return Status is 200 or 404;
+
+			if (operation.Equals("create", StringComparison.OrdinalIgnoreCase) ||
+				operation.Equals("update", StringComparison.OrdinalIgnoreCase) ||
+				operation.Equals("index", StringComparison.OrdinalIgnoreCase))
 			{
-				"delete" => Status == 200 || Status == 404,
-				"update" or "index" or "create" => Status == 200 || Status == 201,
-				_ => false,
-			};
+				return Status is 200 or 201;
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
`ToLower`/`ToUpper` methods are allocating which isn't good for properties which imply performance and no allocations (lazy is fine, but not repeating as here). For `Status` check I used `is` keyword which under the hood creates a local variable. That's not necessary since `Status` is a simple property with a backing field and JIT would be happy to read its value once into a register (different on .NET Fx). So let's think about it as a compensation for added lines by removing a some characters.