### PR TITLE
[9.5] Wrap the inline client call when its argument spans multiple lines (#8967)

### DIFF
--- a/src/RequestConverter.Wasm/README.md
+++ b/src/RequestConverter.Wasm/README.md
@@ -38,8 +38,25 @@ illustrative and generally does not compile or round-trip as-is. Both map to
 executes the request: `statement` declares the request variable and calls
 `var response = await client.Esql.QueryAsync(request);`; `inline` passes the request initializer (object-initializer
 mode) or, in descriptor mode, the chain-head constructor arguments hoisted as labeled call arguments followed by the
-configuration lambda, e.g.
-`var response = await client.Indices.CreateAsync(index: "my-index", d1 => d1.Settings(...));`.
+configuration lambda. A call whose argument spans multiple lines wraps the method onto its own line
+(a lambda additionally closes `);` on its own line):
+
+```csharp
+var response = await client.Indices
+    .CreateAsync(index: "my-index", d1 => d1
+        .Settings(...)
+    );
+
+var response = await client.Indices
+    .CreateAsync(new CreateIndexRequest()
+    {
+        Index = "my-index",
+        Settings = ...
+    });
+```
+
+A call whose argument stays single-line stays on one line, e.g.
+`var response = await client.Indices.CreateAsync(index: "my-index");`.
 Document-bodied requests also hoist the document and optional parameters such as `id: null`.
 `options.client_call_style` (`async` | `sync`, default `async`) selects the awaited asynchronous flavor or the
 synchronous one. In a batch, request and response variables are suffixed (`request1`/`response1`, ...) so the

--- a/src/RequestConverter/CodeWriter.cs
+++ b/src/RequestConverter/CodeWriter.cs
@@ -717,6 +717,32 @@ public sealed class CodeWriter
 	}
 
 	/// <summary>
+	/// Whether <paramref name="writeBody"/> emits no text, probed against a scratch writer with the same options
+	/// (type refs and state recorded during the probe are discarded with it). The inline client call asks this
+	/// about the descriptor chain before writing anything: a non-empty chain wraps the method call onto its own
+	/// line, and that break precedes text the chain itself only produces later.
+	/// </summary>
+	public bool WritesNothing(Action<CodeWriter> writeBody)
+	{
+		var probe = new CodeWriter(Options);
+		writeBody(probe);
+		return probe._builder.Length == 0;
+	}
+
+	/// <summary>
+	/// Whether <paramref name="writeBody"/> emits at least one line break, probed against a scratch writer with the
+	/// same options (type refs and state recorded during the probe are discarded with it). The inline client call
+	/// asks this about the request argument before writing anything: a multi-line argument wraps the method call
+	/// onto its own line, and that break precedes text the argument itself only produces later.
+	/// </summary>
+	public bool WritesMultipleLines(Action<CodeWriter> writeBody)
+	{
+		var probe = new CodeWriter(Options);
+		writeBody(probe);
+		return probe._lineCount > 0;
+	}
+
+	/// <summary>
 	/// Writes the argument list of an inline descriptor client call: the hoisted chain-head constructor arguments,
 	/// then the configuration lambda <c>dN =&gt; dN...</c> holding the fluent chain. An empty chain drops the lambda
 	/// (and its separator, mirroring <see cref="WriteFluentVariantAdd"/>) so the call binds to the actionless

--- a/src/RequestConverter/RequestConverter.cs
+++ b/src/RequestConverter/RequestConverter.cs
@@ -128,33 +128,42 @@ public sealed class RequestConverter
 	}
 
 	/// <summary>
