### PR TITLE
Add basic CD workflow

### DIFF
--- a/.github/.editorconfig
+++ b/.github/.editorconfig
@@ -1,0 +1,83 @@
+### Header #########################################################################################
+
+# Author: Florian Bernd
+
+### Common Settings ################################################################################
+
+# Documentation:
+# http://docs.editorconfig.org/en/master/editorconfig-format.html
+
+# This file is the top-most EditorConfig file
+root = false
+
+### All Files --------------------------------------------------------------------------------------
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+### File Extension Settings ------------------------------------------------------------------------
+
+# XML Configuration Files
+[*.{xml,config}]
+indent_size = 2
+
+# JSON Files
+[*.{json,json5,webmanifest}]
+indent_size = 2
+
+# YAML Files
+[*.{yml,yaml}]
+indent_size = 2
+
+# Markdown Files
+[*.{md,mdx}]
+indent_size = 2
+trim_trailing_whitespace = false
+
+# Web Files
+[*.{htm,html,js,jsm,jsx,ts,tsx,cjs,cts,ctsx,mjs,mts,mtsx,css,sass,scss,less,pcss,svg,vue}]
+indent_size = 2
+
+# Batch Scripts
+[*.{bat,cmd,ps1}]
+end_of_line = crlf
+
+# Bash Scripts
+[*.{bash,fish,sh,zsh}]
+end_of_line = lf
+
+# Makefiles
+[Makefile]
+indent_style = tab
+
+### ------------------------------------------------------------------------------------------------
+
+### License ########################################################################################
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Florian Bernd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+####################################################################################################

--- a/.github/.gitattributes
+++ b/.github/.gitattributes
@@ -1,0 +1,106 @@
+### Header #########################################################################################
+
+# Author: Florian Bernd
+
+### Git Line Endings ###############################################################################
+
+# Set default behavior to automatically normalize line endings
+* text=auto
+
+# Documents
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yml      text linguist-language=YAML linguist-detectable -linguist-vendored
+*.yaml     text linguist-language=YAML linguist-detectable -linguist-vendored
+
+# Graphics
+*.eps      binary
+*.gif      binary
+*.ico      binary
+*.jpg      binary
+*.jpeg     binary
+*.png      binary
+*.tif      binary
+*.tiff     binary
+
+# Force batch scripts to always use CRLF line endings
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Force bash scripts to always use LF line endings
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+### TypeScript / JavaScript ########################################################################
+
+*.js       text
+*.jsx      text
+*.ts       text
+*.tsx      text
+
+### Python #########################################################################################
+
+# Source
+*.pxd      text diff=python
+*.py       text diff=python
+*.py3      text diff=python
+*.pyw      text diff=python
+*.pyx      text diff=python
+*.pyz      text diff=python
+*.pyi      text diff=python
+
+# Binary
+*.db       binary
+*.p        binary
+*.pkl      binary
+*.pickle   binary
+*.pyc      binary export-ignore
+*.pyo      binary export-ignore
+*.pyd      binary
+
+### Linguist exclusions ############################################################################
+
+test/*     linguist-vendored
+
+### Exclude files from exporting ###################################################################
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+### License ########################################################################################
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2024 Florian Bernd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+####################################################################################################

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,130 @@
+name: 'CD'
+
+on:
+  workflow_call:
+    inputs:
+      flavor:
+        description: 'The release flavor (either ''stack'' or ''serverless'')'
+        type: 'string'
+        required: true
+      solution:
+        description: 'The filename of the .NET solution file'
+        type: 'string'
+        required: true
+      release_tag:
+        description: 'The release tag (release version)'
+        type: 'string'
+        required: true
+      release_body:
+        description: 'The release body (release notes)'
+        type: 'string'
+        required: true
+    secrets:
+      NUGET_API_KEY:
+        required: true
+
+concurrency:
+  group: 'release-${{ inputs.flavor }}'
+  cancel-in-progress: false
+
+env:
+  # Configuration
+  BUILD_CONFIG: 'Release'
+  GLOBAL_JSON_FILE: 'global.json'
+  LOCKFILE_PATTERN: '**/packages.lock.json'
+  PACKAGE_PATH: 'nupkg'
+  # .NET SDK related environment variables
+  DOTNET_NOLOGO: 1
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
+  DOTNET_CLI_TELEMETRY_OPTOUT: 1
+  DOTNET_GENERATE_ASPNET_CERTIFICATE: 0
+
+jobs:
+  build:
+    name: 'Build'
+    runs-on: 'ubuntu-latest'
+    steps:
+      - name: 'Parse Version'
+        id: 'version'
+        uses: 'zyactions/semver@v1'
+        with:
+          version: ${{ inputs.release_tag }}
+          prefixes: 'serverless-'
+
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: '.NET Setup'
+        uses: 'actions/setup-dotnet@v4'
+        with:
+          global-json-file: '${{ github.workspace }}/${{ env.GLOBAL_JSON_FILE }}'
+
+      - name: '.NET Cache Packages'
+        uses: 'actions/cache@v4'
+        with:
+          path: '~/.nuget/packages'
+          key: '${{ runner.os }}-nuget-${{ inputs.flavor }}-${{ hashFiles(env.LOCKFILE_PATTERN) }}'
+          restore-keys: '${{ runner.os }}-nuget-${{ inputs.flavor }}-'
+
+      - name: '.NET Restore'
+        run: >-
+          dotnet restore "${{ github.workspace }}/${{ inputs.solution }}"
+
+      - name: '.NET Pack'
+        env:
+          # The complete semver version string
+          CURRENT_VERSION: ${{ steps.version.outputs.version }}
+          # Assembly version is sticky to MAJOR.0.0.0 to avoid binding redirects because we strong name our assemblies
+          CURRENT_ASSEMBLY_VERSION: '${{ steps.version.outputs.major }}.0.0.0'
+          # File version reflects actual version number without prelease and build since these are not allowed in its struct
+          CURRENT_ASSEMBLY_FILE_VERSION: '${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}.${{ steps.version.outputs.patch }}'
+        run: >-
+          dotnet pack
+          "${{ github.workspace }}/${{ inputs.solution }}"
+          --no-restore
+          --configuration "${{ env.BUILD_CONFIG }}"
+          -p:ContinuousIntegrationBuild=true
+          -p:CurrentVersion=${{ env.CURRENT_VERSION }}
+          -p:CurrentAssemblyVersion=${{ env.CURRENT_ASSEMBLY_VERSION }}
+          -p:CurrentAssemblyFileVersion=${{ env.CURRENT_ASSEMBLY_FILE_VERSION }}
+          -o "${{ github.workspace }}/${{ env.PACKAGE_PATH }}"
+
+      - name: 'Upload Artifacts'
+        uses: 'actions/upload-artifact@v4'
+        with:
+          name: 'packages'
+          path: '${{ github.workspace }}/${{ env.PACKAGE_PATH }}'
+          if-no-files-found: 'error'
+          retention-days: 1
+
+  publish:
+    name: Publish to ${{ matrix.feed.name }}
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        feed:
+          - { name: 'NuGet' , source: 'https://api.nuget.org/v3/index.json'                                   , key: 'NUGET_API_KEY' }
+          # - { name: 'GitHub', source: 'https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json', key: 'GITHUB_TOKEN'  }
+    steps:
+      - name: 'Checkout'
+        uses: 'actions/checkout@v4'
+
+      - name: '.NET Setup'
+        uses: 'actions/setup-dotnet@v4'
+        with:
+          global-json-file: '${{ github.workspace }}/${{ env.GLOBAL_JSON_FILE }}'
+
+      - name: 'Download Artifacts'
+        uses: actions/download-artifact@v4
+        with:
+          name: 'packages'
+          path: '${{ github.workspace }}/${{ env.PACKAGE_PATH }}'
+
+      - name: '.NET NuGet Push'
+        run: >-
+          dotnet nuget push ${{ format('{0}/{1}/*.nupkg', github.workspace, env.PACKAGE_PATH) }}
+          --source ${{ matrix.feed.source }}
+          --api-key ${{ secrets[matrix.feed.key] }}
+          --skip-duplicate

