### PR TITLE
[DOCS] Changes getting started button link on landing page

### DIFF
--- a/docs/index-custom-title-page.html
+++ b/docs/index-custom-title-page.html
@@ -63,7 +63,7 @@
         The official .NET client provides one-to-one mapping with Elasticsearch REST APIs.
       </p>
       <p>
-        <a href="https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/introduction.html">
+        <a href="https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/getting-started-net.html">
           <button class="btn btn-primary">Get started</button>
         </a>
       </p>


### PR DESCRIPTION
## Overview

This PR changes the URL of the getting started button on the landing page.

Can be merged after https://github.com/elastic/elasticsearch-net/pull/7767 and https://github.com/elastic/elasticsearch-net/pull/7766.