### PR TITLE
Fix TermSuggester/PhraseSuggester serializing 'text' inside wrong object

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/FieldSuggester.Converters.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/FieldSuggester.Converters.g.cs
@@ -121,9 +121,16 @@ public sealed partial class FieldSuggesterConverter : System.Text.Json.Serializa
 				throw new System.Text.Json.JsonException($"Variant '{value.VariantType}' is not supported for type '{nameof(Elastic.Clients.Elasticsearch.Core.Search.FieldSuggester)}'.");
 		}
 
+		// "text" must always be written at this level (sibling to the variant), never inside the variant object.
+		// If the user set Text on the inner variant (TermSuggester/PhraseSuggester), promote it here.
+		// See: https://github.com/elastic/elasticsearch-net/issues/8310
+		var effectiveText = value.Text
+			?? (value.Variant as Elastic.Clients.Elasticsearch.Core.Search.TermSuggester)?.Text
+			?? (value.Variant as Elastic.Clients.Elasticsearch.Core.Search.PhraseSuggester)?.Text;
+
 		writer.WriteProperty(options, PropPrefix, value.Prefix, null, null);
 		writer.WriteProperty(options, PropRegex, value.Regex, null, null);
-		writer.WriteProperty(options, PropText, value.Text, null, null);
+		writer.WriteProperty(options, PropText, effectiveText, null, null);
 		writer.WriteEndObject();
 	}
 }

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/PhraseSuggester.Converters.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/PhraseSuggester.Converters.g.cs
@@ -191,7 +191,8 @@ public sealed partial class PhraseSuggesterConverter : System.Text.Json.Serializ
 		writer.WriteProperty(options, PropShardSize, value.ShardSize, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, int? v) => w.WriteNullableValue<int>(o, v));
 		writer.WriteProperty(options, PropSize, value.Size, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, int? v) => w.WriteNullableValue<int>(o, v));
 		writer.WriteProperty(options, PropSmoothing, value.Smoothing, null, null);
-		writer.WriteProperty(options, PropText, value.Text, null, null);
+		// "text" is intentionally not written here. It must be serialized at the FieldSuggester level
+		// (as a sibling of "phrase"), not inside the "phrase" object. See: https://github.com/elastic/elasticsearch-net/issues/8310
 		writer.WriteProperty(options, PropTokenLimit, value.TokenLimit, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, int? v) => w.WriteNullableValue<int>(o, v));
 		writer.WriteEndObject();
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/TermSuggester.Converters.g.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Generated/Types/Core/Search/TermSuggester.Converters.g.cs
@@ -183,7 +183,8 @@ public sealed partial class TermSuggesterConverter : System.Text.Json.Serializat
 		writer.WriteProperty(options, PropSort, value.Sort, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, Elastic.Clients.Elasticsearch.Core.Search.SuggestSort? v) => w.WriteNullableValue<Elastic.Clients.Elasticsearch.Core.Search.SuggestSort>(o, v));
 		writer.WriteProperty(options, PropStringDistance, value.StringDistance, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, Elastic.Clients.Elasticsearch.Core.Search.StringDistance? v) => w.WriteNullableValue<Elastic.Clients.Elasticsearch.Core.Search.StringDistance>(o, v));
 		writer.WriteProperty(options, PropSuggestMode, value.SuggestMode, null, static (System.Text.Json.Utf8JsonWriter w, System.Text.Json.JsonSerializerOptions o, Elastic.Clients.Elasticsearch.SuggestMode? v) => w.WriteNullableValue<Elastic.Clients.Elasticsearch.SuggestMode>(o, v));
-		writer.WriteProperty(options, PropText, value.Text, null, null);
+		// "text" is intentionally not written here. It must be serialized at the FieldSuggester level
+		// (as a sibling of "term"), not inside the "term" object. See: https://github.com/elastic/elasticsearch-net/issues/8310
 		writer.WriteEndObject();
 	}
 }


### PR DESCRIPTION
## Summary

Fixes #8310

When using `TermSuggester` or `PhraseSuggester` with the `Text` property set, the client was serializing `text` inside the inner suggester object (e.g. inside `"term": { ... }`). Elasticsearch does not support `text` at that level and returns:

> `parsing_exception: suggester[term] doesn't support field [text]`

The correct structure places `text` as a sibling of the suggester type:

```json
// ❌ Before (invalid)
{ "my-suggest": { "term": { "field": "...", "text": "elastic" } } }

// ✅ After (correct)
{ "my-suggest": { "text": "elastic", "term": { "field": "..." } } }
```

**Changes**:
- `TermSuggesterConverter.Write`: no longer writes `text` inside the `term` object
- `PhraseSuggesterConverter.Write`: no longer writes `text` inside the `phrase` object
- `FieldSuggesterConverter.Write`: promotes `Text` from the inner `TermSuggester` or `PhraseSuggester` variant when `FieldSuggester.Text` is not explicitly set, ensuring it is always written at the correct outer level

Note: these are generated files. The upstream fix should be applied in `elasticsearch-specification` to remove `text` from `TermSuggester` and `PhraseSuggester` model definitions.

## Test plan

- [ ] Serializing a `TermSuggester` with `Text` set produces `"text"` at the `FieldSuggester` level
- [ ] The resulting request is accepted by Elasticsearch without a `parsing_exception`
- [ ] Setting `Text` on `FieldSuggester` directly (the correct API) continues to work
- [ ] Round-trip read of a suggest response preserves `Text`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)