### PR TITLE
Make custom JSON converters safe for multi-segment readers

### DIFF
--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/DateTimeConverters.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/DateTimeConverters.cs
@@ -42,11 +42,15 @@ internal sealed class DateTimeConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochMilliseconds(timestamp);
+			// Leniency for stringified numbers. Sequence-safe: GetValueBytes copies the token value
+			// to a contiguous span when it spans reader segments. Sized for the longest value this
+			// converter sees (ISO 8601 strings, ~40 bytes) with headroom.
+			Span<byte> tmp = stackalloc byte[64];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out long timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochMilliseconds(timestamp);
 		}
 
 		return reader.TokenType switch
@@ -110,11 +114,13 @@ internal sealed class DateTimeSecondsConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochSeconds(timestamp);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out long timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochSeconds(timestamp);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -161,11 +167,13 @@ internal sealed class DateTimeMillisConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochMilliseconds(timestamp);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out long timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochMilliseconds(timestamp);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -212,11 +220,13 @@ internal sealed class DateTimeNanosConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochNanoseconds(timestamp);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out long timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochNanoseconds(timestamp);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -263,11 +273,13 @@ internal sealed class DateTimeSecondsFloatConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out double timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochSeconds((long)timestamp);
+			// Leniency for stringified numbers (sequence-safe). Double round-trip is ~25 bytes; 64 with headroom.
+			Span<byte> tmp = stackalloc byte[64];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out double timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochSeconds((long)timestamp);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -314,11 +326,13 @@ internal sealed class DateTimeMillisFloatConverter :
 {
 	public override DateTimeOffset Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out double timestamp, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return DateTimeHelper.FromEpochMilliseconds((long)timestamp);
+			// Leniency for stringified numbers (sequence-safe). Double round-trip is ~25 bytes; 64 with headroom.
+			Span<byte> tmp = stackalloc byte[64];
+			var value = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(value, out double timestamp, out var consumed) && consumed == value.Length)
+				return DateTimeHelper.FromEpochMilliseconds((long)timestamp);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/DoubleWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/DoubleWithFractionalPortionConverter.cs
@@ -74,9 +74,11 @@ internal sealed class DoubleWithFractionalPortionConverter :
 			return reader.GetDouble();
 		}
 
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: double round-trip ~25 bytes; 64 with headroom.
+		Span<byte> tmp = stackalloc byte[64];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out double result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out double result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException("Unable to convert JSON string value to 'double'.");
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonReaderExtensions.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/JsonReaderExtensions.cs
@@ -130,6 +130,44 @@ internal static class JsonReaderExtensions
 		}
 	}
 
+	/// <summary>
+	/// Copies the current token's value into <paramref name="buffer"/> and returns its length, so the caller
+	/// can use <c>buffer[..length]</c> as a contiguous span. For a single-segment reader this copies
+	/// <see cref="Utf8JsonReader.ValueSpan"/>; for a multi-segment reader it copies <see cref="Utf8JsonReader.ValueSequence"/>.
+	/// Throws when the value is larger than <paramref name="buffer"/>, so size it to the longest token value the
+	/// caller expects (with headroom). Use this instead of <see cref="Utf8JsonReader.ValueSpan"/> in converters
+	/// that must support readers constructed over a multi-segment ReadOnlySequence.
+	/// </summary>
+	public static int GetValueBytes(this ref Utf8JsonReader reader, scoped Span<byte> buffer)
+	{
+		if (!reader.HasValueSequence)
+		{
+			var span = reader.ValueSpan;
+			if (span.Length > buffer.Length)
+				ThrowValueLargerThanBuffer(span.Length, buffer.Length);
+			span.CopyTo(buffer);
+			return span.Length;
+		}
+
+		var sequence = reader.ValueSequence;
+		if (sequence.Length > buffer.Length)
+			ThrowValueLargerThanBuffer((int)sequence.Length, buffer.Length);
+
+		var remaining = buffer;
+		foreach (var segment in sequence)
+		{
+			segment.Span.CopyTo(remaining);
+			remaining = remaining[segment.Length..];
+		}
+		return (int)sequence.Length;
+	}
+
+	[DoesNotReturn]
+	private static void ThrowValueLargerThanBuffer(int valueLength, int bufferLength)
+		=> throw new JsonException(
+			$"JSON token value of {valueLength} bytes exceeds the {bufferLength}-byte scratch buffer. " +
+			"Increase the converter's stackalloc size estimate.");
+
 	#endregion General Purpose
 
 	#region Default Generic Read Methods

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/SingleWithFractionalPortionConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/SingleWithFractionalPortionConverter.cs
@@ -74,9 +74,11 @@ internal sealed class SingleWithFractionalPortionConverter :
 			return reader.GetSingle();
 		}
 
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: single round-trip ~16 bytes; 32 with headroom.
+		Span<byte> tmp = stackalloc byte[32];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out float result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out float result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException("Unable to convert JSON string value to 'float'.");
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/StringifiedConverters.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/StringifiedConverters.cs
@@ -33,9 +33,11 @@ internal sealed class StringifiedBoolConverter :
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static bool ParseValue(ref Utf8JsonReader reader)
 	{
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: "true"/"false" <= 5 bytes; 16 with headroom.
+		Span<byte> tmp = stackalloc byte[16];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out bool result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out bool result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException($"Unable to convert JSON string value '{reader.GetString()!}' to '{nameof(Boolean)}'.");
 	}
