### PR TITLE
[8.19] Fix the reference documentation publish on release

### DIFF
--- a/.github/workflows/docfx.yml
+++ b/.github/workflows/docfx.yml
@@ -13,6 +13,9 @@ on:
         required: false
         default: ${{ github.ref_name }}
 
+permissions:
+  contents: write
+
 concurrency:
   group: 'docfx'
   cancel-in-progress: false
@@ -56,6 +59,10 @@ jobs:
         working-directory: 'docfx'
         run: |-
           docfx docfx.json
+          rm -f ./_site/xrefmap.yml
+          rm -f ./_site/manifest.json
+          find ./_site -name 'index.json' -delete
+          find ./_site -name '*.map' -delete
           mv ./_site ./../..
 
       - name: 'Checkout'
@@ -63,10 +70,277 @@ jobs:
         with:
           ref: ${{ inputs.target_branch }}
 
+      - name: 'Redirect outdated versions'
+        run: |-
+          VERSION="${{ inputs.name }}"
+          if [[ ! "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then exit 0; fi
+          NEW_MAJOR="${BASH_REMATCH[1]}"
+          NEW_MINOR="${BASH_REMATCH[2]}"
+          NEW_PATCH="${BASH_REMATCH[3]}"
+
+          write_redirect() {
+            local mode="$1" dir="$2" url="$3" target="$4" requested="$5" requested_branch="$6"
+            rm -rf "./${dir}"
+            mkdir "./${dir}"
+            if [[ "$mode" == "older_patch" ]]; then
+              {
+                echo '<!DOCTYPE html>'
+                echo '<html lang="en">'
+                echo '<head>'
+                echo '  <meta charset="utf-8">'
+                printf '  <meta http-equiv="refresh" content="0; url=%s">\n' "$url"
+                printf '  <link rel="canonical" href="%s">\n' "$url"
+                printf '  <title>Redirecting to %s</title>\n' "$target"
+                printf '  <script>window.location.replace("%s");</script>\n' "$url"
+                echo '</head>'
+                echo '<body>'
+                printf '  <p>This documentation has been superseded. Redirecting to <a href="%s">%s</a>.</p>\n' "$url" "$target"
+                echo '</body>'
+                echo '</html>'
+              } > "./${dir}/index.html"
+              return
+            fi
+
+            {
+              echo '<!DOCTYPE html>'
+              echo '<html lang="en">'
+              echo '<head>'
+              echo '  <meta charset="utf-8">'
+              echo '  <meta name="viewport" content="width=device-width, initial-scale=1">'
+              printf '  <link rel="canonical" href="%s">\n' "$url"
+              printf '  <title>Unsupported docs version %s</title>\n' "$requested"
+              echo '  <style>'
+              echo '    :root { color-scheme: light dark; }'
+              echo '    body { margin: 0; padding: 2rem 1rem; font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f6f8fa; color: #1f2328; }'
+              echo '    main { max-width: 50rem; margin: 0 auto; }'
+              echo '    h1 { margin: 0 0 0.4rem; font-size: 1.8rem; }'
+              echo '    p { margin: 0.35rem 0; line-height: 1.45; }'
+              echo '    .actions { margin-top: 0.75rem; display: grid; gap: 0.45rem; }'
+              echo '    a.version { display: inline-flex; align-items: center; gap: 0.45rem; width: fit-content; padding: 0.45rem 0.65rem; border: 1px solid #d0d7de; border-radius: 0.5rem; background: #ffffff; color: inherit; text-decoration: none; }'
+              echo '    a.version:hover { background: #f3f4f6; }'
+              echo '    h2 { margin: 1.25rem 0 0.55rem; font-size: 1.15rem; }'
+              echo '    pre { margin: 0; padding: 0.75rem; border: 1px solid #d0d7de; border-radius: 0.5rem; background: #ffffff; overflow-x: auto; }'
+              echo '    code { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace; font-size: 0.9rem; }'
+              echo '    @media (prefers-color-scheme: dark) {'
+              echo '      body { background: #0d1117; color: #e6edf3; }'
+              echo '      a.version { border-color: #30363d; background: #161b22; }'
+              echo '      a.version:hover { background: #1f2937; }'
+              echo '      pre { border-color: #30363d; background: #161b22; }'
+              echo '    }'
+              echo '  </style>'
+              echo '</head>'
+              echo '<body>'
+              echo '  <main>'
+              printf '    <h1>Version %s is no longer supported</h1>\n' "$requested"
+              echo '    <p>This documentation version is outside the retained support window.</p>'
+              echo '    <div class="actions">'
+              printf '      <a class="version" href="%s">Closest supported version: %s</a>\n' "$url" "$target"
+              echo '      <a class="version" href="../">Version overview</a>'
+              echo '    </div>'
+              echo '    <h2>Serve this version locally</h2>'
+              echo '    <pre><code>'
+              echo 'git clone https://github.com/elastic/elasticsearch-net.git'
+              echo 'cd elasticsearch-net'
+              echo 'dotnet tool update -g docfx'
+              echo 'git fetch --tags origin'
+              printf 'git checkout %s || git checkout %s\n' "$requested" "$requested_branch"
+              echo 'cd docfx'
+              echo 'docfx docfx.json'
+              echo 'docfx serve _site'
+              echo '    </code></pre>'
+              echo '  </main>'
+              echo '</body>'
+              echo '</html>'
+            } > "./${dir}/index.html"
+          }
+
+          write_root_index() {
+            local current_major="" version major
+            {
+              echo '<!DOCTYPE html>'
+              echo '<html lang="en">'
+              echo '<head>'
+              echo '  <meta charset="utf-8">'
+              echo '  <meta name="viewport" content="width=device-width, initial-scale=1">'
+              echo '  <title>Elasticsearch .NET Reference Docs</title>'
+              echo '  <style>'
+              echo '    :root { color-scheme: light dark; }'
+              echo '    body { margin: 0; padding: 2rem 1rem; font-family: Inter, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; background: #f6f8fa; color: #1f2328; }'
+              echo '    main { max-width: 50rem; margin: 0 auto; }'
+              echo '    h1 { margin: 0 0 0.4rem; font-size: 1.8rem; }'
+              echo '    p { margin: 0.35rem 0; line-height: 1.45; }'
+              echo '    section { margin-top: 1.5rem; }'
+              echo '    h2 { margin: 0 0 0.55rem; font-size: 1.15rem; }'
+              echo '    ul { list-style: none; padding: 0; margin: 0; display: grid; gap: 0.45rem; }'
+              echo '    a.version { display: inline-flex; align-items: center; gap: 0.45rem; padding: 0.45rem 0.65rem; border: 1px solid #d0d7de; border-radius: 0.5rem; background: #ffffff; color: inherit; text-decoration: none; }'
+              echo '    a.version:hover { background: #f3f4f6; }'
+              echo '    .badge { padding: 0.1rem 0.4rem; border-radius: 999px; font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.02em; background: #0969da; color: #ffffff; }'
+              echo '    @media (prefers-color-scheme: dark) {'
+              echo '      body { background: #0d1117; color: #e6edf3; }'
+              echo '      a.version { border-color: #30363d; background: #161b22; }'
+              echo '      a.version:hover { background: #1f2937; }'
+              echo '    }'
+              echo '  </style>'
+              echo '</head>'
+              echo '<body>'
+              echo '  <main>'
+              echo '    <h1>Elasticsearch .NET Reference Docs</h1>'
+              echo '    <p>Retained versions available on GitHub Pages.</p>'
+              printf '    <p>Latest bleeding-edge version: <a href="./%s/">%s</a></p>\n' "$BLEEDING_EDGE_TARGET" "$BLEEDING_EDGE_TARGET"
+              if (( ${#RETAINED_VERSIONS[@]} == 0 )); then
+                echo '    <p>No retained versions are currently published.</p>'
+              else
+                for version in "${RETAINED_VERSIONS[@]}"; do
+                  major="${version%%.*}"
+                  if [[ "$major" != "$current_major" ]]; then
+                    if [[ -n "$current_major" ]]; then
+                      echo '      </ul>'
+                      echo '    </section>'
+                    fi
+                    echo '    <section>'
+                    printf '      <h2>%s.x</h2>\n' "$major"
+                    echo '      <ul>'
+                    current_major="$major"
+                  fi
+
+                  if [[ "$version" == "$BLEEDING_EDGE_TARGET" ]]; then
+                    printf '        <li><a class="version" href="./%s/">%s <span class="badge">latest</span></a></li>\n' "$version" "$version"
+                  else
+                    printf '        <li><a class="version" href="./%s/">%s</a></li>\n' "$version" "$version"
+                  fi
+                done
+
+                if [[ -n "$current_major" ]]; then
+                  echo '      </ul>'
+                  echo '    </section>'
+                fi
+              fi
+              echo '  </main>'
+              echo '</body>'
+              echo '</html>'
+            } > "./index.html"
+          }
+
+          declare -A LATEST_PATCH
+          declare -A LATEST_MINOR
+          declare -A MINORS_PER_MAJOR
+          shopt -s nullglob
+          for dir in */; do
+            dir="${dir%/}"
+            if [[ "$dir" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              M="${BASH_REMATCH[1]}" N="${BASH_REMATCH[2]}" P="${BASH_REMATCH[3]}"
+              KEY="${M}.${N}"
+              if [[ -z "${LATEST_PATCH[$KEY]}" ]] || (( P > LATEST_PATCH[$KEY] )); then LATEST_PATCH[$KEY]="$P"; fi
+              if [[ -z "${LATEST_MINOR[$M]}" ]] || (( N > LATEST_MINOR[$M] )); then LATEST_MINOR[$M]="$N"; fi
+              if [[ ! " ${MINORS_PER_MAJOR[$M]} " =~ " ${N} " ]]; then MINORS_PER_MAJOR[$M]+=" $N"; fi
+            fi
+          done
+
+          # Include the new version being deployed so the support window accounts for it
+          KEY="${NEW_MAJOR}.${NEW_MINOR}"
+          if [[ -z "${LATEST_PATCH[$KEY]}" ]] || (( NEW_PATCH > LATEST_PATCH[$KEY] )); then LATEST_PATCH[$KEY]="$NEW_PATCH"; fi
+          if [[ -z "${LATEST_MINOR[$NEW_MAJOR]}" ]] || (( NEW_MINOR > LATEST_MINOR[$NEW_MAJOR] )); then LATEST_MINOR[$NEW_MAJOR]="$NEW_MINOR"; fi
+          if [[ ! " ${MINORS_PER_MAJOR[$NEW_MAJOR]} " =~ " ${NEW_MINOR} " ]]; then MINORS_PER_MAJOR[$NEW_MAJOR]+=" $NEW_MINOR"; fi
+
+          # Determine the highest major version (= current major)
+          CURRENT_MAJOR=0
+          for M in "${!LATEST_MINOR[@]}"; do (( M > CURRENT_MAJOR )) && CURRENT_MAJOR="$M"; done
+
+          # Absolute bleeding-edge version = latest patch on highest major/minor
+          BLEEDING_EDGE_MINOR="${LATEST_MINOR[$CURRENT_MAJOR]}"
+          BLEEDING_EDGE_TARGET="${CURRENT_MAJOR}.${BLEEDING_EDGE_MINOR}.${LATEST_PATCH[${CURRENT_MAJOR}.${BLEEDING_EDGE_MINOR}]}"
+
+          # Determine supported major.minor combinations:
+          #   current major  -> last 3 minor versions
+          #   previous majors -> last minor version only
+          declare -A SUPPORTED
+          declare -A SUPPORTED_MINORS_ASC
+          for M in "${!MINORS_PER_MAJOR[@]}"; do
+            mapfile -t sorted_minors < <(echo "${MINORS_PER_MAJOR[$M]}" | tr ' ' '\n' | grep -v '^$' | sort -nu)
+            total=${#sorted_minors[@]}
+            if (( M == CURRENT_MAJOR )); then
+              start=$(( total > 3 ? total - 3 : 0 ))
+              for (( i=start; i<total; i++ )); do
+                minor="${sorted_minors[$i]}"
+                SUPPORTED["${M}.${minor}"]=1
+                SUPPORTED_MINORS_ASC[$M]+=" ${minor}"
+              done
+            else
+              minor="${sorted_minors[-1]}"
+              SUPPORTED["${M}.${minor}"]=1
+              SUPPORTED_MINORS_ASC[$M]+=" ${minor}"
+            fi
+          done
+
+          mapfile -t RETAINED_VERSIONS < <(
+            for KEY in "${!SUPPORTED[@]}"; do
+              PATCH="${LATEST_PATCH[$KEY]}"
+              [[ -z "$PATCH" ]] && continue
+              printf '%s.%s\n' "$KEY" "$PATCH"
+            done | sort -t '.' -k1,1nr -k2,2nr -k3,3nr
+          )
+
+          # Fallback target per major = latest patch of the highest known minor
+          declare -A BEST_TARGET
+          for M in "${!LATEST_MINOR[@]}"; do
+            BEST_M_MINOR="${LATEST_MINOR[$M]}"
+            BEST_TARGET[$M]="${M}.${BEST_M_MINOR}.${LATEST_PATCH[${M}.${BEST_M_MINOR}]}"
+          done
+
+          # Apply redirects to all directories that are no longer supported
+          for dir in */; do
+            dir="${dir%/}"
+            if [[ "$dir" == "$VERSION" ]]; then continue; fi
+            if [[ "$dir" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+              M="${BASH_REMATCH[1]}" N="${BASH_REMATCH[2]}" P="${BASH_REMATCH[3]}"
+              KEY="${M}.${N}"
+              if [[ -z "${SUPPORTED[$KEY]}" ]]; then
+                TARGET_MINOR=""
+                for RETAINED_MINOR in ${SUPPORTED_MINORS_ASC[$M]}; do
+                  if (( RETAINED_MINOR >= N )); then
+                    TARGET_MINOR="$RETAINED_MINOR"
+                    break
+                  fi
+                done
+
+                if [[ -z "$TARGET_MINOR" ]]; then
+                  for RETAINED_MINOR in ${SUPPORTED_MINORS_ASC[$M]}; do TARGET_MINOR="$RETAINED_MINOR"; done
+                fi
+
+                if [[ -n "$TARGET_MINOR" ]]; then
+                  TARGET_KEY="${M}.${TARGET_MINOR}"
+                  TARGET_PATCH="${LATEST_PATCH[$TARGET_KEY]}"
+                  if [[ -n "$TARGET_PATCH" ]]; then
+                    TARGET="${TARGET_KEY}.${TARGET_PATCH}"
+                  else
+                    TARGET="${BEST_TARGET[$M]}"
+                  fi
+                else
+                  TARGET="${BEST_TARGET[$M]}"
+                fi
+                echo "Replacing ${dir} with guidance page linking to ${TARGET} (unsupported minor)"
+              elif (( P != LATEST_PATCH[$KEY] )); then
+                TARGET="${KEY}.${LATEST_PATCH[$KEY]}"
+                echo "Replacing ${dir} with redirect to ${TARGET} (older patch)"
+              else
+                continue
+              fi
+              REDIRECT_URL="https://elastic.github.io/elasticsearch-net/${TARGET}/"
+              if [[ -z "${SUPPORTED[$KEY]}" ]]; then
+                write_redirect "unsupported_minor" "$dir" "$REDIRECT_URL" "$TARGET" "$dir" "${M}.${N}"
+              else
+                write_redirect "older_patch" "$dir" "$REDIRECT_URL" "$TARGET" "" ""
+              fi
+            fi
+          done
+
+          write_root_index
+
       - name: 'Commit'
         run: |-
           rm -r "./${{ inputs.name }}" || true
           mv ../_site "./${{ inputs.name }}"
+          touch .nojekyll
           git config --global user.name '${{ github.actor }}'
           git config --global user.email '${{ github.actor }}@users.noreply.github.com'
           git add -A

--- a/.github/workflows/docfx_manual.yml
+++ b/.github/workflows/docfx_manual.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   docfx:
     name: 'DocFx'
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       target_branch: 'refdoc'

--- a/.github/workflows/docfx_manual.yml
+++ b/.github/workflows/docfx_manual.yml
@@ -2,6 +2,11 @@ name: 'DocFx'
 
 on:
   workflow_dispatch:
+    inputs:
+      name:
+        description: 'The name to use for the documentation folder (defaults to the name of the current ref)'
+        type: 'string'
+        required: false
 
 jobs:
   docfx:
@@ -14,4 +19,8 @@ jobs:
     uses: ./.github/workflows/docfx.yml
     with:
       target_branch: 'refdoc'
+      # An omitted input still arrives as an empty string, which would override
+      # the default declared in docfx.yml and target the refdoc root, so the
+      # fallback has to be applied here.
+      name: ${{ inputs.name || github.ref_name }}
     secrets: 'inherit'

--- a/.github/workflows/release_stack.yml
+++ b/.github/workflows/release_stack.yml
@@ -20,6 +20,11 @@ jobs:
   docfx:
     name: 'DocFx'
     if: ${{ !startsWith(github.event.release.tag_name, 'serverless-') }}
+    # docfx.yml pushes the generated site to the refdoc branch. A called workflow
+    # cannot request more than its caller holds, and the repository default is
+    # read-only, so the grant has to be repeated here.
+    permissions:
+      contents: write
     uses: ./.github/workflows/docfx.yml
     with:
       name: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
## Summary

Restores the `DocFx` job of the `CD` workflow on `8.19` and brings the reference documentation workflows in line with
`main`. `docfx.yml` is taken from `main` unchanged, so an `8.19` release now trims the generated site before pushing,
regenerates the root version index and applies the version retention redirects exactly as a 9.x release does. Both
callers of `docfx.yml` receive the `contents: write` grant they were missing, and `docfx_manual.yml` gains an optional
`name` input so a specific version can be republished.

## Intention

The `DocFx` job has failed on every `8.19` release since 8.19.24, so `refdoc` currently ends at 8.19.23 and neither
8.19.24 nor 8.19.25 was ever published. The push to `refdoc` is rejected:

```
remote: Permission to elastic/elasticsearch-net.git denied to github-actions[bot]
fatal: unable to access 'https://github.com/elastic/elasticsearch-net/': The requested URL returned error: 403
```

The repository default for `GITHUB_TOKEN` is read-only. On `main` that is compensated for by an explicit grant on
`docfx.yml` and on both of its callers, since a called workflow cannot request more than its caller holds. Those grants
were added in #8918 and #8948 and were never backported.

A permissions-only fix would leave `8.19` pushing the payload that caused the oversized `refdoc` failures, and it would
not regenerate the root version index, so `docfx.yml` is synced in full instead.

## Changes

- `docfx.yml`: replaced with `main`'s version, folding in #8850, #8851, #8852, #8853 and #8918. The file is now byte
  identical on both branches.
- `release_stack.yml`: added `contents: write` to the `docfx` job. The serverless tag guards and the `flavor` and
  `solution` inputs of the `release` job are untouched, so #8764 is deliberately not taken.
- `docfx_manual.yml`: added `contents: write` and an optional `name` input selecting the folder to publish into.

## Related

Backports #8850, #8851, #8852, #8853, #8918 and #8948.

The `name` input of `docfx_manual.yml` is added to `main` in #8984, so the file stays identical on both branches.

## Notes

Verified by replaying the redirect script from the backported `docfx.yml` against the current `refdoc` layout with the
published version set to `8.19.25`. It exits cleanly, keeps 9.5.1 as the bleeding edge entry, retains 9.5.1, 9.4.2,
9.3.6 and 8.19.25, and redirects the superseded 8.19.x folders as well as 8.16 through 8.18 to 8.19.25. `actionlint`
reports no findings on the three changed files.

Backfilling 8.19.24 and 8.19.25 still needs a manual run once this is merged. Re-running the failed release jobs does
not help, because `workflow_dispatch` and re-runs read the workflow file from the tag, which still carries the old
definition. Dispatching `docfx_manual.yml` from the `8.19` branch with `name` set to the wanted version is the way
through, at the cost of building the docs from the branch head rather than from the tag.
