### PR TITLE
[DOCS] Add plugin-defined variant types documentation

### DIFF
--- a/docs/reference/plugin-defined-variants.md
+++ b/docs/reference/plugin-defined-variants.md
@@ -75,29 +75,20 @@ Construct the carrier with the discriminator the server-side plugin expects and 
 
 ## Registering a strongly-typed CLR variant [register]
 
-When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TVariantFamily, TImplementation>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TVariantFamily`. After registration the deserializer produces instances of the CLR type directly. The serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
+When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TVariantFamily, TImplementation>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TVariantFamily`. After registration the deserializer produces instances of the CLR type directly. The serializer writes them using the converter resolved from the client's `JsonSerializerOptions`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
 
 ```csharp
-using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elastic.Clients.Elasticsearch.Mapping;
 
-[JsonConverter(typeof(TruncatedCollationPropertyConverter))]
 public sealed class TruncatedCollationProperty : IProperty
 {
     public string Type => "truncated_collation";
+
+    [JsonPropertyName("max_length")]
     public int? MaxLength { get; set; }
+
     public string? Rules { get; set; }
-}
-
-public sealed class TruncatedCollationPropertyConverter
-    : JsonConverter<TruncatedCollationProperty>
-{
-    public override TruncatedCollationProperty Read(
-        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { /* ... */ }
-
-    public override void Write(
-        Utf8JsonWriter writer, TruncatedCollationProperty value, JsonSerializerOptions options) { /* ... */ }
 }
 
 // Register on the client settings at application startup, then build the client from those settings:
@@ -113,9 +104,9 @@ var typed = (TruncatedCollationProperty)property;
 
 ::::{warning}
 
-A `[JsonConverter]` attribute on the registered type is **required**. Without it, the client falls back to a reflection-based converter driven by its own `JsonSerializerOptions`, which produces incorrect JSON and fails at runtime in AOT-published applications.
+For AOT-published applications, a `[JsonConverter]` attribute is **required** on the registered type. The reflection-based fallback used in non-AOT applications cannot be trimmed safely.
 
-Source-generated `JsonSerializerContext` implementations cannot be used. A context registers its type metadata on a specific `JsonSerializerOptions` instance, and there is currently no way to compose a user-supplied context with the client's internal serializer options. Only a hand-written `JsonConverter<TImplementation>` attached via `[JsonConverter]` on the type is supported.
+Source-generated `JsonSerializerContext` implementations cannot be used. A context registers its type metadata on a specific `JsonSerializerOptions` instance, and there is currently no way to compose a user-supplied context with the client's internal serializer options.
 
 ::::
 
@@ -164,4 +155,4 @@ Register the CLR type for the variant name on the client settings at application
 
 ## Limitations [limitations]
 
-The registration mechanism captures the registered CLR type as a generic type argument inside a static delegate. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`. For this to remain trim-safe in AOT-published applications, the registered type must be discoverable by the client's serializer options. In practice, this means a `[JsonConverter]` attribute on the type is required. A source-generated `JsonSerializerContext` cannot be used, because there is currently no way to compose a user-supplied context with the client's internal serializer options.
+The registration mechanism captures the registered CLR type as a generic type argument inside a static delegate. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`. For this to remain trim-safe in AOT-published applications, the registered type must be discoverable by the client's serializer options without reflection. In practice, this means a `[JsonConverter]` attribute on the type is required for AOT. A source-generated `JsonSerializerContext` cannot be used, because there is currently no way to compose a user-supplied context with the client's internal serializer options.

--- a/docs/reference/plugin-defined-variants.md
+++ b/docs/reference/plugin-defined-variants.md
@@ -1,0 +1,203 @@
+---
+mapped_pages:
+  - https://www.elastic.co/guide/en/elasticsearch/client/net-api/current/plugin-defined-variants.html
+---
+
+# Plugin-defined variant types [plugin-defined-variants]
+
+Elasticsearch plugins can introduce additional field types, token filters, char filters, analyzers, tokenizers, query types, and aggregation types beyond the closed set known to the typed client. The .NET client supports these plugin-defined variants through two complementary mechanisms: a zero-configuration **carrier** that round-trips unknown discriminators as raw JSON, and an opt-in **registration API** that maps a plugin discriminator to a caller-supplied CLR type for strongly-typed access.
+
+- [Round-trip carrier](#carrier)
+  - [Reading a plugin field type](#carrier-read)
+  - [Writing a plugin token filter](#carrier-write)
+- [Registering a strongly-typed CLR variant](#register)
+- [Per-family registration surface](#per-family)
+- [Container variants](#containers)
+- [Native AOT](#aot)
+- [Limitations](#limitations)
+
+## Round-trip carrier [carrier]
+
+For every non-container variant family that accepts plugin-defined values, the client emits a public `Unknown{Family}` class that implements the family's interface. When the deserializer encounters a discriminator value that is not part of the closed variant set and that has not been registered, it produces an instance of this carrier instead of throwing.
+
+For internally tagged families such as `IProperty`, `IAnalyzer`, or `ITokenFilter`, the carrier captures the discriminator on a `Type` property and the full JSON object on a `Content` property. The write side emits the discriminator from `Type`, then replays the remaining properties from `Content`, so a value read into the carrier can be written back out without losing fields.
+
+For externally tagged typed-key families such as `IAggregate`, the discriminator comes from the response property name (`type#name`). The carrier still exposes `Type`, but `Content` contains only the JSON value body under that typed key.
+
+### Reading a plugin field type [carrier-read]
+
+```csharp
+using System.Text;
+using System.Linq;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Clients.Elasticsearch.Mapping;
+using Elastic.Transport.Extensions;
+
+var json = """
+{
+  "type": "truncated_collation",
+  "max_length": 64,
+  "rules": "<.*?>"
+}
+""";
+
+var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!; <1>
+
+if (property is UnknownProperty unknown) <2>
+{
+    Console.WriteLine(unknown.Type);                                 // "truncated_collation"
+    Console.WriteLine(unknown.Content.GetProperty("max_length"));     // 64
+    Console.WriteLine(unknown.Content.EnumerateObject().Count());     // 3  (type + max_length + rules)
+}
+```
+
+1. The discriminator (`type: truncated_collation`) is not part of the closed `IProperty` variant set, so the value lands in the carrier.
+2. The carrier exposes `Type` (the JSON discriminator) and `Content` (the full JSON object as a `JsonElement`).
+
+### Writing a plugin token filter [carrier-write]
+
+```csharp
+using System.Text.Json;
+using Elastic.Clients.Elasticsearch.Analysis;
+
+using var document = JsonDocument.Parse("""
+{
+  "type": "sql_normalizer",
+  "preserve_original": true
+}
+""");
+var content = document.RootElement.Clone();
+
+var filter = new UnknownTokenFilter("sql_normalizer", content); <1>
+
+var json = client.RequestResponseSerializer.SerializeToString<ITokenFilter>(filter); <2>
+// {"type":"sql_normalizer","preserve_original":true}
+```
+
+1. Construct the carrier with the discriminator the server-side plugin expects and a raw JSON object containing the plugin's configuration.
+2. Serialize via the union interface (`ITokenFilter`); the converter writes the discriminator first, then every other property from `Content`.
+
+## Registering a strongly-typed CLR variant [register]
+
+When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TUnion, TImpl>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TUnion`. After registration the deserializer produces instances of the CLR type directly; the serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
+
+```csharp
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Elastic.Clients.Elasticsearch.Mapping;
+
+[JsonConverter(typeof(TruncatedCollationPropertyConverter))]      <1>
+public sealed class TruncatedCollationProperty : IProperty
+{
+    public string Type => "truncated_collation";
+    public int? MaxLength { get; set; }
+    public string? Rules { get; set; }
+}
+
+public sealed class TruncatedCollationPropertyConverter
+    : JsonConverter<TruncatedCollationProperty>
+{
+    public override TruncatedCollationProperty Read(
+        ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) { /* ... */ }
+
+    public override void Write(
+        Utf8JsonWriter writer, TruncatedCollationProperty value, JsonSerializerOptions options) { /* ... */ }
+}
+
+// Register on the client settings at application startup, then build the client from those settings:
+var settings = new ElasticsearchClientSettings(/* ... */);
+settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");        <2>
+var client = new ElasticsearchClient(settings);
+
+// Subsequent (de)serialization of IProperty values whose discriminator is "truncated_collation"
+// resolves to the registered CLR type:
+var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!;
+var typed = (TruncatedCollationProperty)property;                                                <3>
+```
+
+1. The user-defined type carries its own `JsonConverter` attribute. The client never reflects on the type — registration captures a typed delegate, so the converter must be resolvable through the `JsonSerializerOptions` used by the client.
+2. `Variants.Register<TUnion, TImpl>(string)` is scoped to the settings instance. Calling it again with the same discriminator replaces the previous registration on that instance. On write, the value's `Type` must match the registered discriminator.
+3. A registered discriminator overrides the carrier fallback. Discriminators that are not registered continue to land in `UnknownProperty`.
+
+## Per-family registration surface [per-family]
+
+All registrations are made on `settings.Variants` (an instance of `VariantRegistry`).
+
+| Family | Registration | Carrier |
+|---|---|---|
+| `IProperty` | `Variants.Register<Mapping.IProperty, T>(string)` | `Mapping.UnknownProperty` |
+| `IAnalyzer` | `Variants.Register<Analysis.IAnalyzer, T>(string)` | `Analysis.UnknownAnalyzer` |
+| `ITokenFilter` | `Variants.Register<Analysis.ITokenFilter, T>(string)` | `Analysis.UnknownTokenFilter` |
+| `ICharFilter` | `Variants.Register<Analysis.ICharFilter, T>(string)` | `Analysis.UnknownCharFilter` |
+| `ITokenizer` | `Variants.Register<Analysis.ITokenizer, T>(string)` | `Analysis.UnknownTokenizer` |
+| `IAggregate` | `Variants.Register<Aggregations.IAggregate, T>(string)` | `Aggregations.UnknownAggregate` |
+| `IRepository` | `Variants.Register<Snapshot.IRepository, T>(string)` | `Snapshot.UnknownRepository` |
+| `ISettingsSimilarity` | `Variants.Register<IndexManagement.ISettingsSimilarity, T>(string)` | `IndexManagement.UnknownSettingsSimilarity` |
+| `Query` (container) | `Variants.RegisterContainer<QueryDsl.Query, T>(string)` | accessed via container methods (see below) |
+| `SpanQuery` (container) | `Variants.RegisterContainer<QueryDsl.SpanQuery, T>(string)` | accessed via container methods |
+| `Aggregation` (container) | `Variants.RegisterContainer<Aggregations.Aggregation, T>(string)` | accessed via container methods (see below) |
+| `Processor` (container) | `Variants.RegisterContainer<Ingest.Processor, T>(string)` | accessed via container methods |
+| `Rescore` (container) | `Variants.RegisterContainer<Core.Search.Rescore, T>(string)` | accessed via container methods |
+| `FieldSuggester` (container) | `Variants.RegisterContainer<Core.Search.FieldSuggester, T>(string)` | accessed via container methods |
+| `ApiKeyQuery` (container) | `Variants.RegisterContainer<Security.ApiKeyQuery, T>(string)` | accessed via container methods |
+| `ApiKeyAggregation` (container) | `Variants.RegisterContainer<Security.ApiKeyAggregation, T>(string)` | accessed via container methods |
+| `RoleQuery` (container) | `Variants.RegisterContainer<Security.RoleQuery, T>(string)` | accessed via container methods |
+| `UserQuery` (container) | `Variants.RegisterContainer<Security.UserQuery, T>(string)` | accessed via container methods |
+
+Namespaces are abbreviated; each family lives under `Elastic.Clients.Elasticsearch`.
+
+## Container variants [containers]
+
+Container types (`Query`, `Aggregation`) don't use a separate `Unknown{Family}` carrier — the container itself holds the variant. Known variants are reached through their typed accessors (`Query.Match`, `Query.Bool`, ...). For plugin-defined variants the container exposes three additional members:
+
+- `string? VariantName { get; }` — the JSON property name of the variant the container currently holds.
+- `T? GetCustomVariant<T>(string variantName)` — returns the stored variant when the container's current name matches, otherwise `null`.
+- `void SetCustomVariant<T>(string variantName, T? value)` — sets the container's variant to the given `(name, value)` pair.
+- Fluent descriptors expose `CustomVariant<T>(string variantName, T? value)` for writing plugin-defined variants in descriptor-based APIs.
+
+```csharp
+using Elastic.Clients.Elasticsearch.QueryDsl;
+
+public sealed class MyCustomQuery
+{
+    public string Field { get; set; } = "";
+    public string Pattern { get; set; } = "";
+}
+
+var settings = new ElasticsearchClientSettings(/* ... */);
+settings.Variants.RegisterContainer<Query, MyCustomQuery>("my_custom_query"); <1>
+var client = new ElasticsearchClient(settings);
+
+// Read side
+var json = """{ "my_custom_query": { "field": "title", "pattern": "^foo" } }""";
+var q = client.RequestResponseSerializer.Deserialize<Query>(json)!;
+
+var typed = q.GetCustomVariant<MyCustomQuery>("my_custom_query"); <2>
+Console.WriteLine($"name = {q.VariantName}, field = {typed?.Field}");
+
+// Write side
+var outgoing = new Query();
+outgoing.SetCustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" }); <3>
+
+// Descriptor write side
+Query descriptorQuery = new QueryDescriptor<object>()
+    .CustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" });
+```
+
+1. Register the CLR type for the variant name on the client settings at application startup. Deserialization produces instances of `MyCustomQuery` rather than a raw `JsonElement`.
+2. `GetCustomVariant<T>(variantName)` returns `null` when the container's variant doesn't match the requested name (for example, when the container holds a known typed variant instead).
+3. `SetCustomVariant<T>(variantName, value)` and descriptor `CustomVariant<T>(variantName, value)` are intended for plugin-defined variants. The known variants are still set through their typed properties (`outgoing.Match = ...`).
+
+## Native AOT [aot]
+
+The registration mechanism avoids runtime type-keyed serialization. `Variants.Register<TUnion, TImpl>(string)` (and `Variants.RegisterContainer<TContainer, TImpl>(string)`) captures `TImpl` as a generic context inside a static lambda; the delegate body dispatches through `ReadValue<TImpl>` / `WriteValue<TImpl>`, which resolve their converter through the `JsonSerializerOptions` already configured on the client. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`.
+
+For the registration to remain trim-safe in published AOT applications, the registered CLR type must be discoverable by the client's serializer options. For request/response variant registration, prefer a `[JsonConverter]` attribute on the type itself, as in the example above. A source-generated `JsonSerializerContext` only helps when it is actually added to the serializer options used for the registered variant type.
+
+## Limitations [limitations]
+
+::::{note}
+
+Registrations are scoped to the `ElasticsearchClientSettings` instance they are made on. A client only sees the variants registered on the settings it was constructed from, so different `ElasticsearchClient` instances in the same process can use different plugin-variant mappings. Register on `settings.Variants` before performing (de)serialization with the client built from those settings.
+
+::::

