### PR TITLE
docs: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,35 +2,51 @@
 
 ## Setup commands
 
-The build system is [Bullseye](https://github.com/adamralph/bullseye), invoked through shell scripts in the repo root.
+The repository builds with the standard .NET SDK CLI; the SDK version is pinned in `global.json`.
 
-- Build and run unit tests: `./build.sh` on macOS/Linux, `.\build.bat` on Windows
-- Build without tests: `./build.sh skiptests`
-- Integration tests (requires a running Elasticsearch): `./build.sh integrate [version]` (e.g. `./build.sh integrate 8.3.2`)
+- Build the client: `dotnet build src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj`
+- Build and test the request converter: `dotnet test RequestConverter.sln` (requires the `wasm-tools` workload:
+  `dotnet workload install wasm-tools`)
 
-There is no separate lint command - code formatting is enforced at build time.
+A legacy Bullseye build system (`./build.sh`, `.\build.bat`, driven by the F# project `build/scripts/scripts.fsproj`)
+still backs a few CI workflows. It is planned to be modernized or removed; do not use it for local development.
+
+There is no separate lint command. Code style is defined in `.editorconfig` and checked with `dotnet format` in
+reporting mode, e.g. `dotnet format src/Elastic.Clients.Elasticsearch/Elastic.Clients.Elasticsearch.csproj
+--verify-no-changes`. The tree carries pre-existing violations, so only make sure your changes do not add new ones.
 
 ## Testing
 
-**The full build (`./build.sh`) must pass and exit cleanly before you commit code.**
+Most of the test suite under `tests/` was never ported from the 7.x client to 8.x, so there is effectively no public
+unit or integration test coverage for the client. Do not rely on these projects and do not extend them; verify client
+changes by making sure the client project builds cleanly.
 
-Integration tests require a reachable Elasticsearch instance. Unit tests have no external dependencies and run as part of the default build target.
+The request converter is the exception: `dotnet test RequestConverter.sln` runs `tests/RequestConverter.Tests` and
+must pass.
 
 ## Project Structure
 
-- **src/** - Client source code
-- **tests/Tests/** - Unit and integration tests
-- **build/** - Build scripts and targets
+- **build/** - legacy build scripts (see Setup commands)
+- **src/Elastic.Clients.Elasticsearch/** - the Elasticsearch client
+- **src/RequestConverter/** - converts Elasticsearch API request examples into .NET client code, with
+  **src/RequestConverter.Console/** as CLI frontend and **src/RequestConverter.Wasm/** as WASM/npm packaging
+- **tests/** - test projects (see Testing)
+
+### Generated code
+
+`src/Elastic.Clients.Elasticsearch/_Generated/` and `src/RequestConverter/_Generated/` contain code produced by a
+source generator that lives in a private repository. Never edit files in these directories manually; any manual
+change will be overwritten on the next regeneration.
 
 ## Development Workflow
 
-1. Make changes to files under `src/`
-2. Run `./build.sh` to compile and run unit tests
-3. If your change touches integration behavior, run `./build.sh integrate [version]` against a local Elasticsearch instance
+1. Make changes to files under `src/`, never inside a `_Generated/` directory
+2. Build the affected project(s) with `dotnet build`
+3. For request converter changes, run `dotnet test RequestConverter.sln`
 
 ## OS Compatibility
 
-All code and build scripts must work on Windows, macOS, and Linux. Use `./build.sh` on macOS/Linux and `.\build.bat` on Windows.
+All code and scripts must work on Windows, macOS, and Linux. The `dotnet` CLI commands above are cross-platform.
 
 ## Adding new agent instructions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# AGENTS.md
+
+## Setup commands
+
+The build system is [Bullseye](https://github.com/adamralph/bullseye), invoked through shell scripts in the repo root.
+
+- Build and run unit tests: `./build.sh` on macOS/Linux, `.\build.bat` on Windows
+- Build without tests: `./build.sh skiptests`
+- Integration tests (requires a running Elasticsearch): `./build.sh integrate [version]` (e.g. `./build.sh integrate 8.3.2`)
+
+There is no separate lint command - code formatting is enforced at build time.
+
+## Testing
+
+**The full build (`./build.sh`) must pass and exit cleanly before you commit code.**
+
+Integration tests require a reachable Elasticsearch instance. Unit tests have no external dependencies and run as part of the default build target.
+
+## Project Structure
+
+- **src/** - Client source code
+- **tests/Tests/** - Unit and integration tests
+- **build/** - Build scripts and targets
+
+## Development Workflow
+
+1. Make changes to files under `src/`
+2. Run `./build.sh` to compile and run unit tests
+3. If your change touches integration behavior, run `./build.sh integrate [version]` against a local Elasticsearch instance
+
+## OS Compatibility
+
+All code and build scripts must work on Windows, macOS, and Linux. Use `./build.sh` on macOS/Linux and `.\build.bat` on Windows.
+
+## Adding new agent instructions
+
+All markdown instructions authored for other agents must be as concise as possible.
+
+If a specific action you learned to do better will be useful to other agents doing the same task in the future, but may not be needed for all agent-related tasks, create or update skills in `.claude/skills/`.
+
+If you learned something that will be useful to any contributor to this project, update `AGENTS.md`.


### PR DESCRIPTION
Adds AGENTS.md to document the build system, test commands, project structure, and conventions for AI coding agents. Mirrors the pattern established in other Elastic client repos.