-	/// Writes <c>var response = [await ]client.[Sub.]Method[Async][&lt;T, ...&gt;](</c> with
-	/// <paramref name="genericArity"/> type arguments. They are spelled explicitly because the compiler cannot infer
-	/// them from the argument, as the placeholder document type in strongly-typed-document mode and
-	/// <see cref="System.Text.Json.JsonElement"/> otherwise. The count depends on which overload the call targets:
-	/// the request overload leaves only the response-only parameters open, while a descriptor-action overload takes
-	/// a lambda and so infers nothing at all.
+	/// Writes <c>var response = [await ]client[.Sub]</c>: the response assignment and the receiver the executing
+	/// method is invoked on, up to but not including the method name, so the caller decides whether the method
+	/// continues on the same line or drops onto its own.
 	/// </summary>
-	private static void WriteClientCallPrefix(CodeWriter writer, ClientCallInfo clientMethod, int genericArity)
+	private static void WriteClientCallReceiver(CodeWriter writer, ClientCallInfo clientMethod)
 	{
 		var options = writer.Options;
-		var async = options.ClientCallStyle == ClientCallStyle.Async;
 
 		writer.Write("var ").Write(options.ResponseVariableName).Write(" = ");
 
-		if (async)
+		if (options.ClientCallStyle == ClientCallStyle.Async)
 		{
 			writer.Write("await ");
 		}
 
-		writer.Write(options.ClientVariableName).Write(".");
+		writer.Write(options.ClientVariableName);
 
 		if (clientMethod.SubClient.Length > 0)
 		{
-			writer.Write(clientMethod.SubClient).Write(".");
+			writer.Write(".").Write(clientMethod.SubClient);
 		}
+	}
 
