### PR TITLE
Add CI and npm packaging for the request converter

### DIFF
--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -46,6 +46,9 @@ jobs:
         with:
           node-version: 22
           registry-url: 'https://registry.npmjs.org'
+      # Trusted publishing (OIDC, no NODE_AUTH_TOKEN) requires npm 11.5.1 or newer;
+      # node 22's bundled npm 10.9.x predates it.
+      - run: npm install -g npm@latest
       - name: Compute package version
         id: version
         env:

--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -1,0 +1,64 @@
+name: Request converter npm publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to build and publish from (e.g. 9.5, 8.19)'
+        required: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve branch
+        id: branch
+        run: |
+          BRANCH="${{ github.event.inputs.branch || github.event.release.target_commitish }}"
+          if ! [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "Refusing to publish from '$BRANCH': only release branches (major.minor) are supported."
+            exit 1
+          fi
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.branch.outputs.branch }}
+      - uses: actions/setup-dotnet@v4
+      - run: dotnet workload install wasm-tools
+      - run: dotnet test RequestConverter.sln
+      - run: dotnet publish src/RequestConverter.Wasm/RequestConverter.Wasm.csproj -c Release
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: 'https://registry.npmjs.org'
+      - name: Compute package version
+        id: version
+        run: |
+          MINOR="${{ steps.branch.outputs.branch }}"
+          LATEST_PATCH=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null \
+            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const v=JSON.parse(d||'[]');const p=v.filter(x=>x.startsWith(process.argv[1]+'.')).map(x=>parseInt(x.split('.')[2],10));console.log(p.length?Math.max(...p):-1)})" "$MINOR" \
+            || echo "-1")
+          VERSION="$MINOR.$((LATEST_PATCH + 1))"
+          CLIENT_VERSION="${{ github.event.release.tag_name }}"
+          CLIENT_VERSION="${CLIENT_VERSION#v}"
+          if [ -z "$CLIENT_VERSION" ]; then
+            CLIENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unreleased")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "client-version=$CLIENT_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Assemble package
+        run: |
+          node src/RequestConverter.Wasm/npm/prepare-package.mjs \
+            --app-bundle .artifacts/bin/RequestConverter.Wasm/release_browser-wasm/AppBundle \
+            --version "${{ steps.version.outputs.version }}" \
+            --client-version "${{ steps.version.outputs.client-version }}" \
+            --commit "$GITHUB_SHA" \
+            --out .artifacts/npm/request-converter-dotnet
+      - run: node src/RequestConverter.Wasm/npm/smoke.mjs .artifacts/npm/request-converter-dotnet
+      - run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance

--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -19,8 +19,10 @@ jobs:
     steps:
       - name: Resolve branch
         id: branch
+        env:
+          BRANCH_INPUT: ${{ github.event.inputs.branch || github.event.release.target_commitish }}
         run: |
-          BRANCH="${{ github.event.inputs.branch || github.event.release.target_commitish }}"
+          BRANCH="$BRANCH_INPUT"
           if ! [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
             echo "Refusing to publish from '$BRANCH': only release branches (major.minor) are supported."
             exit 1
@@ -29,7 +31,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ steps.branch.outputs.branch }}
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Resolve commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - run: dotnet workload install wasm-tools
       - run: dotnet test RequestConverter.sln
       - run: dotnet publish src/RequestConverter.Wasm/RequestConverter.Wasm.csproj -c Release
@@ -39,14 +48,15 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - name: Compute package version
         id: version
+        env:
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
           MINOR="${{ steps.branch.outputs.branch }}"
           LATEST_PATCH=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null \
             | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const v=JSON.parse(d||'[]');const p=v.filter(x=>x.startsWith(process.argv[1]+'.')).map(x=>parseInt(x.split('.')[2],10));console.log(p.length?Math.max(...p):-1)})" "$MINOR" \
             || echo "-1")
           VERSION="$MINOR.$((LATEST_PATCH + 1))"
-          CLIENT_VERSION="${{ github.event.release.tag_name }}"
-          CLIENT_VERSION="${CLIENT_VERSION#v}"
+          CLIENT_VERSION="${RELEASE_TAG#v}"
           if [ -z "$CLIENT_VERSION" ]; then
             CLIENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unreleased")
           fi
@@ -58,7 +68,7 @@ jobs:
             --app-bundle .artifacts/bin/RequestConverter.Wasm/release_browser-wasm/AppBundle \
             --version "${{ steps.version.outputs.version }}" \
             --client-version "${{ steps.version.outputs.client-version }}" \
