### PR TITLE
Publish main request converter builds under latest-main

### DIFF
--- a/.github/workflows/bump-elasticsearch-specification.yml
+++ b/.github/workflows/bump-elasticsearch-specification.yml
@@ -4,8 +4,8 @@ name: Bump elasticsearch-specification
 # converter package pin in docs/examples/package.json. Called from the npm publish
 # workflow after a successful publish; also dispatchable manually for testing.
 #
-# Targets the spec branch matching the published major.minor, and additionally
-# targets `main` when the publish moved the `latest` dist-tag.
+# Targets the spec branch named after the source branch, one for one: a build from
+# `X.Y` bumps spec `X.Y`, a build from `main` bumps spec `main`.
 #
 # Uses an ephemeral Vault (ci-prod) token fetched via OIDC rather than the
 # default GITHUB_TOKEN: bump PRs target a different repo and must trigger its
@@ -21,11 +21,11 @@ on:
         required: true
         type: string
       branch:
-        description: 'Source major.minor branch, e.g. 9.4 (matches the spec branch to target)'
+        description: 'Source branch, e.g. 9.4 or main (names the spec branch to target)'
         required: true
         type: string
       dist-tag:
-        description: 'npm dist-tag the version was published with: "latest" or "latest-<branch>"'
+        description: 'npm dist-tag the version was published with, recorded in the PR body'
         required: true
         type: string
       package:
@@ -43,10 +43,10 @@ on:
         description: 'Published package version, e.g. 9.4.2'
         required: true
       branch:
-        description: 'Source major.minor branch, e.g. 9.4'
+        description: 'Source branch, e.g. 9.4 or main'
         required: true
       dist-tag:
-        description: 'npm dist-tag: "latest" or "latest-<branch>"'
+        description: 'npm dist-tag the version was published with, recorded in the PR body'
         required: true
       package:
         description: 'npm package to bump'
@@ -91,10 +91,9 @@ jobs:
             const pin = `~${version}`;
             const path = 'docs/examples/package.json';
 
-            // Always target the matching major.minor branch; also target main when
-            // the publish moved the "latest" dist-tag.
+            // Spec branches are named for the source branch, so the mapping is explicit:
+            // `X.Y` bumps spec `X.Y`, `main` bumps spec `main`.
             const targets = [branch];
-            if (distTag === 'latest') targets.push('main');
 
             core.info(`Bumping ${pkg} to ${pin} on ${owner}/${repo}: ${targets.join(', ')}${dryRun ? ' (dry-run)' : ''}`);
 

