### PR TITLE
Fix BulkDeleteOperation ignoring index set on BulkRequest

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkDeleteOperation.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkDeleteOperation.cs
@@ -103,7 +103,11 @@ public sealed class BulkDeleteOperation<T> :
 				Routing = routing;
 		}
 
-		Index ??= typeof(T);
+		// Only infer the index from the CLR type if PrepareIndex has not already resolved it
+		// from the BulkRequest URL (in which case _indexPrepared is true and Index is null
+		// intentionally to avoid writing a redundant _index field in the operation body).
+		if (!_indexPrepared)
+			Index ??= typeof(T);
 	}
 
 	protected override Type ClrType => typeof(T);

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkOperation.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/Core/Bulk/BulkOperation.cs
@@ -103,12 +103,18 @@ public abstract class BulkOperation :
 	/// <param name="settings">The <see cref="IElasticsearchClientSettings"/> for the current client instance.</param>
 	protected abstract Task SerializeAsync(Stream stream, IElasticsearchClientSettings settings);
 
+	// Set to true after PrepareIndex has resolved the index from the BulkRequest URL, so that
+	// SetValues overrides in subclasses do not overwrite a null Index with a CLR type inference.
+	private protected bool _indexPrepared;
+
 	void IBulkOperation.PrepareIndex(IndexName? bulkRequestIndex)
 	{
 		Index ??= bulkRequestIndex ?? ClrType;
 
 		if (bulkRequestIndex is not null && (Index?.Equals(bulkRequestIndex) ?? false))
 			Index = null;
+
+		_indexPrepared = true;
 	}
 
 	/// <inheritdoc />


### PR DESCRIPTION
## Summary

Fixes #7988
Fixes #8001
Fixes #8522

When a `BulkRequest` was created with an index name (e.g. `new BulkRequest("my-index")`), bulk delete operations using non-mapped generic types (e.g. `BulkDeleteOperation<IReadOnlyDictionary<string, object>>`) would fail with:

> `Index name is null for the given type and no default index is set`

**Root cause**: `PrepareIndex()` sets `Index = null` as an optimization when the operation index matches the BulkRequest URL index (to avoid writing a redundant `_index` field in the NDJSON body). However, `SetValues()` — called later during serialization — would then set `Index ??= typeof(T)`, which overwrites the `null` with the CLR type. For types without index mappings (like `IReadOnlyDictionary`), resolving this type to an index name throws.

**Fix**: Added `_indexPrepared` flag to `BulkOperation`. It is set in `PrepareIndex()`. `BulkDeleteOperation<T>.SetValues()` now skips `Index ??= typeof(T)` when the flag is set, preserving the intentional `null` from the optimization path.

## Test plan

- [ ] `BulkAsync` with index on `BulkRequest` and `BulkDeleteOperation<IReadOnlyDictionary<string, object>>` completes without exception
- [ ] `BulkAsync(b => b.Index("name").IndexMany(...))` without per-operation index works (issue #8522)
- [ ] Operations with an explicit per-operation index still use that index
- [ ] Operations without any index and no BulkRequest index still infer from CLR type

🤖 Generated with [Claude Code](https://claude.ai/claude-code)