### PR TITLE
Fix DefaultMappingFor not consuming IdPropertyName and DisableIdInference

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/ElasticsearchClientSettings.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/ElasticsearchClientSettings.cs
@@ -321,6 +321,11 @@ public abstract class ElasticsearchClientSettingsBase<TConnectionSettings> :
 		if (!string.IsNullOrWhiteSpace(inferMapping._idProperty))
 			_idProperties[inferMapping._clrType] = inferMapping._idProperty;
 
+		if (inferMapping._disableIdInference)
+			_disableIdInference.Add(inferMapping._clrType);
+		else
+			_disableIdInference.Remove(inferMapping._clrType);
+
 		return (TConnectionSettings)this;
 	}
 
@@ -340,6 +345,14 @@ public abstract class ElasticsearchClientSettingsBase<TConnectionSettings> :
 
 			if (!inferMapping.RelationName.IsNullOrEmpty())
 				_defaultRelationNames[inferMapping.ClrType] = inferMapping.RelationName;
+
+			if (!string.IsNullOrWhiteSpace(inferMapping.IdPropertyName))
+				_idProperties[inferMapping.ClrType] = inferMapping.IdPropertyName;
+
+			if (inferMapping.DisableIdInference)
+				_disableIdInference.Add(inferMapping.ClrType);
+			else
+				_disableIdInference.Remove(inferMapping.ClrType);
 		}
 
 		return (TConnectionSettings)this;


### PR DESCRIPTION
## Summary

- The `IEnumerable<ClrTypeMapping>` overload of `DefaultMappingFor` was missing handling for `IdPropertyName` and `DisableIdInference`
- The non-generic `Action<ClrTypeMappingDescriptor>` overload was also missing `DisableIdInference` handling
- Both overloads now match the behavior of the generic `DefaultMappingFor<TDocument>` overload

Closes #8869