-            --commit "$GITHUB_SHA" \
+            --commit "${{ steps.commit.outputs.sha }}" \
             --out .artifacts/npm/request-converter-dotnet
       - run: node src/RequestConverter.Wasm/npm/smoke.mjs .artifacts/npm/request-converter-dotnet
       - run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance

--- a/.github/workflows/request-converter.yml
+++ b/.github/workflows/request-converter.yml
@@ -10,6 +10,9 @@ on:
       - '.github/workflows/request-converter.yml'
       - 'RequestConverter.sln'
       - 'global.json'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'nuget.config'
       - 'src/Elastic.Clients.Elasticsearch/**'
       - 'src/RequestConverter/**'
       - 'src/RequestConverter.Console/**'
@@ -20,6 +23,9 @@ on:
       - '.github/workflows/request-converter.yml'
       - 'RequestConverter.sln'
       - 'global.json'
+      - 'Directory.Build.props'
+      - 'Directory.Build.targets'
+      - 'nuget.config'
       - 'src/Elastic.Clients.Elasticsearch/**'
       - 'src/RequestConverter/**'
       - 'src/RequestConverter.Console/**'
@@ -34,6 +40,7 @@ jobs:
       - uses: actions/setup-dotnet@v4
         with:
           global-json-file: 'global.json'
+      - run: dotnet workload install wasm-tools
       - run: dotnet test RequestConverter.sln
 
   wasm:

--- a/.github/workflows/request-converter.yml
+++ b/.github/workflows/request-converter.yml
@@ -1,0 +1,47 @@
+name: Request converter
+
+on:
+  push:
+    branches:
+      - main
+      - '8.*'
+      - '9.*'
+    paths:
+      - '.github/workflows/request-converter.yml'
+      - 'RequestConverter.sln'
+      - 'global.json'
+      - 'src/Elastic.Clients.Elasticsearch/**'
+      - 'src/RequestConverter/**'
+      - 'src/RequestConverter.Console/**'
+      - 'src/RequestConverter.Wasm/**'
+      - 'tests/RequestConverter.Tests/**'
+  pull_request:
+    paths:
+      - '.github/workflows/request-converter.yml'
+      - 'RequestConverter.sln'
+      - 'global.json'
+      - 'src/Elastic.Clients.Elasticsearch/**'
+      - 'src/RequestConverter/**'
+      - 'src/RequestConverter.Console/**'
+      - 'src/RequestConverter.Wasm/**'
+      - 'tests/RequestConverter.Tests/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+      - run: dotnet test RequestConverter.sln
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+      - run: dotnet workload install wasm-tools
+      - run: dotnet publish src/RequestConverter.Wasm/RequestConverter.Wasm.csproj -c Release
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: node src/RequestConverter.Wasm/npm/smoke.mjs .artifacts/bin/RequestConverter.Wasm/release_browser-wasm/AppBundle

--- a/.github/workflows/request-converter.yml
+++ b/.github/workflows/request-converter.yml
@@ -32,6 +32,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - run: dotnet test RequestConverter.sln
 
   wasm:
@@ -39,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-dotnet@v4
+        with:
+          global-json-file: 'global.json'
       - run: dotnet workload install wasm-tools
       - run: dotnet publish src/RequestConverter.Wasm/RequestConverter.Wasm.csproj -c Release
       - uses: actions/setup-node@v4

