### PR TITLE
Fix Query operators to reflect nullable parameters

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/QueryDsl/Query.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/QueryDsl/Query.cs
@@ -14,10 +14,10 @@ public partial class Query
 
 	public static bool operator true(Query _) => false;
 
-	public static Query operator &(Query leftContainer, Query rightContainer) =>
+	public static Query operator &(Query? leftContainer, Query? rightContainer) =>
 		And(leftContainer, rightContainer);
 
-	internal static Query And(Query leftContainer, Query rightContainer)
+	internal static Query And(Query? leftContainer, Query? rightContainer)
 	{
 		if (leftContainer is null && rightContainer is null)
 		{
@@ -25,7 +25,7 @@ public partial class Query
 		}
 
 		if (rightContainer is null)
-			return leftContainer;
+			return leftContainer!;
 
 		if (leftContainer is null)
 			return rightContainer;
@@ -33,9 +33,9 @@ public partial class Query
 		return leftContainer.CombineAsMust(rightContainer);
 	}
 
-	public static Query operator |(Query leftContainer, Query rightContainer) => Or(leftContainer, rightContainer);
+	public static Query operator |(Query? leftContainer, Query? rightContainer) => Or(leftContainer, rightContainer);
 
-	internal static Query Or(Query leftContainer, Query rightContainer)
+	internal static Query Or(Query? leftContainer, Query? rightContainer)
 	{
 		if (leftContainer is null && rightContainer is null)
 		{
@@ -43,7 +43,7 @@ public partial class Query
 		}
 
 		if (rightContainer is null)
-			return leftContainer;
+			return leftContainer!;
 
 		if (leftContainer is null)
 			return rightContainer;
@@ -51,11 +51,11 @@ public partial class Query
 		return leftContainer.CombineAsShould(rightContainer);
 	}
 
-	public static Query operator !(Query queryContainer) => queryContainer is null
+	public static Query? operator !(Query? queryContainer) => queryContainer is null
 			? null
 			: new() { Bool = new() { MustNot = [queryContainer] } };
 
-	public static Query operator +(Query queryContainer) => queryContainer is null
+	public static Query? operator +(Query? queryContainer) => queryContainer is null
 		? null
 		: new() { Bool = new() { Filter = [queryContainer] } };
 }


### PR DESCRIPTION
## Summary

Fixes #8807

The `&`, `|`, `!`, and `+` operators on `Query` silently handle `null` arguments in their implementations, but the method signatures declared non-nullable parameters. This caused spurious `CS8604` (possible null reference argument) warnings when combining `Query?` variables with these operators under nullable reference types.

Changes:
- `operator &` and `operator |`: parameters changed from `Query` to `Query?`
- `And()` and `Or()` internal helpers: parameters changed to `Query?`, non-null assertions added where the logic guarantees non-null after null checks
- `operator !` and `operator +`: return types changed to `Query?` to reflect they return `null` when the input is `null`

## Test plan

- [ ] Project compiles without `CS8604` warnings when using `Query?` variables with `&` and `|`
- [ ] `null & query` and `query & null` return the non-null operand (existing behavior preserved)
- [ ] `!((Query?)null)` returns `null` (existing behavior preserved)
- [ ] Existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/claude-code)