### PR TITLE
Fix `MultiSearch` functionality

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
@@ -958,7 +958,7 @@ public sealed partial class SubmitAsyncSearchRequestDescriptor<TDocument> : Requ
 	{
 	}
 
-	public SubmitAsyncSearchRequestDescriptor() : this(typeof(TDocument))
+	public SubmitAsyncSearchRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/Cluster/HealthRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/Cluster/HealthRequest.g.cs
@@ -186,7 +186,7 @@ public sealed partial class HealthRequestDescriptor<TDocument> : RequestDescript
 	{
 	}
 
-	public HealthRequestDescriptor() : this(typeof(TDocument))
+	public HealthRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/CountRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/CountRequest.g.cs
@@ -225,7 +225,7 @@ public sealed partial class CountRequestDescriptor<TDocument> : RequestDescripto
 	{
 	}
 
-	public CountRequestDescriptor() : this(typeof(TDocument))
+	public CountRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/FieldCapsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/FieldCapsRequest.g.cs
@@ -161,7 +161,7 @@ public sealed partial class FieldCapsRequestDescriptor<TDocument> : RequestDescr
 	{
 	}
 
-	public FieldCapsRequestDescriptor() : this(typeof(TDocument))
+	public FieldCapsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
@@ -142,7 +142,7 @@ public sealed partial class ClearCacheRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public ClearCacheRequestDescriptor() : this(typeof(TDocument))
+	public ClearCacheRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
@@ -109,7 +109,7 @@ public sealed partial class ExistsAliasRequestDescriptor<TDocument> : RequestDes
 	{
 	}
 
-	public ExistsAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Serverless.Names name) : this(typeof(TDocument), name)
+	public ExistsAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Serverless.Names name) : base(r => r.Required("name", name))
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/FlushRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/FlushRequest.g.cs
@@ -120,7 +120,7 @@ public sealed partial class FlushRequestDescriptor<TDocument> : RequestDescripto
 	{
 	}
 
-	public FlushRequestDescriptor() : this(typeof(TDocument))
+	public FlushRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
@@ -142,7 +142,7 @@ public sealed partial class ForcemergeRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public ForcemergeRequestDescriptor() : this(typeof(TDocument))
+	public ForcemergeRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetAliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetAliasRequest.g.cs
@@ -117,10 +117,6 @@ public sealed partial class GetAliasRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public GetAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Serverless.Names? name) : this(typeof(TDocument), name)
-	{
-	}
-
 	public GetAliasRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetIndicesSettingsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetIndicesSettingsRequest.g.cs
@@ -150,10 +150,6 @@ public sealed partial class GetIndicesSettingsRequestDescriptor<TDocument> : Req
 	{
 	}
 
-	public GetIndicesSettingsRequestDescriptor(Elastic.Clients.Elasticsearch.Serverless.Names? name) : this(typeof(TDocument), name)
-	{
-	}
-
 	public GetIndicesSettingsRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetMappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/GetMappingRequest.g.cs
@@ -120,7 +120,7 @@ public sealed partial class GetMappingRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public GetMappingRequestDescriptor() : this(typeof(TDocument))
+	public GetMappingRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/IndicesStatsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/IndicesStatsRequest.g.cs
@@ -172,10 +172,6 @@ public sealed partial class IndicesStatsRequestDescriptor<TDocument> : RequestDe
 	{
 	}
 
-	public IndicesStatsRequestDescriptor(Elastic.Clients.Elasticsearch.Serverless.Metrics? metric) : this(typeof(TDocument), metric)
-	{
-	}
-
 	public IndicesStatsRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/RecoveryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/RecoveryRequest.g.cs
@@ -87,7 +87,7 @@ public sealed partial class RecoveryRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public RecoveryRequestDescriptor() : this(typeof(TDocument))
+	public RecoveryRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/RefreshRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/RefreshRequest.g.cs
@@ -98,7 +98,7 @@ public sealed partial class RefreshRequestDescriptor<TDocument> : RequestDescrip
 	{
 	}
 
-	public RefreshRequestDescriptor() : this(typeof(TDocument))
+	public RefreshRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
@@ -109,7 +109,7 @@ public sealed partial class SegmentsRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public SegmentsRequestDescriptor() : this(typeof(TDocument))
+	public SegmentsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
@@ -203,7 +203,7 @@ public sealed partial class ValidateQueryRequestDescriptor<TDocument> : RequestD
 	{
 	}
 
