### PR TITLE
Fixed the equality contract on Metrics type

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
@@ -70,7 +70,16 @@ public sealed class Metrics : IEquatable<Metrics>, IUrlParameter
 	}
 
 	/// <inheritdoc />
-	public override int GetHashCode() => Values != null ? Values.GetHashCode() : 0;
+	public override int GetHashCode()
+	{
+		// Lifting the minimal target framework to .NET Standard 2.1
+		// would be the best solution ever due to the HashCode type.
+		var hashCode = 0;
+		foreach (var metric in Values)
+			hashCode ^= metric.GetHashCode();
+
+		return hashCode;
+	}
 
 	public static bool operator ==(Metrics left, Metrics right) => Equals(left, right);
 	public static bool operator !=(Metrics left, Metrics right) => !Equals(left, right);

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
@@ -4,7 +4,6 @@
 
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using Elastic.Transport;
 
 namespace Elastic.Clients.Elasticsearch;
@@ -53,8 +52,8 @@ public sealed class Metrics : IEquatable<Metrics>, IUrlParameter
 	{
 		if (other is null) return false;
 
-		// Equality is true when the metrics names in both instances are equal, regardless of their order in the set.
-		return Values.OrderBy(t => t).SequenceEqual(other.Values.OrderBy(t => t));
+		// Equality is true when both instances have the same metric names.
+		return Values.SetEquals(other.Values);
 	}
 
 	string IUrlParameter.GetString(ITransportConfiguration settings) => GetString();

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Metric/Metrics.cs
@@ -76,7 +76,7 @@ public sealed class Metrics : IEquatable<Metrics>, IUrlParameter
 		// would be the best solution ever due to the HashCode type.
 		var hashCode = 0;
 		foreach (var metric in Values)
-			hashCode ^= metric.GetHashCode();
+			hashCode = (hashCode * 397) ^ metric.GetHashCode();
 
 		return hashCode;
 	}


### PR DESCRIPTION
`HashSet<T>` doesn't override `GetHashCode`. Therefore, the default provided algorithm for reference types is used which doesn't take fields into account as it happens for value types. That breaks the equality contracts on Metrics.

Ideally `HashCode` type should be used for more correct computations with less number of collisions, but that requires increasing the minimal target framework.

`SetEqual` is available since .NET Fx 3.5 and is destined for equality comparison of two different hash set instances. Since both instances of the `Metrics` type has the same default comparer, the method works as a sugar over a length check followed by iteration over one set and probing the second one for containing the current element through the `Contains` method.