### PR TITLE
[docs] Clean up cross-repo links

### DIFF
--- a/docs/reference/migration-guide.md
+++ b/docs/reference/migration-guide.md
@@ -160,7 +160,7 @@ The following are some of the main features which have not been re-implemented f
 * Visitor pattern support for types such as `Properties`.
 * Support for `JoinField` which affects `ChildrenAggregation`.
 * Conditionless queries.
-* DiagnosticSources have been removed in `Elastic.Transport` to provide a clean-slate for an improved diagnostics story. The Elasticsearch .NET Client emits [OpenTelemetry](https://opentelemetry.io/) compatible `Activity` spans which can be consumed by APM agents such as the [Elastic APM Agent for .NET](apm-agent-dotnet://docs/reference/index.md).
+* DiagnosticSources have been removed in `Elastic.Transport` to provide a clean-slate for an improved diagnostics story. The Elasticsearch .NET Client emits [OpenTelemetry](https://opentelemetry.io/) compatible `Activity` spans which can be consumed by APM agents such as the [Elastic APM Agent for .NET](apm-agent-dotnet://reference/index.md).
 * Documentation is a work in progress, and we will expand on the documented scenarios in future releases.
 
 

--- a/docs/reference/using-net-client.md
+++ b/docs/reference/using-net-client.md
@@ -7,7 +7,7 @@ mapped_pages:
 
 The sections below provide tutorials on the most frequently used and some less obvious features of {{es}}.
 
-For a full reference, see the [Elasticsearch documentation](docs-content://get-started/index.md) and in particular the [REST APIs](elasticsearch://docs/reference/elasticsearch/rest-apis/index.md) section. The Elasticsearch .NET Client follows closely the JSON structures described there.
+For a full reference, see the [Elasticsearch documentation](docs-content://get-started/index.md) and in particular the [REST APIs](elasticsearch://reference/elasticsearch/rest-apis/index.md) section. The Elasticsearch .NET Client follows closely the JSON structures described there.
 
 A .NET API reference documentation for the Elasticsearch client package is available [here](https://elastic.github.io/elasticsearch-net).
 


### PR DESCRIPTION
Follow up to #8460 

When using cross-repo links, the path should be relative to the `docset.yml` not the full path within the repo ([updated docs-builder docs](https://elastic.github.io/docs-builder/syntax/links/#cross-repository-links)).