### PR TITLE
Update `Elastic.Transport` to `0.5.6`

### DIFF
--- a/src/Elastic.Clients.Elasticsearch.Serverless/Elastic.Clients.Elasticsearch.Serverless.csproj
+++ b/src/Elastic.Clients.Elasticsearch.Serverless/Elastic.Clients.Elasticsearch.Serverless.csproj
@@ -21,7 +21,7 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport" Version="0.5.5" />
+    <PackageReference Include="Elastic.Transport" Version="0.5.6" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Tests" Key="$(ExposedPublicKey)" />

--- a/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
+++ b/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
@@ -21,7 +21,7 @@
     <Nullable>annotations</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Elastic.Transport" Version="0.5.5" />
+    <PackageReference Include="Elastic.Transport" Version="0.5.6" />
   </ItemGroup>
   <ItemGroup>
     <InternalsVisibleTo Include="Tests" Key="$(ExposedPublicKey)" />

--- a/src/Playground/Playground.csproj
+++ b/src/Playground/Playground.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Moq" Version="4.18.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-    <PackageReference Include="Elastic.Transport" Version="0.5.5" />
+    <PackageReference Include="Elastic.Transport" Version="0.5.6" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 


### PR DESCRIPTION
Fixes a `NullReferenceException` when instrumentation is used.