### PR TITLE
fix: object initializer syntax for source filtering

### DIFF
--- a/docs/search/request/source-filtering-usage.asciidoc
+++ b/docs/search/request/source-filtering-usage.asciidoc
@@ -49,7 +49,7 @@ new SearchRequest<Project>
     Source = new SourceFilter
     {
         Includes = "*",
-        Excludes = Fields<Project>(p => p.Description)
+        Excludes = new Field[] { "Description" }
     }
 }
 ----


### PR DESCRIPTION
Found the same syntax bug in at least 7.17 documentation also, but I'm not sure whether the syntax is correct for other versions. We use 6.0 in our project, so I provided a fix for it.