--- a/.github/workflows/release_serverless.yml
+++ b/.github/workflows/release_serverless.yml
@@ -1,0 +1,18 @@
+name: 'CD'
+
+on:
+  release:
+    types:
+      - 'published'
+
+jobs:
+  release:
+    name: 'Release'
+    if: ${{ startsWith(github.event.release.tag_name, 'serverless-') }}
+    uses: ./.github/workflows/release.yml
+    with:
+      flavor: 'serverless'
+      solution: 'Packages.Serverless.slnf'
+      release_tag: ${{ github.event.release.tag_name }}
+      release_body: ${{ github.event.release.body }}
+    secrets: 'inherit'

--- a/.github/workflows/release_stack.yml
+++ b/.github/workflows/release_stack.yml
@@ -1,0 +1,18 @@
+name: 'CD'
+
+on:
+  release:
+    types:
+      - 'published'
+
+jobs:
+  release:
+    name: 'Release'
+    if: ${{ !startsWith(github.event.release.tag_name, 'serverless-') }}
+    uses: ./.github/workflows/release.yml
+    with:
+      flavor: 'stack'
+      solution: 'Packages.Stack.slnf'
+      release_tag: ${{ github.event.release.tag_name }}
+      release_body: ${{ github.event.release.body }}
+    secrets: 'inherit'

--- a/Packages.Serverless.slnf
+++ b/Packages.Serverless.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "Elasticsearch.sln",
+    "projects": [
+      "src\\Elastic.Clients.Elasticsearch.Serverless\\Elastic.Clients.Elasticsearch.Serverless.csproj",
+      "src\\Elastic.Clients.Elasticsearch.Shared\\Elastic.Clients.Elasticsearch.Shared.shproj"
+    ]
+  }
+}

--- a/Packages.Stack.slnf
+++ b/Packages.Stack.slnf
@@ -1,0 +1,9 @@
+{
+  "solution": {
+    "path": "Elasticsearch.sln",
+    "projects": [
+      "src\\Elastic.Clients.Elasticsearch.Shared\\Elastic.Clients.Elasticsearch.Shared.shproj",
+      "src\\Elastic.Clients.Elasticsearch\\Elastic.Clients.Elasticsearch.csproj"
+    ]
+  }
+}


### PR DESCRIPTION
Adds a bassic release workflow that is triggered by publishing releases on GitHub.

### Roadmap

- Automatically convert the Markdown release notes to the AsciiDocs format and push to the correct branches (e.g. `serverless` or `main` and `8.x`
- Automatically create reference documentation for new versions using DocFX and publish to a central place (e.g. GitHub Pages)