### PR TITLE
Allow overriding the docfx folder name on manual runs

### DIFF
--- a/.github/workflows/docfx_manual.yml
+++ b/.github/workflows/docfx_manual.yml
@@ -2,6 +2,11 @@ name: 'DocFx'
 
 on:
   workflow_dispatch:
+    inputs:
+      name:
+        description: 'The name to use for the documentation folder (defaults to the name of the current ref)'
+        type: 'string'
+        required: false
 
 jobs:
   docfx:
@@ -14,4 +19,8 @@ jobs:
     uses: ./.github/workflows/docfx.yml
     with:
       target_branch: 'refdoc'
+      # An omitted input still arrives as an empty string, which would override
+      # the default declared in docfx.yml and target the refdoc root, so the
+      # fallback has to be applied here.
+      name: ${{ inputs.name || github.ref_name }}
     secrets: 'inherit'


### PR DESCRIPTION
## Summary

Adds an optional `name` input to the manually dispatched `DocFx` workflow, selecting the folder that the generated site
is published into on the `refdoc` branch.

## Intention

`docfx.yml` defaults the folder name to `github.ref_name`, so a manual run can only ever publish under the name of the
dispatched ref. That makes it unusable for republishing a specific version, which is exactly what is needed whenever a
release's `DocFx` job has to be repeated. Going through the tag is not an option either, because `workflow_dispatch`
reads the workflow file from the dispatched ref, so a tag created before a workflow fix still runs the old definition.
Dispatching from a branch resolves `github.ref_name` to the branch name and would publish into a folder named after the
branch.

## Changes

- `docfx_manual.yml`: optional `name` dispatch input, passed through to `docfx.yml` with an explicit fallback to
  `github.ref_name`.

## Notes

The fallback is applied by the caller because an omitted `workflow_dispatch` input arrives as an empty string rather
than being absent, which would override the default declared in `docfx.yml`. An empty name would make the commit step
target the `refdoc` root.

Labelled `skip-backport`, because the identical change is already part of #8985.
