### PR TITLE
Default DOTNET_VERSION=9.0.305 for unified-release workflow

### DIFF
--- a/.ci/make.sh
+++ b/.ci/make.sh
@@ -42,7 +42,7 @@ OUTPUT_DIR="$repo/${output_folder}"
 REPO_BINDING="${OUTPUT_DIR}:/sln/${output_folder}"
 mkdir -p "$OUTPUT_DIR"
 
-DOTNET_VERSION=${DOTNET_VERSION-9.0.100}
+DOTNET_VERSION=${DOTNET_VERSION-9.0.305}
 
 echo -e "\033[34;1mINFO:\033[0m PRODUCT ${product}\033[0m"
 echo -e "\033[34;1mINFO:\033[0m VERSION ${STACK_VERSION}\033[0m"


### PR DESCRIPTION
This should resolve the unified-release workflow failures.

The errors were most likely caused by the discard operators in `JsonUnionSelector.T1` and `JsonUnionSelector.T2`.

`DOTNET_VERSION=9.0.100 ./.ci/make.sh assemble 9.0.0-SNAPSHOT` fails.
`DOTNET_VERSION=9.0.305 ./.ci/make.sh assemble 9.0.0-SNAPSHOT` succeeds.

Went through release notes of different versions of .NET 9. Couldn't find any mentions of this issue. But hey - it works.