### PR TITLE
Update CrudExamplesTests.cs

### DIFF
--- a/tests/Tests/Documentation/Usage/CrudExamplesTests.cs
+++ b/tests/Tests/Documentation/Usage/CrudExamplesTests.cs
@@ -56,7 +56,7 @@ var tweet = new Tweet // <1>
     Message = "Trying out the client, so far so good?"
 };
 
-var response = await client.IndexAsync(tweet, "my-tweet-index"); // <2>
+var response = await client.IndexAsync(tweet, (IndexName)"my-tweet-index"); // <2>
 
 if (response.IsValidResponse) // <3>
 {


### PR DESCRIPTION
Small change in the documentation:
 
var response = await client.IndexAsync(tweet, "my-tweet-index"); // <2>

To 
var response = await client.IndexAsync(tweet, (IndexName)"my-tweet-index"); // <2>

in order to avoid an ambiguous call:

error CS0121: The call is ambiguous between the following methods or properties: 'ElasticsearchClient.IndexAsync(TDocument, IndexName, CancellationToken)' and 'ElasticsearchClient.IndexAsync(TDocument, Id?, CancellationToken)'