### PR TITLE
Remove obsolete ElasticsearchClientProductRegistration overrides

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/Core/ElasticsearchClientProductRegistration.cs
+++ b/src/Elastic.Clients.Elasticsearch/Core/ElasticsearchClientProductRegistration.cs
@@ -3,8 +3,6 @@
 // See the LICENSE file in the project root for more information.
 
 using System;
-using System.Diagnostics.CodeAnalysis;
-using Elastic.Transport;
 using Elastic.Transport.Products.Elasticsearch;
 
 namespace Elastic.Clients.Elasticsearch;
@@ -14,26 +12,4 @@ internal sealed class ElasticsearchClientProductRegistration : ElasticsearchProd
 	public ElasticsearchClientProductRegistration(Type markerType) : base(markerType) { }
 
 	public static ElasticsearchClientProductRegistration DefaultForElasticsearchClientsElasticsearch { get; } = new(typeof(ElasticsearchClient));
-
-	/// <summary>
-	///     Elastic.Clients.Elasticsearch handles 404 in its <see cref="ElasticsearchResponse.IsValidResponse" />, we do not want the low level client throwing
-	///     exceptions
-	///     when <see cref="IRequestConfiguration.ThrowExceptions" /> is enabled for 404's. The client is in charge of
-	///     composing paths
-	///     so a 404 never signals a wrong URL but a missing entity.
-	/// </summary>
-	public override bool HttpStatusCodeClassifier(HttpMethod method, int statusCode) =>
-		statusCode is >= 200 and < 300 or 404;
-
-	/// <summary>
-	///     Makes the low level transport aware of Elastic.Clients.Elasticsearch's <see cref="ElasticsearchResponse" />
-	///     so that it can peek in to its exposed error when reporting failures.
-	/// </summary>
-	public override bool TryGetServerErrorReason<TResponse>(TResponse response, [NotNullWhen(returnValue: true)] out string? reason)
-	{
-		if (response is not ElasticsearchResponse r)
-			return base.TryGetServerErrorReason(response, out reason);
-		reason = r.ElasticsearchServerError?.Error?.ToString();
-		return !string.IsNullOrEmpty(reason);
-	}
 }

--- a/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
+++ b/src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
@@ -32,7 +32,7 @@
 
   <ItemGroup>
     <PackageReference Include="Elastic.Esql" Version="0.11.0" />
-    <PackageReference Include="Elastic.Transport" Version="0.16.0" />
+    <PackageReference Include="Elastic.Transport" Version="0.17.0" />
     <PackageReference Include="PolySharp" Version="1.15.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Summary

Both overrides on `ElasticsearchClientProductRegistration` are obsoleted by the centralised error-extraction work in `Elastic.Transport` (elastic/elastic-transport-net#205) and the throw-alignment change in elastic/elastic-transport-net#208. The class is now constructor + `DefaultForElasticsearchClientsElasticsearch` factory only.

Fixes #8890. The `Elastic.Transport` PackageReference bump that ships the throw-alignment change will follow as a separate commit once that PR is released.

## Why each override is removed

### `HttpStatusCodeClassifier` (`or 404`)

The override was added to keep the low-level transport from throwing on legitimate 404s under `ThrowExceptions=true`. Post-#8890 the same predicate also gates `mayHaveErrorBody` in `DefaultResponseFactory` — so for every 404 the entire product error-extraction block was silently skipped, leaving `ProductError` null, `IsValidResponse` lenient, and the typed builder downstream blowing up with `UnexpectedTransportException` whenever the body didn't match the typed response shape (e.g. `client.Indices.GetAliasAsync(name: "missing")`, `client.Indices.GetAsync("missing-index")`).

The throw concern is now addressed product-side via `ProductRegistration.IsValidResponse` (elastic/elastic-transport-net#208), which the new transport throw path consults. With that change merged, real-error 404s throw under `ThrowExceptions=true` and valid 404s (missing-doc, missing-index existence checks) don't — the desired contract. Keeping this override here would re-introduce the error-extraction regression.

### `TryGetServerErrorReason`

Pure no-op duplicate post-#8890. The override casts to `ElasticsearchResponse` and reads `r.ElasticsearchServerError?.Error`, but `ElasticsearchServerError` is now a computed property over `ApiCallDetails.ProductError`, which is exactly what the base implementation in `ElasticsearchProductRegistration.TryGetServerErrorReason` already reads. Same code path, same result.

## Behavior change

Under `ThrowExceptions=true` (default is `false`):

- Real-error 4xx/5xx now throw — previously the `or 404` override was masking real-error 404s (e.g. `pit_not_found`, `index_not_found`) by claiming 404 was a successful status code.
- Valid 404s — `client.GetAsync<MyDoc>(idx, missing-id)` returning `{"_index":"…","_id":"…","found":false}` — continue to NOT throw, this time correctly via `ProductRegistration.IsValidResponse` rather than by lying about status-code success.

Default `ThrowExceptions=false` users see no change; both real errors and valid 404s now flow through the response correctly (`IsValidResponse=false` + populated `ElasticsearchServerError` for real errors, `IsValidResponse=true` + `Found=false` for valid 404s).