### PR TITLE
[DOCS] Includes 8.10.0 release note file in index

### DIFF
--- a/docs/release-notes/release-notes.asciidoc
+++ b/docs/release-notes/release-notes.asciidoc
@@ -40,6 +40,7 @@
 * <<release-notes-8.0.0,Release notes v8.0.0>>
 
 include::breaking-change-policy.asciidoc[]
+include::release-notes-8.10.0.asciidoc[]
 include::release-notes-8.9.3.asciidoc[]
 include::release-notes-8.9.2.asciidoc[]
 include::release-notes-8.9.1.asciidoc[]


### PR DESCRIPTION
## Overview

This PR adds the `release-notes-8.10.0` file to the list of included files in the `release-notes.asciidoc` index to fix a broken docs build.