### PR TITLE
Set `typed_keys` to `true` by default

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/AsyncSearch/SubmitAsyncSearchRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/AsyncSearch/SubmitAsyncSearchRequest.cs
@@ -9,8 +9,9 @@ namespace Elastic.Clients.Elasticsearch.AsyncSearch;
 
 public partial class SubmitAsyncSearchRequest
 {
-	// Any request may contain aggregations so we force typed_keys in order to successfully deserialize them.
-	internal override void BeforeRequest() => TypedKeys = true;
+	// Any request may contain aggregations so we force `typed_keys` in order to successfully
+	// // deserialize them.
+	internal override void BeforeRequest() => TypedKeys ??= true;
 }
 
 public readonly partial struct SubmitAsyncSearchRequestDescriptor

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/MultiSearchTemplateRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/MultiSearchTemplateRequest.cs
@@ -22,7 +22,7 @@ public partial class MultiSearchTemplateResponse<TDocument>
 
 public partial class MultiSearchTemplateRequest : IStreamSerializable
 {
-	internal override void BeforeRequest() => TypedKeys = true;
+	internal override void BeforeRequest() => TypedKeys ??= true;
 
 	void IStreamSerializable.Serialize(Stream stream, IElasticsearchClientSettings settings, SerializationFormatting formatting)
 	{

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/Rollup/RollupSearchRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/Rollup/RollupSearchRequest.cs
@@ -2,9 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Elastic.Clients.Elasticsearch.AsyncSearch;
+namespace Elastic.Clients.Elasticsearch.Rollup;
 
-public partial class GetAsyncSearchRequest
+public partial class RollupSearchRequest
 {
 	// Any request may contain aggregations so we force `typed_keys` in order to successfully
 	// deserialize them.

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchApplication/RollupSearchRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchApplication/RollupSearchRequest.cs
@@ -2,9 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Elastic.Clients.Elasticsearch.AsyncSearch;
+namespace Elastic.Clients.Elasticsearch.SearchApplication;
 
-public partial class GetAsyncSearchRequest
+public partial class SearchApplicationSearchRequest
 {
 	// Any request may contain aggregations so we force `typed_keys` in order to successfully
 	// deserialize them.

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchRequest.cs
@@ -16,9 +16,9 @@ public partial class SearchRequest
 {
 	internal override void BeforeRequest()
 	{
-		if (Aggregations is not null || Suggest is not null)
+		if (Aggregations is { Count: > 0 } || Suggest is { Suggesters: { Count: > 0 } })
 		{
-			TypedKeys = true;
+			TypedKeys ??= true;
 		}
 	}
 

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchTemplateRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/SearchTemplateRequest.cs
@@ -2,9 +2,9 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Elastic.Clients.Elasticsearch.AsyncSearch;
+namespace Elastic.Clients.Elasticsearch;
 
-public partial class GetAsyncSearchRequest
+public partial class SearchTemplateRequest
 {
 	// Any request may contain aggregations so we force `typed_keys` in order to successfully
 	// deserialize them.

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Api/Security/QueryApiKeysRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Api/Security/QueryApiKeysRequest.cs
@@ -2,11 +2,17 @@
 // Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
 // See the LICENSE file in the project root for more information.
 
-namespace Elastic.Clients.Elasticsearch.AsyncSearch;
+namespace Elastic.Clients.Elasticsearch.Security;
 
-public partial class GetAsyncSearchRequest
+public partial class QueryApiKeysRequest
 {
 	// Any request may contain aggregations so we force `typed_keys` in order to successfully
 	// deserialize them.
-	internal override void BeforeRequest() => TypedKeys ??= true;
+	internal override void BeforeRequest()
+	{
+		if (Aggregations is { Count: > 0 })
+		{
+			TypedKeys ??= true;
+		}
+	}
 }


### PR DESCRIPTION
Sets `TypedKeys` to `true` before executing a request that might return aggregations or suggestions (if not explictly set to `false`). This is required to correctly deserialize the aggregation / suggestion results.