### PR TITLE
Add plugin-defined (non-exhaustive) variant registry

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,93 @@
+### Header #########################################################################################
+
+# Author: Florian Bernd
+# Source: https://github.com/zysharp/templates
+
+### Git Line Endings ###############################################################################
+
+# Set default behavior to automatically normalize line endings
 * text=auto
 
-*.sh text eol=lf
-.ci/run-tests text eol=lf
+# Documents
+*.md       text diff=markdown
+*.mdx      text diff=markdown
+
+# Serialization
+*.json     text
+*.toml     text
+*.xml      text
+*.yaml     text
+*.yml      text
+
+# Graphics
+*.eps      binary
+*.gif      binary
+*.ico      binary
+*.jpg      binary
+*.jpeg     binary
+*.png      binary
+*.tif      binary
+*.tiff     binary
+
+# Force batch scripts to always use CRLF line endings
+*.bat      text eol=crlf
+*.cmd      text eol=crlf
+*.ps1      text eol=crlf
+
+# Force bash scripts to always use LF line endings
+*.bash     text eol=lf
+*.fish     text eol=lf
+*.sh       text eol=lf
+*.zsh      text eol=lf
+
+# Text files where line endings should be preserved
+*.patch    -text
+
+### .NET ###########################################################################################
+
+*.sln      text
+
+### C# #############################################################################################
+
+*.cs       text diff=csharp
+*.csx      text diff=csharp
+*.cshtml   text diff=html
+*.csproj   text
+
+### F# #############################################################################################
+
+*.fs       text diff=fsharp
+*.fsx      text diff=fsharp
+*.fsproj   text
+
+### Exclude files from exporting ###################################################################
+
+.gitattributes export-ignore
+.gitignore     export-ignore
+.gitkeep       export-ignore
+
+### License ########################################################################################
+
+# The MIT License (MIT)
+#
+# Copyright (c) 2023 Florian Bernd
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+####################################################################################################

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/ElasticsearchClientSettings.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/ElasticsearchClientSettings.cs
@@ -113,6 +113,7 @@ public abstract class ElasticsearchClientSettingsBase<TConnectionSettings> :
 	private readonly FluentDictionary<MemberInfo, PropertyMapping> _propertyMappings = new();
 	private readonly FluentDictionary<Type, string> _routeProperties = new();
 	private readonly Serializer _sourceSerializer;
+	private readonly VariantRegistry _variantRegistry = new();
 	private BeforeRequestEvent? _onBeforeRequest;
 	private bool _experimentalEnableSerializeNullInferredValues;
 	private FloatVectorDataEncoding _floatVectorDataEncoding = Serialization.FloatVectorDataEncoding.Base64;
@@ -151,6 +152,9 @@ public abstract class ElasticsearchClientSettingsBase<TConnectionSettings> :
 
 	public Serializer SourceSerializer => _sourceSerializer;
 
+	/// <inheritdoc cref="IElasticsearchClientSettings.Variants" />
+	public VariantRegistry Variants => _variantRegistry;
+
 	bool IElasticsearchClientSettings.DefaultDisableIdInference => _defaultDisableAllInference;
 	Func<string, string> IElasticsearchClientSettings.DefaultFieldNameInferrer => _defaultFieldNameInferrer;
 	string IElasticsearchClientSettings.DefaultIndex => _defaultIndex;
@@ -170,6 +174,7 @@ public abstract class ElasticsearchClientSettingsBase<TConnectionSettings> :
 	FloatVectorDataEncoding IElasticsearchClientSettings.FloatVectorDataEncoding => _floatVectorDataEncoding;
 	ByteVectorDataEncoding IElasticsearchClientSettings.ByteVectorDataEncoding => _byteVectorDataEncoding;
 	ExperimentalSettings IElasticsearchClientSettings.Experimental => _experimentalSettings;
+	VariantRegistry IElasticsearchClientSettings.Variants => _variantRegistry;
 
 	bool IElasticsearchClientSettings.ExperimentalEnableSerializeNullInferredValues => _experimentalEnableSerializeNullInferredValues;
 

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/IElasticsearchClientSettings.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Core/Configuration/IElasticsearchClientSettings.cs
@@ -154,6 +154,11 @@ public interface IElasticsearchClientSettings : ITransportConfiguration
 	/// Experimental settings.
 	/// </summary>
 	ExperimentalSettings Experimental { get; }
