### PR TITLE
BulkResponseItemConverter: Continue after skipping unmapped json member

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkResponseItemConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkResponseItemConverter.cs
@@ -109,6 +109,7 @@ public sealed class BulkResponseItemConverter : JsonConverter<ResponseItem>
 			if (options.UnmappedMemberHandling is JsonUnmappedMemberHandling.Skip)
 			{
 				reader.Skip();
+				continue;
 			}
 
 			throw new JsonException($"Unknown JSON property '{reader.GetString()}' for type '{typeToConvert.Name}'.");


### PR DESCRIPTION
Should resolve #8697