### PR TITLE
[docs] Fix image paths for docs-assembler

### DIFF
--- a/docs/reference/getting-started.md
+++ b/docs/reference/getting-started.md
@@ -35,15 +35,11 @@ var client = new ElasticsearchClient("<CLOUD_ID>", new ApiKey("<API_KEY>"));
 
 Your Elasticsearch endpoint can be found on the **My deployment** page of your deployment:
 
-:::{image} images/es-endpoint.jpg
-:alt: Finding Elasticsearch endpoint
-:::
+![Finding Elasticsearch endpoint](images/es-endpoint.jpg)
 
 You can generate an API key on the **Management** page under Security.
 
-:::{image} images/create-api-key.png
-:alt: Create API key
-:::
+![Create API key](images/create-api-key.png)
 
 For other connection options, refer to the [*Connecting*](/reference/connecting.md) section.
 

--- a/docs/reference/troubleshoot/logging-with-fiddler.md
+++ b/docs/reference/troubleshoot/logging-with-fiddler.md
@@ -11,9 +11,7 @@ A web debugging proxy such as [Fiddler](http://www.telerik.com/fiddler) is a use
 
 To capture traffic against a remote cluster is as simple as launching Fiddler! You may want to also filter traffic to only show requests to the remote cluster by using the filters tab
 
-:::{image} ../images/elasticsearch-client-net-api-capture-requests-remotehost.png
-:alt: Capturing requests to a remote host
-:::
+![Capturing requests to a remote host](../images/elasticsearch-client-net-api-capture-requests-remotehost.png)
 
 
 ## Capturing traffic to a local cluster [_capturing_traffic_to_a_local_cluster]
@@ -37,14 +35,10 @@ var client = new ElasticClient(connectionSettings);
 
 With Fiddler running, the requests and responses will now be captured and can be inspected in the Inspectors tab
 
-:::{image} ../images/elasticsearch-client-net-api-inspect-requests.png
-:alt: Inspecting requests and responses
-:::
+![Inspecting requests and responses](../images/elasticsearch-client-net-api-inspect-requests.png)
 
 As before, you may also want to filter traffic to only show requests to `ipv4.fiddler` on the port on which you are running Elasticsearch.
 
-:::{image} ../images/elasticsearch-client-net-api-capture-requests-localhost.png
-:alt: Capturing requests to localhost
-:::
+![Capturing requests to localhost](../images/elasticsearch-client-net-api-capture-requests-localhost.png)
 
 


### PR DESCRIPTION
Fixes image paths to work with docs-assembler.

Notes for the reviewer:
* I was not able to get images in reference, extend, or release-notes to work using the `:::{image}` syntax because it seems to resolve differently than the Markdown `![]()` syntax. We should address this in docs-builder, but in order to get images working as soon as possible, I've used Markdown syntax and left us a `TO DO` in a code comment to add back the `screenshot` class where applicable. 
* Can you please add the appropriate labels needed for backporting?