--- a/docs/reference/plugin-defined-variants.md
+++ b/docs/reference/plugin-defined-variants.md
@@ -41,9 +41,9 @@ var json = """
 }
 """;
 
-var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!; <1>
+var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!;
 
-if (property is UnknownProperty unknown) <2>
+if (property is UnknownProperty unknown)
 {
     Console.WriteLine(unknown.Type);                                 // "truncated_collation"
     Console.WriteLine(unknown.Content.GetProperty("max_length"));     // 64
@@ -51,8 +51,7 @@ if (property is UnknownProperty unknown) <2>
 }
 ```
 
-1. The discriminator (`type: truncated_collation`) is not part of the closed `IProperty` variant set, so the value lands in the carrier.
-2. The carrier exposes `Type` (the JSON discriminator) and `Content` (the full JSON object as a `JsonElement`).
+`Deserialize<IProperty>` produces an `UnknownProperty` carrier because `truncated_collation` is not in the closed `IProperty` variant set. The carrier exposes `Type` (the JSON discriminator) and `Content` (the full JSON object as a `JsonElement`).
 
 ### Writing a plugin token filter [carrier-write]
 
@@ -68,25 +67,24 @@ using var document = JsonDocument.Parse("""
 """);
 var content = document.RootElement.Clone();
 
-var filter = new UnknownTokenFilter("sql_normalizer", content); <1>
+var filter = new UnknownTokenFilter("sql_normalizer", content);
 
-var json = client.RequestResponseSerializer.SerializeToString<ITokenFilter>(filter); <2>
+var json = client.RequestResponseSerializer.SerializeToString<ITokenFilter>(filter);
 // {"type":"sql_normalizer","preserve_original":true}
 ```
 
