### PR TITLE
[DOCS] Spruce up the Introduction

### DIFF
--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -15,7 +15,7 @@ The {es} .NET client is available as a https://www.nuget.org/packages/Elastic.Cl
 package for use with .NET Core, .NET 5+, and .NET Framework (4.6.1 and later) 
 applications.
 
-_NOTE: This documentation covers the v8 .NET client for {es}, designed for use 
+_NOTE: This documentation covers the v8 .NET client for {es}, for use 
 with {es} 8.x versions. To develop applications targeting {es} v7, use the 
 https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.17[v7 (NEST) client]._
 

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -5,34 +5,33 @@
 
 *Rapidly develop applications with the .NET client for {es}.*
 
-Designed for .NET client-application developers, you can utilize the .NET language client 
-library, which provides a strongly-typed API and query DSL to interact with {es}. 
-The .NET client library is designed to make it easy to use {es} from your .NET 
-applications. The .NET client includes higher-level abstractions, such as 
+Designed for .NET application developers, the .NET language client 
+library provides a strongly typed API and query DSL for interacting with {es}. 
+The .NET client includes higher-level abstractions, such as 
 helpers for coordinating bulk indexing and update operations. It also comes with 
 built-in, configurable cluster failover retry mechanisms.
 
 The {es} .NET client is available as a https://www.nuget.org/packages/Elastic.Clients.Elasticsearch[NuGet] 
-package that can be used in .NET Core, .NET 5+ and .NET Framework (4.6.1 and higher) 
+package for use with .NET Core, .NET 5+, and .NET Framework (4.6.1 and later) 
 applications.
 
-_NOTE: This documentation relates to the v8 .NET client for {es}, designed for use 
-with {es} 8.x versions. To develop applications targetting {es} v7, you should 
-use the https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.17[v7 (NEST) client]._
+_NOTE: This documentation covers the v8 .NET client for {es}, designed for use 
+with {es} 8.x versions. To develop applications targeting {es} v7, use the 
+https://www.elastic.co/guide/en/elasticsearch/client/net-api/7.17[v7 (NEST) client]._
 
 [discrete]
 [[features]]
 === Features
 
-* One-to-one mapping with REST API.
+* One-to-one mapping with the REST API.
 * Strongly typed requests and responses for {es} APIs.
 * Fluent API for building requests.
 * Query DSL to assist with constructing search queries.
 * Helpers for common tasks such as bulk indexing of documents. 
-* Pluggable serialization of requests and responses based on System.Text.Json.
+* Pluggable serialization of requests and responses based on `System.Text.Json`.
 * Diagnostics, auditing, and .NET activity integration.
 
-The .NET {es} client is built upon the Elastic Transport library which provides:
+The .NET {es} client is built on the Elastic Transport library, which provides:
 
 * Connection management and load balancing across all available nodes.
 * Request retries and dead connections handling.
@@ -40,17 +39,15 @@ The .NET {es} client is built upon the Elastic Transport library which provides:
 [discrete]
 === {es} version compatibility
 
-Language clients are forward compatible; meaning that clients support communicating 
-with greater or equal minor versions of {es}. {es} language clients are only 
-backwards compatible with default distributions and without guarantees made.
+Language clients are forward compatible: clients support communicating 
+with current and later minor versions of {es}. {es} language clients are 
+backward compatible with default distributions only and without guarantees.
 
 [discrete]
 === Questions, bugs, comments, feature requests
 
-Bug reports and feature requests are more than welcome on the 
-{github}/issues[github issues pages]!
+To submit a bug report or feature request, use 
+{github}/issues[GitHub issues].
 
-For more general questions and comments, we monitor questions and discussions 
-opened on our community forum, https://discuss.elastic.co/c/elasticsearch[discuss.elastic.co]. 
-Mentioning `.NET` in the title helps folks quickly identify what 
-the question is about.
+For more general questions and comments, try the community forum on https://discuss.elastic.co/c/elasticsearch[discuss.elastic.co]. 
+Mention `.NET` in the title to indicate the discussion topic.

--- a/docs/intro.asciidoc
+++ b/docs/intro.asciidoc
@@ -49,5 +49,6 @@ backward compatible with default distributions only and without guarantees.
 To submit a bug report or feature request, use 
 {github}/issues[GitHub issues].
 
-For more general questions and comments, try the community forum on https://discuss.elastic.co/c/elasticsearch[discuss.elastic.co]. 
+For more general questions and comments, try the community forum 
+on https://discuss.elastic.co/c/elasticsearch[discuss.elastic.co]. 
 Mention `.NET` in the title to indicate the discussion topic.


### PR DESCRIPTION
- Fix egregious typos and grammar issues
- Edits for style; more idiomatic expressions
- Shorter is better

## [Preview](https://elasticsearch-net_bk_8372.docs-preview.app.elstc.co/guide/en/elasticsearch/client/net-api/master/introduction.html) 