### PR TITLE
Removed unused `JsonIgnore`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/Field.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/Field.cs
@@ -73,7 +73,6 @@ public sealed class Field : IEquatable<Field>, IUrlParameter
 	/// </remarks>
 	public string? Format { get; set; }
 
-	[JsonIgnore]
 	internal bool CachableExpression { get; }
 
 	/// <summary>


### PR DESCRIPTION
Since the `Field` type has a JSON converter specified through an attribute, member attributes are ignored. Therefore, `JsonIgnore` has no effect at all and can be removed.