### PR TITLE
Fix mutable Metrics.All singleton and constructor bugs

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Core/Infer/Metric/Metrics.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Core/Infer/Metric/Metrics.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 
 using Elastic.Transport;
 
@@ -20,8 +21,6 @@ public sealed class Metrics :
 	, IParsable<Metrics>
 #endif
 {
-	private static readonly HashSet<string> EmptyMetrics = new();
-
 	/// <summary>
 	/// An instance of <see cref="Metrics"/> representing all statistics.
 	/// </summary>
@@ -33,12 +32,12 @@ public sealed class Metrics :
 	public Metrics(string metric)
 	{
 		if (string.IsNullOrEmpty(metric))
-			Values = EmptyMetrics;
-
-		Values = new HashSet<string>()
 		{
-			metric
-		};
+			Values = [];
+			return;
+		}
+
+		Values = [metric];
 	}
 
 	/// <summary>
@@ -47,12 +46,17 @@ public sealed class Metrics :
 	public Metrics(IEnumerable<string> metrics)
 	{
 		if (metrics is null)
-			Values = EmptyMetrics;
+		{
+			Values = [];
+			return;
+		}
 
-		Values = new HashSet<string>(metrics);
+		Values = new HashSet<string>(metrics).ToArray();
 	}
 
-	private HashSet<string> Values { get; }
+	// Stored as an immutable array to prevent mutation of the shared Metrics.All singleton
+	// and any other Metrics instances.
+	private string[] Values { get; }
 
 	/// <inheritdoc />
 	public bool Equals(Metrics other)
@@ -61,7 +65,7 @@ public sealed class Metrics :
 			return false;
 
 		// Equality is true when both instances have the same metric names.
-		return Values.SetEquals(other.Values);
+		return new HashSet<string>(Values).SetEquals(other.Values);
 	}
 
 	string IUrlParameter.GetString(ITransportConfiguration settings) => GetString();
@@ -71,7 +75,7 @@ public sealed class Metrics :
 
 	private string GetString()
 	{
-		if (Values == EmptyMetrics)
+		if (Values.Length == 0)
 			return string.Empty;
 
 		return string.Join(",", Values);


### PR DESCRIPTION
## Summary

Fixes #7732

- **Immutability**: Changed the backing type of `Metrics.Values` from `HashSet<string>` to `string[]`. Arrays are fixed-size and cannot have elements added or removed, making `Metrics.All` and all other `Metrics` instances genuinely immutable.
- **Constructor bug**: The null/empty guard in both constructors assigned `Values = EmptyMetrics` but then fell through to overwrite it unconditionally. Added `return` after the guard so it takes effect.
- **Shared mutable field removed**: Removed the `private static readonly HashSet<string> EmptyMetrics` shared field; replaced with array literals `[]`.

## Test plan

- [ ] Verify `Metrics.All.ToString()` returns `"_all"` after this change
- [ ] Verify `new Metrics(string.Empty).ToString()` returns `""` (was broken before due to constructor bug)
- [ ] Verify `new Metrics((string)null)` no longer silently produces a set containing `null`
- [ ] Existing unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)