### PR TITLE
Fix localization issue with floating-point deserialization from string

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Serialization/DoubleWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/DoubleWithFractionalPortionConverter.cs
@@ -25,7 +25,7 @@ internal sealed class DoubleWithFractionalPortionConverter : JsonConverter<doubl
 		{
 			var value = reader.GetString();
 
-			if (!double.TryParse(value, out var parsedValue))
+			if (!double.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedValue))
 				ThrowHelper.ThrowJsonException($"Unable to parse '{value}' as a double.");
 
 			return parsedValue;
@@ -67,7 +67,7 @@ internal sealed class DoubleWithFractionalPortionConverter : JsonConverter<doubl
 		var utf16Text = value.ToString("G17", CultureInfo.InvariantCulture);
 
 		if (utf16Text.Length < utf8bytes.Length)
-        {
+		{
 			try
 			{
 				var bytes = Encoding.UTF8.GetBytes(utf16Text);

--- a/src/Elastic.Clients.Elasticsearch/Serialization/FloatWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/Serialization/FloatWithFractionalPortionConverter.cs
@@ -25,7 +25,7 @@ internal sealed class FloatWithFractionalPortionConverter : JsonConverter<float>
 		{
 			var value = reader.GetString();
 
-			if (!float.TryParse(value, out var parsedValue))
+			if (!float.TryParse(value, NumberStyles.Any, CultureInfo.InvariantCulture, out var parsedValue))
 				ThrowHelper.ThrowJsonException($"Unable to parse '{value}' as a float.");
 
 			return parsedValue;
@@ -67,7 +67,7 @@ internal sealed class FloatWithFractionalPortionConverter : JsonConverter<float>
 		var utf16Text = value.ToString("G9", CultureInfo.InvariantCulture);
 
 		if (utf16Text.Length < utf8bytes.Length)
-        {
+		{
 			try
 			{
 				var bytes = Encoding.UTF8.GetBytes(utf16Text);


### PR DESCRIPTION
Fixes deserialization of "floating-point strings" on machines with German localization:

```
 FAIL  Tests.Serialization.SourceSerializationForNumericPropertiesTests.DoubleAsString_DeserializesCorrectly
       Expected deserialized.Double to be 1.0, but found 10.0.
..........................................................................
 FAIL  Tests.Common.Fields.FieldValueTests.CanSerialize_DoubleFieldValueKind
       Expected result.FieldValue.ToString() to be "1.1", but "1,1" differs near ",1" (index 1).
```