### PR TITLE
Fix (de-)serialization of `Fields` in custom converters

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
@@ -606,7 +606,7 @@ internal sealed partial class SubmitAsyncSearchRequestConverter : JsonConverter<
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Api/SearchRequest.g.cs
@@ -660,7 +660,7 @@ internal sealed partial class SearchRequestConverter : JsonConverter<SearchReque
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
@@ -185,7 +185,8 @@ internal sealed partial class MultisearchBodyConverter : JsonConverter<Multisear
 
 				if (property == "stored_fields")
 				{
-					variant.StoredFields = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Serverless.Fields?>(ref reader, options);
+					reader.Read();
+					variant.StoredFields = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 
@@ -380,7 +381,7 @@ internal sealed partial class MultisearchBodyConverter : JsonConverter<Multisear
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Types/Core/Search/SourceFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/_Generated/Types/Core/Search/SourceFilter.g.cs
@@ -41,13 +41,15 @@ internal sealed partial class SourceFilterConverter : JsonConverter<SourceFilter
 				var property = reader.GetString();
 				if (property == "excludes" || property == "exclude")
 				{
-					variant.Excludes = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Serverless.Fields?>(ref reader, options);
+					reader.Read();
+					variant.Excludes = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 
 				if (property == "includes" || property == "include")
 				{
-					variant.Includes = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Serverless.Fields?>(ref reader, options);
+					reader.Read();
+					variant.Includes = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 			}
@@ -62,13 +64,13 @@ internal sealed partial class SourceFilterConverter : JsonConverter<SourceFilter
 		if (value.Excludes is not null)
 		{
 			writer.WritePropertyName("excludes");
-			JsonSerializer.Serialize(writer, value.Excludes, options);
+			new FieldsConverter().Write(writer, value.Excludes, options);
 		}
 
 		if (value.Includes is not null)
 		{
 			writer.WritePropertyName("includes");
-			JsonSerializer.Serialize(writer, value.Includes, options);
+			new FieldsConverter().Write(writer, value.Includes, options);
 		}
 
 		writer.WriteEndObject();

--- a/src/Elastic.Clients.Elasticsearch.Shared/Core/Infer/Field/Field.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Core/Infer/Field/Field.cs
@@ -20,7 +20,7 @@ namespace Elastic.Clients.Elasticsearch;
 #endif
 
 [JsonConverter(typeof(FieldConverter))]
-[DebuggerDisplay($"{nameof(DebuggerDisplay)},nq")]
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
 public sealed class Field :
 	IEquatable<Field>,
 	IUrlParameter

--- a/src/Elastic.Clients.Elasticsearch.Shared/Core/Infer/Fields/Fields.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Core/Infer/Fields/Fields.cs
@@ -18,7 +18,7 @@ namespace Elastic.Clients.Elasticsearch.Serverless;
 namespace Elastic.Clients.Elasticsearch;
 #endif
 
-[DebuggerDisplay($"{nameof(DebuggerDisplay)},nq")]
+[DebuggerDisplay($"{{{nameof(DebuggerDisplay)},nq}}")]
 public sealed class Fields :
 	IEquatable<Fields>,
 	IEnumerable<Field>,

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/AsyncSearch/SubmitAsyncSearchRequest.g.cs
@@ -606,7 +606,7 @@ internal sealed partial class SubmitAsyncSearchRequestConverter : JsonConverter<
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Api/SearchRequest.g.cs
@@ -669,7 +669,7 @@ internal sealed partial class SearchRequestConverter : JsonConverter<SearchReque
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/MSearch/MultisearchBody.g.cs
@@ -185,7 +185,8 @@ internal sealed partial class MultisearchBodyConverter : JsonConverter<Multisear
 
 				if (property == "stored_fields")
 				{
-					variant.StoredFields = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Fields?>(ref reader, options);
+					reader.Read();
+					variant.StoredFields = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 
@@ -380,7 +381,7 @@ internal sealed partial class MultisearchBodyConverter : JsonConverter<Multisear
 		if (value.StoredFields is not null)
 		{
 			writer.WritePropertyName("stored_fields");
-			JsonSerializer.Serialize(writer, value.StoredFields, options);
+			new FieldsConverter().Write(writer, value.StoredFields, options);
 		}
 
 		if (value.Suggest is not null)

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/SourceFilter.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/SourceFilter.g.cs
@@ -41,13 +41,15 @@ internal sealed partial class SourceFilterConverter : JsonConverter<SourceFilter
 				var property = reader.GetString();
 				if (property == "excludes" || property == "exclude")
 				{
-					variant.Excludes = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Fields?>(ref reader, options);
+					reader.Read();
+					variant.Excludes = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 
 				if (property == "includes" || property == "include")
 				{
-					variant.Includes = JsonSerializer.Deserialize<Elastic.Clients.Elasticsearch.Fields?>(ref reader, options);
+					reader.Read();
+					variant.Includes = new FieldsConverter().Read(ref reader, typeToConvert, options);
 					continue;
 				}
 			}
@@ -62,13 +64,13 @@ internal sealed partial class SourceFilterConverter : JsonConverter<SourceFilter
 		if (value.Excludes is not null)
 		{
 			writer.WritePropertyName("excludes");
-			JsonSerializer.Serialize(writer, value.Excludes, options);
+			new FieldsConverter().Write(writer, value.Excludes, options);
 		}
 
 		if (value.Includes is not null)
 		{
 			writer.WritePropertyName("includes");
-			JsonSerializer.Serialize(writer, value.Includes, options);
+			new FieldsConverter().Write(writer, value.Includes, options);
 		}
 
 		writer.WriteEndObject();


### PR DESCRIPTION
Fix (de-)serialization of `Fields` in custom converters.

Performance can be improved in a second step by reusing a static instance of the converters.