### PR TITLE
[9.5] fix: grant contents write to docfx callers (#8948)

### DIFF
--- a/.github/workflows/docfx_manual.yml
+++ b/.github/workflows/docfx_manual.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   docfx:
     name: 'DocFx'
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       target_branch: 'refdoc'

--- a/.github/workflows/release_stack.yml
+++ b/.github/workflows/release_stack.yml
@@ -17,6 +17,11 @@ jobs:
 
   docfx:
     name: 'DocFx'
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
Backport of #8948.

## Summary

Grants `contents: write` to the two jobs that call the reusable `docfx.yml` workflow, so the CD workflow can start again on this branch.

## Intention

`docfx.yml` declares `permissions: contents: write` at workflow level so it can push the generated site to the `refdoc` branch. A called workflow cannot request more permissions than its caller holds, and this repository's default workflow token is read-only, so GitHub rejected the whole run before any job started.

`9.5` is the branch that actually needs this: both CD attempts for the 9.5.0 release ended in `startup_failure` and no packages were published. `9.4` and `8.19` do not carry the `docfx.yml` permissions block and are unaffected.

## Changes

- `release_stack.yml`: grant `contents: write` on the `docfx` job
- `docfx_manual.yml`: grant `contents: write` on the `docfx` job

The grant is scoped per job, so the `release` job keeps its read-only token.