### PR TITLE
 Number converters should not fall through and throw exceptions in non NETCore builds

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Serialization/DoubleWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/DoubleWithFractionalPortionConverter.cs
@@ -75,6 +75,7 @@ internal sealed class DoubleWithFractionalPortionConverter : JsonConverter<doubl
 				if (bytes.Length < utf8bytes.Length)
 				{
 					bytes.CopyTo(utf8bytes);
+					return;
 				}
 			}
 			catch

--- a/src/Elastic.Clients.Elasticsearch/Serialization/FloatWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/FloatWithFractionalPortionConverter.cs
@@ -75,6 +75,7 @@ internal sealed class FloatWithFractionalPortionConverter : JsonConverter<float>
 				if (bytes.Length < utf8bytes.Length)
 				{
 					bytes.CopyTo(utf8bytes);
+					return;
 				}
 			}
 			catch


### PR DESCRIPTION
In both `DoubleWithFractionalPortionConverter` and `FloatWithFractionalPortionConverter`, when building for non NETCore there is a missing `return` statement that makes the code always fall through into `ThrowHelper.ThrowJsonException($"Unable to serialize float value.");`

This fix just adds the missing `return` statements. I can't find that tests are run for net4x (which I guess is how this was unnoticed) so I haven't tried adding any new tests to cover this case.

Fixes #7757