-	public ValidateQueryRequestDescriptor() : this(typeof(TDocument))
+	public ValidateQueryRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/MultiSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/MultiSearchRequest.g.cs
@@ -214,7 +214,7 @@ public sealed partial class MultiSearchRequest : PlainRequest<MultiSearchRequest
 /// <summary>
 /// <para>Allows to execute several search operations in one request.</para>
 /// </summary>
-public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchRequestDescriptor<TDocument>, MultiSearchRequestParameters>
+public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchRequestDescriptor<TDocument>, MultiSearchRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchRequestDescriptor(Action<MultiSearchRequestDescriptor<TDocument>> configure) => configure.Invoke(this);
 
@@ -222,7 +222,7 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 	{
 	}
 
-	public MultiSearchRequestDescriptor() : this(typeof(TDocument))
+	public MultiSearchRequestDescriptor()
 	{
 	}
 
@@ -259,6 +259,28 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 
 	List<Elastic.Clients.Elasticsearch.Serverless.Core.MSearch.SearchRequestItem> _items = new();
 
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
+
 	public MultiSearchRequestDescriptor<TDocument> AddSearches(Elastic.Clients.Elasticsearch.Serverless.Core.MSearch.SearchRequestItem searches)
 	{
 		_items.Add(searches);
@@ -269,7 +291,7 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 /// <summary>
 /// <para>Allows to execute several search operations in one request.</para>
 /// </summary>
-public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<MultiSearchRequestDescriptor, MultiSearchRequestParameters>
+public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<MultiSearchRequestDescriptor, MultiSearchRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchRequestDescriptor(Action<MultiSearchRequestDescriptor> configure) => configure.Invoke(this);
 
@@ -313,6 +335,28 @@ public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<Mul
 	}
 
 	List<Elastic.Clients.Elasticsearch.Serverless.Core.MSearch.SearchRequestItem> _items = new();
