### PR TITLE
Update getting-started.asciidoc

### DIFF
--- a/docs/getting-started.asciidoc
+++ b/docs/getting-started.asciidoc
@@ -27,16 +27,17 @@ Refer to the <<installation>> page to learn more.
 === Connecting
 
 You can connect to the Elastic Cloud using an API key and the Elasticsearch 
-endpoint. 
+cloud id. 
 
 [source,net]
 ----
 var client = new ElasticsearchClient("<CLOUD_ID>", new ApiKey("<API_KEY>")); 
 ----
 
-Your Elasticsearch endpoint can be found on the **My deployment** page of your 
+Your Elasticsearch cloud id can be found on the **My deployment** page of your 
 deployment:
 
+****** REPLACE IMAGE WITH CORRECTED ONE*****
 image::images/es-endpoint.jpg[alt="Finding Elasticsearch endpoint",align="center"]
 
 You can generate an API key on the **Management** page under Security.


### PR DESCRIPTION
The connection should be using the cloud id and API key, not the cloud endpoint.

The image unfortunately will need to be updated to as it obfuscates the cloud id and highlights the endpoint copy.

Sample Screenshot
<img width="1149" alt="Screenshot 2024-12-20 at 9 51 28 AM" src="https://github.com/user-attachments/assets/666548b2-d32a-495e-81f5-18b975ad28f6" />

This would be consistent with our docs here
https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/connecting.html#cloud-deployment

Which states always use the cloud id, for our Elastic Cloud Hosted deployments to connect.
