### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize]
 
+permissions:
+  pull-requests: write
+
 jobs:
   auto-label:
     name: Auto Label

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,6 +4,10 @@ on:
   pull_request_target:
     types: ["labeled", "closed"]
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   backport:
     name: Backport PR

--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: ${{ github.ref_name }}
 
+permissions:
+  contents: write
+
 concurrency:
   group: 'docfx'
   cancel-in-progress: false

--- a/.github/workflows/integration-jobs.yml
+++ b/.github/workflows/integration-jobs.yml
@@ -14,6 +14,9 @@ on:
       - '[0-9]+.[0-9]+'
       - '[0-9]+.x'
 
+permissions:
+  checks: write
+
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 

--- a/.github/workflows/make-bump.yml
+++ b/.github/workflows/make-bump.yml
@@ -9,6 +9,11 @@ on:
         description: 'The new version number to branch'
         required: true
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
 jobs:
   createBranches:
     name: "Bump ${{ github.event.inputs.version }} on branch ${{ github.event.inputs.branch }} "

--- a/.github/workflows/make-codegen.yml
+++ b/.github/workflows/make-codegen.yml
@@ -1,7 +1,11 @@
-name: Code Generation 
+name: Code Generation
 on:
   schedule:
     - cron: "0 0/2 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   active-branches:

--- a/.github/workflows/make-release-notes.yml
+++ b/.github/workflows/make-release-notes.yml
@@ -8,6 +8,10 @@ on:
   schedule:
     - cron: "0 0/12 * * *"
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
 
   active-branches:

--- a/.github/workflows/test-jobs.yml
+++ b/.github/workflows/test-jobs.yml
@@ -14,6 +14,9 @@ on:
       - '[0-9]+.[0-9]+'
       - '[0-9]+.x'
 
+permissions:
+  checks: write
+
 env:
   NUGET_PACKAGES: ${{ github.workspace }}/.nuget/packages
 


### PR DESCRIPTION
## Summary

InfoSec is changing the default `GITHUB_TOKEN` permissions from read/write to **read-only** on **July 15th**. Any workflow that writes to the repository, creates pull requests, or updates checks without an explicit `permissions:` block will break after that date.

This PR adds workflow-level `permissions:` blocks to all 8 affected workflows, granting only the minimum permissions each workflow actually needs.

## Changes

| Workflow | Permissions added |
|---|---|
| `auto-label.yml` | `pull-requests: write` (labels PRs via `banyan/auto-label`) |
| `backport.yml` | `contents: write`, `pull-requests: write` (creates backport PRs via `sorenlouv/backport-github-action`) |
| `docfx.yml` | `contents: write` (commits and pushes generated docs to the target branch) |
| `integration-jobs.yml` | `checks: write` (posts test results via `mikepenz/action-junit-report`) |
| `make-bump.yml` | `contents: write`, `pull-requests: write`, `issues: write` (creates version-bump PRs and applies labels via `peter-evans/create-pull-request`) |
| `make-codegen.yml` | `contents: write`, `pull-requests: write` (creates codegen sync PRs via `peter-evans/create-pull-request`) |
| `make-release-notes.yml` | `contents: write`, `pull-requests: write` (creates release-notes PRs via `peter-evans/create-pull-request`) |
| `test-jobs.yml` | `checks: write` (posts test results via `mikepenz/action-junit-report`) |

## Why `permissions:` at the workflow level?

Placing the block at the top level (same indentation as `name:`, `on:`, `jobs:`) sets the default for all jobs in the workflow while still allowing individual jobs to further restrict their own scope if needed. No existing job-level `permissions:` blocks were present in these files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)