### PR TITLE
[9.5] Publish request converter with an explicit npm dist-tag

### DIFF
--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -74,4 +74,20 @@ jobs:
             --commit "${{ steps.commit.outputs.sha }}" \
             --out .artifacts/npm/request-converter-dotnet
       - run: node src/RequestConverter.Wasm/npm/smoke.mjs .artifacts/npm/request-converter-dotnet
-      - run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance
+      # npm refuses to publish a version lower than the current "latest" without an explicit
+      # dist-tag (it would implicitly move "latest" backwards). Tag "latest" only when the new
+      # version is the highest published one; otherwise use a per-branch tag. Plain "8.19" is
+      # not a legal dist-tag (npm rejects tags that parse as semver ranges), hence the prefix.
+      - name: Compute dist-tag
+        id: dist-tag
+        run: |
+          CURRENT_LATEST=$(npm view @elastic/request-converter-dotnet version 2>/dev/null || echo "0.0.0")
+          NEW_VERSION="${{ steps.version.outputs.version }}"
+          if [ "$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -n1)" = "$NEW_VERSION" ]; then
+            TAG="latest"
+          else
+            TAG="latest-${{ steps.branch.outputs.branch }}"
+          fi
+          echo "Publishing ${NEW_VERSION} with dist-tag ${TAG} (current latest: ${CURRENT_LATEST})"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+      - run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance --tag "${{ steps.dist-tag.outputs.tag }}"


### PR DESCRIPTION
## Summary

The first 8.19 publish attempt (run [30354740150](https://github.com/elastic/elasticsearch-net/actions/runs/30354740150)) got all the way to `npm publish` and failed on npm's pre-publish check:

> Cannot implicitly apply the "latest" tag because previously published version 9.4.0 is higher than the new version 8.19.0. You must specify a tag using --tag.

Publishing a version lower than the current `latest` requires an explicit dist-tag, otherwise npm would implicitly move `latest` backwards. This adds a `Compute dist-tag` step: tag `latest` only when the new version is the highest published one, otherwise tag `latest-<branch>` (e.g. `latest-8.19`; plain `8.19` is not a legal dist-tag because npm rejects tags that parse as semver ranges).

## Test plan

- [ ] After merge: dispatch `request-converter-npm-publish.yml` with ref/branch 8.19 and verify `@elastic/request-converter-dotnet@8.19.0` publishes with dist-tag `latest-8.19` while `latest` stays on 9.4.0
