### PR TITLE
Add `WithAlias` extensions for CreateIndexRequestDescriptor

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Shared/Api/Extensions/CreateIndexRequestDescriptorExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Api/Extensions/CreateIndexRequestDescriptorExtensions.cs
@@ -32,34 +32,6 @@ public static class CreateIndexRequestDescriptorExtensions
 	}
 
 	/// <summary>
-	/// Add multiple aliases to the index at creation time.
-	/// </summary>
-	/// <param name="descriptor">A descriptor for an index request.</param>
-	/// <param name="aliasNames">The names of the aliases.</param>
-	/// <returns>The <see cref="CreateIndexRequestDescriptor"/> to allow fluent chaining of calls to configure the indexing request.</returns>
-	public static CreateIndexRequestDescriptor WithAliases(this CreateIndexRequestDescriptor descriptor, params ReadOnlySpan<string> aliasNames)
-	{
-		foreach (var name in aliasNames)
-			descriptor.Aliases(a => a.Add(name, static _ => { }));
-
-		return descriptor;
-	}
-
-	/// <summary>
-	/// Add multiple aliases to the index at creation time.
-	/// </summary>
-	/// <param name="descriptor">A descriptor for an index request.</param>
-	/// <param name="aliasNames">The names of the aliases.</param>
-	/// <returns>The <see cref="CreateIndexRequestDescriptor"/> to allow fluent chaining of calls to configure the indexing request.</returns>
-	public static CreateIndexRequestDescriptor WithAliases(this CreateIndexRequestDescriptor descriptor, params string[] aliasNames)
-	{
-		foreach (var name in aliasNames)
-			descriptor.Aliases(a => a.Add(name, static _ => { }));
-
-		return descriptor;
-	}
-
-	/// <summary>
 	/// Adds an alias to the index at creation time.
 	/// </summary>
 	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
@@ -76,36 +48,6 @@ public static class CreateIndexRequestDescriptorExtensions
 #endif
 
 		descriptor.Aliases(a => a.Add(aliasName, static _ => { }));
-		return descriptor;
-	}
-
-	/// <summary>
-	/// Add multiple aliases to the index at creation time.
-	/// </summary>
-	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
-	/// <param name="descriptor">A fluent descriptor for an index request.</param>
-	/// <param name="aliasNames">The names of the aliases.</param>
-	/// <returns>The <see cref="CreateIndexRequestDescriptor{TDocument}"/> to allow fluent chaining of calls to configure the indexing request.</returns>
-	public static CreateIndexRequestDescriptor<TDocument> WithAliases<TDocument>(this CreateIndexRequestDescriptor<TDocument> descriptor, params ReadOnlySpan<string> aliasNames)
-	{
-		foreach (var name in aliasNames)
-			descriptor.Aliases(a => a.Add(name, static _ => { }));
-
-		return descriptor;
-	}
-
-	/// <summary>
-	/// Add multiple aliases to the index at creation time.
-	/// </summary>
-	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
-	/// <param name="descriptor">A fluent descriptor for an index request.</param>
-	/// <param name="aliasNames">The names of the aliases.</param>
-	/// <returns>The <see cref="CreateIndexRequestDescriptor{TDocument}"/> to allow fluent chaining of calls to configure the indexing request.</returns>
-	public static CreateIndexRequestDescriptor<TDocument> WithAliases<TDocument>(this CreateIndexRequestDescriptor<TDocument> descriptor, params string[] aliasNames)
-	{
-		foreach (var name in aliasNames)
-			descriptor.Aliases(a => a.Add(name, static _ => { }));
-
 		return descriptor;
 	}
 }

