### PR TITLE
Adjust ToCamelCase Extension

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Shared/Core/Extensions/StringExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Core/Extensions/StringExtensions.cs
@@ -18,10 +18,25 @@ internal static class StringExtensions
 		if (!char.IsUpper(s[0]))
 			return s;
 
-		var camelCase = char.ToLowerInvariant(s[0]).ToString();
-		if (s.Length > 1)
-			camelCase += s.Substring(1);
+		var chars = s.ToCharArray();
 
-		return camelCase;
+		for (var i = 0; i < chars.Length; i++)
+		{
+			var current = chars[i];
+
+			if (char.IsSeparator(current))
+				break;
+
+			if (0 < i && i + 1 < chars.Length)
+			{
+				var next = chars[i + 1];
+				if (!char.IsUpper(next) && !char.IsSeparator(next))
+					break;
+			}
+
+			chars[i] = char.ToLowerInvariant(current);
+		}
+
+		return new string(chars);
 	}
 }

--- a/tests/Tests/Core/Extensions/StringExtensionsTests.cs
+++ b/tests/Tests/Core/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,19 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+namespace Tests.Core.Extensions;
+
+public class StringExtensionsTests
+{
+	[U]
+	public void ToCamelCase()
+	{
+		"camelCase".ToCamelCase().Should().Be("camelCase");
+		"CamelCase".ToCamelCase().Should().Be("camelCase");
+		"CAMELCase".ToCamelCase().Should().Be("camelCase");
+		"CamelCASE".ToCamelCase().Should().Be("camelCASE");
+		"Camel Case".ToCamelCase().Should().Be("camel Case");
+		"camel Case".ToCamelCase().Should().Be("camel Case");
+	}
+}


### PR DESCRIPTION
Adjust `ToCamelCase` Extension of `string` to match the behavior of `System.Text.Json` and `Newtonsoft.Json`.
Bug: #8273