--- a/src/RequestConverter.Wasm/npm/README.md
+++ b/src/RequestConverter.Wasm/npm/README.md
@@ -1,0 +1,98 @@
+# @elastic/request-converter-dotnet
+
+The .NET request converter for Elasticsearch, compiled to WebAssembly. It turns a parsed Dev
+Console request into `Elastic.Clients.Elasticsearch` (.NET) client code, with the target
+`Elastic.Clients.Elasticsearch` version embedded in the WASM bundle itself.
+
+This package is consumed by `@elastic/request-converter`'s C# exporter, which loads it as an
+`ExternalExporter` plugin. It is also usable standalone from Node by calling its `boot()` factory
+directly, as shown below.
+
+## Usage
+
+```js
+import { boot } from "@elastic/request-converter-dotnet";
+
+const { check, convert } = await boot();
+
+const payload = {
+  requests: [
+    {
+      api: "search",
+      body: { query: { term: { "user.id": { value: "kimchy" } } } },
+      method: "GET",
+      params: { index: "my-index-000001" },
+      path: "/my-index-000001/_search",
+      query: { from: "40", size: "20" },
+      raw_path: "/my-index-000001/_search",
+      source: "GET /my-index-000001/_search?from=40&size=20",
+      url: "/my-index-000001/_search?from=40&size=20",
+    },
+  ],
+  options: {
+    document_type_name: "MyDocument",
+    syntax_mode: "descriptor",
+    use_strongly_typed_document: true,
+  },
+};
+
+const checked = JSON.parse(check(JSON.stringify(payload)));
+// checked.return === true
+
+const converted = JSON.parse(convert(JSON.stringify(payload)));
+console.log(converted.return);
+// var request = new SearchRequestDescriptor<MyDocument>() ...
+```
+
+## Contract
+
+Both `check` and `convert` are synchronous, take a JSON string, and return a JSON string. Field
+names are snake_case throughout.
+
+- `check(input)` - input `{"requests": ParsedRequest[]}`; output `{"return": <bool>, "error"?: "..."}`.
+  It is a yes/no probe: a request the converter cannot handle (unsupported endpoint, invalid body,
+  ...) makes it return `false` rather than an error.
+- `convert(input)` - input `{"requests": ParsedRequest[], "options": ConvertOptions}`; output
+  `{"return": <string>, "error"?: "..."}`. On failure, `error` is a concise, user-facing message (no
+  stack trace) naming the failing request and the reason.
+
+`ParsedRequest` is produced by the host's parser (turning Dev Console text into an API name and URL
+parameters needs the Elasticsearch schema, which this package does not carry), so this package only
+converts requests already parsed into that shape.
+
+## Options
+
+`options` on `convert` accepts:
+
+- `document_type_name` (string, default `MyDocument`) - the placeholder document type name used when
+  `use_strongly_typed_document` is set.
+- `syntax_mode` (`object_initializer` | `descriptor`, default `object_initializer`) - the emitted C#
+  syntax. `object_initializer` emits object initializers (`new SearchRequest { Query = ... }`);
+  `descriptor` emits the fluent descriptor chain (`new SearchRequestDescriptor().Query(q => ...)`).
+- `type_name_style` (`Simplified` | `Fqn` | `GlobalFqn`, default `Simplified`) - how type names are
+  spelled in the generated code.
+- `use_strongly_typed_document` (bool, default `false`) - switches field references to
+  `Infer.Field<DocumentTypeName>(x => x.Path)` lambdas and a generic request's document body to
+  `new DocumentTypeName { ... }`. Pairs with `syntax_mode: "descriptor"` to produce the generic
+  `XDescriptor<DocumentTypeName>` flavor.
+- `debug` (bool, default `false`) - appends the full exception (type and stack trace) to a failed
+  `convert`'s `error`, after a `--- debug ---` marker.
+
+The `document_type_name` given (`MyDocument` by default) is not a type the converter generates; the
+caller supplies it, so any typed-document example in the generated output is illustrative and
+generally does not compile or round-trip as-is.
+
+## Versioning
+
+This package's major and minor version track the elasticsearch-net branch it was built from (for
+example a build from the `9.1` branch ships as `9.1.x`); the patch number increments freely on each
+publish and carries no meaning beyond ordering. The exact embedded client is recorded in
+`package.json` under the `elasticsearch` key: `clientVersion` is the `Elastic.Clients.Elasticsearch`
+version compiled into the bundle, and `commit` is the elasticsearch-net commit the bundle was built
+from.
+
+## Building from source
+
+This package is assembled from a published .NET WASM AppBundle; see
+[`src/RequestConverter.Wasm`](https://github.com/elastic/elasticsearch-net/tree/main/src/RequestConverter.Wasm)
+in the elasticsearch-net repository for build prerequisites and instructions.

--- a/src/RequestConverter.Wasm/npm/package.template.json
+++ b/src/RequestConverter.Wasm/npm/package.template.json
@@ -1,0 +1,17 @@
+{
+  "name": "@elastic/request-converter-dotnet",
+  "version": "0.0.0",
+  "description": "Converts Elasticsearch Dev Console requests to Elastic.Clients.Elasticsearch (.NET) code. .NET WASM bundle consumed by @elastic/request-converter.",
+  "type": "module",
+  "exports": "./main.mjs",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/elastic/elasticsearch-net.git",
+    "directory": "src/RequestConverter.Wasm"
+  },
+  "elasticsearch": {
+    "clientVersion": "0.0.0",
+    "commit": ""
+  }
+}

