### PR TITLE
Add `Experimental` attribute to `FilterPath`

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -5,7 +5,7 @@
     <AssemblyOriginatorKeyFile>$(SolutionRoot)\build\keys\keypair.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <PropertyGroup Condition="$(IsPackable) == True">
-    <NoWarn>1591,1572,1571,1573,1587,1570,NU5048</NoWarn>
+    <NoWarn>$(NoWarn), 1591,1572,1571,1573,1587,1570,NU5048</NoWarn>
     <CheckEolTargetFramework>false</CheckEolTargetFramework>
     <Prefer32Bit>false</Prefer32Bit>
     <DebugSymbols>true</DebugSymbols>

--- a/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
+++ b/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
@@ -22,9 +22,7 @@
     <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0')) or
-                            $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net9.0')) or
-                            $([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net10.0'))">
+  <PropertyGroup Condition="$([MSBuild]::IsTargetFrameworkCompatible('$(TargetFramework)', 'net8.0'))">
     <IsAotCompatible>true</IsAotCompatible>
   </PropertyGroup>
 

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Core/Request/PlainRequest.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Core/Request/PlainRequest.cs
@@ -3,6 +3,7 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Text.Json.Serialization;
 using Elastic.Transport;
 
@@ -28,11 +29,17 @@ public abstract class PlainRequest<TParameters> : Request<TParameters>
 	/// <summary>
 	/// A list of filters used to reduce the response.
 	/// <para>
-	///     Use of response filtering can result in a response from Elasticsearch
-	///     that cannot be correctly deserialized to the respective response type for the request.
-	///     In such situations, use the low level client to issue the request and handle response deserialization.
+	///     Use of response filtering can result in a response from Elasticsearch that cannot be correctly deserialized
+	///     to the respective response type for the request. In such situations, use the low level client to issue the
+	///     request and handle response deserialization.
 	/// </para>
 	/// </summary>
+	[Experimental("ESCEXP0001", UrlFormat = "https://www.elastic.co/docs/reference/elasticsearch/clients/dotnet/experimental#{0}"
+#if NET10_0_OR_GREATER
+		, Message = "Use of response filtering can result in a response from Elasticsearch that cannot be correctly deserialized " +
+		            "to the respective response type for the request."
+#endif
+	)]
 	[JsonIgnore]
 	public string[]? FilterPath
 	{


### PR DESCRIPTION
The `FilterPath` usage is a frequent source of issues. This PR adds the `Experimental` attribute to the `FilterPath` property to emit a `ESCEXP0001` diagnostic that requires users to explicitly opt-in.

The generator was updated as well to also emit this attribute for all related descriptors.