### PR TITLE
Fix #8340: Prevent null reference exception in SearchResponse<T>

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchResponse.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchResponse.cs
@@ -2,6 +2,7 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json.Serialization;
@@ -11,10 +12,10 @@ namespace Elastic.Clients.Elasticsearch;
 public partial class SearchResponse<TDocument>
 {
 	[JsonIgnore]
-	public IReadOnlyCollection<Core.Search.Hit<TDocument>> Hits => HitsMetadata.Hits;
+	public IReadOnlyCollection<Core.Search.Hit<TDocument>> Hits => HitsMetadata?.Hits ?? [];
 
 	[JsonIgnore]
-	public IReadOnlyCollection<TDocument> Documents => HitsMetadata.Hits.Select(s => s.Source).ToReadOnlyCollection();
+	public IReadOnlyCollection<TDocument> Documents => HitsMetadata?.Hits?.Select(s => s.Source).ToReadOnlyCollection() ?? [];
 
 	[JsonIgnore]
 	public long Total => HitsMetadata?.Total?.Item1?.Value ?? HitsMetadata?.Total?.Item2 ?? -1;


### PR DESCRIPTION
- Added null checks for `HitsMetadata` in `SearchResponse<T>.Documents`
- Ensured `HitsMetadata` and `Hits` are properly validated before accessing them
- Prevented potential crashes when the response contains no hits

Closes #8340