### PR TITLE
Serialize request-converter npm publishes

### DIFF
--- a/.github/workflows/request-converter-npm-publish.yml
+++ b/.github/workflows/request-converter-npm-publish.yml
@@ -18,6 +18,15 @@ permissions:
   contents: read
   id-token: write
 
+# npm rewrites the whole packument on publish, so two releases publishing this package
+# seconds apart make the loser fail with E409. Release branches are tagged together, so
+# the publishes have to be serialized. "queue: max" holds a later run rather than
+# cancelling it, which the default single pending slot would do.
+concurrency:
+  group: request-converter-npm-publish
+  queue: max
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Adds a concurrency group to the request-converter npm publish workflow so only one run at a time publishes
`@elastic/request-converter-dotnet`.

## Intention

Releases on different branches are tagged within seconds of each other, and every one of them publishes the same
npm package. npm rewrites the entire packument on publish, so when two runs overlap the loser fails with
`409 Conflict - Failed to save packument`.

That happened on 2026-08-28: `8.19.25` was published at 13:02:33 and `9.5.1` at 13:02:54. The `9.5.1` run won, the
`8.19.25` run published nothing, and `latest-8.19` stayed pinned to the previous patch until the job was re-run
by hand.

## Changes

* Serialize the workflow under a `request-converter-npm-publish` concurrency group.

## Related

Failed run: https://github.com/elastic/elasticsearch-net/actions/runs/33173631357

## Notes

`queue: max` is deliberate rather than incidental. The default, `queue: single`, allows only one pending run per
group and cancels an already-pending run when a newer one arrives, so a three-release cluster would silently drop
the middle publish instead of failing loudly. `docfx.yml` uses a concurrency group without it and lost the
`9.3.7` documentation publish exactly that way on 2026-05-06, when `8.19.21`, `9.3.7` and `9.4.0` were tagged
within 31 seconds.

Release events read the workflow file from the release tag rather than from `main`, so this only takes effect on
a branch once it has been backported there.