-		writer.Write(async ? clientMethod.Method + "Async" : clientMethod.Method);
+	/// <summary>
+	/// Writes <c>.Method[Async][&lt;T, ...&gt;](</c> with <paramref name="genericArity"/> type arguments. They are
+	/// spelled explicitly because the compiler cannot infer them from the argument, as the placeholder document type
+	/// in strongly-typed-document mode and <see cref="System.Text.Json.JsonElement"/> otherwise. The count depends on
+	/// which overload the call targets: the request overload leaves only the response-only parameters open, while a
+	/// descriptor-action overload takes a lambda and so infers nothing at all.
+	/// </summary>
+	private static void WriteClientCallMethod(CodeWriter writer, ClientCallInfo clientMethod, int genericArity)
+	{
+		var options = writer.Options;
+		var async = options.ClientCallStyle == ClientCallStyle.Async;
+
+		writer.Write(".").Write(async ? clientMethod.Method + "Async" : clientMethod.Method);
 
 		if (genericArity > 0)
 		{
@@ -182,6 +191,14 @@ public sealed class RequestConverter
 		writer.Write("(");
 	}
 
+	/// <summary>Writes <c>var response = [await ]client.[Sub.]Method[Async][&lt;T, ...&gt;](</c> on one line;
+	/// see <see cref="WriteClientCallMethod"/> for the generic-arity rules.</summary>
+	private static void WriteClientCallPrefix(CodeWriter writer, ClientCallInfo clientMethod, int genericArity)
+	{
+		WriteClientCallReceiver(writer, clientMethod);
+		WriteClientCallMethod(writer, clientMethod, genericArity);
+	}
+
 	/// <summary>Appends the executing client invocation as a second statement referencing the request variable.</summary>
 	private static void WriteClientCall(CodeWriter writer, ClientCallInfo clientMethod)
 	{
@@ -190,9 +207,14 @@ public sealed class RequestConverter
 		writer.Write(writer.Options.VariableName).Write(");");
 	}
 
-	/// <summary>Writes the whole invocation with the request inlined as the argument: the configuration lambda
+	/// <summary>
+	/// Writes the whole invocation with the request inlined as the argument: the configuration lambda
 	/// (plus hoisted chain-head arguments) for a descriptor-capable request in descriptor mode, the request
-	/// expression otherwise.</summary>
+	/// expression otherwise. A call whose argument spans multiple lines wraps: the method drops onto its own
+	/// line one indent in, so the lambda or initializer reads as a block under it (the lambda additionally
+	/// closes <c>);</c> on its own line at the method's indent; the initializer keeps C#'s customary
+	/// <c>});</c> on the closing-brace line). A call whose argument stays single-line stays on one line.
+	/// </summary>
 	private static void WriteInlineClientCall(CodeWriter writer, ClientCallInfo clientMethod, ICodeFormattable formattable)
 	{
 		// A negative descriptor arity means no client overload accepts the hoisted arguments plus a configuration
@@ -201,25 +223,70 @@ public sealed class RequestConverter
 			&& clientMethod.DescriptorGenericArity >= 0
 			&& formattable is IClientCallFormattable descriptorFormattable)
 		{
-			WriteClientCallPrefix(writer, clientMethod, clientMethod.DescriptorGenericArity);
+			// The wrap decision must precede the prefix, but whether the chain is empty only shows once it is
+			// written, so probe it against a scratch writer first.
+			if (writer.WritesNothing(descriptorFormattable.FormatDescriptorChain))
+			{
+				WriteClientCallPrefix(writer, clientMethod, clientMethod.DescriptorGenericArity);
+				writer.WriteInlineDescriptorArguments(
+					descriptorFormattable.FormatDescriptorHeadArguments,
+					descriptorFormattable.FormatDescriptorChain);
+				writer.Write(");");
+				return;
+			}
+
+			WriteClientCallReceiver(writer, clientMethod);
+			writer.WriteLine();
+			using (writer.Indent())
+			{
+				WriteClientCallMethod(writer, clientMethod, clientMethod.DescriptorGenericArity);
+			}
+
+			// The arguments are written at the statement's own level: the chain body already renders two levels
+			// deeper (the configuration lambda's indent plus the indent the generated chain applies to itself),
+			// which is exactly one level below the wrapped method line.
 			writer.WriteInlineDescriptorArguments(
 				descriptorFormattable.FormatDescriptorHeadArguments,
 				descriptorFormattable.FormatDescriptorChain);
+
+			writer.WriteLine();
+			using (writer.Indent())
+			{
+				writer.Write(");");
+			}
+
+			return;
 		}
-		else
+
+		// The argument is a request, so it must render as one even in descriptor mode - a split-capable
+		// request's FormatCode would otherwise emit a descriptor the request overload does not accept. The root
+		// argument must also name its type: a target-typed new() is ambiguous against the client method's
+		// overload set (request vs. descriptor-action overloads).
+		void WriteRequestArgument(CodeWriter w)
 		{
-			WriteClientCallPrefix(writer, clientMethod, clientMethod.ResponseGenericArity);
-
-			// The argument is a request, so it must render as one even in descriptor mode - a split-capable
-			// request's FormatCode would otherwise emit a descriptor the request overload does not accept.
-			using var _objectInitializer = writer.ForceObjectInitializer();
-
-			// The root argument must name its type: a target-typed new() is ambiguous against the client method's
-			// overload set (request vs. descriptor-action overloads).
-			writer.ForceNextExplicitConstructor();
-			formattable.FormatCode(writer);
+			using var _objectInitializer = w.ForceObjectInitializer();
+			w.ForceNextExplicitConstructor();
+			formattable.FormatCode(w);
 		}
 
+		// The wrap decision must precede the prefix, but whether the initializer spans multiple lines only shows
+		// once it is written, so probe it against a scratch writer first.
+		if (writer.WritesMultipleLines(WriteRequestArgument))
+		{
+			WriteClientCallReceiver(writer, clientMethod);
+			writer.WriteLine();
+			using (writer.Indent())
+			{
+				WriteClientCallMethod(writer, clientMethod, clientMethod.ResponseGenericArity);
+				WriteRequestArgument(writer);
+				writer.Write(");");
+			}
+
+			return;
+		}
+
+		WriteClientCallPrefix(writer, clientMethod, clientMethod.ResponseGenericArity);
+		WriteRequestArgument(writer);
 		writer.Write(");");
 	}
 }