@@ -62,9 +64,11 @@ internal sealed class StringifiedIntConverter :
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static int ParseValue(ref Utf8JsonReader reader)
 	{
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: Int32 max is 10 digits + sign = 11; 16 with headroom.
+		Span<byte> tmp = stackalloc byte[16];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out int result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out int result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException($"Unable to convert JSON string value '{reader.GetString()!}' to '{nameof(Int32)}'.");
 	}
@@ -91,9 +95,11 @@ internal sealed class StringifiedLongConverter :
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static long ParseValue(ref Utf8JsonReader reader)
 	{
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: Int64 max is 19 digits + sign = 20; 32 with headroom.
+		Span<byte> tmp = stackalloc byte[32];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out long result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out long result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException($"Unable to convert JSON string value '{reader.GetString()!}' to '{nameof(Int64)}'.");
 	}
@@ -120,9 +126,11 @@ internal sealed class StringifiedSingleConverter :
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static float ParseValue(ref Utf8JsonReader reader)
 	{
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: single round-trip ~16 bytes; 32 with headroom.
+		Span<byte> tmp = stackalloc byte[32];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out float result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out float result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException($"Unable to convert JSON string value '{reader.GetString()!}' to '{nameof(Single)}'.");
 	}
@@ -149,9 +157,11 @@ internal sealed class StringifiedDoubleConverter :
 	[MethodImpl(MethodImplOptions.AggressiveInlining)]
 	private static double ParseValue(ref Utf8JsonReader reader)
 	{
-		Debug.Assert(!reader.HasValueSequence);
+		// Sequence-safe: double round-trip ~25 bytes; 64 with headroom.
+		Span<byte> tmp = stackalloc byte[64];
+		var bytes = tmp[..reader.GetValueBytes(tmp)];
 
-		return Utf8Parser.TryParse(reader.ValueSpan, out double result, out var consumed) && (consumed == reader.ValueSpan.Length)
+		return Utf8Parser.TryParse(bytes, out double result, out var consumed) && (consumed == bytes.Length)
 			? result
 			: throw new JsonException($"Unable to convert JSON string value '{reader.GetString()!}' to '{nameof(Double)}'.");
 	}

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Next/TimeSpanConverters.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Next/TimeSpanConverters.cs
@@ -46,11 +46,13 @@ internal sealed class TimeSpanSecondsConverter :
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long value, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return TimeSpan.FromSeconds(value);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var bytes = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(bytes, out long value, out var consumed) && consumed == bytes.Length)
+				return TimeSpan.FromSeconds(value);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -97,11 +99,13 @@ internal sealed class TimeSpanMillisConverter :
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long value, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return TimeSpan.FromMilliseconds(value);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var bytes = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(bytes, out long value, out var consumed) && consumed == bytes.Length)
+				return TimeSpan.FromMilliseconds(value);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -148,11 +152,13 @@ internal sealed class TimeSpanNanosConverter :
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out long value, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return TimeSpanHelper.FromNanoseconds(value);
+			// Leniency for stringified numbers (sequence-safe). Int64 max is 19 digits + sign = 20; 32 with headroom.
+			Span<byte> tmp = stackalloc byte[32];
+			var bytes = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(bytes, out long value, out var consumed) && consumed == bytes.Length)
+				return TimeSpanHelper.FromNanoseconds(value);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -199,11 +205,13 @@ internal sealed class TimeSpanSecondsFloatConverter :
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out double value, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return TimeSpan.FromSeconds(value);
+			// Leniency for stringified numbers (sequence-safe). Double round-trip is ~25 bytes; 64 with headroom.
+			Span<byte> tmp = stackalloc byte[64];
+			var bytes = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(bytes, out double value, out var consumed) && consumed == bytes.Length)
+				return TimeSpan.FromSeconds(value);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);
@@ -250,11 +258,13 @@ internal sealed class TimeSpanMillisFloatConverter :
 {
 	public override TimeSpan Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
 	{
-		if ((reader.TokenType is JsonTokenType.String) && Utf8Parser.TryParse(reader.ValueSpan, out double value, out var consumed) &&
-			(consumed == reader.ValueSpan.Length))
+		if (reader.TokenType is JsonTokenType.String)
 		{
-			// Leniency for stringified numbers.
-			return TimeSpan.FromMilliseconds(value);
+			// Leniency for stringified numbers (sequence-safe). Double round-trip is ~25 bytes; 64 with headroom.
+			Span<byte> tmp = stackalloc byte[64];
+			var bytes = tmp[..reader.GetValueBytes(tmp)];
+			if (Utf8Parser.TryParse(bytes, out double value, out var consumed) && consumed == bytes.Length)
+				return TimeSpan.FromMilliseconds(value);
 		}
 
 		reader.ValidateToken(JsonTokenType.Number);

--- a/src/Elastic.Clients.Elasticsearch/_Shared/Types/IndexManagement/IndexSettingsTimeSeriesConverter.cs
+++ b/src/Elastic.Clients.Elasticsearch/_Shared/Types/IndexManagement/IndexSettingsTimeSeriesConverter.cs
@@ -63,11 +63,16 @@ public sealed class IndexSettingsTimeSeriesConverter : JsonConverter<IndexSettin
 		// represented by DateTimeOffset. Clamp to the nearest representable value.
 		if (reader.TokenType is JsonTokenType.String)
 		{
-			var span = reader.ValueSpan;
-			if (span.Length > 0 && span[0] == (byte)'-')
-				return DateTimeOffset.MinValue;
-			if (span.Length > 0 && span[0] == (byte)'+')
-				return DateTimeOffset.MaxValue;
+			// Allocation-free and sequence-safe: for a multi-segment reader the first value byte is in
+			// ValueSequence.FirstSpan; for a single-segment reader it is in ValueSpan.
+			var valueSpan = reader.HasValueSequence ? reader.ValueSequence.First.Span : reader.ValueSpan;
+			if (valueSpan.Length > 0)
+			{
+				if (valueSpan[0] == (byte)'-')
+					return DateTimeOffset.MinValue;
+				if (valueSpan[0] == (byte)'+')
+					return DateTimeOffset.MaxValue;
+			}
 		}
 
 		return reader.ReadNullableValueEx<DateTimeOffset>(options, typeof(DateTimeMarker));


### PR DESCRIPTION
## Summary

The hand-written DateTime, TimeSpan, Stringified, and fractional numeric converters read `reader.ValueSpan` directly to parse stringified numbers with `Utf8Parser`. `ValueSpan` is unsafe when `Utf8JsonReader` is constructed over a multi-segment `ReadOnlySequence<byte>` (it throws, or returns a non-contiguous span), so these converters only worked on the single-segment reader that `JsonSerializer` uses for stream deserialization. Any sequence-based deserializer, such as a streaming reader over a `PipeReader`, failed on the first stringified epoch date or duration. Surfaced while prototyping streaming deserialization for #8919.

## Changes

- Add `JsonReaderExtensions.GetValueBytes(ref reader, scoped Span<byte>)`: copies the current token's value into a caller-provided contiguous buffer (single-segment via `ValueSpan`, multi-segment by iterating `ValueSequence` segments), returns the length, and throws `JsonException` when the value exceeds the buffer.
- Update the 18 numeric/date converters to parse from `buffer[..length]`, with the scratch buffer sized per type (bool/int 16, long/float 32, double and ISO date 64).
- `IndexSettingsTimeSeriesConverter` extended-year first-byte peek now reads `reader.ValueSequence.First.Span` / `reader.ValueSpan` directly, avoiding a `GetString` allocation.
- The `scoped` modifier on the buffer parameter is required so a stackalloc can be passed (otherwise the by-value `Span` would be escape-able through the unscoped `ref Utf8JsonReader`, CS8350).

Generated converters were already sequence-safe via the `HasValueSequence`-guarded `ValueTextEquals`, so no generator changes are needed. Builds clean across the target frameworks (verified `net10.0` and `netstandard2.0`); the existing single-segment typed deserialize path is unchanged.
