### PR TITLE
Introduce `DictionaryResponse.Values`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Shared/Core/Response/DictionaryResponse.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Core/Response/DictionaryResponse.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections.Generic;
+
 using Elastic.Transport.Products.Elasticsearch;
 
 #if ELASTICSEARCH_SERVERLESS
@@ -25,4 +26,8 @@ public abstract class DictionaryResponse<TKey, TValue> : ElasticsearchResponse
 	internal DictionaryResponse() => BackingDictionary = EmptyReadOnly<TKey, TValue>.Dictionary;
 
 	protected IReadOnlyDictionary<TKey, TValue> BackingDictionary { get; }
+
+	// TODO: Remove after exposing the values in the derived responses
+	[Obsolete("Temporary workaround. This field will be removed in the future and replaced by custom accessors in the derived classes.")]
+	public IReadOnlyDictionary<TKey, TValue> Values => BackingDictionary;
 }


### PR DESCRIPTION
This is an intermediate fix that allows access to the protected `DictionaryResponse.BackingDictionary` field to allow using the results of e.g. `Indices.GetSettings` or `Snapshot.GetRepository`.

Closes #8352
Closes #8266
Closes #8115