### PR TITLE
Optimized `FieldConverter`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
@@ -96,10 +96,8 @@ internal sealed class FieldConverter : JsonConverter<Field>
 		else
 		{
 			writer.WriteStartObject();
-			writer.WritePropertyName(FieldProperty);
-			writer.WriteStringValue(fieldName);
-			writer.WritePropertyName(FormatProperty);
-			writer.WriteStringValue(value.Format);
+			writer.WriteString(FieldProperty, fieldName);
+			writer.WriteString(FormatProperty, value.Format);
 			writer.WriteEndObject();
 		}
 	}

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
@@ -12,6 +12,9 @@ namespace Elastic.Clients.Elasticsearch;
 
 internal sealed class FieldConverter : JsonConverter<Field>
 {
+	private static readonly JsonEncodedText FieldProperty = JsonEncodedText.Encode("field");
+	private static readonly JsonEncodedText FormatProperty = JsonEncodedText.Encode("format");
+
 	private IElasticsearchClientSettings _settings;
 
 	public override void WriteAsPropertyName(Utf8JsonWriter writer, Field value, JsonSerializerOptions options)
@@ -51,16 +54,17 @@ internal sealed class FieldConverter : JsonConverter<Field>
 				var propertyName = reader.GetString();
 				reader.Read();
 
-				switch (propertyName)
+				if (reader.ValueTextEquals(FieldProperty.EncodedUtf8Bytes))
 				{
-					case "field":
-						field = reader.GetString();
-						break;
-					case "format":
-						format = reader.GetString();
-						break;
-					default:
-						throw new JsonException("Unexpected property while reading `Field`.");
+					field = reader.GetString();
+				}
+				else if (reader.ValueTextEquals(FormatProperty.EncodedUtf8Bytes))
+				{
+					format = reader.GetString();
+				}
+				else
+				{
+					throw new JsonException("Unexpected property while reading `Field`.");
 				}
 			}
 		}
@@ -92,9 +96,9 @@ internal sealed class FieldConverter : JsonConverter<Field>
 		else
 		{
 			writer.WriteStartObject();
-			writer.WritePropertyName("field");
+			writer.WritePropertyName(FieldProperty);
 			writer.WriteStringValue(fieldName);
-			writer.WritePropertyName("format");
+			writer.WritePropertyName(FormatProperty);
 			writer.WriteStringValue(value.Format);
 			writer.WriteEndObject();
 		}

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
@@ -81,12 +81,6 @@ internal sealed class FieldConverter : JsonConverter<Field>
 	{
 		InitializeSettings(options);
 
-		if (value is null)
-		{
-			writer.WriteNullValue();
-			return;
-		}
-
 		var fieldName = _settings.Inferrer.Field(value);
 
 		if (string.IsNullOrEmpty(value.Format))

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
@@ -51,15 +51,14 @@ internal sealed class FieldConverter : JsonConverter<Field>
 		{
 			if (reader.TokenType == JsonTokenType.PropertyName)
 			{
-				var propertyName = reader.GetString();
-				reader.Read();
-
 				if (reader.ValueTextEquals(FieldProperty.EncodedUtf8Bytes))
 				{
+					reader.Read();
 					field = reader.GetString();
 				}
 				else if (reader.ValueTextEquals(FormatProperty.EncodedUtf8Bytes))
 				{
+					reader.Read();
 					format = reader.GetString();
 				}
 				else

--- a/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/Infer/Field/FieldConverter.cs
@@ -64,7 +64,7 @@ internal sealed class FieldConverter : JsonConverter<Field>
 				}
 				else
 				{
-					throw new JsonException("Unexpected property while reading `Field`.");
+					throw new JsonException($"Unexpected property while reading `{nameof(Field)}`.");
 				}
 			}
 		}
@@ -74,7 +74,7 @@ internal sealed class FieldConverter : JsonConverter<Field>
 			return new Field(field, format);
 		}
 
-		throw new JsonException("Unable to read `Field` from JSON.");
+		throw new JsonException($"Unable to read `{nameof(Field)}` from JSON.");
 	}
 
 	public override void Write(Utf8JsonWriter writer, Field value, JsonSerializerOptions options)


### PR DESCRIPTION
This pull request has three commits:

1. Optimizes read and writes using prencoded property names:
1.1. Reading doesn't allocate and decode a JSON property name.
1.2. Writing doesn't encode property names.
2. Writing has two length checks less, one for each property name write since there's a limit for non-encoded literals.
3. Since any interpolated string using static values is preprocessed and turned into a constant string type names where replaced by `nameof(Field)` expressions.
4. `null` values are handled by the writer itself ([see this](https://github.com/dotnet/runtime/blob/bdf5df39c4749dd88cf45de008f9f3c2d5905fba/src/libraries/System.Text.Json/src/System/Text/Json/Serialization/JsonConverterOfT.cs#L188-L189)).