--- a/.github/workflows/bump-elasticsearch-specification.yml
+++ b/.github/workflows/bump-elasticsearch-specification.yml
@@ -88,8 +88,13 @@ jobs:
             const distTag = process.env.SPEC_DIST_TAG;
             const dryRun = String(process.env.SPEC_DRY_RUN) === 'true';
             const unscoped = pkg.replace(/^@[^/]+\//, '');
-            const pin = `~${version}`;
             const path = 'docs/examples/package.json';
+
+            // main builds are versioned off their commit, so there is no meaningful range to
+            // pin: spec main references the channel instead, and npm resolves the dist-tag to
+            // whatever it currently points at. The first main publish sets the pin and every
+            // later one no-ops against the existing-pin check below.
+            const pin = branch === 'main' ? 'latest-main' : `~${version}`;
 
             // Spec branches are named for the source branch, so the mapping is explicit:
             // `X.Y` bumps spec `X.Y`, `main` bumps spec `main`.

--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -6,8 +6,13 @@ on:
   workflow_dispatch:
     inputs:
       branch:
-        description: 'Branch to build and publish from (e.g. 9.5, 8.19)'
+        description: 'Branch to build and publish from (e.g. main, 9.5, 8.19)'
         required: true
+      dry-run:
+        description: 'Compute and log the version/dist-tag without publishing or opening bump PRs'
+        required: false
+        default: false
+        type: boolean
 
 permissions:
   contents: read
@@ -27,8 +32,8 @@ jobs:
           BRANCH_INPUT: ${{ github.event.inputs.branch || github.event.release.target_commitish }}
         run: |
           BRANCH="$BRANCH_INPUT"
-          if ! [[ "$BRANCH" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "Refusing to publish from '$BRANCH': only release branches (major.minor) are supported."
+          if ! [[ "$BRANCH" =~ ^([0-9]+\.[0-9]+|main)$ ]]; then
+            echo "Refusing to publish from '$BRANCH': only 'main' and release branches (major.minor) are supported."
             exit 1
           fi
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
@@ -53,20 +58,54 @@ jobs:
       # Trusted publishing (OIDC, no NODE_AUTH_TOKEN) requires npm 11.5.1 or newer;
       # node 22's bundled npm 10.9.x predates it.
       - run: npm install -g npm@latest
+      # A numeric branch takes the next free patch on its own minor; "main" has no release line
+      # of its own and takes the next "-main.<n>" prerelease of the next unreleased minor.
+      # Prereleases are excluded from both scans so a 9.6.0-main.* build is never mistaken for
+      # an existing 9.6 release.
       - name: Compute package version
         id: version
         env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          MINOR="${{ steps.branch.outputs.branch }}"
-          LATEST_PATCH=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null \
-            | node -e "let d='';process.stdin.on('data',c=>d+=c).on('end',()=>{const v=JSON.parse(d||'[]');const p=v.filter(x=>x.startsWith(process.argv[1]+'.')).map(x=>parseInt(x.split('.')[2],10));console.log(p.length?Math.max(...p):-1)})" "$MINOR" \
-            || echo "-1")
-          VERSION="$MINOR.$((LATEST_PATCH + 1))"
-          CLIENT_VERSION="${RELEASE_TAG#v}"
-          if [ -z "$CLIENT_VERSION" ]; then
-            CLIENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unreleased")
+          VERSIONS=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null || echo "[]")
+          VERSION=$(node -e '
+            let raw;
+            try { raw = JSON.parse(process.argv[1]) } catch { raw = [] }
+            // "npm view versions --json" yields a bare string, not an array, for a single-version package.
+            const all = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
+            const released = all.filter(v => !v.includes("-"));
+            const branch = process.argv[2];
+            if (branch === "main") {
+              const [major, minor] = released.reduce((max, v) => {
+                const p = v.split(".").map(Number);
+                return p[0] > max[0] || (p[0] === max[0] && p[1] > max[1]) ? [p[0], p[1]] : max;
+              }, [0, 0]);
+              const base = major + "." + (minor + 1);
+              const counter = new RegExp("^" + base.replace(".", "\\.") + "\\.0-main\\.(\\d+)$");
+              const n = all.reduce((max, v) => {
+                const m = v.match(counter);
+                return m ? Math.max(max, Number(m[1])) : max;
+              }, 0);
+              console.log(base + ".0-main." + (n + 1));
+            } else {
+              const patch = released
+                .filter(v => v.startsWith(branch + "."))
+                .reduce((max, v) => Math.max(max, Number(v.split(".")[2])), -1);
+              console.log(branch + "." + (patch + 1));
+            }
+          ' "$VERSIONS" "$BRANCH")
+          if [ "$BRANCH" = "main" ]; then
+            # No client release corresponds to a main build, and "git describe" would attach an
+            # unrelated tag; the recorded commit is the build's identity instead.
+            CLIENT_VERSION="unreleased"
+          else
+            CLIENT_VERSION="${RELEASE_TAG#v}"
+            if [ -z "$CLIENT_VERSION" ]; then
+              CLIENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unreleased")
+            fi
           fi
+          echo "Computed version ${VERSION} (client version ${CLIENT_VERSION}) for branch ${BRANCH}"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           echo "client-version=$CLIENT_VERSION" >> "$GITHUB_OUTPUT"
       - name: Assemble package
@@ -82,22 +121,32 @@ jobs:
       # dist-tag (it would implicitly move "latest" backwards). Tag "latest" only when the new
       # version is the highest published one; otherwise use a per-branch tag. Plain "8.19" is
       # not a legal dist-tag (npm rejects tags that parse as semver ranges), hence the prefix.
+      # main builds are prereleases of a minor that has not shipped, so they must never take or
+      # influence "latest" and are pinned to "latest-main".
       - name: Compute dist-tag
         id: dist-tag
+        env:
+          BRANCH: ${{ steps.branch.outputs.branch }}
         run: |
           CURRENT_LATEST=$(npm view @elastic/request-converter-dotnet version 2>/dev/null || echo "0.0.0")
           NEW_VERSION="${{ steps.version.outputs.version }}"
-          if [ "$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -n1)" = "$NEW_VERSION" ]; then
+          if [ "$BRANCH" = "main" ]; then
+            TAG="latest-main"
+          elif [ "$(printf '%s\n%s\n' "$CURRENT_LATEST" "$NEW_VERSION" | sort -V | tail -n1)" = "$NEW_VERSION" ]; then
             TAG="latest"
           else
-            TAG="latest-${{ steps.branch.outputs.branch }}"
+            TAG="latest-$BRANCH"
           fi
           echo "Publishing ${NEW_VERSION} with dist-tag ${TAG} (current latest: ${CURRENT_LATEST})"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-      - run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance --tag "${{ steps.dist-tag.outputs.tag }}"
+      - name: Log package metadata (dry run)
+        if: ${{ github.event.inputs.dry-run == 'true' }}
+        run: cat .artifacts/npm/request-converter-dotnet/package.json
+      - if: ${{ github.event.inputs.dry-run != 'true' }}
+        run: npm publish .artifacts/npm/request-converter-dotnet --access public --provenance --tag "${{ steps.dist-tag.outputs.tag }}"
 
-  # After a successful publish, open a bump PR in elasticsearch-specification targeting
-  # the matching major.minor branch (and main when this publish moved the "latest" tag).
+  # After a successful publish, open a bump PR in elasticsearch-specification targeting the
+  # spec branch of the same name as the branch this was built from.
   bump-spec:
     needs: publish
     if: ${{ needs.publish.result == 'success' }}
@@ -107,4 +156,4 @@ jobs:
       branch: ${{ needs.publish.outputs.branch }}
       dist-tag: ${{ needs.publish.outputs.dist-tag }}
       package: "@elastic/request-converter-dotnet"
-      dry-run: false
+      dry-run: ${{ github.event.inputs.dry-run == 'true' }}

--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -58,48 +58,38 @@ jobs:
       # Trusted publishing (OIDC, no NODE_AUTH_TOKEN) requires npm 11.5.1 or newer;
       # node 22's bundled npm 10.9.x predates it.
       - run: npm install -g npm@latest
-      # A numeric branch takes the next free patch on its own minor; "main" has no release line
-      # of its own and takes the next "-main.<n>" prerelease of the next unreleased minor.
-      # Prereleases are excluded from both scans so a 9.6.0-main.* build is never mistaken for
-      # an existing 9.6 release.
+      # A numeric branch takes the next free patch on its own minor, ignoring prereleases so a
+      # prerelease publish is never mistaken for an existing release.
+      #
+      # main is versioned off the commit it was built from, because it may target the next minor
+      # or the next major: the version must encode no target release. The "g" prefix keeps the
+      # identifier from being an all-digit token with a leading zero, which semver rejects. A
+      # given commit publishes exactly once - re-dispatching it fails as an npm duplicate-version
+      # error, by design.
       - name: Compute package version
         id: version
         env:
           BRANCH: ${{ steps.branch.outputs.branch }}
           RELEASE_TAG: ${{ github.event.release.tag_name }}
         run: |
-          VERSIONS=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null || echo "[]")
-          VERSION=$(node -e '
-            let raw;
-            try { raw = JSON.parse(process.argv[1]) } catch { raw = [] }
-            // "npm view versions --json" yields a bare string, not an array, for a single-version package.
-            const all = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
-            const released = all.filter(v => !v.includes("-"));
-            const branch = process.argv[2];
-            if (branch === "main") {
-              const [major, minor] = released.reduce((max, v) => {
-                const p = v.split(".").map(Number);
-                return p[0] > max[0] || (p[0] === max[0] && p[1] > max[1]) ? [p[0], p[1]] : max;
-              }, [0, 0]);
-              const base = major + "." + (minor + 1);
-              const counter = new RegExp("^" + base.replace(".", "\\.") + "\\.0-main\\.(\\d+)$");
-              const n = all.reduce((max, v) => {
-                const m = v.match(counter);
-                return m ? Math.max(max, Number(m[1])) : max;
-              }, 0);
-              console.log(base + ".0-main." + (n + 1));
-            } else {
-              const patch = released
-                .filter(v => v.startsWith(branch + "."))
-                .reduce((max, v) => Math.max(max, Number(v.split(".")[2])), -1);
-              console.log(branch + "." + (patch + 1));
-            }
-          ' "$VERSIONS" "$BRANCH")
           if [ "$BRANCH" = "main" ]; then
+            VERSION="0.0.0-main.g$(git rev-parse --short=12 HEAD)"
             # No client release corresponds to a main build, and "git describe" would attach an
-            # unrelated tag; the recorded commit is the build's identity instead.
+            # unrelated tag; the commit is the build's identity instead.
             CLIENT_VERSION="unreleased"
           else
+            VERSIONS=$(npm view @elastic/request-converter-dotnet versions --json 2>/dev/null || echo "[]")
+            VERSION=$(node -e '
+              let raw;
+              try { raw = JSON.parse(process.argv[1]) } catch { raw = [] }
+              // "npm view versions --json" yields a bare string, not an array, for a single-version package.
+              const all = Array.isArray(raw) ? raw : typeof raw === "string" ? [raw] : [];
+              const branch = process.argv[2];
+              const patch = all
+                .filter(v => !v.includes("-") && v.startsWith(branch + "."))
+                .reduce((max, v) => Math.max(max, Number(v.split(".")[2])), -1);
+              console.log(branch + "." + (patch + 1));
+            ' "$VERSIONS" "$BRANCH")
             CLIENT_VERSION="${RELEASE_TAG#v}"
             if [ -z "$CLIENT_VERSION" ]; then
               CLIENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "unreleased")
@@ -121,8 +111,8 @@ jobs:
       # dist-tag (it would implicitly move "latest" backwards). Tag "latest" only when the new
       # version is the highest published one; otherwise use a per-branch tag. Plain "8.19" is
       # not a legal dist-tag (npm rejects tags that parse as semver ranges), hence the prefix.
-      # main builds are prereleases of a minor that has not shipped, so they must never take or
-      # influence "latest" and are pinned to "latest-main".
+      # main builds name a commit rather than a release, so they must never take or influence
+      # "latest" and are pinned to "latest-main", which is the tag consumers reference.
       - name: Compute dist-tag
         id: dist-tag
         env:

--- a/src/RequestConverter.Wasm/npm/README.md
+++ b/src/RequestConverter.Wasm/npm/README.md
@@ -91,6 +91,11 @@ publish and carries no meaning beyond ordering. The exact embedded client is rec
 version compiled into the bundle, and `commit` is the elasticsearch-net commit the bundle was built
 from.
 
+Builds from the `main` branch have no release line of their own, so they ship as prereleases of the
+next unreleased minor: `<next-minor>.0-main.<n>`, for example `9.6.0-main.1`, with `n` incrementing
+per publish. They are published under the `latest-main` dist-tag and never take `latest`, and they
+record `clientVersion: unreleased` - use `commit` to identify what they were built from.
+
 ## Building from source
 
 This package is assembled from a published .NET WASM AppBundle; see

--- a/src/RequestConverter.Wasm/npm/README.md
+++ b/src/RequestConverter.Wasm/npm/README.md
@@ -91,10 +91,12 @@ publish and carries no meaning beyond ordering. The exact embedded client is rec
 version compiled into the bundle, and `commit` is the elasticsearch-net commit the bundle was built
 from.
 
-Builds from the `main` branch have no release line of their own, so they ship as prereleases of the
-next unreleased minor: `<next-minor>.0-main.<n>`, for example `9.6.0-main.1`, with `n` incrementing
-per publish. They are published under the `latest-main` dist-tag and never take `latest`, and they
-record `clientVersion: unreleased` - use `commit` to identify what they were built from.
+Builds from the `main` branch are versioned off the commit they were built from, as
+`0.0.0-main.g<commit>` (for example `0.0.0-main.g1a2b3c4d5e6f`). That version names the built commit
+and claims no target release, since `main` may be aiming at the next minor or at the next major.
+Such builds are published under the `latest-main` dist-tag and never take `latest`; reference that
+tag rather than a version range. Their provenance is in the `elasticsearch` metadata as usual:
+`commit` for the full commit, and `clientVersion` set to `unreleased`.
 
 ## Building from source
 


### PR DESCRIPTION
## Summary

Decouples `@elastic/request-converter-dotnet` publishing from client releases where it still forced a coupling:
`main` builds become publishable via `workflow_dispatch`, versioned `0.0.0-main.g<commit>` and always dist-tagged
`latest-main`, and the elasticsearch-specification bump automation targets exactly the build's own branch. Client
releases on numeric branches keep auto-publishing the converter as before.

## Intention

elasticsearch-specification needs to reference `main` and `9.5` converter builds without a premature client
release. Numeric branches could already publish manually; `main` had no path at all: the branch gate was
numeric-only, `main` has no version identity, the dist-tag rule handed `latest` to whatever sorted highest, and
spec `main` was only reachable as a side effect of winning that sort.

## Changes

- Branch gate accepts `main` alongside `major.minor` release branches.
- `main` versions are commit-based (`0.0.0-main.g<sha12>`): the version deliberately claims no target release
  (`main` may aim at the next minor or the next major), provenance lives in the version itself and the package
  metadata (`clientVersion: unreleased`), and a given commit publishes exactly once (a re-dispatch of the same
  commit fails as an npm duplicate-version error by design).
- `main` publishes are always dist-tagged `latest-main` and never take or influence `latest`.
- The spec bump targets only the build's own branch; the `latest`-moved-so-also-bump-`main` side effect is gone.
  For `main` builds the written pin is the literal dist-tag `latest-main`, so the first publish sets it and every
  later one no-ops - spec `main` follows the channel, not per-version pins.
- Numeric-branch version computation now filters out prerelease versions and handles npm's single-version JSON
  string shape.
- New `dry-run` dispatch input: computes and logs version/dist-tag/package metadata without publishing or opening
  bump PRs.

## Notes

- The `latest-main` token fetch for the spec bump relies on the already-merged catalog-info `@*` policy binding;
  direct dispatches of the reusable bump workflow additionally get their own policy (separate catalog-info PR).
- First post-merge validation: a `dry-run: true` dispatch for `main`.
- Installing a `main` build next to the JS host emits an unmet-optional-peer warning (npm ranges cannot admit
  foreign-tuple prereleases); this is warning-only and accepted.