-1. Construct the carrier with the discriminator the server-side plugin expects and a raw JSON object containing the plugin's configuration.
-2. Serialize via the union interface (`ITokenFilter`); the converter writes the discriminator first, then every other property from `Content`.
+Construct the carrier with the discriminator the server-side plugin expects and a raw JSON object containing the plugin's configuration. Serializing via the union interface (`ITokenFilter`) causes the converter to write the discriminator first, then every other property from `Content`.
 
 ## Registering a strongly-typed CLR variant [register]
 
-When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TUnion, TImpl>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TUnion`. After registration the deserializer produces instances of the CLR type directly; the serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
+When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TUnion, TImpl>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TUnion`. After registration the deserializer produces instances of the CLR type directly. The serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
 
 ```csharp
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Elastic.Clients.Elasticsearch.Mapping;
 
-[JsonConverter(typeof(TruncatedCollationPropertyConverter))]      <1>
+[JsonConverter(typeof(TruncatedCollationPropertyConverter))]
 public sealed class TruncatedCollationProperty : IProperty
 {
     public string Type => "truncated_collation";
@@ -106,18 +104,18 @@ public sealed class TruncatedCollationPropertyConverter
 
 // Register on the client settings at application startup, then build the client from those settings:
 var settings = new ElasticsearchClientSettings(/* ... */);
-settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");        <2>
+settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");
 var client = new ElasticsearchClient(settings);
 
 // Subsequent (de)serialization of IProperty values whose discriminator is "truncated_collation"
 // resolves to the registered CLR type:
 var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!;
-var typed = (TruncatedCollationProperty)property;                                                <3>
+var typed = (TruncatedCollationProperty)property;
 ```
 
