### PR TITLE
Fix missing quote in docs example

### DIFF
--- a/docs/reference/transport.md
+++ b/docs/reference/transport.md
@@ -56,7 +56,7 @@ var response = await client.Transport
 The `OnBeforeRequest` callback in `IElasticsearchClientSettings` can be used to dynamically modify requests.
 
 ```csharp
-var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200))
+var settings = new ElasticsearchClientSettings(new Uri("http://localhost:9200"))
     .OnBeforeRequest(OnBeforeRequest); <1>
 
 RequestConfiguration? globalRequestConfiguration = null;


### PR DESCRIPTION
Fixes a missing quote reported in https://github.com/elastic/docs-content/issues/2164

Closes: https://github.com/elastic/docs-content/issues/2164