+
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
 
 	public MultiSearchRequestDescriptor AddSearches(Elastic.Clients.Elasticsearch.Serverless.Core.MSearch.SearchRequestItem searches)
 	{

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/MultiSearchTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/MultiSearchTemplateRequest.g.cs
@@ -137,7 +137,7 @@ public sealed partial class MultiSearchTemplateRequest : PlainRequest<MultiSearc
 /// <summary>
 /// <para>Runs multiple templated searches with a single request.</para>
 /// </summary>
-public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateRequestParameters>
+public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchTemplateRequestDescriptor(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configure) => configure.Invoke(this);
 
@@ -145,7 +145,7 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 	{
 	}
 
-	public MultiSearchTemplateRequestDescriptor() : this(typeof(TDocument))
+	public MultiSearchTemplateRequestDescriptor()
 	{
 	}
 
@@ -175,6 +175,28 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 
 	List<Elastic.Clients.Elasticsearch.Serverless.Core.MSearchTemplate.SearchTemplateRequestItem> _items = new();
 
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
+
 	public MultiSearchTemplateRequestDescriptor<TDocument> AddSearchTemplates(Elastic.Clients.Elasticsearch.Serverless.Core.MSearchTemplate.SearchTemplateRequestItem searchTemplates)
 	{
 		_items.Add(searchTemplates);
@@ -185,7 +207,7 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 /// <summary>
 /// <para>Runs multiple templated searches with a single request.</para>
 /// </summary>
-public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescriptor<MultiSearchTemplateRequestDescriptor, MultiSearchTemplateRequestParameters>
+public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescriptor<MultiSearchTemplateRequestDescriptor, MultiSearchTemplateRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchTemplateRequestDescriptor(Action<MultiSearchTemplateRequestDescriptor> configure) => configure.Invoke(this);
 
@@ -222,6 +244,28 @@ public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescri
 	}
 
 	List<Elastic.Clients.Elasticsearch.Serverless.Core.MSearchTemplate.SearchTemplateRequestItem> _items = new();
+
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
 
 	public MultiSearchTemplateRequestDescriptor AddSearchTemplates(Elastic.Clients.Elasticsearch.Serverless.Core.MSearchTemplate.SearchTemplateRequestItem searchTemplates)
 	{

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/RankEvalRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/RankEvalRequest.g.cs
@@ -121,7 +121,7 @@ public sealed partial class RankEvalRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public RankEvalRequestDescriptor() : this(typeof(TDocument))
+	public RankEvalRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchRequest.g.cs
@@ -1007,7 +1007,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 	{
 	}
 
-	public SearchRequestDescriptor() : this(typeof(TDocument))
+	public SearchRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchTemplateRequest.g.cs
@@ -216,7 +216,7 @@ public sealed partial class SearchTemplateRequestDescriptor<TDocument> : Request
 	{
 	}
 
-	public SearchTemplateRequestDescriptor() : this(typeof(TDocument))
+	public SearchTemplateRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Client/ElasticsearchClient.Indices.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Client/ElasticsearchClient.Indices.g.cs
@@ -1668,29 +1668,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	/// <para>Returns an alias.</para>
 	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
 	/// </summary>
-	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Names? name, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Names? name, Action<GetAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
 	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetAliasRequestDescriptor<TDocument>();
@@ -2101,29 +2078,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Indices? indices, Elastic.Clients.Elasticsearch.Serverless.Names? name, Action<GetIndicesSettingsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(indices, name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Names? name, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Names? name, Action<GetIndicesSettingsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
@@ -3642,29 +3596,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Indices? indices, Elastic.Clients.Elasticsearch.Serverless.Metrics? metric, Action<IndicesStatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(indices, metric);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Metrics? metric, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Serverless.Metrics? metric, Action<IndicesStatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
 		configureRequest?.Invoke(descriptor);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
@@ -958,7 +958,7 @@ public sealed partial class SubmitAsyncSearchRequestDescriptor<TDocument> : Requ
 	{
 	}
 
-	public SubmitAsyncSearchRequestDescriptor() : this(typeof(TDocument))
+	public SubmitAsyncSearchRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/HealthRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/Cluster/HealthRequest.g.cs
@@ -186,7 +186,7 @@ public sealed partial class HealthRequestDescriptor<TDocument> : RequestDescript
 	{
 	}
 
-	public HealthRequestDescriptor() : this(typeof(TDocument))
+	public HealthRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/CountRequest.g.cs
@@ -225,7 +225,7 @@ public sealed partial class CountRequestDescriptor<TDocument> : RequestDescripto
 	{
 	}
 
-	public CountRequestDescriptor() : this(typeof(TDocument))
+	public CountRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/FieldCapsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/FieldCapsRequest.g.cs
@@ -161,7 +161,7 @@ public sealed partial class FieldCapsRequestDescriptor<TDocument> : RequestDescr
 	{
 	}
 
-	public FieldCapsRequestDescriptor() : this(typeof(TDocument))
+	public FieldCapsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ClearCacheRequest.g.cs
@@ -142,7 +142,7 @@ public sealed partial class ClearCacheRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public ClearCacheRequestDescriptor() : this(typeof(TDocument))
+	public ClearCacheRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ExistsAliasRequest.g.cs
@@ -109,7 +109,7 @@ public sealed partial class ExistsAliasRequestDescriptor<TDocument> : RequestDes
 	{
 	}
 
-	public ExistsAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Names name) : this(typeof(TDocument), name)
+	public ExistsAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Names name) : base(r => r.Required("name", name))
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FlushRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/FlushRequest.g.cs
@@ -120,7 +120,7 @@ public sealed partial class FlushRequestDescriptor<TDocument> : RequestDescripto
 	{
 	}
 
-	public FlushRequestDescriptor() : this(typeof(TDocument))
+	public FlushRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ForcemergeRequest.g.cs
@@ -142,7 +142,7 @@ public sealed partial class ForcemergeRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public ForcemergeRequestDescriptor() : this(typeof(TDocument))
+	public ForcemergeRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetAliasRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetAliasRequest.g.cs
@@ -117,10 +117,6 @@ public sealed partial class GetAliasRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public GetAliasRequestDescriptor(Elastic.Clients.Elasticsearch.Names? name) : this(typeof(TDocument), name)
-	{
-	}
-
 	public GetAliasRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetFieldMappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetFieldMappingRequest.g.cs
@@ -120,7 +120,7 @@ public sealed partial class GetFieldMappingRequestDescriptor<TDocument> : Reques
 	{
 	}
 
-	public GetFieldMappingRequestDescriptor(Elastic.Clients.Elasticsearch.Fields fields) : this(typeof(TDocument), fields)
+	public GetFieldMappingRequestDescriptor(Elastic.Clients.Elasticsearch.Fields fields) : base(r => r.Required("fields", fields))
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetIndicesSettingsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetIndicesSettingsRequest.g.cs
@@ -150,10 +150,6 @@ public sealed partial class GetIndicesSettingsRequestDescriptor<TDocument> : Req
 	{
 	}
 
-	public GetIndicesSettingsRequestDescriptor(Elastic.Clients.Elasticsearch.Names? name) : this(typeof(TDocument), name)
-	{
-	}
-
 	public GetIndicesSettingsRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetMappingRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/GetMappingRequest.g.cs
@@ -120,7 +120,7 @@ public sealed partial class GetMappingRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public GetMappingRequestDescriptor() : this(typeof(TDocument))
+	public GetMappingRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/IndicesStatsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/IndicesStatsRequest.g.cs
@@ -172,10 +172,6 @@ public sealed partial class IndicesStatsRequestDescriptor<TDocument> : RequestDe
 	{
 	}
 
-	public IndicesStatsRequestDescriptor(Elastic.Clients.Elasticsearch.Metrics? metric) : this(typeof(TDocument), metric)
-	{
-	}
-
 	public IndicesStatsRequestDescriptor()
 	{
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RecoveryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RecoveryRequest.g.cs
@@ -87,7 +87,7 @@ public sealed partial class RecoveryRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public RecoveryRequestDescriptor() : this(typeof(TDocument))
+	public RecoveryRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/RefreshRequest.g.cs
@@ -98,7 +98,7 @@ public sealed partial class RefreshRequestDescriptor<TDocument> : RequestDescrip
 	{
 	}
 
-	public RefreshRequestDescriptor() : this(typeof(TDocument))
+	public RefreshRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/SegmentsRequest.g.cs
@@ -109,7 +109,7 @@ public sealed partial class SegmentsRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public SegmentsRequestDescriptor() : this(typeof(TDocument))
+	public SegmentsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ShardStoresRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ShardStoresRequest.g.cs
@@ -109,7 +109,7 @@ public sealed partial class ShardStoresRequestDescriptor<TDocument> : RequestDes
 	{
 	}
 
-	public ShardStoresRequestDescriptor() : this(typeof(TDocument))
+	public ShardStoresRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/IndexManagement/ValidateQueryRequest.g.cs
@@ -203,7 +203,7 @@ public sealed partial class ValidateQueryRequestDescriptor<TDocument> : RequestD
 	{
 	}
 
-	public ValidateQueryRequestDescriptor() : this(typeof(TDocument))
+	public ValidateQueryRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchRequest.g.cs
@@ -214,7 +214,7 @@ public sealed partial class MultiSearchRequest : PlainRequest<MultiSearchRequest
 /// <summary>
 /// <para>Allows to execute several search operations in one request.</para>
 /// </summary>
-public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchRequestDescriptor<TDocument>, MultiSearchRequestParameters>
+public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchRequestDescriptor<TDocument>, MultiSearchRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchRequestDescriptor(Action<MultiSearchRequestDescriptor<TDocument>> configure) => configure.Invoke(this);
 
@@ -222,7 +222,7 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 	{
 	}
 
-	public MultiSearchRequestDescriptor() : this(typeof(TDocument))
+	public MultiSearchRequestDescriptor()
 	{
 	}
 
@@ -259,6 +259,28 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 
 	List<Elastic.Clients.Elasticsearch.Core.MSearch.SearchRequestItem> _items = new();
 
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
+
 	public MultiSearchRequestDescriptor<TDocument> AddSearches(Elastic.Clients.Elasticsearch.Core.MSearch.SearchRequestItem searches)
 	{
 		_items.Add(searches);
@@ -269,7 +291,7 @@ public sealed partial class MultiSearchRequestDescriptor<TDocument> : RequestDes
 /// <summary>
 /// <para>Allows to execute several search operations in one request.</para>
 /// </summary>
-public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<MultiSearchRequestDescriptor, MultiSearchRequestParameters>
+public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<MultiSearchRequestDescriptor, MultiSearchRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchRequestDescriptor(Action<MultiSearchRequestDescriptor> configure) => configure.Invoke(this);
 
@@ -313,6 +335,28 @@ public sealed partial class MultiSearchRequestDescriptor : RequestDescriptor<Mul
 	}
 
 	List<Elastic.Clients.Elasticsearch.Core.MSearch.SearchRequestItem> _items = new();
+
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
 
 	public MultiSearchRequestDescriptor AddSearches(Elastic.Clients.Elasticsearch.Core.MSearch.SearchRequestItem searches)
 	{

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/MultiSearchTemplateRequest.g.cs
@@ -137,7 +137,7 @@ public sealed partial class MultiSearchTemplateRequest : PlainRequest<MultiSearc
 /// <summary>
 /// <para>Runs multiple templated searches with a single request.</para>
 /// </summary>
-public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateRequestParameters>
+public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : RequestDescriptor<MultiSearchTemplateRequestDescriptor<TDocument>, MultiSearchTemplateRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchTemplateRequestDescriptor(Action<MultiSearchTemplateRequestDescriptor<TDocument>> configure) => configure.Invoke(this);
 
@@ -145,7 +145,7 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 	{
 	}
 
-	public MultiSearchTemplateRequestDescriptor() : this(typeof(TDocument))
+	public MultiSearchTemplateRequestDescriptor()
 	{
 	}
 
@@ -175,6 +175,28 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 
 	List<Elastic.Clients.Elasticsearch.Core.MSearchTemplate.SearchTemplateRequestItem> _items = new();
 
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
+
 	public MultiSearchTemplateRequestDescriptor<TDocument> AddSearchTemplates(Elastic.Clients.Elasticsearch.Core.MSearchTemplate.SearchTemplateRequestItem searchTemplates)
 	{
 		_items.Add(searchTemplates);
@@ -185,7 +207,7 @@ public sealed partial class MultiSearchTemplateRequestDescriptor<TDocument> : Re
 /// <summary>
 /// <para>Runs multiple templated searches with a single request.</para>
 /// </summary>
-public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescriptor<MultiSearchTemplateRequestDescriptor, MultiSearchTemplateRequestParameters>
+public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescriptor<MultiSearchTemplateRequestDescriptor, MultiSearchTemplateRequestParameters>, IStreamSerializable
 {
 	internal MultiSearchTemplateRequestDescriptor(Action<MultiSearchTemplateRequestDescriptor> configure) => configure.Invoke(this);
 
@@ -222,6 +244,28 @@ public sealed partial class MultiSearchTemplateRequestDescriptor : RequestDescri
 	}
 
 	List<Elastic.Clients.Elasticsearch.Core.MSearchTemplate.SearchTemplateRequestItem> _items = new();
+
+	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				serializable.Serialize(stream, settings, formatting);
+		}
+	}
+
+	async Task IStreamSerializable.SerializeAsync(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
+	{
+		if (_items is null)
+			return;
+		foreach (var item in _items)
+		{
+			if (item is IStreamSerializable serializable)
+				await serializable.SerializeAsync(stream, settings, formatting).ConfigureAwait(false);
+		}
+	}
 
 	public MultiSearchTemplateRequestDescriptor AddSearchTemplates(Elastic.Clients.Elasticsearch.Core.MSearchTemplate.SearchTemplateRequestItem searchTemplates)
 	{

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/RankEvalRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/RankEvalRequest.g.cs
@@ -121,7 +121,7 @@ public sealed partial class RankEvalRequestDescriptor<TDocument> : RequestDescri
 	{
 	}
 
-	public RankEvalRequestDescriptor() : this(typeof(TDocument))
+	public RankEvalRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
@@ -1018,7 +1018,7 @@ public sealed partial class SearchRequestDescriptor<TDocument> : RequestDescript
 	{
 	}
 
-	public SearchRequestDescriptor() : this(typeof(TDocument))
+	public SearchRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchShardsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchShardsRequest.g.cs
@@ -131,7 +131,7 @@ public sealed partial class SearchShardsRequestDescriptor<TDocument> : RequestDe
 	{
 	}
 
-	public SearchShardsRequestDescriptor() : this(typeof(TDocument))
+	public SearchShardsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchTemplateRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchTemplateRequest.g.cs
@@ -216,7 +216,7 @@ public sealed partial class SearchTemplateRequestDescriptor<TDocument> : Request
 	{
 	}
 
-	public SearchTemplateRequestDescriptor() : this(typeof(TDocument))
+	public SearchTemplateRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchableSnapshots/ClearCacheRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchableSnapshots/ClearCacheRequest.g.cs
@@ -98,7 +98,7 @@ public sealed partial class ClearCacheRequestDescriptor<TDocument> : RequestDesc
 	{
 	}
 
-	public ClearCacheRequestDescriptor() : this(typeof(TDocument))
+	public ClearCacheRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchableSnapshots/SearchableSnapshotsStatsRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchableSnapshots/SearchableSnapshotsStatsRequest.g.cs
@@ -76,7 +76,7 @@ public sealed partial class SearchableSnapshotsStatsRequestDescriptor<TDocument>
 	{
 	}
 
-	public SearchableSnapshotsStatsRequestDescriptor() : this(typeof(TDocument))
+	public SearchableSnapshotsStatsRequestDescriptor()
 	{
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Client/ElasticsearchClient.Indices.g.cs
@@ -4371,31 +4371,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
 	/// </summary>
 	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual GetAliasResponse GetAlias<TDocument>(Elastic.Clients.Elasticsearch.Names? name)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequest<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual GetAliasResponse GetAlias<TDocument>(Elastic.Clients.Elasticsearch.Names? name, Action<GetAliasRequestDescriptor<TDocument>> configureRequest)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequest<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
 	public virtual GetAliasResponse GetAlias<TDocument>()
 	{
 		var descriptor = new GetAliasRequestDescriptor<TDocument>();
@@ -4505,29 +4480,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices? indices, Elastic.Clients.Elasticsearch.Names? name, Action<GetAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetAliasRequestDescriptor<TDocument>(indices, name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Names? name, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns an alias.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-aliases.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetAliasResponse> GetAliasAsync<TDocument>(Elastic.Clients.Elasticsearch.Names? name, Action<GetAliasRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetAliasRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetAliasRequestDescriptor<TDocument>, GetAliasResponse, GetAliasRequestParameters>(descriptor, cancellationToken);
@@ -5550,31 +5502,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
 	/// </summary>
 	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual GetIndicesSettingsResponse GetSettings<TDocument>(Elastic.Clients.Elasticsearch.Names? name)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequest<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual GetIndicesSettingsResponse GetSettings<TDocument>(Elastic.Clients.Elasticsearch.Names? name, Action<GetIndicesSettingsRequestDescriptor<TDocument>> configureRequest)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequest<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
 	public virtual GetIndicesSettingsResponse GetSettings<TDocument>()
 	{
 		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>();
@@ -5684,29 +5611,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices? indices, Elastic.Clients.Elasticsearch.Names? name, Action<GetIndicesSettingsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(indices, name);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Names? name, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Returns settings for one or more indices.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-get-settings.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<GetIndicesSettingsResponse> GetSettingsAsync<TDocument>(Elastic.Clients.Elasticsearch.Names? name, Action<GetIndicesSettingsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new GetIndicesSettingsRequestDescriptor<TDocument>(name);
 		configureRequest?.Invoke(descriptor);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<GetIndicesSettingsRequestDescriptor<TDocument>, GetIndicesSettingsResponse, GetIndicesSettingsRequestParameters>(descriptor, cancellationToken);
@@ -9870,31 +9774,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
 	/// </summary>
 	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual IndicesStatsResponse Stats<TDocument>(Elastic.Clients.Elasticsearch.Metrics? metric)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
-		descriptor.BeforeRequest();
-		return DoRequest<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
-	public virtual IndicesStatsResponse Stats<TDocument>(Elastic.Clients.Elasticsearch.Metrics? metric, Action<IndicesStatsRequestDescriptor<TDocument>> configureRequest)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequest<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	[Obsolete("Synchronous methods are deprecated and could be removed in the future.")]
 	public virtual IndicesStatsResponse Stats<TDocument>()
 	{
 		var descriptor = new IndicesStatsRequestDescriptor<TDocument>();
@@ -10004,29 +9883,6 @@ public partial class IndicesNamespacedClient : NamespacedClientProxy
 	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Indices? indices, Elastic.Clients.Elasticsearch.Metrics? metric, Action<IndicesStatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
 	{
 		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(indices, metric);
-		configureRequest?.Invoke(descriptor);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Metrics? metric, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
-		descriptor.BeforeRequest();
-		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);
-	}
-
-	/// <summary>
-	/// <para>Provides statistics on operations happening in an index.</para>
-	/// <para><see href="https://www.elastic.co/guide/en/elasticsearch/reference/master/indices-stats.html">Learn more about this API in the Elasticsearch documentation.</see></para>
-	/// </summary>
-	public virtual Task<IndicesStatsResponse> StatsAsync<TDocument>(Elastic.Clients.Elasticsearch.Metrics? metric, Action<IndicesStatsRequestDescriptor<TDocument>> configureRequest, CancellationToken cancellationToken = default)
-	{
-		var descriptor = new IndicesStatsRequestDescriptor<TDocument>(metric);
 		configureRequest?.Invoke(descriptor);
 		descriptor.BeforeRequest();
 		return DoRequestAsync<IndicesStatsRequestDescriptor<TDocument>, IndicesStatsResponse, IndicesStatsRequestParameters>(descriptor, cancellationToken);


### PR DESCRIPTION
- Implement `IStreamSerializable` for array request descriptors
- Do not automatically infer index for optional `Indices` parameters

Closes #7742