### PR TITLE
Switch to custom `SafeSkip()` method that works with partial JSON blocks

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonUnionSelector.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonUnionSelector.cs
@@ -119,7 +119,7 @@ internal static class JsonUnionSelector
 			}
 
 			internalReader.Read();
-			internalReader.Skip();
+			internalReader.SafeSkip();
 		}
 
 		return UnionTag.None;

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkResponseItemConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkResponseItemConverter.cs
@@ -108,7 +108,7 @@ public sealed class BulkResponseItemConverter : JsonConverter<ResponseItem>
 
 			if (options.UnmappedMemberHandling is JsonUnmappedMemberHandling.Skip)
 			{
-				reader.Skip();
+				reader.SafeSkip();
 				continue;
 			}
 


### PR DESCRIPTION
Related to #8718