--- a/tests/RequestConverter.Tests/ClientCallTests.cs
+++ b/tests/RequestConverter.Tests/ClientCallTests.cs
@@ -155,8 +155,8 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline };
 		var result = Convert("esql.query", """{"query":"FROM library"}""", options);
 
-		Assert.StartsWith("var response = await client.Esql.QueryAsync(new EsqlQueryRequest()", result.Code, StringComparison.Ordinal);
-		Assert.EndsWith(");", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client.Esql\n    .QueryAsync(new EsqlQueryRequest()", result.Code, StringComparison.Ordinal);
+		Assert.EndsWith("});", result.Code, StringComparison.Ordinal);
 		Assert.DoesNotContain("request =", result.Code, StringComparison.Ordinal);
 		Assert.Contains("Elastic.Clients.Elasticsearch.Esql", result.Namespaces);
 	}
@@ -167,7 +167,7 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline };
 		var result = Convert("search", """{"query":{"match_all":{}}}""", options);
 
-		Assert.StartsWith("var response = await client.SearchAsync<JsonElement>(new SearchRequest()", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .SearchAsync<JsonElement>(new SearchRequest()", result.Code, StringComparison.Ordinal);
 		Assert.Contains("System.Text.Json", result.Namespaces);
 	}
 
@@ -177,7 +177,7 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline, ClientCallStyle = ClientCallStyle.Sync };
 		var result = Convert("esql.query", """{"query":"FROM library"}""", options);
 