--- a/src/RequestConverter.Wasm/npm/prepare-package.mjs
+++ b/src/RequestConverter.Wasm/npm/prepare-package.mjs
@@ -1,0 +1,38 @@
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+
+const { values: args } = parseArgs({
+  options: {
+    "app-bundle": { type: "string" },
+    "client-version": { type: "string" },
+    commit: { type: "string" },
+    out: { type: "string" },
+    version: { type: "string" },
+  },
+});
+
+for (const required of ["app-bundle", "client-version", "commit", "out", "version"]) {
+  if (!args[required]) {
+    console.error(`Missing required argument: --${required}`);
+    process.exit(1);
+  }
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const outDir = resolve(args.out);
+
+await rm(outDir, { recursive: true, force: true });
+await mkdir(outDir, { recursive: true });
+await cp(resolve(args["app-bundle"]), outDir, { recursive: true });
+
+const template = JSON.parse(await readFile(join(here, "package.template.json"), "utf8"));
+template.version = args.version;
+template.elasticsearch.clientVersion = args["client-version"];
+template.elasticsearch.commit = args.commit;
+// The AppBundle ships its own minimal package.json ({"type":"module"}); ours replaces it.
+await writeFile(join(outDir, "package.json"), JSON.stringify(template, null, 2) + "\n");
+await cp(join(here, "README.md"), join(outDir, "README.md"));
+
+console.log(`Package assembled at ${outDir} (version ${args.version})`);

--- a/src/RequestConverter.Wasm/npm/smoke.mjs
+++ b/src/RequestConverter.Wasm/npm/smoke.mjs
@@ -1,0 +1,49 @@
+import { resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+
+const bundleDir = process.argv[2];
+if (!bundleDir) {
+  console.error("Usage: node smoke.mjs <appBundleOrPackageDir>");
+  process.exit(1);
+}
+
+const { boot } = await import(pathToFileURL(resolve(bundleDir, "main.mjs")).href);
+const { check, convert } = await boot();
+
+const payload = {
+  requests: [
+    {
+      api: "search",
+      body: { query: { term: { "user.id": { value: "kimchy" } } } },
+      method: "GET",
+      params: { index: "my-index-000001" },
+      path: "/my-index-000001/_search",
+      query: { from: "40", size: "20" },
+      raw_path: "/my-index-000001/_search",
+      source: "GET /my-index-000001/_search?from=40&size=20",
+      url: "/my-index-000001/_search?from=40&size=20",
+    },
+  ],
+  options: {
+    document_type_name: "MyDocument",
+    syntax_mode: "descriptor",
+    use_strongly_typed_document: true,
+  },
+};
+
+const checked = JSON.parse(check(JSON.stringify(payload)));
+if (checked.error || checked.return !== true) {
+  console.error("check failed:", JSON.stringify(checked));
+  process.exit(1);
+}
+
+const converted = JSON.parse(convert(JSON.stringify(payload)));
+if (converted.error) {
+  console.error("convert failed:", converted.error);
+  process.exit(1);
+}
+if (!converted.return.includes("new SearchRequestDescriptor<MyDocument>()")) {
+  console.error("unexpected output:\n" + converted.return);
+  process.exit(1);
+}
+console.log("smoke OK");

--- a/tests/RequestConverter.Tests/RequestConverter.Tests.csproj
+++ b/tests/RequestConverter.Tests/RequestConverter.Tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>annotations</Nullable>
     <ImplicitUsings>disable</ImplicitUsings>
+    <AllowMissingPrunePackageData>true</AllowMissingPrunePackageData>
     <IsPackable>false</IsPackable>
     <IsPublishable>false</IsPublishable>
     <!-- This project only round-trips converter output; it never ships. -->

--- a/tests/RequestConverter.Tests/RoundtripRegressionTests.cs
+++ b/tests/RequestConverter.Tests/RoundtripRegressionTests.cs
@@ -243,6 +243,67 @@ public sealed class RoundtripRegressionTests
 	}
 
 	/// <summary>
+	/// Gates the published-example flavor (Descriptor syntax + strongly typed document): every corpus example
+	/// the round-trip Theory converts must also convert here without throwing. This flavor's <c>MyDocument</c>
+	/// type is illustrative and never compiles or round-trips, so unlike the Theory above this only exercises
+	/// conversion, not compilation or round-tripping.
+	/// </summary>
+	[Fact]
+	public void Converted_requests_convert_in_typed_document_mode()
+	{
+		var reportPath = LocateRepoRootFile(Path.Combine("tests", "RequestConverter.Tests", "TestData", "alternatives_report.json"));
+		using var reportStream = File.OpenRead(reportPath);
+		var examples = JsonSerializer.Deserialize<ExampleModel[]>(reportStream)
+			?? throw new InvalidOperationException("Failed to parse alternatives_report.json.");
+
+		var serializer = global::RequestConverter.RequestConverter.DefaultSerializer;
+
+		var options = new FormattingOptions
+		{
+			SyntaxMode = SyntaxMode.Descriptor,
+			UseStronglyTypedDocument = true,
+			EmitVariableDeclaration = true,
+		};
+
+		var failures = new List<string>();
+		var converted = 0;
+		var skippedUnsupported = 0;
+
+		foreach (var example in examples)
+		{
+			if (example.Lang != "console" || example.ParsedSource is null || example.ParsedSource.Count == 0)
+				continue;
+			if (Blacklist.Contains(example.Digest))
+				continue;
+
+			foreach (var source in example.ParsedSource)
+			{
+				var body = source.Body?.GetRawText();
+				try
+				{
+					_ = global::RequestConverter.RequestConverter.ConvertCore(
+						serializer, source.Api, source.PathParameters, source.QueryParameters, body, options);
+					converted++;
+				}
+				catch (NotSupportedException)
+				{
+					// The converter doesn't (yet) support this endpoint; not a regression (mirrors the Theory above).
+					skippedUnsupported++;
+				}
+				catch (Exception ex)
+				{
+					failures.Add($"{source.Api} [{example.Digest}]: {ex.GetType().Name}: {ex.Message}");
+				}
+			}
+		}
+
+		_output.WriteLine($"converted={converted}, skipped(unsupported)={skippedUnsupported}, typed-document-failures={failures.Count}");
+
+		Assert.True(failures.Count == 0,
+			$"{failures.Count} typed-document conversion failures:\n{string.Join("\n", failures)}");
+	}
+
+	/// <summary>
 	/// Resolves a request to its on-the-wire endpoint shape: HTTP method, resolved route values, and
 	/// query-string parameters, using the client's own URL and query-string builder (the same calls the
 	/// client makes in <c>PrepareRequest</c>). <c>RequestParameters</c> is internal and lives on the


### PR DESCRIPTION
## Summary

Makes the `RequestConverter` solution CI-gated and publishable: a path-filtered workflow builds and tests `RequestConverter.sln` on converter-relevant changes, new packaging scripts assemble the WASM AppBundle into the `@elastic/request-converter-dotnet` npm package, and a publish workflow ships that package with npm trusted publishing.

## Intention

The .NET request converter is being integrated into `@elastic/request-converter` as a first-class C# exporter (elastic/request-converter#107), which generates the C# language examples in elasticsearch-specification (elastic/elasticsearch-specification#6509). Both consume the WASM bundle as an npm package. Because the bundle compiles the entire client in, each minor branch needs its own package version to produce valid examples for that stack version: the package version tracks the branch major.minor with a freely incrementing patch, and the exact embedded client version and commit are recorded in package.json metadata.

## Changes

- Allow missing prune package data in the test project so `dotnet test RequestConverter.sln` works without extra properties.
- Add a conversion-only corpus gate for the descriptor + strongly-typed-document flavor used for published examples (all 3640 convertible corpus examples pass).
- Add npm packaging under `src/RequestConverter.Wasm/npm/`: package template, assembly script, Node smoke test, package README.
- Add `.github/workflows/request-converter.yml`: build and test on pull requests and pushes, path-filtered to converter-relevant inputs (including the client sources the converter compiles in).
- Add `.github/workflows/request-converter-npm-publish.yml`: publishes the npm package on client releases and via manual dispatch, with provenance.

## Notes

- Before the publish workflow can succeed, the `@elastic` npm org must configure trusted publishing for `@elastic/request-converter-dotnet` targeting `request-converter-npm-publish.yml` in this repo. The workflow upgrades npm at runtime because OIDC publishing requires npm 11.5.1 or newer.
- On release events the workflow builds the release branch HEAD; `package.json` records the exact built commit, so any drift from the tag is discoverable.
- Releases from branches that are not `major.minor` (for example `serverless-*`) fail the publish workflow's branch guard by design.