### PR TITLE
fix: grant contents write to docfx callers

### DIFF
--- a/.github/workflows/docfx_manual.yml
+++ b/.github/workflows/docfx_manual.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   docfx:
     name: 'DocFx'
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       target_branch: 'refdoc'

--- a/.github/workflows/release_stack.yml
+++ b/.github/workflows/release_stack.yml
@@ -17,6 +17,11 @@ jobs:
 
   docfx:
     name: 'DocFx'
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

Grants `contents: write` to the two jobs that call the reusable `docfx.yml` workflow, so the CD workflow can start again.

## Intention

`docfx.yml` declares `permissions: contents: write` at workflow level so it can push the generated site to the `refdoc` branch. A called workflow cannot request more permissions than its caller holds, and this repository's default workflow token is read-only (`default_workflow_permissions: read`). Neither caller granted anything, so GitHub rejected the whole run before any job started.

That is what broke CD for the 9.5.0 release: both attempts ended in `startup_failure`, so no packages were published. `9.4` and `8.19` are unaffected because they do not carry the `docfx.yml` permissions block.

`docfx_manual.yml` had the same latent problem and would have failed on its next manual run.

## Changes

- `release_stack.yml`: grant `contents: write` on the `docfx` job
- `docfx_manual.yml`: grant `contents: write` on the `docfx` job

The grant is scoped per job rather than workflow-wide, so the `release` job keeps its read-only token.

## Notes

Needs a backport to `9.5`, which is the branch that carries the `docfx.yml` permissions block. `9.4` and `8.19` do not need it.