-		Assert.StartsWith("var response = client.Esql.Query(new EsqlQueryRequest()", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = client.Esql\n    .Query(new EsqlQueryRequest()", result.Code, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -196,7 +196,7 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline };
 		var result = Convert("bulk", "{\"index\":{\"_id\":\"1\"}}\n{\"field\":1}\n", options);
 
-		Assert.StartsWith("var response = await client.BulkAsync(new BulkRequest", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .BulkAsync(new BulkRequest", result.Code, StringComparison.Ordinal);
 		Assert.Contains("Elastic.Clients.Elasticsearch", result.Namespaces);
 	}
 
@@ -206,11 +206,14 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline, SyntaxMode = SyntaxMode.Descriptor };
 		var result = Convert("esql.query", """{"query":"FROM library"}""", options);
 
-		Assert.StartsWith("var response = await client.Esql.QueryAsync(", result.Code, StringComparison.Ordinal);
-		Assert.Contains(" => ", result.Code, StringComparison.Ordinal);
-		Assert.Contains(".Query(\"FROM library\")", result.Code, StringComparison.Ordinal);
-		Assert.EndsWith("));", result.Code, StringComparison.Ordinal);
-		Assert.DoesNotContain("new EsqlQueryRequestDescriptor", result.Code, StringComparison.Ordinal);
+		// Spelled with explicit "\n" (the FormattingOptions default) so the expectation does not depend on the
+		// checkout's line endings. The non-empty chain wraps the method onto its own line and closes ");" on its own.
+		Assert.Equal(
+			"var response = await client.Esql\n"
+			+ "    .QueryAsync(d1 => d1\n"
+			+ "        .Query(\"FROM library\")\n"
+			+ "    );",
+			result.Code);
 	}
 
 	[Fact]
@@ -220,8 +223,9 @@ public sealed class ClientCallTests
 		var result = Convert("indices.create", """{"settings":{"number_of_shards":1}}""", options,
 			new Dictionary<string, string> { ["index"] = "my-index" });
 
-		Assert.StartsWith("var response = await client.Indices.CreateAsync(index: \"my-index\", ", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client.Indices\n    .CreateAsync(index: \"my-index\", d1 => d1\n", result.Code, StringComparison.Ordinal);
 		Assert.Contains(".Settings(", result.Code, StringComparison.Ordinal);
+		Assert.EndsWith("\n    );", result.Code, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -248,7 +252,7 @@ public sealed class ClientCallTests
 		var options = new FormattingOptions { ClientCallFormat = ClientCallFormat.Inline, SyntaxMode = SyntaxMode.Descriptor };
 		var result = Convert("bulk", "{\"index\":{\"_id\":\"1\"}}\n{\"field\":1}\n", options);
 
-		Assert.StartsWith("var response = await client.BulkAsync(new BulkRequest", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .BulkAsync(new BulkRequest", result.Code, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -278,7 +282,7 @@ public sealed class ClientCallTests
 
 		// Every descriptor-action overload is SearchAsync<TDocument, TEvent>, so both arguments are spelled even
 		// though the request overload leaves only TEvent open.
-		Assert.StartsWith("var response = await client.Eql.SearchAsync<JsonElement, JsonElement>(", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client.Eql\n    .SearchAsync<JsonElement, JsonElement>(", result.Code, StringComparison.Ordinal);
 		Assert.Contains("indices: new[] { \"books\" }", result.Code, StringComparison.Ordinal);
 	}
 
@@ -289,7 +293,7 @@ public sealed class ClientCallTests
 		var result = Convert("update", """{"doc":{"name":"book"}}""", options,
 			new Dictionary<string, string> { ["index"] = "books", ["id"] = "1" });
 
-		Assert.StartsWith("var response = await client.UpdateAsync<JsonElement, JsonElement>(index: \"books\", id: \"1\", ", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .UpdateAsync<JsonElement, JsonElement>(index: \"books\", id: \"1\", ", result.Code, StringComparison.Ordinal);
 		Assert.Contains(" => ", result.Code, StringComparison.Ordinal);
 	}
 
@@ -305,7 +309,7 @@ public sealed class ClientCallTests
 		var result = Convert("eql.search", """{"query":"any where true"}""", options,
 			new Dictionary<string, string> { ["index"] = "books" });
 
-		Assert.StartsWith("var response = await client.Eql.SearchAsync<MyDocument, MyDocument>(", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client.Eql\n    .SearchAsync<MyDocument, MyDocument>(", result.Code, StringComparison.Ordinal);
 	}
 
 	[Fact]
@@ -315,7 +319,7 @@ public sealed class ClientCallTests
 		var result = Convert("put_script", """{"script":{"lang":"painless","source":"ctx._source.counter += 1"}}""", options,
 			new Dictionary<string, string> { ["id"] = "my-script" });
 
-		Assert.StartsWith("var response = await client.PutScriptAsync(new PutScriptRequest", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .PutScriptAsync(new PutScriptRequest", result.Code, StringComparison.Ordinal);
 		Assert.DoesNotContain(" => ", result.Code, StringComparison.Ordinal);
 	}
 
@@ -341,6 +345,6 @@ public sealed class ClientCallTests
 		};
 		var result = Convert("search", """{"query":{"match_all":{}}}""", options);
 
-		Assert.StartsWith("var response = await client.SearchAsync<MyDocument>(", result.Code, StringComparison.Ordinal);
+		Assert.StartsWith("var response = await client\n    .SearchAsync<MyDocument>(", result.Code, StringComparison.Ordinal);
 	}
 }


### PR DESCRIPTION
Manual backport of the remaining delta from #8967 ("Emit the executing client call in the request converter").

The automatic backport of #8967 failed because its squash commit carries the whole client-call feature, which this branch already contains via the #8951 backport. The only missing piece is the multi-line wrapping of the inline client call, cherry-picked here:

```csharp
var response = await client.Indices
    .CreateAsync(index: "my-index", d1 => d1
        .Settings(d2 => d2
            .NumberOfShards(1)
        )
    );
```

Single-line calls stay one-liners. `dotnet test tests/RequestConverter.Tests` passes on this branch (84 tests, including the compile corpus for all client-call format/syntax combinations).