--- a/src/Elastic.Clients.Elasticsearch.Shared/Api/Extensions/CreateIndexRequestDescriptorExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch.Shared/Api/Extensions/CreateIndexRequestDescriptorExtensions.cs
@@ -1,0 +1,111 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+
+#if ELASTICSEARCH_SERVERLESS
+namespace Elastic.Clients.Elasticsearch.Serverless.IndexManagement;
+#else
+namespace Elastic.Clients.Elasticsearch.IndexManagement;
+#endif
+
+public static class CreateIndexRequestDescriptorExtensions
+{
+	/// <summary>
+	/// Add multiple aliases to the index at creation time.
+	/// </summary>
+	/// <param name="descriptor">A descriptor for an index request.</param>
+	/// <param name="aliasName">The name of the alias.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor WithAlias(this CreateIndexRequestDescriptor descriptor, string aliasName)
+	{
+#if NET8_0_OR_GREATER
+		ArgumentException.ThrowIfNullOrEmpty(aliasName);
+#else
+		if (string.IsNullOrEmpty(aliasName))
+			throw new ArgumentNullException(nameof(aliasName));
+#endif
+
+		descriptor.Aliases(a => a.Add(aliasName, static _ => { }));
+		return descriptor;
+	}
+
+	/// <summary>
+	/// Add multiple aliases to the index at creation time.
+	/// </summary>
+	/// <param name="descriptor">A descriptor for an index request.</param>
+	/// <param name="aliasNames">The names of the aliases.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor WithAliases(this CreateIndexRequestDescriptor descriptor, params ReadOnlySpan<string> aliasNames)
+	{
+		foreach (var name in aliasNames)
+			descriptor.Aliases(a => a.Add(name, static _ => { }));
+
+		return descriptor;
+	}
+
+	/// <summary>
+	/// Add multiple aliases to the index at creation time.
+	/// </summary>
+	/// <param name="descriptor">A descriptor for an index request.</param>
+	/// <param name="aliasNames">The names of the aliases.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor WithAliases(this CreateIndexRequestDescriptor descriptor, params string[] aliasNames)
+	{
+		foreach (var name in aliasNames)
+			descriptor.Aliases(a => a.Add(name, static _ => { }));
+
+		return descriptor;
+	}
+
+	/// <summary>
+	/// Adds an alias to the index at creation time.
+	/// </summary>
+	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
+	/// <param name="descriptor">A fluent descriptor for an index request.</param>
+	/// <param name="aliasName">The name of the alias.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor{TDocument}"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor<TDocument> WithAlias<TDocument>(this CreateIndexRequestDescriptor<TDocument> descriptor, string aliasName)
+	{
+#if NET8_0_OR_GREATER
+		ArgumentException.ThrowIfNullOrEmpty(aliasName);
+#else
+		if (string.IsNullOrEmpty(aliasName))
+			throw new ArgumentNullException(nameof(aliasName));
+#endif
+
+		descriptor.Aliases(a => a.Add(aliasName, static _ => { }));
+		return descriptor;
+	}
+
+	/// <summary>
+	/// Add multiple aliases to the index at creation time.
+	/// </summary>
+	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
+	/// <param name="descriptor">A fluent descriptor for an index request.</param>
+	/// <param name="aliasNames">The names of the aliases.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor{TDocument}"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor<TDocument> WithAliases<TDocument>(this CreateIndexRequestDescriptor<TDocument> descriptor, params ReadOnlySpan<string> aliasNames)
+	{
+		foreach (var name in aliasNames)
+			descriptor.Aliases(a => a.Add(name, static _ => { }));
+
+		return descriptor;
+	}
+
+	/// <summary>
+	/// Add multiple aliases to the index at creation time.
+	/// </summary>
+	/// <typeparam name="TDocument">The type representing documents stored in this index.</typeparam>
+	/// <param name="descriptor">A fluent descriptor for an index request.</param>
+	/// <param name="aliasNames">The names of the aliases.</param>
+	/// <returns>The <see cref="CreateIndexRequestDescriptor{TDocument}"/> to allow fluent chaining of calls to configure the indexing request.</returns>
+	public static CreateIndexRequestDescriptor<TDocument> WithAliases<TDocument>(this CreateIndexRequestDescriptor<TDocument> descriptor, params string[] aliasNames)
+	{
+		foreach (var name in aliasNames)
+			descriptor.Aliases(a => a.Add(name, static _ => { }));
+
+		return descriptor;
+	}
+}

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsAliasResponse.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsAliasResponse.cs
@@ -5,7 +5,7 @@
 using Elastic.Transport.Products.Elasticsearch;
 
 #if ELASTICSEARCH_SERVERLESS
-namespace Elastic.Clients.Elasticsearch.IndexManagement.Serverless;
+namespace Elastic.Clients.Elasticsearch.Serverless.IndexManagement;
 #else
 namespace Elastic.Clients.Elasticsearch.IndexManagement;
 #endif

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsIndexTemplateResponse.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsIndexTemplateResponse.cs
@@ -5,7 +5,7 @@
 using Elastic.Transport.Products.Elasticsearch;
 
 #if ELASTICSEARCH_SERVERLESS
-namespace Elastic.Clients.Elasticsearch.IndexManagement.Serverless;
+namespace Elastic.Clients.Elasticsearch.Serverless.IndexManagement;
 #else
 namespace Elastic.Clients.Elasticsearch.IndexManagement;
 #endif

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsTemplateResponse.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/IndexManagement/ExistsTemplateResponse.cs
@@ -5,7 +5,7 @@
 using Elastic.Transport.Products.Elasticsearch;
 
 #if ELASTICSEARCH_SERVERLESS
-namespace Elastic.Clients.Elasticsearch.IndexManagement.Serverless;
+namespace Elastic.Clients.Elasticsearch.Serverless.IndexManagement;
 #else
 namespace Elastic.Clients.Elasticsearch.IndexManagement;
 #endif


### PR DESCRIPTION
This improves the developer experience with extension methods to simplify adding alias(es) to an index at creation time using the `CreateIndexRequestDescriptor` and `CreateIndexRequestDescriptor<T>`.

This also fixes up some incorrect namespaces in some of the manual files.