### PR TITLE
[DOCS] Adds compatibility matrix to the docs and readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the new features of the 8.13 version of Elasticsearch, the 8.13 client version
 is required for that. Elasticsearch language clients are only backwards
 compatible with default distributions and without guarantees made.
 
-| Elasticsearch Version | Elasticsearch-Java Branch | Supported |
+| Elasticsearch Version | Elasticsearch-NET Branch | Supported |
 | --------------------- | ------------------------- | --------- |
 | main                  | main                      |           |
 | 8.x                   | 8.x                       | 8.x       |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the new features of the 8.13 version of Elasticsearch, the 8.13 client version
 is required for that. Elasticsearch language clients are only backwards
 compatible with default distributions and without guarantees made.
 
-| Elasticsearch Version | Elasticsearch-NET Branch | Supported |
+| Elasticsearch Version | Elasticsearch-NET Branch  | Supported |
 | --------------------- | ------------------------- | --------- |
 | main                  | main                      |           |
 | 8.x                   | 8.x                       | 8.x       |

--- a/README.md
+++ b/README.md
@@ -17,10 +17,20 @@ The .NET client for Elasticsearch provides strongly typed requests and responses
 
 ## Compatibility
 
-Language clients are forward compatible; meaning that clients support
-communicating with greater or equal minor versions of Elasticsearch.
-Elasticsearch language clients are only backwards compatible with default
-distributions and without guarantees made.
+Language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of Elasticsearch without
+breaking. It does not mean that the clients automatically support new features
+of newer Elasticsearch versions; it is only possible after a release of a new
+client version. For example, a 8.12 client version won't automatically support
+the new features of the 8.13 version of Elasticsearch, the 8.13 client version
+is required for that. Elasticsearch language clients are only backwards
+compatible with default distributions and without guarantees made.
+
+| Elasticsearch Version | Elasticsearch-Java Branch | Supported |
+| --------------------- | ------------------------- | --------- |
+| main                  | main                      |           |
+| 8.x                   | 8.x                       | 8.x       |
+| 7.x                   | 7.x                       | 7.17      |
 
 ## Installation
 

--- a/docs/install.asciidoc
+++ b/docs/install.asciidoc
@@ -58,12 +58,25 @@ To learn how to connect the {es} client, refer to the <<connecting,Connecting>> 
 === Compatibility
 
 The {es} client is compatible with currently maintained .NET runtime versions. 
-Compatibility with End of Life (EOL) .NET runtimes is not guaranteed or supported.
+Compatibility with End of Life (EOL) .NET runtimes is not guaranteed or
+supported.
 
-Language clients are forward compatible; meaning that clients support 
-communicating with greater or equal minor versions of {es}. {es} language 
-clients are only backward compatible with default distributions and without 
-guarantees made.
+Language clients are forward compatible; meaning that the clients support
+communicating with greater or equal minor versions of {es} without breaking. It
+does not mean that the clients automatically support new features of newer
+{es} versions; it is only possible after a release of a new client version. For
+example, a 8.12 client version won't automatically support the new features of
+the 8.13 version of {es}, the 8.13 client version is required for that. {es}
+language clients are only backwards compatible with default distributions and
+without guarantees made.
+
+|===
+| Elasticsearch Version | Elasticsearch-NET Branch   | Supported
+
+| main                  | main                      | 
+| 8.x                   | 8.x                       | 8.x
+| 7.x                   | 7.x                       | 7.17
+|===
 
 Refer to the https://www.elastic.co/support/eol[end-of-life policy] for more 
 information.

--- a/docs/install.asciidoc
+++ b/docs/install.asciidoc
@@ -71,7 +71,7 @@ language clients are only backwards compatible with default distributions and
 without guarantees made.
 
 |===
-| Elasticsearch Version | Elasticsearch-NET Branch   | Supported
+| Elasticsearch Version | Elasticsearch-NET Branch  | Supported
 
 | main                  | main                      | 
 | 8.x                   | 8.x                       | 8.x


### PR DESCRIPTION
## Overview

This PR adds a compatibility matrix to the Installation section of the .NET book and the repo readme.

### Preview

[Compatibility](https://elasticsearch-net_bk_8045.docs-preview.app.elstc.co/guide/en/elasticsearch/client/net-api/master/installation.html#compatibility)