### PR TITLE
[8.19] Add an emit_usings option to the WASM host (#8953)

### DIFF
--- a/src/RequestConverter.Wasm/Program.cs
+++ b/src/RequestConverter.Wasm/Program.cs
@@ -92,6 +92,7 @@ internal static partial class Exporter
 
 			var requests = parsed.Requests ?? [];
 			var debug = parsed.Options?.Debug ?? false;
+			var emitUsings = parsed.Options?.EmitUsings ?? true;
 
 			// Each request becomes a typed variable declaration. In a batch the first variables are `request`/`response`,
 			// then `request1`/`response1`, `request2`/`response2`, ... so the snippets don't collide when pasted together.
@@ -120,8 +121,9 @@ internal static partial class Exporter
 				}
 			}
 
-			// The using directives appear once at the top, deduplicated and ordered, covering every request below.
-			var usings = string.Concat(namespaces.Select(ns => $"using {ns};\n"));
+			// Unless disabled via emit_usings, the using directives appear once at the top, deduplicated and ordered,
+			// covering every request below.
+			var usings = emitUsings ? string.Concat(namespaces.Select(ns => $"using {ns};\n")) : "";
 			var body = string.Join("\n\n", declarations);
 
 			return StringResponse(usings.Length > 0 ? $"{usings}\n{body}" : body);

--- a/src/RequestConverter.Wasm/README.md
+++ b/src/RequestConverter.Wasm/README.md
@@ -45,6 +45,10 @@ Document-bodied requests also hoist the document and optional parameters such as
 synchronous one. In a batch, request and response variables are suffixed (`request1`/`response1`, ...) so the
 snippets can be pasted together.
 
+`options.emit_usings` (bool, default `true`) prepends the `using` directives for the namespaces the generated code
+references, deduplicated across the batch. Disable it when the host supplies its own directives; with the default
+`type_name_style` of `Simplified` the snippet does not compile without them.
+
 `ParsedRequest` is produced by the host's parser, not by this module: turning Dev Console text into
 the API name and URL parameters needs the Elasticsearch schema, which the host library owns. The
 browser harness below shows the full pipeline (parse with the host, convert with this module).

--- a/src/RequestConverter.Wasm/harness/harness.mjs
+++ b/src/RequestConverter.Wasm/harness/harness.mjs
@@ -19,6 +19,7 @@ const els = {
   callStyle: document.getElementById("callStyle"),
   clientCall: document.getElementById("clientCall"),
   documentType: document.getElementById("documentType"),
+  emitUsings: document.getElementById("emitUsings"),
   namespaces: document.getElementById("namespaces"),
   output: document.getElementById("output"),
   source: document.getElementById("source"),
@@ -93,12 +94,13 @@ async function run() {
   try {
     const requests = await parseRequests(source);
     const code = convert(requests, {
-      type_name_style: els.style.value,
-      syntax_mode: els.syntax.value,
-      use_strongly_typed_document: els.typedDocument.checked,
-      document_type_name: els.documentType.value,
       client_call_format: els.clientCall.value,
       client_call_style: els.callStyle.value,
+      document_type_name: els.documentType.value,
+      emit_usings: els.emitUsings.checked,
+      syntax_mode: els.syntax.value,
+      type_name_style: els.style.value,
+      use_strongly_typed_document: els.typedDocument.checked,
     });
     els.output.textContent = code;
     setStatus("Converted.");
@@ -111,6 +113,7 @@ async function run() {
 els.callStyle.addEventListener("change", run);
 els.clientCall.addEventListener("change", run);
 els.documentType.addEventListener("input", schedule);
+els.emitUsings.addEventListener("change", run);
 els.source.addEventListener("input", schedule);
 els.style.addEventListener("change", run);
 els.syntax.addEventListener("change", run);

--- a/src/RequestConverter.Wasm/harness/index.html
+++ b/src/RequestConverter.Wasm/harness/index.html
@@ -71,6 +71,10 @@
         <input id="typedDocument" type="checkbox" />
         Strongly-typed document
       </label>
+      <label>
+        <input id="emitUsings" type="checkbox" checked />
+        emit usings
+      </label>
       <label>Document type
         <input id="documentType" value="MyDocument" style="width: 16ch;" />
       </label>

--- a/src/RequestConverter/Hosting/ParsedRequest.cs
+++ b/src/RequestConverter/Hosting/ParsedRequest.cs
@@ -27,10 +27,10 @@ public sealed record ParsedRequest
 
 /// <summary>
 /// The host's conversion options. The typed fields - <see cref="TypeNameStyle"/>, <see cref="SyntaxMode"/>,
-/// <see cref="UseStronglyTypedDocument"/>, <see cref="DocumentTypeName"/>, <see cref="ClientCallFormat"/>, and
-/// <see cref="ClientCallStyle"/> - drive the .NET converter output. The remaining fields exist to round-trip
-/// the host contract. <see cref="TypeNameStyle"/> is an extension the harness passes through the host's
-/// open-ended options bag to select the emitted type-name spelling.
+/// <see cref="UseStronglyTypedDocument"/>, <see cref="DocumentTypeName"/>, <see cref="ClientCallFormat"/>,
+/// <see cref="ClientCallStyle"/>, and <see cref="EmitUsings"/> - drive the .NET converter output. The remaining
+/// fields exist to round-trip the host contract. <see cref="TypeNameStyle"/> is an extension the harness passes
+/// through the host's open-ended options bag to select the emitted type-name spelling.
 /// </summary>
 public sealed record ConvertOptions
 {
@@ -60,4 +60,9 @@ public sealed record ConvertOptions
 	/// <c>statement</c> (request variable plus a call statement), or <c>inline</c> (request or descriptor lambda
 	/// inlined as the call argument). Extension to the host contract.</summary>
 	public string? ClientCallFormat { get; init; }
+
+	/// <summary>Prepend the <c>using</c> directives for the namespaces the generated code references. Defaults to
+	/// <c>true</c>; with the default <see cref="TypeNameStyle"/> of <c>Simplified</c> the code does not compile
+	/// without them. Extension to the host contract.</summary>
+	public bool? EmitUsings { get; init; }
 }


### PR DESCRIPTION
# Backport

This will backport the following commits from `request-converter-client-call` to `8.19`:
 - [Add an emit_usings option to the WASM host (#8953)](https://github.com/elastic/elasticsearch-net/pull/8953)

### Questions ?
Please refer to the [Backport tool documentation](https://github.com/sorenlouv/backport)
