### PR TITLE
Synchronize `DefaultFieldNameInferrer` and `JsonSerializerOptions.PropertyNamingPolicy`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Shared/Core/Configuration/ElasticsearchClientSettings.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Core/Configuration/ElasticsearchClientSettings.cs
@@ -133,7 +133,7 @@ public abstract class
 
 		_sourceSerializer = sourceSerializerFactory?.Invoke(sourceSerializer, this) ?? sourceSerializer;
 		_propertyMappingProvider = propertyMappingProvider ?? sourceSerializer as IPropertyMappingProvider ?? new DefaultPropertyMappingProvider();
-		_defaultFieldNameInferrer = p => p.ToCamelCase();
+		_defaultFieldNameInferrer = (_sourceSerializer is DefaultSourceSerializer dfs) ? p => dfs.Options?.PropertyNamingPolicy?.ConvertName(p) ?? p : p => p.ToCamelCase();
 		_defaultIndices = new FluentDictionary<Type, string>();
 		_defaultRelationNames = new FluentDictionary<Type, string>();
 		_inferrer = new Inferrer(this);


### PR DESCRIPTION
Configure `DefaultFieldNameInferrer` to use `JsonSerializerOptions.PropertyNamingPolicy`, if the `DefaultSourceSerializer` is used.

The other way around is already implemented. If the `DefaultSourceSerializer` is used and the `DefaultFieldNameInferrer`  is changed, the `JsonSerializerOptions.PropertyNamingPolicy` gets configured to use a custom `PropertyNamingPolicy` that applies the `DefaultFieldNameInferrer` transformations.

Closes #8357