-1. The user-defined type carries its own `JsonConverter` attribute. The client never reflects on the type — registration captures a typed delegate, so the converter must be resolvable through the `JsonSerializerOptions` used by the client.
-2. `Variants.Register<TUnion, TImpl>(string)` is scoped to the settings instance. Calling it again with the same discriminator replaces the previous registration on that instance. On write, the value's `Type` must match the registered discriminator.
-3. A registered discriminator overrides the carrier fallback. Discriminators that are not registered continue to land in `UnknownProperty`.
+The user-defined type carries its own `[JsonConverter]` attribute. The client never reflects on the type — registration captures a typed delegate, so the converter must be resolvable through the `JsonSerializerOptions` used by the client.
+
+`Variants.Register<TUnion, TImpl>(string)` is scoped to the settings instance. Calling it again with the same discriminator replaces the previous registration on that instance. On write, the value's `Type` must match the registered discriminator. A registered discriminator overrides the carrier fallback — discriminators that are not registered continue to land in `UnknownProperty`.
 
 ## Per-family registration surface [per-family]
 
@@ -144,11 +142,11 @@ All registrations are made on `settings.Variants` (an instance of `VariantRegist
 | `RoleQuery` (container) | `Variants.RegisterContainer<Security.RoleQuery, T>(string)` | accessed via container methods |
 | `UserQuery` (container) | `Variants.RegisterContainer<Security.UserQuery, T>(string)` | accessed via container methods |
 
-Namespaces are abbreviated; each family lives under `Elastic.Clients.Elasticsearch`.
+Namespaces are abbreviated. Each family lives under `Elastic.Clients.Elasticsearch`.
 
 ## Container variants [containers]
 
-Container types (`Query`, `Aggregation`) don't use a separate `Unknown{Family}` carrier — the container itself holds the variant. Known variants are reached through their typed accessors (`Query.Match`, `Query.Bool`, ...). For plugin-defined variants the container exposes three additional members:
+Container types (`Query`, `Aggregation`) don't use a separate `Unknown{Family}` carrier — the container itself holds the variant. Known variants are reached through their typed accessors (`Query.Match`, `Query.Bool`, and so on). For plugin-defined variants the container exposes three additional members:
 
 - `string? VariantName { get; }` — the JSON property name of the variant the container currently holds.
 - `T? GetCustomVariant<T>(string variantName)` — returns the stored variant when the container's current name matches, otherwise `null`.
@@ -165,34 +163,32 @@ public sealed class MyCustomQuery
 }
 
 var settings = new ElasticsearchClientSettings(/* ... */);
-settings.Variants.RegisterContainer<Query, MyCustomQuery>("my_custom_query"); <1>
+settings.Variants.RegisterContainer<Query, MyCustomQuery>("my_custom_query");
 var client = new ElasticsearchClient(settings);
 
 // Read side
 var json = """{ "my_custom_query": { "field": "title", "pattern": "^foo" } }""";
 var q = client.RequestResponseSerializer.Deserialize<Query>(json)!;
 
-var typed = q.GetCustomVariant<MyCustomQuery>("my_custom_query"); <2>
+var typed = q.GetCustomVariant<MyCustomQuery>("my_custom_query");
 Console.WriteLine($"name = {q.VariantName}, field = {typed?.Field}");
 
 // Write side
 var outgoing = new Query();
-outgoing.SetCustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" }); <3>
+outgoing.SetCustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" });
 
 // Descriptor write side
 Query descriptorQuery = new QueryDescriptor<object>()
     .CustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" });
 ```
 
-1. Register the CLR type for the variant name on the client settings at application startup. Deserialization produces instances of `MyCustomQuery` rather than a raw `JsonElement`.
-2. `GetCustomVariant<T>(variantName)` returns `null` when the container's variant doesn't match the requested name (for example, when the container holds a known typed variant instead).
-3. `SetCustomVariant<T>(variantName, value)` and descriptor `CustomVariant<T>(variantName, value)` are intended for plugin-defined variants. The known variants are still set through their typed properties (`outgoing.Match = ...`).
+Register the CLR type for the variant name on the client settings at application startup. Deserialization then produces instances of `MyCustomQuery` rather than a raw `JsonElement`. `GetCustomVariant<T>(variantName)` returns `null` when the container's variant doesn't match the requested name — for example, when the container holds a known typed variant instead. `SetCustomVariant<T>(variantName, value)` and the descriptor `CustomVariant<T>(variantName, value)` are intended for plugin-defined variants. Known variants are still set through their typed properties (`outgoing.Match = ...`).
 
 ## Native AOT [aot]
 
 The registration mechanism avoids runtime type-keyed serialization. `Variants.Register<TUnion, TImpl>(string)` (and `Variants.RegisterContainer<TContainer, TImpl>(string)`) captures `TImpl` as a generic context inside a static lambda; the delegate body dispatches through `ReadValue<TImpl>` / `WriteValue<TImpl>`, which resolve their converter through the `JsonSerializerOptions` already configured on the client. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`.
 
-For the registration to remain trim-safe in published AOT applications, the registered CLR type must be discoverable by the client's serializer options. For request/response variant registration, prefer a `[JsonConverter]` attribute on the type itself, as in the example above. A source-generated `JsonSerializerContext` only helps when it is actually added to the serializer options used for the registered variant type.
+For the registration to remain trim-safe in published AOT applications, the registered CLR type must be discoverable by the client's serializer options. For request/response variant registration, prefer a `[JsonConverter]` attribute on the type itself, as in the preceding example. A source-generated `JsonSerializerContext` only helps when it is actually added to the serializer options used for the registered variant type.
 
 ## Limitations [limitations]
 

--- a/docs/reference/plugin-defined-variants.md
+++ b/docs/reference/plugin-defined-variants.md
@@ -11,18 +11,12 @@ Elasticsearch plugins can introduce additional field types, token filters, char 
   - [Reading a plugin field type](#carrier-read)
   - [Writing a plugin token filter](#carrier-write)
 - [Registering a strongly-typed CLR variant](#register)
-- [Per-family registration surface](#per-family)
 - [Container variants](#containers)
-- [Native AOT](#aot)
 - [Limitations](#limitations)
 
 ## Round-trip carrier [carrier]
 
 For every non-container variant family that accepts plugin-defined values, the client emits a public `Unknown{Family}` class that implements the family's interface. When the deserializer encounters a discriminator value that is not part of the closed variant set and that has not been registered, it produces an instance of this carrier instead of throwing.
-
-For internally tagged families such as `IProperty`, `IAnalyzer`, or `ITokenFilter`, the carrier captures the discriminator on a `Type` property and the full JSON object on a `Content` property. The write side emits the discriminator from `Type`, then replays the remaining properties from `Content`, so a value read into the carrier can be written back out without losing fields.
-
-For externally tagged typed-key families such as `IAggregate`, the discriminator comes from the response property name (`type#name`). The carrier still exposes `Type`, but `Content` contains only the JSON value body under that typed key.
 
 ### Reading a plugin field type [carrier-read]
 
@@ -45,13 +39,17 @@ var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!;
 
 if (property is UnknownProperty unknown)
 {
-    Console.WriteLine(unknown.Type);                                 // "truncated_collation"
-    Console.WriteLine(unknown.Content.GetProperty("max_length"));     // 64
-    Console.WriteLine(unknown.Content.EnumerateObject().Count());     // 3  (type + max_length + rules)
+    Console.WriteLine(unknown.Type); <1>
+    Console.WriteLine(unknown.Content.GetProperty("max_length")); <2>
+    Console.WriteLine(unknown.Content.EnumerateObject().Count()); <3>
 }
 ```
 
-`Deserialize<IProperty>` produces an `UnknownProperty` carrier because `truncated_collation` is not in the closed `IProperty` variant set. The carrier exposes `Type` (the JSON discriminator) and `Content` (the full JSON object as a `JsonElement`).
+`Deserialize<IProperty>` produces an `UnknownProperty` carrier because `truncated_collation` is not in the closed `IProperty` variant set.
+
+1. Outputs: `"truncated_collation"` (the JSON discriminator, stored on `Type`).
+2. Outputs: `64`. Individual properties of the plugin object are accessible via `Content`.
+3. Outputs: `3`. `Content` preserves all fields from the original JSON object, including `type`, `max_length`, and `rules`.
 
 ### Writing a plugin token filter [carrier-write]
 
@@ -77,7 +75,7 @@ Construct the carrier with the discriminator the server-side plugin expects and 
 
 ## Registering a strongly-typed CLR variant [register]
 
-When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TUnion, TImpl>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TUnion`. After registration the deserializer produces instances of the CLR type directly. The serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
+When the same plugin variant appears in several places, working with raw `JsonElement` content can become awkward. For these cases the client settings expose a per-instance registry, `ElasticsearchClientSettings.Variants`, whose `Register<TVariantFamily, TImplementation>(string discriminator)` method binds a caller-defined CLR type to a discriminator of the variant family `TVariantFamily`. After registration the deserializer produces instances of the CLR type directly. The serializer writes them through the CLR type's own `JsonConverter`. Because the registry lives on the settings instance, different `ElasticsearchClient` instances in the same process can register different CLR types (or none) independently.
 
 ```csharp
 using System.Text.Json;
@@ -113,44 +111,24 @@ var property = client.RequestResponseSerializer.Deserialize<IProperty>(json)!;
 var typed = (TruncatedCollationProperty)property;
 ```
 
-The user-defined type carries its own `[JsonConverter]` attribute. The client never reflects on the type — registration captures a typed delegate, so the converter must be resolvable through the `JsonSerializerOptions` used by the client.
+::::{warning}
 
-`Variants.Register<TUnion, TImpl>(string)` is scoped to the settings instance. Calling it again with the same discriminator replaces the previous registration on that instance. On write, the value's `Type` must match the registered discriminator. A registered discriminator overrides the carrier fallback — discriminators that are not registered continue to land in `UnknownProperty`.
+A `[JsonConverter]` attribute on the registered type is **required**. Without it, the client falls back to a reflection-based converter driven by its own `JsonSerializerOptions`, which produces incorrect JSON and fails at runtime in AOT-published applications.
 
-## Per-family registration surface [per-family]
+Source-generated `JsonSerializerContext` implementations cannot be used. A context registers its type metadata on a specific `JsonSerializerOptions` instance, and there is currently no way to compose a user-supplied context with the client's internal serializer options. Only a hand-written `JsonConverter<TImplementation>` attached via `[JsonConverter]` on the type is supported.
 
-All registrations are made on `settings.Variants` (an instance of `VariantRegistry`).
+::::
 
-| Family | Registration | Carrier |
-|---|---|---|
-| `IProperty` | `Variants.Register<Mapping.IProperty, T>(string)` | `Mapping.UnknownProperty` |
-| `IAnalyzer` | `Variants.Register<Analysis.IAnalyzer, T>(string)` | `Analysis.UnknownAnalyzer` |
-| `ITokenFilter` | `Variants.Register<Analysis.ITokenFilter, T>(string)` | `Analysis.UnknownTokenFilter` |
-| `ICharFilter` | `Variants.Register<Analysis.ICharFilter, T>(string)` | `Analysis.UnknownCharFilter` |
-| `ITokenizer` | `Variants.Register<Analysis.ITokenizer, T>(string)` | `Analysis.UnknownTokenizer` |
-| `IAggregate` | `Variants.Register<Aggregations.IAggregate, T>(string)` | `Aggregations.UnknownAggregate` |
-| `IRepository` | `Variants.Register<Snapshot.IRepository, T>(string)` | `Snapshot.UnknownRepository` |
-| `ISettingsSimilarity` | `Variants.Register<IndexManagement.ISettingsSimilarity, T>(string)` | `IndexManagement.UnknownSettingsSimilarity` |
-| `Query` (container) | `Variants.RegisterContainer<QueryDsl.Query, T>(string)` | accessed via container methods (see below) |
-| `SpanQuery` (container) | `Variants.RegisterContainer<QueryDsl.SpanQuery, T>(string)` | accessed via container methods |
-| `Aggregation` (container) | `Variants.RegisterContainer<Aggregations.Aggregation, T>(string)` | accessed via container methods (see below) |
-| `Processor` (container) | `Variants.RegisterContainer<Ingest.Processor, T>(string)` | accessed via container methods |
-| `Rescore` (container) | `Variants.RegisterContainer<Core.Search.Rescore, T>(string)` | accessed via container methods |
-| `FieldSuggester` (container) | `Variants.RegisterContainer<Core.Search.FieldSuggester, T>(string)` | accessed via container methods |
-| `ApiKeyQuery` (container) | `Variants.RegisterContainer<Security.ApiKeyQuery, T>(string)` | accessed via container methods |
-| `ApiKeyAggregation` (container) | `Variants.RegisterContainer<Security.ApiKeyAggregation, T>(string)` | accessed via container methods |
-| `RoleQuery` (container) | `Variants.RegisterContainer<Security.RoleQuery, T>(string)` | accessed via container methods |
-| `UserQuery` (container) | `Variants.RegisterContainer<Security.UserQuery, T>(string)` | accessed via container methods |
 
-Namespaces are abbreviated. Each family lives under `Elastic.Clients.Elasticsearch`.
+`Variants.Register<TVariantFamily, TImplementation>(string)` is scoped to the settings instance. Calling it again with the same discriminator replaces the previous registration on that instance. On write, the value's `Type` must match the registered discriminator. A registered discriminator overrides the carrier fallback. Discriminators that are not registered continue to land in `UnknownProperty`.
 
 ## Container variants [containers]
 
-Container types (`Query`, `Aggregation`) don't use a separate `Unknown{Family}` carrier — the container itself holds the variant. Known variants are reached through their typed accessors (`Query.Match`, `Query.Bool`, and so on). For plugin-defined variants the container exposes three additional members:
+Container types (for example `Query` or `Aggregation`) don't use a separate `Unknown{Family}` carrier. The container itself holds the variant. Known variants are reached through their typed accessors (`Query.Match`, `Query.Bool`, and so on). For plugin-defined variants the container exposes three additional members:
 
-- `string? VariantName { get; }` — the JSON property name of the variant the container currently holds.
-- `T? GetCustomVariant<T>(string variantName)` — returns the stored variant when the container's current name matches, otherwise `null`.
-- `void SetCustomVariant<T>(string variantName, T? value)` — sets the container's variant to the given `(name, value)` pair.
+- `string? VariantName { get; }`: the JSON property name of the variant the container currently holds.
+- `T? GetCustomVariant<T>(string variantName)`: returns the stored variant when the container's current name matches, otherwise `null`.
+- `void SetCustomVariant<T>(string variantName, T? value)`: sets the container's variant to the given `(name, value)` pair.
 - Fluent descriptors expose `CustomVariant<T>(string variantName, T? value)` for writing plugin-defined variants in descriptor-based APIs.
 
 ```csharp
@@ -182,18 +160,8 @@ Query descriptorQuery = new QueryDescriptor<object>()
     .CustomVariant("my_custom_query", new MyCustomQuery { Field = "title", Pattern = "^foo" });
 ```
 
-Register the CLR type for the variant name on the client settings at application startup. Deserialization then produces instances of `MyCustomQuery` rather than a raw `JsonElement`. `GetCustomVariant<T>(variantName)` returns `null` when the container's variant doesn't match the requested name — for example, when the container holds a known typed variant instead. `SetCustomVariant<T>(variantName, value)` and the descriptor `CustomVariant<T>(variantName, value)` are intended for plugin-defined variants. Known variants are still set through their typed properties (`outgoing.Match = ...`).
-
-## Native AOT [aot]
-
-The registration mechanism avoids runtime type-keyed serialization. `Variants.Register<TUnion, TImpl>(string)` (and `Variants.RegisterContainer<TContainer, TImpl>(string)`) captures `TImpl` as a generic context inside a static lambda; the delegate body dispatches through `ReadValue<TImpl>` / `WriteValue<TImpl>`, which resolve their converter through the `JsonSerializerOptions` already configured on the client. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`.
-
-For the registration to remain trim-safe in published AOT applications, the registered CLR type must be discoverable by the client's serializer options. For request/response variant registration, prefer a `[JsonConverter]` attribute on the type itself, as in the preceding example. A source-generated `JsonSerializerContext` only helps when it is actually added to the serializer options used for the registered variant type.
+Register the CLR type for the variant name on the client settings at application startup. Deserialization then produces instances of `MyCustomQuery` rather than a raw `JsonElement`. `GetCustomVariant<T>(variantName)` returns `null` when the container's variant doesn't match the requested name, for example when the container holds a known typed variant instead. `SetCustomVariant<T>(variantName, value)` and the descriptor `CustomVariant<T>(variantName, value)` are intended for plugin-defined variants. Known variants are still set through their typed properties (`outgoing.Match = ...`).
 
 ## Limitations [limitations]
 
-::::{note}
-
-Registrations are scoped to the `ElasticsearchClientSettings` instance they are made on. A client only sees the variants registered on the settings it was constructed from, so different `ElasticsearchClient` instances in the same process can use different plugin-variant mappings. Register on `settings.Variants` before performing (de)serialization with the client built from those settings.
-
-::::
+The registration mechanism captures the registered CLR type as a generic type argument inside a static delegate. There is no runtime use of `JsonSerializer.Deserialize(Type)` or `JsonSerializer.Serialize(object, Type)`. For this to remain trim-safe in AOT-published applications, the registered type must be discoverable by the client's serializer options. In practice, this means a `[JsonConverter]` attribute on the type is required. A source-generated `JsonSerializerContext` cannot be used, because there is currently no way to compose a user-supplied context with the client's internal serializer options.

--- a/docs/reference/plugin-defined-variants.md
+++ b/docs/reference/plugin-defined-variants.md
@@ -37,7 +37,7 @@ var json = """
 {
   "type": "truncated_collation",
   "max_length": 64,
-  "rules": "<.*?>"
+  "rules": "latin_to_base"
 }
 """;
 

--- a/docs/reference/request-response-serialization.md
+++ b/docs/reference/request-response-serialization.md
@@ -134,7 +134,7 @@ When deserializing a request type, it may happen that otherwise required path or
 
 A few request and response types in Elasticsearch do not support JSON bodies and therefore cannot be serialized in the above described way.
 
-Two prominent examples are the `Bulk` or `MultiGet` APIs, which use NDJSON bodies. Binary responses also occur in some cases.
+Two prominent examples are the `Bulk` or `MultiGet` APIs, which use NDJSON bodies. Binary responses also occur sometimes.
 
 ## See also
 

--- a/docs/reference/request-response-serialization.md
+++ b/docs/reference/request-response-serialization.md
@@ -135,3 +135,7 @@ When deserializing a request type, it may happen that otherwise required path or
 A few request and response types in Elasticsearch do not support JSON bodies and therefore cannot be serialized in the above described way.
 
 Two prominent examples are the `Bulk` or `MultiGet` APIs, which use NDJSON bodies. Binary responses also occur in some cases.
+
+## See also
+
+For (de)serialization of variants introduced by Elasticsearch plugins (custom field types, token filters, analyzers, char filters, tokenizers, query types, aggregation types), see [Plugin-defined variant types](plugin-defined-variants.md).

--- a/docs/reference/toc.yml
+++ b/docs/reference/toc.yml
@@ -12,6 +12,7 @@ toc:
         children:
           - file: source-serialization.md
           - file: request-response-serialization.md
+          - file: plugin-defined-variants.md
   - file: using-net-client.md
     children:
       - file: aggregations.md

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -22,7 +22,7 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 #### 1. Plugin-defined variant types [1-plugin-defined-variant-types]
 
-Field types, token filters, char filters, analyzers, tokenizers, query types, and aggregation types introduced by Elasticsearch plugins (for example `icu_collation_keyword`, `truncated_collation`, or `sql_normalizer`) round-trip through the typed client. Unknown discriminators on interface-union families deserialize into an `Unknown{Family}` carrier; callers can opt into strongly-typed dispatch by registering a CLR type for a discriminator on the client settings (`settings.Variants`) at application startup. Registrations are scoped to the settings instance, so different client instances can map plugin variants independently:
+Field types, token filters, char filters, analyzers, tokenizers, query types, and aggregation types introduced by Elasticsearch plugins (for example `icu_collation_keyword`, `truncated_collation`, or `sql_normalizer`) round-trip through the typed client. Unknown discriminators on interface-union families deserialize into an `Unknown{Family}` carrier. Callers can opt into strongly-typed dispatch by registering a CLR type for a discriminator on the client settings (`settings.Variants`) at application startup. Registrations are scoped to the settings instance, so different client instances can map plugin variants independently:
 
 ```csharp
 settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");

--- a/docs/release-notes/index.md
+++ b/docs/release-notes/index.md
@@ -12,10 +12,25 @@ To check for security updates, go to [Security announcements for the Elastic sta
 
 % Release notes include only features, enhancements, and fixes. Add breaking changes, deprecations, and known issues to the applicable release notes sections.
 
-% ## version.next [felasticsearch-net-client-next-release-notes]
+## version.next [felasticsearch-net-client-next-release-notes]
 
-% ### Features and enhancements [elasticsearch-net-client-next-features-enhancements]
-% *
+### Overview
+
+- [1. Plugin-defined variant types](#1-plugin-defined-variant-types)
+
+### Features and enhancements [elasticsearch-net-client-next-features-enhancements]
+
+#### 1. Plugin-defined variant types [1-plugin-defined-variant-types]
+
+Field types, token filters, char filters, analyzers, tokenizers, query types, and aggregation types introduced by Elasticsearch plugins (for example `icu_collation_keyword`, `truncated_collation`, or `sql_normalizer`) round-trip through the typed client. Unknown discriminators on interface-union families deserialize into an `Unknown{Family}` carrier; callers can opt into strongly-typed dispatch by registering a CLR type for a discriminator on the client settings (`settings.Variants`) at application startup. Registrations are scoped to the settings instance, so different client instances can map plugin variants independently:
+
+```csharp
+settings.Variants.Register<IProperty, TruncatedCollationProperty>("truncated_collation");
+settings.Variants.Register<ITokenFilter, SqlNormalizerTokenFilter>("sql_normalizer");
+settings.Variants.RegisterContainer<Query, MyCustomQuery>("my_custom_query");
+```
+
+Refer to the [Plugin-defined variant types](../reference/plugin-defined-variants.md) documentation for details.
 
 % ### Fixes [elasticsearch-net-client-next-fixes]
 % *


### PR DESCRIPTION
## Summary

- Adds new reference page `docs/reference/plugin-defined-variants.md` documenting the non-exhaustive variant registry feature
- Registers the new page in `docs/reference/toc.yml` under the serialization section
- Adds a "See also" link from `request-response-serialization.md` to the new page
- Adds a `version.next` release notes entry in `docs/release-notes/index.md` describing the feature with code examples