+
+	/// <summary>
+	/// The registry of plugin-defined CLR types for non-exhaustive variant families.
+	/// </summary>
+	VariantRegistry Variants { get; }
 }
 
 public sealed class ExperimentalSettings

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonSerializerOptionsExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonSerializerOptionsExtensions.cs
@@ -40,4 +40,12 @@ internal static partial class JsonSerializerOptionsExtensions
 	{
 		return ContextProvider<TContext>.GetContext(options);
 	}
+
+	[UnconditionalSuppressMessage("AOT", "IL3050:Calling members annotated with 'RequiresDynamicCodeAttribute'", Justification = "Always using explicit TypeInfoResolver")]
+	[UnconditionalSuppressMessage("Trimming", "IL2026:Members annotated with 'RequiresUnreferencedCodeAttribute'", Justification = "Always using explicit TypeInfoResolver")]
+	[MethodImpl(MethodImplOptions.AggressiveInlining)]
+	public static bool TryGetContext<TContext>(this JsonSerializerOptions options, [MaybeNullWhen(false)] out TContext context)
+	{
+		return ContextProvider<TContext>.TryGetContext(options, out context);
+	}
 }

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/VariantDelegates.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/VariantDelegates.cs
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System.Text.Json;
+
+namespace Elastic.Clients.Elasticsearch.Serialization;
+
+internal delegate T? VariantReader<out T>(ref Utf8JsonReader reader, JsonSerializerOptions options);
+
+internal delegate void VariantWriter<in T>(Utf8JsonWriter writer, T value, JsonSerializerOptions options);
+
+internal readonly struct VariantWriterRegistration<T>
+{
+	public VariantWriterRegistration(string discriminator, VariantWriter<T> writer)
+	{
+		Discriminator = discriminator;
+		_writer = writer;
+	}
+
+	private readonly VariantWriter<T> _writer;
+
+	public string Discriminator { get; }
+
+	public void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+		_writer(writer, value, options);
+}

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/VariantRegistry.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/VariantRegistry.cs
@@ -1,0 +1,145 @@
+// Licensed to Elasticsearch B.V under one or more agreements.
+// Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information.
+
+using System;
+using System.Collections.Concurrent;
+using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
+
+namespace Elastic.Clients.Elasticsearch.Serialization;
+
+/// <summary>
+/// A per-<see cref="IElasticsearchClientSettings"/> registry that lets callers plug in their own CLR types for
+/// plugin-defined discriminator values of non-exhaustive variant families.
+/// </summary>
+public sealed class VariantRegistry
+{
+	private sealed class RegisteredVariantWriter(string discriminator, Delegate writer)
+	{
+		public string Discriminator { get; } = discriminator;
+		public Delegate Writer { get; } = writer;
+	}
+
+	// Keyed by (family, discriminator) / (family, CLR type). The "family" is the union interface type for tagged and
+	// external variants, or the container type for container variants. Keying by an explicit family type keeps the
+	// same discriminator string from clashing across different families (notably across containers).
+	private readonly ConcurrentDictionary<(Type Family, string Discriminator), Delegate> _readers = new();
+	private readonly ConcurrentDictionary<(Type Family, Type Clr), RegisteredVariantWriter> _writers = new();
+
+	/// <summary>
+	/// Registers a CLR type <typeparamref name="TImplementation"/> for a plugin-defined <paramref name="discriminator"/> value
+	/// of the non-exhaustive variant family represented by the union interface <typeparamref name="TVariantFamily"/>.
+	/// </summary>
+	/// <typeparam name="TVariantFamily">The variant family's union interface (e.g. <c>IAnalyzer</c>).</typeparam>
+	/// <typeparam name="TImplementation">The CLR type to (de-)serialize for the given discriminator.</typeparam>
+	/// <param name="discriminator">The JSON discriminator value the type is registered for.</param>
+	/// <returns>This registry instance, to allow chaining multiple registrations.</returns>
+	public VariantRegistry Register<TVariantFamily, TImplementation>(string discriminator)
+		where TImplementation : TVariantFamily
+	{
+		if (discriminator is null)
+			throw new ArgumentNullException(nameof(discriminator));
+
+		_readers[(typeof(TVariantFamily), discriminator)] =
+			(VariantReader<TVariantFamily>)(static (ref Utf8JsonReader r, JsonSerializerOptions o) => r.ReadValue<TImplementation>(o));
+		_writers[(typeof(TVariantFamily), typeof(TImplementation))] =
+			new RegisteredVariantWriter(
+				discriminator,
+				(VariantWriter<TVariantFamily>)(static (Utf8JsonWriter w, TVariantFamily v, JsonSerializerOptions o) => w.WriteValue<TImplementation>(o, (TImplementation)v!)));
+
+		return this;
+	}
+
+	/// <summary>
+	/// Registers a CLR type <typeparamref name="TVariant"/> for a plugin-defined <paramref name="variantName"/> of the
+	/// non-exhaustive container type <typeparamref name="TContainer"/>.
+	/// </summary>
+	/// <typeparam name="TContainer">The container type the variant belongs to.</typeparam>
+	/// <typeparam name="TVariant">The CLR type to (de-)serialize for the given variant name.</typeparam>
+	/// <param name="variantName">The JSON property name the variant is registered for.</param>
+	/// <returns>This registry instance, to allow chaining multiple registrations.</returns>
+	public VariantRegistry RegisterContainer<TContainer, TVariant>(string variantName)
+	{
+		if (variantName is null)
+			throw new ArgumentNullException(nameof(variantName));
+
+		_readers[(typeof(TContainer), variantName)] =
+			(VariantReader<object>)(static (ref Utf8JsonReader r, JsonSerializerOptions o) => (object?)r.ReadValue<TVariant>(o));
+		_writers[(typeof(TContainer), typeof(TVariant))] =
+			new RegisteredVariantWriter(
+				variantName,
+				(VariantWriter<object>)(static (Utf8JsonWriter w, object v, JsonSerializerOptions o) => w.WriteValue<TVariant>(o, (TVariant)v!)));
+
+		return this;
+	}
+
+	internal bool TryGetReader<TVariantFamily>(string discriminator, [NotNullWhen(true)] out VariantReader<TVariantFamily>? reader)
+	{
+		if (_readers.TryGetValue((typeof(TVariantFamily), discriminator), out var del))
+		{
+			reader = (VariantReader<TVariantFamily>)del;
+			return true;
+		}
+
+		reader = null;
+		return false;
+	}
+
+	internal bool TryGetWriter<TVariantFamily>(Type clrType, out VariantWriterRegistration<TVariantFamily> writer)
+	{
+		var family = typeof(TVariantFamily);
+		if (TryGetWriter(family, clrType, out var registration))
+		{
+			writer = new VariantWriterRegistration<TVariantFamily>(registration.Discriminator, (VariantWriter<TVariantFamily>)registration.Writer);
+			return true;
+		}
+
+		writer = default;
+		return false;
+	}
+
+	internal bool TryGetContainerReader(Type container, string variantName, [NotNullWhen(true)] out VariantReader<object>? reader)
+	{
+		if (_readers.TryGetValue((container, variantName), out var del))
+		{
+			reader = (VariantReader<object>)del;
+			return true;
+		}
+
+		reader = null;
+		return false;
+	}
+
+	internal bool TryGetContainerWriter(Type container, Type clrType, out VariantWriterRegistration<object> writer)
+	{
+		if (TryGetWriter(container, clrType, out var registration))
+		{
+			writer = new VariantWriterRegistration<object>(registration.Discriminator, (VariantWriter<object>)registration.Writer);
+			return true;
+		}
+
+		writer = default;
+		return false;
+	}
+
+	private bool TryGetWriter(Type family, Type clrType, [NotNullWhen(true)] out RegisteredVariantWriter? writer)
+	{
+		if (_writers.TryGetValue((family, clrType), out writer))
+		{
+			return true;
+		}
+
+		foreach (var pair in _writers)
+		{
+			if (pair.Key.Family == family && pair.Key.Clr.IsAssignableFrom(clrType))
+			{
+				writer = pair.Value;
+				return true;
+			}
+		}
+
+		writer = null;
+		return false;
+	}
+}


### PR DESCRIPTION
## Summary

Adds the runtime foundation for **plugin-defined variant types**: field types, token filters, char filters, analyzers, tokenizers, query types, and aggregation types introduced by Elasticsearch plugins (for example `icu_collation_keyword`, `truncated_collation`, or `sql_normalizer`) can round-trip through the typed client.

## How it works

- Unknown discriminators on interface-union families deserialize into an `Unknown{Family}` carrier and re-serialize losslessly — no data is dropped when the server returns a variant the client doesn't model.
- Callers can opt into strong typing by registering a CLR type for a discriminator on the client settings, at application startup:

```csharp
settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");
settings.Variants.Register<ITokenFilter, SqlNormalizerTokenFilter>("sql_normalizer");
settings.Variants.RegisterContainer<Query, MyCustomQuery>("my_custom_query");
```

- Registrations are **scoped to the settings instance**, so different client instances in the same process can map plugin variants independently, and are **AOT-safe** (no reflection-based deserialization).

## Scope

This PR contains the hand-written runtime (`VariantRegistry`, settings hooks, delegates). The generated `Unknown*` carrier types and the reference documentation are delivered separately.
